### PR TITLE
restructure worker config to be more in line with the machine spec

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -49,27 +49,24 @@ provider:
 # worker nodes in your cluster. Each element in this "workers"
 # list is a single deployment and must have a unique name.
 # workers:
-# - replicas: 5
-#   name: my-workers
+# - name: my-workers
+#   replicas: 5
 
 #   # refer to the machine-controller documentation to see which
 #   # flags you need to specify for your workers; this is dependent
 #   # on the chosen cloud provider and the example below would
 #   # provision Ubuntu 18.04 machines in EU-Frankfurt with 50GB SSD
 #   # disks each.
-#   spec:
-#     ami: ami-0bdf93799014acdc4
-#     region: 'eu-central-1'
-#     availabilityZone: 'eu-central-1a'
-#     vpcId: 'vpc-819f62e9'
-#     subnetId: 'subnet-2bff4f43'
-#     instanceType: 't2.medium'
-#     diskSize: 50
-#     diskType: 'gp2'
-
-#   # Configure the OS spec here; this is once again defined by the
-#   # machine-controller.
-#   operating_system:
-#     name: ubuntu
-#     spec:
+#   config:
+#     cloudProviderSpec:
+#       ami: ami-0bdf93799014acdc4
+#       region: 'eu-central-1'
+#       availabilityZone: 'eu-central-1a'
+#       vpcId: 'vpc-819f62e9'
+#       subnetId: 'subnet-2bff4f43'
+#       instanceType: 't2.medium'
+#       diskSize: 50
+#       diskType: 'gp2'
+#     operatingSystem: ubuntu
+#     operatingSystemSpec:
 #       distUpgradeOnBoot: false

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -221,15 +221,17 @@ func (p *NetworkConfig) Validate() error {
 	return nil
 }
 
+type providerConfig struct {
+	CloudProviderSpec   map[string]interface{} `yaml:"cloudProviderSpec"`
+	OperatingSystem     string                 `yaml:"operatingSystem"`
+	OperatingSystemSpec map[string]interface{} `yaml:"operatingSystemSpec"`
+}
+
 // WorkerConfig describes a set of worker machines.
 type WorkerConfig struct {
-	Replicas        int                    `yaml:"replicas"`
-	Name            string                 `yaml:"name"`
-	Spec            map[string]interface{} `yaml:"spec"`
-	OperatingSystem struct {
-		Name string                 `yaml:"name"`
-		Spec map[string]interface{} `yaml:"spec"`
-	} `yaml:"operating_system"`
+	Name     string         `yaml:"name"`
+	Replicas int            `yaml:"replicas"`
+	Config   providerConfig `yaml:"config"`
 }
 
 // Validate checks if the Config makes sense.

--- a/pkg/templates/machinecontroller/machines.go
+++ b/pkg/templates/machinecontroller/machines.go
@@ -48,8 +48,8 @@ func createMachineDeployment(cluster *config.Cluster, workerset config.WorkerCon
 	config := providerConfig{
 		CloudProvider:       provider,
 		CloudProviderSpec:   providerSpec,
-		OperatingSystem:     workerset.OperatingSystem.Name,
-		OperatingSystemSpec: workerset.OperatingSystem.Spec,
+		OperatingSystem:     workerset.Config.OperatingSystem,
+		OperatingSystemSpec: workerset.Config.OperatingSystemSpec,
 	}
 
 	encoded, err := json.Marshal(config)
@@ -110,7 +110,7 @@ func createMachineDeployment(cluster *config.Cluster, workerset config.WorkerCon
 func machineSpec(cluster *config.Cluster, workerset config.WorkerConfig, provider config.ProviderName) (map[string]interface{}, error) {
 	var err error
 
-	spec := workerset.Spec
+	spec := workerset.Config.CloudProviderSpec
 	tagName := fmt.Sprintf("kubernetes.io/cluster/%s", cluster.Name)
 	tagValue := "shared"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes it easier to read through the machine-controller docs and figure out how to configure worker machines.

**Release note**:
```release-note
NONE
```
