### PR TITLE
Export Kubeconfig and Clientset functions

### DIFF
--- a/pkg/cmd/kubeconfig.go
+++ b/pkg/cmd/kubeconfig.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/kubermatic/kubeone/pkg/installer/util"
 )
 
 type kubeconfigOptions struct {
@@ -69,26 +70,12 @@ func runKubeconfig(kubeconfigOptions *kubeconfigOptions) error {
 		return err
 	}
 
-	// connect to leader
-	leader, err := cluster.Leader()
+	kubeconfig, err := util.DownloadKubeconfig(cluster)
 	if err != nil {
 		return err
 	}
-	connector := ssh.NewConnector()
 
-	conn, err := connector.Connect(*leader)
-	if err != nil {
-		return fmt.Errorf("failed to connect to leader: %v", err)
-	}
-	defer conn.Close()
-
-	// get the kubeconfig
-	kubeconfig, _, _, err := conn.Exec("sudo cat /etc/kubernetes/admin.conf")
-	if err != nil {
-		return fmt.Errorf("failed to read kubeconfig: %v", err)
-	}
-
-	fmt.Println(kubeconfig)
+	fmt.Println(string(kubeconfig))
 
 	return nil
 }

--- a/pkg/installer/installation/install.go
+++ b/pkg/installer/installation/install.go
@@ -36,7 +36,7 @@ func Install(ctx *util.Context) error {
 	if err := copyKubeconfig(ctx); err != nil {
 		return fmt.Errorf("unable to copy kubeconfig to home directory: %v", err)
 	}
-	if err := buildKubernetesClientset(ctx); err != nil {
+	if err := util.BuildKubernetesClientset(ctx); err != nil {
 		return fmt.Errorf("unable to build kubernetes clientset: %v", err)
 	}
 	if err := applyCNI(ctx, "canal"); err != nil {

--- a/pkg/installer/installation/kubeconfig.go
+++ b/pkg/installer/installation/kubeconfig.go
@@ -1,15 +1,9 @@
 package installation
 
 import (
-	"fmt"
-
 	"github.com/kubermatic/kubeone/pkg/config"
 	"github.com/kubermatic/kubeone/pkg/installer/util"
 	"github.com/kubermatic/kubeone/pkg/ssh"
-
-	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func copyKubeconfig(ctx *util.Context) error {
@@ -27,44 +21,4 @@ sudo chown $(id -u):$(id -u) $HOME/.kube/config
 
 		return nil
 	}, true)
-}
-
-func buildKubernetesClientset(ctx *util.Context) error {
-	ctx.Logger.Infoln("Building Kubernetes clientset…")
-
-	// connect to leader
-	leader, err := ctx.Cluster.Leader()
-	if err != nil {
-		return err
-	}
-	connector := ssh.NewConnector()
-
-	conn, err := connector.Connect(*leader)
-	if err != nil {
-		return fmt.Errorf("failed to connect to leader: %v", err)
-	}
-	defer conn.Close()
-
-	// get the kubeconfig
-	kubeconfig, _, _, err := conn.Exec("sudo cat /etc/kubernetes/admin.conf")
-	if err != nil {
-		return fmt.Errorf("failed to read kubeconfig: %v", err)
-	}
-
-	ctx.RESTConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
-	if err != nil {
-		return fmt.Errorf("unable to build config from kubeconfig bytes: %v", err)
-	}
-
-	ctx.Clientset, err = kubernetes.NewForConfig(ctx.RESTConfig)
-	if err != nil {
-		return fmt.Errorf("unable to build kubernetes clientset: %v", err)
-	}
-
-	ctx.APIExtensionClientset, err = apiextensionsclientset.NewForConfig(ctx.RESTConfig)
-	if err != nil {
-		return fmt.Errorf("unable to build apiextension-apiserver clientset: %v", err)
-	}
-
-	return nil
 }

--- a/pkg/installer/util/kubeconfig.go
+++ b/pkg/installer/util/kubeconfig.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/kubermatic/kubeone/pkg/config"
+	"github.com/kubermatic/kubeone/pkg/ssh"
+
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// DownloadKubeconfig downloads Kubeconfig over SSH
+func DownloadKubeconfig(cluster *config.Cluster) ([]byte, error) {
+	// connect to leader
+	leader, err := cluster.Leader()
+	if err != nil {
+		return nil, err
+	}
+	connector := ssh.NewConnector()
+
+	conn, err := connector.Connect(*leader)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	// get the kubeconfig
+	kubeconfig, _, _, err := conn.Exec("sudo cat /etc/kubernetes/admin.conf")
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(kubeconfig), nil
+}
+
+// BuildKubernetesClientset builds core kubernetes and apiextensions clientsets
+func BuildKubernetesClientset(ctx *Context) error {
+	ctx.Logger.Infoln("Building Kubernetes clientset…")
+
+	kubeconfig, err := DownloadKubeconfig(ctx.Cluster)
+	if err != nil {
+		return fmt.Errorf("unable to download kubeconfig: %v", err)
+	}
+
+	ctx.RESTConfig, err = clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("unable to build config from kubeconfig bytes: %v", err)
+	}
+
+	ctx.Clientset, err = kubernetes.NewForConfig(ctx.RESTConfig)
+	if err != nil {
+		return fmt.Errorf("unable to build kubernetes clientset: %v", err)
+	}
+
+	ctx.APIExtensionClientset, err = apiextensionsclientset.NewForConfig(ctx.RESTConfig)
+	if err != nil {
+		return fmt.Errorf("unable to build apiextension-apiserver clientset: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Export functions for downloading Kubeconfig and building clientset to utility package, so it can be easily reused

**Release note**:
```release-note
NONE
```

/assign @kron4eg 