### PR TITLE
Handle credentials for MachineController

### DIFF
--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -39,6 +39,7 @@ func InstallAction(logger *logrus.Logger) cli.ActionFunc {
 		if err != nil {
 			return fmt.Errorf("failed to load cluster: %v", err)
 		}
+		cluster.Provider.Credentials = loadMachineControllerCredentials()
 
 		tf := ctx.String("tfjson")
 		if err = applyTerraform(tf, cluster); err != nil {

--- a/pkg/command/shared.go
+++ b/pkg/command/shared.go
@@ -81,3 +81,31 @@ func applyTerraform(tf string, cluster *config.Cluster) error {
 
 	return nil
 }
+
+func loadMachineControllerCredentials() map[string]string {
+	data := map[string]string{}
+
+	// ----- AWS -----
+	data["AWS_ACCESS_KEY_ID"] = os.Getenv("AWS_ACCESS_KEY_ID")
+	data["AWS_ACCESS_KEY_ID"] = os.Getenv("AWS_ACCESS_KEY_ID")
+
+	// ----- OpenStack -----
+	data["OS_AUTH_URL"] = os.Getenv("OS_AUTH_URL")
+	data["OS_USER_NAME"] = os.Getenv("OS_USER_NAME")
+	data["OS_PASSWORD"] = os.Getenv("OS_PASSWORD")
+	data["OS_DOMAIN_NAME"] = os.Getenv("OS_DOMAIN_NAME")
+	data["OS_TENANT_NAME"] = os.Getenv("OS_TENANT_NAME")
+
+	// ----- Hetzner -----
+	data["HZ_TOKEN"] = os.Getenv("HZ_TOKEN")
+
+	// ----- DigitalOcean -----
+	data["DO_TOKEN"] = os.Getenv("DO_TOKEN")
+
+	// ----- vSphere -----
+	data["VSPHERE_ADDRESS"] = os.Getenv("VSPHERE_ADDRESS")
+	data["VSPHERE_USERNAME"] = os.Getenv("VSPHERE_USERNAME")
+	data["VSPHERE_PASSWORD"] = os.Getenv("VSPHERE_PASSWORD")
+
+	return data
+}

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -103,8 +103,9 @@ type APIServerConfig struct {
 
 // ProviderConfig describes the cloud provider that is running the machines.
 type ProviderConfig struct {
-	Name        string `yaml:"name"`
-	CloudConfig string `yaml:"cloud_config"`
+	Name        string            `yaml:"name"`
+	CloudConfig string            `yaml:"cloud_config"`
+	Credentials map[string]string `yaml:"credentials"`
 }
 
 // VersionConfig describes the versions of Kubernetes and Docker that are installed.


### PR DESCRIPTION
This PR adds logic for creating a Kubernetes Secret with credentials for cloud providers, to be used by machine-controller to create and manage cloud instances.

Fixes #23

To accomplish this, this PR adds a new field in the `ProviderConfig` struct which is populated when user runs `kubeone install` by reading environment variables used by machine-controller and storing them in a map.

If the environment variable is unset `os.Getenv` just returns empty string, so this part of code is safe from panics.

This also ensures that even if the environment variable is unset, the binding from a field in the Secret to an environment variable in the machine-controller container will be created. This means that if user updates Secret after deploying machine-controller, machine-controller will pick up credentials automatically as ensured by Kubelet.

Action items:
* [ ] Document environment variables used by KubeOne and machine-controller in a follow up PR (part of #3)