### PR TITLE
Add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/*
 !/vendor/modules.txt
 /kubeone
+.envrc


### PR DESCRIPTION
This PR adds a `.envrc` file used by [`direnv`](https://direnv.net/) to enable support for Go modules (`GO111MODULE`).

Go modules is still an experimental feature and by default disabled for Go 1.11. As a developer working on projects that don't use Go modules, such as kubernetes/kubernetes or kubernetes-sigs/cluster-api, I don't want Go modules enabled system-wide, so I don't run into edge cases or break something for other projects. Instead I'd like to have Go modules enabled only for KubeOne and `direnv` ensures I can easily achieve this.

Alternative to this is to add `.envrc` to `.gitingore` so I don't commit it and Git doesn't report it, but I believe this could be very useful to other developers using `direnv` as well.