### PR TITLE
do not create N empty env variables for credentials

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -658,7 +658,7 @@ func machineControllerCredentialsSecret(cluster *config.Cluster) corev1.Secret {
 }
 
 func getEnvVarCredentials(cluster *config.Cluster) []corev1.EnvVar {
-	env := make([]corev1.EnvVar, len(cluster.Provider.Credentials))
+	env := make([]corev1.EnvVar, 0)
 
 	for k := range cluster.Provider.Credentials {
 		env = append(env, corev1.EnvVar{


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #92

**Release note**:
```release-note
NONE
```
