### PR TITLE
prevents npe in createInstallerOptions function

### DIFF
--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -85,7 +85,7 @@ func createInstallerOptions(clusterFile string, cluster *config.Cluster, ctx *cl
 	// of the installer fails; for this reason it's okay to find an
 	// existing, zero byte backup)
 	stat, err := os.Stat(backupFile)
-	if err != nil && stat.Size() > 0 {
+	if err != nil && stat != nil && stat.Size() > 0 {
 		return nil, fmt.Errorf("backup %s already exists, refusing to overwrite", backupFile)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**: Prevents `npe` by checking if `stat` variable is not `nil`. If the backup file doesn't exist "stat" variable is nil and causes the program to panic.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
