### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Documentation**:
+<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
+
+**Release note**:
+<!--  Write your release note:
+1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. If  no release note is required, just write "NONE".
+-->
+```release-note
+```


### PR DESCRIPTION
This PR adds the PR template as used by our other projects including kubermatic/kubermatic.

The release note part and release note is required if we want to use `gchl` to generate our changelogs. For now there are no rules for release note messages but we may establish some in the future.