### PR TITLE
Fix typo in error handling for workers manifest generation

### DIFF
--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -31,7 +31,7 @@ func generateConfigurationFiles(ctx *util.Context) error {
 
 	if len(ctx.Cluster.Workers) > 0 {
 		machines, deployErr := machinecontroller.MachineDeployments(ctx.Cluster)
-		if err != nil {
+		if deployErr != nil {
 			return fmt.Errorf("failed to create worker machine configuration: %v", deployErr)
 		}
 		ctx.Configuration.AddFile("workers.yaml", machines)

--- a/pkg/installer/version/kube112/01-install-prerequisites.go
+++ b/pkg/installer/version/kube112/01-install-prerequisites.go
@@ -36,7 +36,7 @@ Environment="KUBELET_EXTRA_ARGS= --cloud-provider=%s --cloud-config=/etc/kuberne
 
 	if len(ctx.Cluster.Workers) > 0 {
 		machines, deployErr := machinecontroller.MachineDeployments(ctx.Cluster)
-		if err != nil {
+		if deployErr != nil {
 			return fmt.Errorf("failed to create worker machine configuration: %v", deployErr)
 		}
 		ctx.Configuration.AddFile("workers.yaml", machines)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a typo in error checking when generating workers manifests, causing error to be ignored

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->

```release-note
NONE
```
