### PR TITLE
Improve SSH Error Handling

### DIFF
--- a/pkg/installer/version/kube112/01-install-prerequisites.go
+++ b/pkg/installer/version/kube112/01-install-prerequisites.go
@@ -87,13 +87,13 @@ func installPrerequisitesOnNode(ctx *util.Context, node *config.HostConfig, conn
 }
 
 func determineOS(ctx *util.Context, conn ssh.Connection) (string, error) {
-	stdout, _, _, err := util.RunCommand(conn, "cat /etc/os-release | grep '^ID=' | sed s/^ID=//", ctx.Verbose)
+	stdout, _, err := util.RunCommand(conn, "cat /etc/os-release | grep '^ID=' | sed s/^ID=//", ctx.Verbose)
 
 	return stdout, err
 }
 
 func determineHostname(ctx *util.Context, conn ssh.Connection, _ *config.HostConfig) (string, error) {
-	stdout, _, _, err := util.RunCommand(conn, "hostname -f", ctx.Verbose)
+	stdout, _, err := util.RunCommand(conn, "hostname -f", ctx.Verbose)
 
 	return stdout, err
 }
@@ -118,7 +118,7 @@ func installKubeadm(ctx *util.Context, conn ssh.Connection, node *config.HostCon
 }
 
 func installKubeadmDebian(ctx *util.Context, conn ssh.Connection) error {
-	_, _, _, err := util.RunShellCommand(conn, ctx.Verbose, kubeadmDebianCommand, util.TemplateVariables{
+	_, _, err := util.RunShellCommand(conn, ctx.Verbose, kubeadmDebianCommand, util.TemplateVariables{
 		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
 		"DOCKER_VERSION":     ctx.Cluster.Versions.Docker,
 	})
@@ -167,7 +167,7 @@ sudo systemctl daemon-reload
 `
 
 func installKubeadmCoreOS(ctx *util.Context, conn ssh.Connection) error {
-	_, _, _, err := util.RunShellCommand(conn, ctx.Verbose, kubeadmCoreOSCommand, util.TemplateVariables{
+	_, _, err := util.RunShellCommand(conn, ctx.Verbose, kubeadmCoreOSCommand, util.TemplateVariables{
 		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
 		"DOCKER_VERSION":     ctx.Cluster.Versions.Docker,
 		"CNI_VERSION":        "v0.7.1",
@@ -210,7 +210,7 @@ func deployConfigurationFiles(ctx *util.Context, conn ssh.Connection) error {
 	}
 
 	// move config files to their permanent locations
-	_, _, _, err = util.RunShellCommand(conn, ctx.Verbose, `
+	_, _, err = util.RunShellCommand(conn, ctx.Verbose, `
 sudo mkdir -p /etc/systemd/system/kubelet.service.d/ /etc/kubernetes
 sudo mv ./{{ .WORK_DIR }}/cfg/20-cloudconfig-kubelet.conf /etc/systemd/system/kubelet.service.d/
 sudo mv ./{{ .WORK_DIR }}/cfg/cloud-config /etc/kubernetes/cloud-config

--- a/pkg/installer/version/kube112/03-kubeadm-leader.go
+++ b/pkg/installer/version/kube112/03-kubeadm-leader.go
@@ -1,8 +1,6 @@
 package kube112
 
 import (
-	"fmt"
-
 	"github.com/kubermatic/kubeone/pkg/config"
 	"github.com/kubermatic/kubeone/pkg/installer/util"
 	"github.com/kubermatic/kubeone/pkg/ssh"
@@ -14,14 +12,11 @@ func initKubernetesLeader(ctx *util.Context) error {
 	return util.RunTaskOnLeader(ctx, func(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Running kubeadm…")
 
-		stdout, stderr, _, err := util.RunShellCommand(conn, ctx.Verbose, kubeadmInitCommand, util.TemplateVariables{
+		_, _, err := util.RunShellCommand(conn, ctx.Verbose, kubeadmInitCommand, util.TemplateVariables{
 			"WORK_DIR": ctx.WorkDir,
 		})
-		if err != nil {
-			return fmt.Errorf("error: %v, stdout: %s, stderr: %s", err, stdout, stderr)
-		}
 
-		return nil
+		return err
 	})
 }
 

--- a/pkg/installer/version/kube112/04-deploy-ca.go
+++ b/pkg/installer/version/kube112/04-deploy-ca.go
@@ -16,7 +16,7 @@ func downloadCA(ctx *util.Context) error {
 	return util.RunTaskOnLeader(ctx, func(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Running kubeadm…")
 
-		_, _, _, err := util.RunShellCommand(conn, ctx.Verbose, `
+		_, _, err := util.RunShellCommand(conn, ctx.Verbose, `
 mkdir -p ./{{ .WORK_DIR }}/pki/etcd
 sudo cp /etc/kubernetes/pki/ca.crt ./{{ .WORK_DIR }}/pki/
 sudo cp /etc/kubernetes/pki/ca.key ./{{ .WORK_DIR }}/pki/
@@ -73,7 +73,7 @@ func deployCAOnNode(ctx *util.Context, node *config.HostConfig, conn ssh.Connect
 
 	ctx.Logger.Infoln("Setting up certificates and restarting kubelet…")
 
-	_, _, _, err = util.RunShellCommand(conn, ctx.Verbose, `
+	_, _, err = util.RunShellCommand(conn, ctx.Verbose, `
 sudo rsync -av ./{{ .WORK_DIR }}/pki/ /etc/kubernetes/pki/
 sudo mv /etc/kubernetes/pki/admin.conf /etc/kubernetes/admin.conf
 rm -rf ./{{ .WORK_DIR }}/pki

--- a/pkg/installer/version/kube112/05-master-join-cluster.go
+++ b/pkg/installer/version/kube112/05-master-join-cluster.go
@@ -26,7 +26,7 @@ func joinNodesMasterCluster(ctx *util.Context, node *config.HostConfig, conn ssh
 	}
 
 	ctx.Logger.Infoln("Finalizing cluster…")
-	_, _, _, err = util.RunShellCommand(conn, ctx.Verbose, `
+	_, _, err = util.RunShellCommand(conn, ctx.Verbose, `
 sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec \
   -n kube-system etcd-{{ .LEADER_HOSTNAME }} -- \
   etcdctl \

--- a/pkg/installer/version/kube112/06-install-kube-proxy.go
+++ b/pkg/installer/version/kube112/06-install-kube-proxy.go
@@ -10,7 +10,7 @@ func installKubeProxy(ctx *util.Context) error {
 	return util.RunTaskOnLeader(ctx, func(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Installing kube-proxy…")
 
-		_, _, _, err := util.RunShellCommand(conn, ctx.Verbose, `
+		_, _, err := util.RunShellCommand(conn, ctx.Verbose, `
 mkdir -p ~/.kube
 sudo cp /etc/kubernetes/admin.conf ~/.kube/config
 sudo chown -R $(id -u):$(id -g) ~/.kube

--- a/pkg/installer/version/kube112/07-apply-cni.go
+++ b/pkg/installer/version/kube112/07-apply-cni.go
@@ -21,7 +21,7 @@ func applyFlannelCNI(ctx *util.Context) error {
 	return util.RunTaskOnLeader(ctx, func(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Applying Flannel CNI plugin…")
 
-		_, _, _, err := util.RunShellCommand(conn, ctx.Verbose, `sudo kubectl create -f ./{{ .WORK_DIR }}/kube-flannel.yaml`, util.TemplateVariables{
+		_, _, err := util.RunShellCommand(conn, ctx.Verbose, `sudo kubectl create -f ./{{ .WORK_DIR }}/kube-flannel.yaml`, util.TemplateVariables{
 			"WORK_DIR": ctx.WorkDir,
 		})
 

--- a/pkg/installer/version/kube112/08-machine-controller.go
+++ b/pkg/installer/version/kube112/08-machine-controller.go
@@ -26,7 +26,7 @@ func installMachineController(ctx *util.Context) error {
 
 		ctx.Logger.Infoln("Installing machine-controller…")
 
-		_, _, _, err = util.RunShellCommand(conn, ctx.Verbose, `
+		_, _, err = util.RunShellCommand(conn, ctx.Verbose, `
 kubectl apply -f ./{{ .WORK_DIR }}/machine-controller.yaml
 kubectl apply -f ./{{ .WORK_DIR }}/machine-controller-webhook.yaml
 `, util.TemplateVariables{

--- a/pkg/installer/version/kube112/09-create-workers.go
+++ b/pkg/installer/version/kube112/09-create-workers.go
@@ -43,7 +43,7 @@ func createWorkerMachines(ctx *util.Context) error {
 		time.Sleep(10 * time.Second)
 
 		ctx.Logger.Infoln("Creating worker machines…")
-		_, _, _, err := util.RunShellCommand(conn, ctx.Verbose, `kubectl apply -f ./{{ .WORK_DIR }}/workers.yaml`, util.TemplateVariables{
+		_, _, err := util.RunShellCommand(conn, ctx.Verbose, `kubectl apply -f ./{{ .WORK_DIR }}/workers.yaml`, util.TemplateVariables{
 			"WORK_DIR": ctx.WorkDir,
 		})
 

--- a/pkg/installer/version/kube112/10-deploy-ark.go
+++ b/pkg/installer/version/kube112/10-deploy-ark.go
@@ -36,7 +36,7 @@ func deployArk(ctx *util.Context) error {
 			return err
 		}
 
-		_, _, _, err = util.RunCommand(conn, cmd, ctx.Verbose)
+		_, _, err = util.RunCommand(conn, cmd, ctx.Verbose)
 		return err
 	})
 }

--- a/pkg/installer/version/kube112/11-create-join-token.go
+++ b/pkg/installer/version/kube112/11-create-join-token.go
@@ -10,7 +10,7 @@ func createJoinToken(ctx *util.Context) error {
 	return util.RunTaskOnLeader(ctx, func(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Creating join token…")
 
-		stdout, _, _, err := util.RunCommand(conn, `sudo kubeadm token create --print-join-command`, ctx.Verbose)
+		stdout, _, err := util.RunCommand(conn, `sudo kubeadm token create --print-join-command`, ctx.Verbose)
 		if err != nil {
 			return err
 		}

--- a/pkg/installer/version/kube112/reset.go
+++ b/pkg/installer/version/kube112/reset.go
@@ -23,7 +23,7 @@ func Reset(ctx *util.Context) error {
 func destroyWorkers(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Destroying worker nodes…")
 
-	_, _, _, err := util.RunShellCommand(conn, ctx.Verbose, destroyScript, util.TemplateVariables{
+	_, _, err := util.RunShellCommand(conn, ctx.Verbose, destroyScript, util.TemplateVariables{
 		"WORK_DIR":   ctx.WorkDir,
 		"MACHINE_NS": machinecontroller.MachineControllerNamespace,
 	})
@@ -34,7 +34,7 @@ func destroyWorkers(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection
 func resetNode(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Resetting node…")
 
-	_, _, _, err := util.RunShellCommand(conn, ctx.Verbose, resetScript, util.TemplateVariables{
+	_, _, err := util.RunShellCommand(conn, ctx.Verbose, resetScript, util.TemplateVariables{
 		"WORK_DIR": ctx.WorkDir,
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The old code had slight problems when it came to dealing with errors. This PR improves it like this:

* The base `ssh.Connection` is still a "raw" SSH exec handler, so it returns stdout, stderr, exit code and errors as they are produced by `crypto/ssh`.
* The utility functions in `util` takes care of doing what our UI needs:
  * When *not* streaming the output of commands to the user's terminal, the stderr is appended to the error, so that users who use KubeOne without `--verbose` get to see the error output if something bad happens.
  * When streaming the output, stderr is not appended, because it would be redundant.
  * stdout and stderr are returned in any case, but the utility layer omits the exit code. It can be assumed that we only have to deal with `err == nil` vs. `err != nil`.
* `RunShellCommand()` does not accidentally duplicate the "append stderr" logic anymore and relies entirely on `RunCommand()`.
* Regardless of streaming the output or not, the shell is setup the same way every time.

**Release note**:
```release-note
NONE
```