### PR TITLE
run kubectl as a sudo user when destroying workers

### DIFF
--- a/pkg/installer/version/kube112/reset.go
+++ b/pkg/installer/version/kube112/reset.go
@@ -42,14 +42,14 @@ func resetNode(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) err
 }
 
 const destroyScript = `
-if kubectl cluster-info > /dev/null; then
-  kubectl annotate --all --overwrite node kubermatic.io/skip-eviction=true
-  kubectl delete machinedeployment -n "{{ .MACHINE_NS }}" --all
-  kubectl delete machineset -n "{{ .MACHINE_NS }}" --all
-  kubectl delete machine -n "{{ .MACHINE_NS }}" --all
+if sudo kubectl cluster-info > /dev/null; then
+  sudo kubectl annotate --all --overwrite node kubermatic.io/skip-eviction=true
+  sudo kubectl delete machinedeployment -n "{{ .MACHINE_NS }}" --all
+  sudo kubectl delete machineset -n "{{ .MACHINE_NS }}" --all
+  sudo kubectl delete machine -n "{{ .MACHINE_NS }}" --all
 
   for try in {1..30}; do
-    if kubectl get machine -n "{{ .MACHINE_NS }}" 2>&1 | grep -q  'No resources found.'; then
+    if sudo kubectl get machine -n "{{ .MACHINE_NS }}" 2>&1 | grep -q  'No resources found.'; then
       exit 0
     fi
     sleep 10s


### PR DESCRIPTION
**What this PR does / why we need it**: `kubectl` needs access to `/etc/kubeneters/admin.conf`
which is not accessible for normal users, this pull runs `kubectl` as a sudo user.

**Special notes for your reviewer**: I've discovered this issue while I was running the `e2e` tests which were failing because:
```
Ginkgo ran 1 suite in 8m26.708104523s
Test Suite Passed
2018/12/18 18:49:43 process.go:155: Step './hack/ginkgo-e2e.sh --ginkgo.focus=\[NodeConformance\] --ginkgo.skip=Alpha|\[(Disruptive|Feature:[^\]]+|Flaky|Serial|Slow)\]' finished in 8m27.48104245s
time="18:49:43 UTC" level=info msg="Resetting kubeadm…"
time="18:49:43 UTC" level=info msg="Destroying worker nodes…" node=52.47.205.168
+ kubectl cluster-info
error: Error loading config file "/etc/kubernetes/admin.conf": open /etc/kubernetes/admin.conf: permission denied
```

I've updated my test branch and run the test again, the results https://prow.loodse.com/log?job=pull-kubeone-e2e&id=1075116957319041024 proves it works.

See https://github.com/kubermatic/kubeone/pull/115 for more details.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
```
