### PR TITLE
Add tfstate.json to .gitignore

### DIFF
--- a/terraform/aws/.gitignore
+++ b/terraform/aws/.gitignore
@@ -1,4 +1,6 @@
 manifest.yaml
+
 .terraform
+tfstate.json
 terraform.tfstate*
 terraform.tfvars


### PR DESCRIPTION
This PR adds `tfstate.json` to `.gitignore` in the `./terraform/aws` directory, so Terraform State doesn't get committed as it contains potentially secret data such as EC2 IP address.