### PR TITLE
Add support for external cloud provider

### DIFF
--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -252,6 +252,17 @@ func (p *ProviderConfig) ApplyEnvironment() error {
 	return nil
 }
 
+// CloudProviderInTree detects is there in-tree cloud provider implementation for specified provider.
+// List of in-tree provider can be found here: https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider
+func (p *ProviderConfig) CloudProviderInTree() bool {
+	switch p.Name {
+	case ProviderNameAWS, ProviderNameOpenStack, ProviderNameVSphere:
+		return true
+	default:
+		return false
+	}
+}
+
 // VersionConfig describes the versions of Kubernetes and Docker that are installed.
 type VersionConfig struct {
 	Kubernetes string `json:"kubernetes"`

--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -92,7 +92,7 @@ func NewConfig(ctx *util.Context, host *config.HostConfig) ([]runtime.Object, er
 		},
 		ClusterName: cluster.Name,
 	}
-	if cluster.Provider.Name != "" {
+	if cluster.Provider.CloudProviderInTree() {
 		renderedCloudConfig := "/etc/kubernetes/cloud-config"
 		cloudConfigVol := kubeadmv1beta1.HostPathMount{
 			Name:      "cloud-config",
@@ -113,6 +113,11 @@ func NewConfig(ctx *util.Context, host *config.HostConfig) ([]runtime.Object, er
 
 		nodeRegistration.KubeletExtraArgs["cloud-provider"] = provider
 		nodeRegistration.KubeletExtraArgs["cloud-config"] = renderedCloudConfig
+	}
+	if cluster.Provider.Name == "external" {
+		clusterConfig.APIServer.ExtraArgs["cloud-provider"] = ""
+		clusterConfig.ControllerManager.ExtraArgs["cloud-provider"] = ""
+		nodeRegistration.KubeletExtraArgs["cloud-provider"] = "external"
 	}
 	initConfig.NodeRegistration = nodeRegistration
 	joinConfig.NodeRegistration = nodeRegistration


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR brings the following changes:
- Deploy Cloud Provider config and configure cloud provider only if we deploy on cloud provider that has in-tree cloud provider implementation
    - This allows setting `provider.Name` to other providers such as DigitalOcean or Hetzner (instead of specifying nothing). This way we know on what cloud we deploy and can use Terraform automation for workers. 
- Support setting provider name to `external`, which configures cluster to work with external CCM

There are several problems with this PR:
- If user sets provider name to `external` it is up to user's responsibility to deploy external CCM (this is expected behavior) 
- If user sets provider name to `external`, we lose information about on what cloud provider we deploy on and can't use automation (this is unexpected behavior) 
- This implementation doesn't support using cloud config with external cloud provider (this is unexpected behavior) 

As @kron4eg tested this already and it works well, I'm proposing to merge this PR and then create follow-up issues and PRs. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #117 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support for specifying provider.Name for providers without in-tree CCM implementation. Add support for external CCM implementations. 
```
