### PR TITLE
Allow disabling machine-controller deployment

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -63,8 +63,8 @@ backup:
 # If the cluster runs on bare metal or an unsupported cloud provider,
 # you can disable the machine-controller deployment entirely. In this
 # case, anything you configure in your "workers" sections is ignored.
-machine_controller:
-  deploy: true
+#machine_controller:
+#  deploy: false
 
 # KubeOne can automatically create MachineDeployments to create
 # worker nodes in your cluster. Each element in this "workers"

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -57,7 +57,11 @@ func (m *Cluster) DefaultAndValidate() error {
 		}
 	}
 
-	if m.MachineController.Deploy {
+	if err := m.MachineController.DefaultAndValidate(); err != nil {
+		return fmt.Errorf("failed to configure machine-controller: %v", err)
+	}
+
+	if !*m.MachineController.Deploy {
 		for idx, workerset := range m.Workers {
 			if err := workerset.Validate(); err != nil {
 				return fmt.Errorf("worker set %d is invalid: %v", idx+1, err)
@@ -409,5 +413,18 @@ func (m *BackupConfig) ApplyEnvironment() error {
 }
 
 type MachineControllerConfig struct {
-	Deploy bool `json:"deploy"`
+	Deploy *bool `json:"deploy"`
+}
+
+// DefaultAndValidate checks if the machine-controller config makes sense.
+func (m *MachineControllerConfig) DefaultAndValidate() error {
+	if m.Deploy == nil {
+		m.Deploy = boolPtr(true)
+	}
+
+	return nil
+}
+
+func boolPtr(val bool) *bool {
+	return &val
 }

--- a/pkg/installer/version/kube112/08-machine-controller.go
+++ b/pkg/installer/version/kube112/08-machine-controller.go
@@ -10,7 +10,7 @@ import (
 )
 
 func installMachineController(ctx *util.Context) error {
-	if !ctx.Cluster.MachineController.Deploy {
+	if !*ctx.Cluster.MachineController.Deploy {
 		ctx.Logger.Info("Skipping machine-controller deployment because it was disabled in configuration.")
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new option to the cluster configuration to disable the MC deployment. At first I wanted to make this dependent on whether or no the user specified some workersets, but this could be bad if the user wants to use the MC, but not let KubeOne create workers *just yet*. Making it explicit seems to be the better option.

**Which issue(s) this PR fixes**:
Fixes #116

**Release note**:
```release-note
machine-controller deployment can be disabled for bare-metal setups
```
