### PR TITLE
Store rest.Config (kubeconfig) in Context

### DIFF
--- a/pkg/installer/installation/kubeconfig.go
+++ b/pkg/installer/installation/kubeconfig.go
@@ -51,17 +51,17 @@ func buildKubernetesClientset(ctx *util.Context) error {
 		return fmt.Errorf("failed to read kubeconfig: %v", err)
 	}
 
-	c, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
+	ctx.RESTConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
 	if err != nil {
 		return fmt.Errorf("unable to build config from kubeconfig bytes: %v", err)
 	}
 
-	ctx.Clientset, err = kubernetes.NewForConfig(c)
+	ctx.Clientset, err = kubernetes.NewForConfig(ctx.RESTConfig)
 	if err != nil {
 		return fmt.Errorf("unable to build kubernetes clientset: %v", err)
 	}
 
-	ctx.APIExtensionClientset, err = apiextensionsclientset.NewForConfig(c)
+	ctx.APIExtensionClientset, err = apiextensionsclientset.NewForConfig(ctx.RESTConfig)
 	if err != nil {
 		return fmt.Errorf("unable to build apiextension-apiserver clientset: %v", err)
 	}

--- a/pkg/installer/util/context.go
+++ b/pkg/installer/util/context.go
@@ -8,6 +8,7 @@ import (
 
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // Context hold together currently test flags and parsed info, along with
@@ -23,6 +24,7 @@ type Context struct {
 	JoinToken             string
 	Clientset             *kubernetes.Clientset
 	APIExtensionClientset *apiextensionsclientset.Clientset
+	RESTConfig            *rest.Config
 	Verbose               bool
 	BackupFile            string
 	DestroyWorkers        bool


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new field to the KubeOne Context which stores `*rest.Config` for creating Kubernetes Clientsets, based on downloaded Kubeconfig. This is required so we can build clientsets for non-core components (such as clientset for Ark and `machine-controller`).

Required for #186 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add Kubernetes REST configuration to KubeOne Context.
```

/assign @kron4eg 