### PR TITLE
Make E2E tests cloud-agnostic

### DIFF
--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -9,10 +9,14 @@ import (
 )
 
 // testRunIdentifier aka. the build number, a unique identifier for the test run.
-var testRunIdentifier string
+var (
+	testRunIdentifier string
+	testProvider      string
+)
 
 func init() {
 	flag.StringVar(&testRunIdentifier, "identifier", "", "The unique identifier for this test run")
+	flag.StringVar(&testProvider, "provider", "", "Provider to run tests on")
 	flag.Parse()
 }
 
@@ -27,9 +31,15 @@ func TestClusterConformance(t *testing.T) {
 		region            string
 	}{
 		{
-			name:              "scenario 1, verify k8s cluster deployment on AWS",
+			name:              "verify k8s cluster deployment on AWS",
 			provider:          AWS,
-			kubernetesVersion: "v1.13.1",
+			kubernetesVersion: "v1.13.3",
+			scenario:          NodeConformance,
+		},
+		{
+			name:              "verify k8s cluster deployment on DO",
+			provider:          DigitalOcean,
+			kubernetesVersion: "v1.13.3",
 			scenario:          NodeConformance,
 		},
 	}
@@ -40,6 +50,9 @@ func TestClusterConformance(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if len(testRunIdentifier) == 0 {
 				t.Fatalf("-identifier must be set")
+			}
+			if testProvider != tc.provider {
+				t.SkipNow()
 			}
 			testPath := fmt.Sprintf("../../_build/%s", testRunIdentifier)
 

--- a/test/e2e/helper.go
+++ b/test/e2e/helper.go
@@ -17,13 +17,15 @@ func CreateProvisioner(testPath string, identifier string, provider string) (Pro
 	if provider == AWS {
 		return NewAWSProvisioner(testPath, identifier)
 	}
+	if provider == DigitalOcean {
+		return NewDOProvisioner(testPath, identifier)
+	}
 
 	return nil, fmt.Errorf("unsuported provider %v", provider)
 }
 
 // IsCommandAvailable checks if command is available OS
 func IsCommandAvailable(name string) bool {
-
 	path, err := exec.LookPath(name)
 	if err != nil {
 		return false
@@ -95,7 +97,6 @@ func executeCommand(path, name string, arg []string, additionalEnv map[string]st
 
 // CreateFile create file with given content
 func CreateFile(filepath, content string) error {
-
 	// Create directory if needed.
 	basepath := path.Dir(filepath)
 	filename := path.Base(filepath)
@@ -115,7 +116,6 @@ func CreateFile(filepath, content string) error {
 
 // ValidateCommon validates variables necessary to start process
 func ValidateCommon() error {
-
 	sshPublicKey := os.Getenv("SSH_PUBLIC_KEY_FILE")
 	if len(sshPublicKey) == 0 {
 		return errors.New("unable to run the test suite, SSH_PUBLIC_KEY_FILE environment variables cannot be empty")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes E2E script used in CI cloud agnostic, so we can use it on any cloud we support.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #163
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
