### PR TITLE
Use Docker 18.09.2 on Ubuntu to fix CVE-2019-573. Remove Docker version from API

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -6,7 +6,6 @@ name: my-demo-cluster
 
 versions:
   kubernetes: '1.13.1'
-  docker: '18.06' # depends on the OS installed on your machines
 
 network:
   # the subnet used for pods (flannel);

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -298,10 +298,9 @@ func (p *ProviderConfig) CloudProviderInTree() bool {
 	}
 }
 
-// VersionConfig describes the versions of Kubernetes and Docker that are installed.
+// VersionConfig describes the versions of Kubernetes that is installed.
 type VersionConfig struct {
 	Kubernetes string `json:"kubernetes"`
-	Docker     string `json:"docker"`
 }
 
 func (m *VersionConfig) Validate() error {

--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -9,6 +9,8 @@ import (
 	"github.com/kubermatic/kubeone/pkg/templates/machinecontroller"
 )
 
+const dockerVersion = "18.09.2"
+
 func installPrerequisites(ctx *util.Context) error {
 	ctx.Logger.Infoln("Installing prerequisites…")
 
@@ -101,7 +103,7 @@ func installKubeadm(ctx *util.Context, node *config.HostConfig) error {
 func installKubeadmDebian(ctx *util.Context) error {
 	_, _, err := ctx.Runner.Run(kubeadmDebianCommand, util.TemplateVariables{
 		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
-		"DOCKER_VERSION":     ctx.Cluster.Versions.Docker,
+		"DOCKER_VERSION":     dockerVersion,
 	})
 
 	return err
@@ -198,7 +200,6 @@ func installKubeadmCentOS(ctx *util.Context) error {
 func installKubeadmCoreOS(ctx *util.Context) error {
 	_, _, err := ctx.Runner.Run(kubeadmCoreOSCommand, util.TemplateVariables{
 		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
-		"DOCKER_VERSION":     ctx.Cluster.Versions.Docker,
 		"CNI_VERSION":        "v0.7.1",
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed:
* CVE is fixed for Ubuntu by installing Docker 18.09.2
* [Breaking] `.versions.docker` API field is removed

Non-fixed:
* CVE for CentOS is not fixed, however it seems to use the latest version as there's no version binding

Action not required: 
* CoreOS Docker version depends on the CoreOS version

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #192 

**Release note**:
```release-note
Deploy Docker 18.09.2 when provisioning Ubuntu clusters to fix CVE-2019-573. Remove API field for choosing Docker version.
```

/assign @kron4eg 