### PR TITLE
Schedule automatic Ark backups

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -31,6 +31,10 @@ backup:
   s3_secret_access_key: 'env:BACKUP_AWS_SECRET_ACCESS_KEY'
   # Name of the to store backups in
   bucket_name: 'backup'
+  # Time for how long backups are stored
+  backup_ttl: '336h' # 14 days
+  # Crontab defining how often are we doing backups
+  backup_schedule: '0 * * * *' # each hour
   # Additional backup options
   # https://heptio.github.io/ark/v0.10.0/api-types/backupstoragelocation.html
   # backup_storage_config:

--- a/pkg/templates/ark/ark.go
+++ b/pkg/templates/ark/ark.go
@@ -31,14 +31,22 @@ func Manifest(cluster *config.Cluster) (string, error) {
 		serviceAccount(),
 		rbacRole(),
 
-		// Configuration
+		// Credentials
+		// TODO(xmudrii): Credentials needed for other provider stores.
 		awsCredentials(cluster),
+
+		// Backup location confiugration
 		backupLocation(cluster),
 		volumeSnapshotLocation(cluster),
 
 		// Deployment
 		deploymentManifest,
+
+		// Restic
 		resticDaemonset(),
+
+		// Etcd automatic backup schedule
+		etcdBackupSchedule(cluster),
 	}
 
 	return templates.KubernetesToYAML(items)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds creation of Ark Schedule object used to schedule automatic backups creation. The following fields are added to Cluster.Backup spec:

* `backup_ttl` - used to specify how long backups are stored for, defaulted to 2 weeks if value not provided,
* `backup_schedule` - used to specify how often backups are created. The value is specified in form of [crontab](https://crontab.guru/) (as used by Ark) and if no value is specified it defaults to 1 hour.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #24.

**Release note**:
```release-note
Schedule automatic Ark backups
```
