### PR TITLE
Fix etcd init on cluster with more then 1 interface

### DIFF
--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -37,6 +37,10 @@ func NewConfig(ctx *util.Context, host *config.HostConfig) ([]runtime.Object, er
 	}
 
 	controlPlaneEndpoint := fmt.Sprintf("%s:6443", cluster.APIServer.Address)
+	hostAdvertiseAddress := host.PrivateAddress
+	if hostAdvertiseAddress == "" {
+		hostAdvertiseAddress = host.PublicAddress
+	}
 
 	initConfig := &kubeadmv1beta1.InitConfiguration{
 		TypeMeta: metav1.TypeMeta{
@@ -44,6 +48,9 @@ func NewConfig(ctx *util.Context, host *config.HostConfig) ([]runtime.Object, er
 			Kind:       "InitConfiguration",
 		},
 		BootstrapTokens: []kubeadmv1beta1.BootstrapToken{{Token: bootstrapToken}},
+		LocalAPIEndpoint: kubeadmv1beta1.APIEndpoint{
+			AdvertiseAddress: hostAdvertiseAddress,
+		},
 	}
 
 	joinConfig := &kubeadmv1beta1.JoinConfiguration{
@@ -53,7 +60,7 @@ func NewConfig(ctx *util.Context, host *config.HostConfig) ([]runtime.Object, er
 		},
 		ControlPlane: &kubeadmv1beta1.JoinControlPlane{
 			LocalAPIEndpoint: kubeadmv1beta1.APIEndpoint{
-				AdvertiseAddress: host.PrivateAddress,
+				AdvertiseAddress: hostAdvertiseAddress,
 			},
 		},
 		Discovery: kubeadmv1beta1.Discovery{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix etcd init on 3rd node in cluster on machines with more the 1 network interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
