### PR TITLE
changes kubernetes version in config.yaml.dist file

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -3,7 +3,7 @@
 # Terraform output at runtime, like explained in the documentation.
 
 versions:
-  kubernetes: '1.12'
+  kubernetes: '1.12.2'
   docker: '18.06' # depends on the OS installed on your machines
 
 network:


### PR DESCRIPTION
**What this PR does / why we need it**: while running `kubeone` one of the steps failed due to incorrect version. The exact error was: `version "v1.12" doesn't match patterns for neither semantic version nor labels`. 

It turns out that `v1.12` is not a valid version for `kubeadm` changing the version to `1.12.0` resolves the issue.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
