### PR TITLE
Add check-dependencies make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ lint:
 dep:
 	dep ensure -v
 
+check-dependencies:
+	dep status
+	dep check
+
 docker-make-install:
 	docker run -it --rm \
 		-v $(PWD):/go/src/github.com/kubermatic/kubeone \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a target for checking are dependencies vendored and Gopkg files in sync.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @kron4eg 
