### PR TITLE
Disable CoreDNS feature gate

### DIFF
--- a/pkg/templates/kubeadm/v1alpha3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1alpha3/kubeadm.go
@@ -57,6 +57,7 @@ type configuration struct {
 	APIServerCertSANs          []string          `yaml:"apiServerCertSANs,omitempty"`
 	APIServerExtraArgs         map[string]string `yaml:"apiServerExtraArgs,omitempty"`
 	ControllerManagerExtraArgs map[string]string `yaml:"controllerManagerExtraArgs,omitempty"`
+	FeatureGates               map[string]bool   `yaml:"featureGates,omitempty"`
 }
 
 func NewConfig(cluster *config.Cluster, instance int) (*configuration, error) {
@@ -108,6 +109,10 @@ func NewConfig(cluster *config.Cluster, instance int) (*configuration, error) {
 		APIServerExtraArgs: map[string]string{
 			"endpoint-reconciler-type": "lease",
 			"service-node-port-range":  cluster.Network.NodePortRange(),
+		},
+
+		FeatureGates: map[string]bool{
+			"CoreDNS": false,
 		},
 	}
 


### PR DESCRIPTION
Due to various errors with CoreDNS, this PR disables CoreDNS and by default replaces with KubeDNS until issues are not resolved.

When CoreDNS is enabled, its pods are stuck in CrashLoopBackOff:
```
NAMESPACE     NAME                                       READY   STATUS              RESTARTS   AGE
kube-system   coredns-576cbf47c7-d2pxj                   0/1     ContainerCreating   0          5m44s
kube-system   coredns-576cbf47c7-m8kkp                   0/1     CrashLoopBackOff    5          5m44s
```

This is what CoreDNS logs show:
```
2018/11/13 10:34:15 [INFO] CoreDNS-1.2.2
2018/11/13 10:34:15 [INFO] linux/amd64, go1.11, eb51e8b
CoreDNS-1.2.2
linux/amd64, go1.11, eb51e8b
2018/11/13 10:34:15 [INFO] plugin/reload: Running configuration MD5 = f65c4821c8a9b7b5eb30fa4fbc167769
2018/11/13 10:34:15 [FATAL] plugin/loop: Seen "HINFO IN 9092728187714189058.3535744278062856330." more than twice, loop detected
```

I've been in contact with upstream SIG-Cluster-Lifecycle about this issue, and it is kind of ecosystem, i.e. it happens but nobody know why.

For most of cases, CoreDNS works without any problem. Even for example, I used the same steps to create a HA cluster on DigitalOcean, and CoreDNS works there.

Related issues:
* https://github.com/kubernetes/kubeadm/issues/1162
* https://github.com/coredns/coredns/issues/2087

SIG have instructed me to check [troubleshooting document](https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#coredns-pods-have-crashloopbackoff-or-error-state), but most of issues are related to SELinux, which we don't have enabled on Ubuntu.

I have also been instructed to upgrade to the latest version of CoreDNS, but it doesn't work similar to this.

For now to go forward, let's disable CoreDNS and later debug why this happens. This is going to be really important as we go to new versions.

Action items:
* [ ] Can we get CoreDNS works? 
* [ ] Check with SIG-Cluster-Lifecycle how we can debug the bug.