### PR TITLE
Write kubelet environment file for masters

### DIFF
--- a/pkg/installer/version/kube112/04-deploy-ca.go
+++ b/pkg/installer/version/kube112/04-deploy-ca.go
@@ -97,6 +97,9 @@ set -xeu pipefail
 
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+mkdir -p /var/lib/kubelet
+sudo sh -c 'echo "KUBELET_KUBEADM_ARGS=--cgroup-driver=cgroupfs --network-plugin=cni --resolv-conf=/run/systemd/resolve/resolv.conf" > /var/lib/kubelet/kubeadm-flags.env'
+
 sudo rsync -av ./{{ .WORK_DIR }}/pki/ /etc/kubernetes/pki/
 sudo mv /etc/kubernetes/pki/admin.conf /etc/kubernetes/admin.conf
 rm -rf ./{{ .WORK_DIR }}/pki

--- a/pkg/templates/kubeadm/v1alpha3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1alpha3/kubeadm.go
@@ -110,10 +110,6 @@ func NewConfig(cluster *config.Cluster, instance int) (*configuration, error) {
 			"endpoint-reconciler-type": "lease",
 			"service-node-port-range":  cluster.Network.NodePortRange(),
 		},
-
-		FeatureGates: map[string]bool{
-			"CoreDNS": false,
-		},
 	}
 
 	if cluster.Provider.CloudConfig != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR simulates the following `kubeadm`, which has a bug in 1.12:
```  
kubeadm alpha phase kubelet write-env-file --config kubeadm-config.yaml
```

Omitting this command is causing the CoreDNS to fail, as Kubelet environment file is not initialized correctly. Initially I have thought it is enough to pass flags to the systemd unit file, like we do for the first master.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes part of #56 

**Release note**:

```release-note
NONE
```
