### PR TITLE
bring back explicit hostnames in clusters

### DIFF
--- a/pkg/installer/version/kube112/05-master-join-cluster.go
+++ b/pkg/installer/version/kube112/05-master-join-cluster.go
@@ -22,8 +22,8 @@ fi
 
 sudo systemctl stop kubelet
 sudo {{ .JOIN_COMMAND }} \
-	  --experimental-control-plane \
-	  --node-name="{{ .NODE_NAME }}" \
+     --experimental-control-plane \
+     --node-name="{{ .NODE_NAME }}" \
      --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests
 `, util.TemplateVariables{
 		"WORK_DIR":     ctx.WorkDir,


### PR DESCRIPTION
**What this PR does / why we need it**:
`kubeadm join` ignores hostnames in the init config and even if we wrote the `kubeadm-flags.env` with the explicit kubeadm alpha phase, the join command would override it again and get rid of it.

After this fix, all master nodes of the cluster appear in `kubectl get nodes` and we can see all etcd pods, flannel pods etc. again.

**Release note**:
```release-note
NONE
```
