### PR TITLE
Add an example Terraform script for DigitalOcean

### DIFF
--- a/terraform/digitalocean/.gitignore
+++ b/terraform/digitalocean/.gitignore
@@ -1,0 +1,4 @@
+manifest.yaml
+.terraform
+terraform.tfstate*
+terraform.tfvars

--- a/terraform/digitalocean/README.md
+++ b/terraform/digitalocean/README.md
@@ -1,0 +1,6 @@
+```
+$ terraform init
+$ terraform plan
+$ terraform apply
+$ terraform output -json > tf.json
+```

--- a/terraform/digitalocean/main.tf
+++ b/terraform/digitalocean/main.tf
@@ -1,0 +1,55 @@
+provider "digitalocean" {}
+
+locals {
+    kube_cluster_tag = "kubernetes-cluster:${var.cluster_name}"
+}
+
+resource "digitalocean_tag" "kube_cluster_tag" {
+    name = "${local.kube_cluster_tag}"
+}
+
+resource "digitalocean_ssh_key" "deployer" {
+    name = "${var.cluster_name}-deployer-key"
+    public_key = "${file("${var.ssh_public_key_file}")}"
+}
+
+resource "digitalocean_droplet" "control_plane" {
+    count = "${var.control_plane_count}"
+    name = "${var.cluster_name}-control-plane-${count.index + 1}"
+
+    tags = [
+        "${local.kube_cluster_tag}"
+    ]
+
+    image = "${var.droplet_image}"
+    region = "${var.region}"
+    size = "${var.droplet_size}"
+
+    private_networking = "${var.droplet_private_networking}"
+    monitoring = "${var.droplet_monitoring}"
+    ipv6 = "${var.droplet_ipv6}"
+
+    ssh_keys = [
+        "${digitalocean_ssh_key.deployer.id}"
+    ]
+}
+
+resource "digitalocean_loadbalancer" "control_plane" {
+    name = "${var.cluster_name}-load-balancer"
+    region = "${var.region}"
+
+    forwarding_rule {
+        entry_port = 6443
+        entry_protocol = "tcp"
+
+        target_port = 6443
+        target_protocol = "tcp"
+    }
+
+    healthcheck {
+        port = 6443
+        protocol = "tcp"
+    }
+
+    droplet_tag = "${local.kube_cluster_tag}"
+}

--- a/terraform/digitalocean/manifest.example.yaml
+++ b/terraform/digitalocean/manifest.example.yaml
@@ -1,0 +1,7 @@
+provider:
+  name: digitalocean
+versions:
+  kubernetes: "1.11.4"
+  docker: "18.03.1"
+network:
+  node_port_range: 30000-32767

--- a/terraform/digitalocean/output.tf
+++ b/terraform/digitalocean/output.tf
@@ -1,0 +1,20 @@
+output "kubeone_api" {
+  value = {
+    endpoint = "${digitalocean_loadbalancer.control_plane.ip}"
+  }
+}
+
+output "kubeone_hosts" {
+  value = {
+    control_plane = {
+      public_address  = "${digitalocean_droplet.control_plane.*.ipv4_address}"
+      private_address = "${digitalocean_droplet.control_plane.*.ipv4_address_private}"
+      hostnames       = "${digitalocean_droplet.control_plane.*.name}"
+      ssh_user        = "root"
+      ssh_port        = "${var.ssh_port}"
+
+      ssh_agent_socket     = "${var.ssh_agent_socket}"
+      ssh_private_key_file = "${var.ssh_private_key_file}"
+    }
+  }
+}

--- a/terraform/digitalocean/variables.tf
+++ b/terraform/digitalocean/variables.tf
@@ -1,0 +1,57 @@
+variable "cluster_name" {
+  description = "Name of the cluster"
+}
+
+variable "region" {
+  default     = "fra1"
+  description = "Region to speak to"
+}
+
+variable "control_plane_count" {
+  default     = 3
+  description = "Number of master instances"
+}
+
+variable "ssh_public_key_file" {
+  description = "SSH public key file"
+}
+
+variable "ssh_port" {
+  default = 22
+  description = "SSH port to be used to provision instances"
+}
+
+variable "ssh_private_key_file" {
+  description = "SSH private key file used to access instances"
+  default     = ""
+}
+
+variable "ssh_agent_socket" {
+  description = "SSH Agent socket, default to grab from $SSH_AUTH_SOCK"
+  default     = "env:SSH_AUTH_SOCK"
+}
+
+variable "droplet_image" {
+    default = "ubuntu-18-04-x64"
+    description = "Image to use for provisioning droplet"
+}
+
+variable "droplet_size" {
+    default = "s-2vcpu-4gb"
+    description = "Size of Droplets"
+}
+
+variable "droplet_private_networking" {
+  default = true
+  description = "Enable Private Networking on Droplets (recommended)"
+}
+
+variable "droplet_monitoring" {
+  default = false
+  description = "Enable advance Droplet metrics"
+}
+
+variable "droplet_ipv6" {
+  default = "false"
+  description = "Enable IPv6"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an example script used to create cloud resources on DigitalOcean. Later we will use those resources with KubeOne to build a HA Kubernetes cluster like we do for AWS.

The following resources are created by this Terraform script:

* A new tag named `kubernetes-cluster:${cluster-name}`
* A new SSH key
* Two firewalls, one with common roles and another with control plane roles (copied from AWS)
* One Load Balancer with the newly created tag added to it
* Droplets (number specified as a variable) with the newly created SSH key and tagged using the new tag

The default number of control planes are 3 and the default size is `s-2vcpu-4gb` which comes with 4 GB RAM, 2 vCPU and 80 GB SSD. The estimated cost in the default case is $70/month (3 * $20 for Droplets and $10 for Load Balancer).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Addresses part of #18 

**Special notes for your reviewer**:

Known problems:

* This script fails if the SSH key already exists

**Documentation**:

It is up to document example Terraform scripts in a follow up PR.

**Release note**:
```release-note
NONE
```
