### PR TITLE
Integrate with Restic for Ark backups

### DIFF
--- a/pkg/templates/ark/ark.go
+++ b/pkg/templates/ark/ark.go
@@ -37,8 +37,8 @@ func Manifest(cluster *config.Cluster) (string, error) {
 		volumeSnapshotLocation(cluster),
 
 		// Deployment
-		// TODO(xmudrii): Restic
 		deploymentManifest,
+		resticDaemonset(),
 	}
 
 	return templates.KubernetesToYAML(items)

--- a/pkg/templates/ark/deployment.go
+++ b/pkg/templates/ark/deployment.go
@@ -76,3 +76,63 @@ spec:
 
 	return buf.String(), nil
 }
+
+func resticDaemonset() string {
+	return `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: restic
+  namespace: heptio-ark
+spec:
+  selector:
+    matchLabels:
+      name: restic
+  template:
+    metadata:
+      labels:
+        name: restic
+    spec:
+      serviceAccountName: ark
+      securityContext:
+        runAsUser: 0
+      volumes:
+        - name: cloud-credentials
+          secret:
+            secretName: cloud-credentials
+        - name: host-pods
+          hostPath:
+            path: /var/lib/kubelet/pods
+        - name: scratch
+          emptyDir: {}
+      containers:
+        - name: ark
+          image: gcr.io/heptio-images/ark:v0.10.0
+          command:
+            - /ark
+          args:
+            - restic
+            - server
+          volumeMounts:
+            - name: cloud-credentials
+              mountPath: /credentials
+            - name: host-pods
+              mountPath: /host_pods
+              mountPropagation: HostToContainer
+            - name: scratch
+              mountPath: /scratch
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HEPTIO_ARK_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /credentials/cloud
+            - name: ARK_SCRATCH_DIR
+              value: /scratch
+`
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates Ark implementation to deploy Restic along with Ark, so we can backup other volume types, as per https://heptio.github.io/ark/v0.10.0/restic#setup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #132 

**Release note**:
```release-note
NONE
```

/assign @xrstf 