### PR TITLE
Copy kubeconfig to HOME and stop using kubectl with sudo

### DIFF
--- a/pkg/installer/installation/ark.go
+++ b/pkg/installer/installation/ark.go
@@ -29,7 +29,7 @@ func deployArk(ctx *util.Context) error {
 
 		ctx.Logger.Infoln("Deploying Ark…")
 
-		_, _, err = ctx.Runner.Run(`sudo kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f "{{ .WORK_DIR }}/ark/ark.yaml"`, util.TemplateVariables{
+		_, _, err = ctx.Runner.Run(`kubectl apply -f "{{ .WORK_DIR }}/ark/ark.yaml"`, util.TemplateVariables{
 			"WORK_DIR": ctx.WorkDir,
 		})
 

--- a/pkg/installer/installation/cni.go
+++ b/pkg/installer/installation/cni.go
@@ -20,7 +20,7 @@ func applyCNI(ctx *util.Context, cni string) error {
 func applyCanalCNI(ctx *util.Context) error {
 	return ctx.RunTaskOnLeader(func(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Applying canal CNI plugin…")
-		_, _, err := ctx.Runner.Run(`sudo kubectl apply -f {{ .WORK_DIR }}/canal.yaml`, util.TemplateVariables{
+		_, _, err := ctx.Runner.Run(`kubectl apply -f {{ .WORK_DIR }}/canal.yaml`, util.TemplateVariables{
 			"WORK_DIR": ctx.WorkDir,
 		})
 

--- a/pkg/installer/installation/install.go
+++ b/pkg/installer/installation/install.go
@@ -33,6 +33,9 @@ func Install(ctx *util.Context) error {
 	if err := joinControlplaneNode(ctx); err != nil {
 		return fmt.Errorf("unable to join other masters a cluster: %v", err)
 	}
+	if err := copyKubeconfig(ctx); err != nil {
+		return fmt.Errorf("unable to copy kubeconfig to home directory: %v", err)
+	}
 	if err := applyCNI(ctx, "canal"); err != nil {
 		return fmt.Errorf("failed to install cni plugin canal: %v", err)
 	}

--- a/pkg/installer/installation/kubeadm_leader.go
+++ b/pkg/installer/installation/kubeadm_leader.go
@@ -10,7 +10,6 @@ import (
 
 const (
 	kubeadmCertCommand = `
-grep -q KUBECONFIG /etc/environment || { echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' | sudo tee -a /etc/environment; }
 if [[ -d ./{{ .WORK_DIR }}/pki ]]; then
        sudo rsync -av ./{{ .WORK_DIR }}/pki/ /etc/kubernetes/pki/
        rm -rf ./{{ .WORK_DIR }}/pki

--- a/pkg/installer/installation/kubeconfig.go
+++ b/pkg/installer/installation/kubeconfig.go
@@ -1,0 +1,24 @@
+package installation
+
+import (
+	"github.com/kubermatic/kubeone/pkg/config"
+	"github.com/kubermatic/kubeone/pkg/installer/util"
+	"github.com/kubermatic/kubeone/pkg/ssh"
+)
+
+func copyKubeconfig(ctx *util.Context) error {
+	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
+		ctx.Logger.Infoln("Copying Kubeconfig to home directory…")
+
+		_, _, err := ctx.Runner.Run(`
+mkdir -p $HOME/.kube/
+sudo cp /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -u) $HOME/.kube/config
+`, util.TemplateVariables{})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, true)
+}

--- a/pkg/installer/installation/machine_controller.go
+++ b/pkg/installer/installation/machine_controller.go
@@ -32,8 +32,8 @@ func installMachineController(ctx *util.Context) error {
 		ctx.Logger.Infoln("Installing machine-controller…")
 
 		_, _, err = ctx.Runner.Run(`
-sudo kubectl apply -f ./{{ .WORK_DIR }}/machine-controller.yaml
-sudo kubectl apply -f ./{{ .WORK_DIR }}/machine-controller-webhook.yaml
+kubectl apply -f ./{{ .WORK_DIR }}/machine-controller.yaml
+kubectl apply -f ./{{ .WORK_DIR }}/machine-controller-webhook.yaml
 `, util.TemplateVariables{
 			"WORK_DIR": ctx.WorkDir,
 		})

--- a/pkg/installer/installation/reset.go
+++ b/pkg/installer/installation/reset.go
@@ -42,14 +42,14 @@ func resetNode(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) err
 }
 
 const destroyScript = `
-if sudo kubectl cluster-info > /dev/null; then
-  sudo kubectl annotate --all --overwrite node kubermatic.io/skip-eviction=true
-  sudo kubectl delete machinedeployment -n "{{ .MACHINE_NS }}" --all
-  sudo kubectl delete machineset -n "{{ .MACHINE_NS }}" --all
-  sudo kubectl delete machine -n "{{ .MACHINE_NS }}" --all
+if kubectl cluster-info > /dev/null; then
+  kubectl annotate --all --overwrite node kubermatic.io/skip-eviction=true
+  kubectl delete machinedeployment -n "{{ .MACHINE_NS }}" --all
+  kubectl delete machineset -n "{{ .MACHINE_NS }}" --all
+  kubectl delete machine -n "{{ .MACHINE_NS }}" --all
 
   for try in {1..30}; do
-    if sudo kubectl get machine -n "{{ .MACHINE_NS }}" 2>&1 | grep -q  'No resources found.'; then
+    if kubectl get machine -n "{{ .MACHINE_NS }}" 2>&1 | grep -q  'No resources found.'; then
       exit 0
     fi
     sleep 10s

--- a/pkg/installer/installation/worker.go
+++ b/pkg/installer/installation/worker.go
@@ -20,7 +20,7 @@ func createWorkerMachines(ctx *util.Context) error {
 		ctx.Logger.Infoln("Waiting for machine-controller to come up…")
 
 		cmd := fmt.Sprintf(
-			`sudo kubectl -n "%s" get pods -l '%s=%s' -o jsonpath='{.items[0].status.phase}'`,
+			`kubectl -n "%s" get pods -l '%s=%s' -o jsonpath='{.items[0].status.phase}'`,
 			machinecontroller.WebhookNamespace,
 			machinecontroller.WebhookAppLabelKey,
 			machinecontroller.WebhookAppLabelValue,
@@ -30,7 +30,7 @@ func createWorkerMachines(ctx *util.Context) error {
 		}
 
 		cmd = fmt.Sprintf(
-			`sudo kubectl -n "%s" get pods -l '%s=%s' -o jsonpath='{.items[0].status.phase}'`,
+			`kubectl -n "%s" get pods -l '%s=%s' -o jsonpath='{.items[0].status.phase}'`,
 			machinecontroller.MachineControllerNamespace,
 			machinecontroller.MachineControllerAppLabelKey,
 			machinecontroller.MachineControllerAppLabelValue,
@@ -43,7 +43,7 @@ func createWorkerMachines(ctx *util.Context) error {
 		time.Sleep(10 * time.Second)
 
 		ctx.Logger.Infoln("Creating worker machines…")
-		_, _, err := ctx.Runner.Run(`sudo kubectl apply -f ./{{ .WORK_DIR }}/workers.yaml`, util.TemplateVariables{
+		_, _, err := ctx.Runner.Run(`kubectl apply -f ./{{ .WORK_DIR }}/workers.yaml`, util.TemplateVariables{
 			"WORK_DIR": ctx.WorkDir,
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds a new installation step to copy kubeconfig on all nodes to `$HOME/.kube/config`
* Use `$HOME/.kube/config` as default kubeconfig
* Stop running kubectl with sudo

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #171 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
