### PR TITLE
Fix typo when loading machine-controller credentials

### DIFF
--- a/pkg/command/shared.go
+++ b/pkg/command/shared.go
@@ -87,7 +87,7 @@ func loadMachineControllerCredentials() map[string]string {
 
 	// ----- AWS -----
 	data["AWS_ACCESS_KEY_ID"] = os.Getenv("AWS_ACCESS_KEY_ID")
-	data["AWS_ACCESS_KEY_ID"] = os.Getenv("AWS_ACCESS_KEY_ID")
+	data["AWS_SECRET_ACCESS_KEY"] = os.Getenv("AWS_SECRET_ACCESS_KEY")
 
 	// ----- OpenStack -----
 	data["OS_AUTH_URL"] = os.Getenv("OS_AUTH_URL")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a typo made in #17, as we were loading one AWS environment variable two times instead of loading two different environment variables.

**Release note**:
```release-note
NONE
```
