### PR TITLE
Fix golangci lint errors found by the latest golangci version

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -29,7 +29,7 @@ func installCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 
 This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
 It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)
 			if err != nil {
 				return err

--- a/pkg/cmd/kubeconfig.go
+++ b/pkg/cmd/kubeconfig.go
@@ -25,7 +25,7 @@ func kubeconfigCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 
 This command takes KubeOne manifest which contains information about hosts.
 It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)
 			if err != nil {
 				return err

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -26,7 +26,7 @@ func resetCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 
 This command takes KubeOne manifest which contains information about hosts.
 It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)
 			if err != nil {
 				return err

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -25,7 +25,7 @@ func newRoot() *cobra.Command {
 		Use:   "kubeone",
 		Short: "Kubernetes Cluster provisioning and maintaining tool",
 		Long:  "Provision and maintain Kubernetes High-Availability clusters with ease",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
 	}

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -16,7 +16,7 @@ func upgradeCmd(_ *pflag.FlagSet) *cobra.Command {
 This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
 It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.`,
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return errors.New("not implemented yet")
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The latest `golangci` version catches few more lint errors than previous one, so this PR fixes those errors.

**Release note**:
```release-note
NONE
```

/assign @kron4eg 