### PR TITLE
[WIP] enable cloud provider functionality

### DIFF
--- a/pkg/installer/version/kube112/01-install-prerequisites.go
+++ b/pkg/installer/version/kube112/01-install-prerequisites.go
@@ -23,7 +23,7 @@ func installPrerequisites(ctx *util.Context) error {
 func generateConfigurationFiles(ctx *util.Context) error {
 	ctx.Configuration.AddFile("cfg/20-cloudconfig-kubelet.conf", fmt.Sprintf(`
 [Service]
-Environment="KUBELET_EXTRA_ARGS= --cloud-provider=%s --cloud-config=/etc/kubernetes/cloud-config"`,
+Environment="KUBELET_EXTRA_ARGS=--cloud-provider=%s --cloud-config=/etc/kubernetes/cloud-config"`,
 		ctx.Cluster.Provider.Name))
 
 	ctx.Configuration.AddFile("cfg/cloud-config", ctx.Cluster.Provider.CloudConfig)
@@ -200,6 +200,7 @@ func deployConfigurationFiles(ctx *util.Context, conn ssh.Connection, operatingS
 set -xeu pipefail
 
 sudo mkdir -p /etc/systemd/system/kubelet.service.d/ /etc/kubernetes
+sudo cp ./{{ .WORK_DIR }}/cfg/20-cloudconfig-kubelet.conf /etc/default/kubelet
 sudo mv ./{{ .WORK_DIR }}/cfg/20-cloudconfig-kubelet.conf /etc/systemd/system/kubelet.service.d/
 sudo mv ./{{ .WORK_DIR }}/cfg/cloud-config /etc/kubernetes/cloud-config
 sudo chown root:root /etc/kubernetes/cloud-config

--- a/pkg/templates/kubeadm/v1alpha3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1alpha3/kubeadm.go
@@ -114,18 +114,20 @@ func NewConfig(cluster *config.Cluster, instance int) (*configuration, error) {
 		FeatureGates: map[string]bool{
 			"CoreDNS": false,
 		},
+
+		ControllerManagerExtraArgs: map[string]string{},
+	}
+
+	if cluster.Provider.Name != "" {
+		cfg.APIServerExtraArgs["cloud-provider"] = cluster.Provider.Name
+		cfg.ControllerManagerExtraArgs["cloud-provider"] = cluster.Provider.Name
 	}
 
 	if cluster.Provider.CloudConfig != "" {
 		renderedCloudConfig := "/etc/kubernetes/cloud-config"
 
 		cfg.APIServerExtraArgs["cloud-config"] = renderedCloudConfig
-		cfg.APIServerExtraArgs["cloud-provider"] = cluster.Provider.Name
-
-		cfg.ControllerManagerExtraArgs = map[string]string{
-			"cloud-provider": cluster.Provider.Name,
-			"cloud-config":   renderedCloudConfig,
-		}
+		cfg.ControllerManagerExtraArgs["cloud-config"] = renderedCloudConfig
 	}
 
 	return cfg, nil


### PR DESCRIPTION
**What this PR does / why we need it**: tries to fix `cloud provider` functionality by passing cloud providers specific flags to various components: `kube-api`, `kube-controller` and `kubelet`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: not sure if we want to merge it because:

* i'm unable to use `kubeone`. I'm getting the following error:
```
[apiclient] All control plane components are healthy after 24.503223 seconds
[uploadconfig] storing the configuration used in ConfigMap "kubeadm-config" in the "kube-system" Namespace
[kubelet] Creating a ConfigMap "kubelet-config-1.12" in namespace kube-system with the configuration for the kubelets in the cluster
[markmaster] Marking the node ip-172-31-12-150 as master by adding the label "node-role.kubernetes.io/master=''"
[markmaster] Marking the node ip-172-31-12-150 as master by adding the taints [node-role.kubernetes.io/master:NoSchedule]
error marking master: timed out waiting for the condition
ERRO[14:51:38 CET] failed to init kubernetes on leader: failed to exec command: Process exited with status 1: 
````

* additionally I have only changed `1.12` version what about the others ?


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
```
