### PR TITLE
Implement core scripts and logic for running upgrades

### DIFF
--- a/pkg/upgrader/upgrade/kubeadm_package.go
+++ b/pkg/upgrader/upgrade/kubeadm_package.go
@@ -1,0 +1,84 @@
+package upgrade
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/kubermatic/kubeone/pkg/config"
+	"github.com/kubermatic/kubeone/pkg/installer/util"
+)
+
+const (
+	upgradeKubeadmDebianCommand = `
+source /etc/os-release
+source /etc/kubeone/proxy-env
+
+sudo apt-get update
+
+kube_ver=$(apt-cache madison kubelet | grep "{{ .KUBERNETES_VERSION }}" | head -1 | awk '{print $3}')
+
+sudo apt-mark unhold kubeadm
+sudo apt-get install kubeadm=${kube_ver}
+sudo apt-mark hold kubeadm
+`
+	upgradeKubeadmCentOSCommand = `
+source /etc/kubeone/proxy-env
+
+sudo yum install -y --disableexcludes=kubernetes \
+			kubeadm-{{ .KUBERNETES_VERSION }}-0
+`
+	upgradeKubeadmCoreOSCommand = `
+source /etc/kubeone/proxy-env
+
+RELEASE="v{{ .KUBERNETES_VERSION }}"
+
+sudo mkdir -p /opt/bin
+cd /opt/bin
+sudo curl -L --remote-name-all \
+     https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/kubeadm
+sudo chmod +x kubeadm
+`
+)
+
+func upgradeKubeadm(ctx *util.Context, node *config.HostConfig) error {
+	var err error
+
+	switch node.OperatingSystem {
+	case "ubuntu", "debian":
+		err = upgradeKubeadmDebian(ctx)
+
+	case "coreos":
+		err = upgradeKubeadmCoreOS(ctx)
+
+	case "centos":
+		err = upgradeKubeadmCentOS(ctx)
+
+	default:
+		err = errors.Errorf("'%s' is not a supported operating system", node.OperatingSystem)
+	}
+
+	return err
+}
+
+func upgradeKubeadmDebian(ctx *util.Context) error {
+	_, _, err := ctx.Runner.Run(upgradeKubeadmDebianCommand, util.TemplateVariables{
+		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
+	})
+
+	return errors.WithStack(err)
+}
+
+func upgradeKubeadmCentOS(ctx *util.Context) error {
+	_, _, err := ctx.Runner.Run(upgradeKubeadmCentOSCommand, util.TemplateVariables{
+		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
+	})
+
+	return errors.WithStack(err)
+}
+
+func upgradeKubeadmCoreOS(ctx *util.Context) error {
+	_, _, err := ctx.Runner.Run(upgradeKubeadmCoreOSCommand, util.TemplateVariables{
+		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
+	})
+
+	return errors.WithStack(err)
+}

--- a/pkg/upgrader/upgrade/kubeadm_upgrade.go
+++ b/pkg/upgrader/upgrade/kubeadm_upgrade.go
@@ -1,0 +1,28 @@
+package upgrade
+
+import (
+	"github.com/kubermatic/kubeone/pkg/installer/util"
+)
+
+const (
+	kubeadmUpgradeLeaderCommand = `
+if [[ -f /etc/kubernetes/kubelet.conf ]]; then exit 0; fi
+sudo kubeadm upgrade {{ .VERSION }}
+`
+	kubeadmUpgradeFollowerCommand = `
+if [[ -f /etc/kubernetes/kubelet.conf ]]; then exit 0; fi
+sudo kubeadm upgrade node experimental-control-plane
+`
+)
+
+func upgradeLeaderControlPlane(ctx *util.Context) error {
+	_, _, err := ctx.Runner.Run(kubeadmUpgradeLeaderCommand, util.TemplateVariables{
+		"VERSION": ctx.Cluster.Versions.Kubernetes,
+	})
+	return err
+}
+
+func upgradeFollowerControlPlane(ctx *util.Context) error {
+	_, _, err := ctx.Runner.Run(kubeadmUpgradeFollowerCommand, util.TemplateVariables{})
+	return err
+}

--- a/pkg/upgrader/upgrade/kubelet_package.go
+++ b/pkg/upgrader/upgrade/kubelet_package.go
@@ -1,0 +1,84 @@
+package upgrade
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/kubermatic/kubeone/pkg/config"
+	"github.com/kubermatic/kubeone/pkg/installer/util"
+)
+
+const (
+	upgradeKubeletDebianCommand = `
+source /etc/os-release
+source /etc/kubeone/proxy-env
+
+sudo apt-get update
+
+kube_ver=$(apt-cache madison kubelet | grep "{{ .KUBERNETES_VERSION }}" | head -1 | awk '{print $3}')
+
+sudo apt-mark unhold kubelet
+sudo apt-get install kubelet=${kube_ver}
+sudo apt-mark hold kubelet
+`
+	upgradeKubeletCentOSCommand = `
+source /etc/kubeone/proxy-env
+
+sudo yum install -y --disableexcludes=kubernetes \
+			kubelet-{{ .KUBERNETES_VERSION }}-0
+`
+	upgradeKubeletCoreOSCommand = `
+source /etc/kubeone/proxy-env
+
+RELEASE="v{{ .KUBERNETES_VERSION }}"
+
+sudo mkdir -p /opt/bin
+cd /opt/bin
+sudo curl -L --remote-name-all \
+     https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/kubelet
+sudo chmod +x kubelet
+`
+)
+
+func upgradeKubelet(ctx *util.Context, node *config.HostConfig) error {
+	var err error
+
+	switch node.OperatingSystem {
+	case "ubuntu", "debian":
+		err = upgradeKubeletDebian(ctx)
+
+	case "coreos":
+		err = upgradeKubeletCoreOS(ctx)
+
+	case "centos":
+		err = upgradeKubeletCentOS(ctx)
+
+	default:
+		err = errors.Errorf("'%s' is not a supported operating system", node.OperatingSystem)
+	}
+
+	return err
+}
+
+func upgradeKubeletDebian(ctx *util.Context) error {
+	_, _, err := ctx.Runner.Run(upgradeKubeletDebianCommand, util.TemplateVariables{
+		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
+	})
+
+	return errors.WithStack(err)
+}
+
+func upgradeKubeletCentOS(ctx *util.Context) error {
+	_, _, err := ctx.Runner.Run(upgradeKubeletCentOSCommand, util.TemplateVariables{
+		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
+	})
+
+	return errors.WithStack(err)
+}
+
+func upgradeKubeletCoreOS(ctx *util.Context) error {
+	_, _, err := ctx.Runner.Run(upgradeKubeletCoreOSCommand, util.TemplateVariables{
+		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
+	})
+
+	return errors.WithStack(err)
+}

--- a/pkg/upgrader/upgrade/upgrade.go
+++ b/pkg/upgrader/upgrade/upgrade.go
@@ -7,18 +7,30 @@ import (
 )
 
 const (
-	labelUpgradeLock      = "kubeone.io/upgrading-in-process"
+	labelUpgradeLock      = "kubeone.io/upgrade-in-progress"
 	labelControlPlaneNode = "node-role.kubernetes.io/master"
 )
 
 // Upgrade performs all the steps required to upgrade Kubernetes on
 // cluster provisioned using KubeOne
 func Upgrade(ctx *util.Context) error {
-	if err := util.BuildKubernetesClientset(ctx); err != nil {
-		return errors.Wrap(err, "unable to build kubernetes clientset")
+	// commonSteps are same for all worker nodes and they are safe to be run in parallel
+	commonSteps := []struct {
+		fn     func(ctx *util.Context) error
+		errMsg string
+	}{
+		{fn: util.BuildKubernetesClientset, errMsg: "unable to build kubernetes clientset"},
+		{fn: determineHostname, errMsg: "unable to determine hostname"},
+		{fn: determineOS, errMsg: "unable to determine operating system"},
+		{fn: runPreflightChecks, errMsg: "preflight checks failed"},
+		{fn: upgradeLeader, errMsg: "unable to upgrade leader control plane"},
+		{fn: upgradeFollower, errMsg: "unable to upgrade follower control plane"},
 	}
-	if err := runPreflightChecks(ctx); err != nil {
-		return errors.Wrap(err, "preflight checks failed")
+
+	for _, step := range commonSteps {
+		if err := step.fn(ctx); err != nil {
+			return errors.Wrap(err, step.errMsg)
+		}
 	}
 
 	return nil

--- a/pkg/upgrader/upgrade/upgrade_follower.go
+++ b/pkg/upgrader/upgrade/upgrade_follower.go
@@ -1,0 +1,47 @@
+package upgrade
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/kubermatic/kubeone/pkg/config"
+	"github.com/kubermatic/kubeone/pkg/installer/util"
+	"github.com/kubermatic/kubeone/pkg/ssh"
+)
+
+func upgradeFollower(ctx *util.Context) error {
+	return ctx.RunTaskOnFollowers(upgradeFollowerExecutor, false)
+}
+
+func upgradeFollowerExecutor(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+	ctx.Logger.Infoln("Labeling follower control plane…")
+	err := labelNode(ctx.Clientset.CoreV1().Nodes(), node)
+	if err != nil {
+		return errors.Wrap(err, "failed to label leader control plane node")
+	}
+
+	ctx.Logger.Infoln("Upgrading kubeadm on follower control plane…")
+	err = upgradeKubeadm(ctx, node)
+	if err != nil {
+		return errors.Wrap(err, "failed to upgrade kubeadm on follower control plane")
+	}
+
+	ctx.Logger.Infoln("Running 'kubeadm upgrade' on the follower control plane node…")
+	err = upgradeFollowerControlPlane(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to upgrade follower control plane")
+	}
+
+	ctx.Logger.Infoln("Upgrading kubelet…")
+	err = upgradeKubelet(ctx, node)
+	if err != nil {
+		return errors.Wrap(err, "failed to upgrade kubelet")
+	}
+
+	ctx.Logger.Infoln("Unlabeling follower control plane…")
+	err = unlabelNode(ctx.Clientset.CoreV1().Nodes(), node)
+	if err != nil {
+		return errors.Wrap(err, "failed to unlabel follower control plane node")
+	}
+
+	return nil
+}

--- a/pkg/upgrader/upgrade/upgrade_leader.go
+++ b/pkg/upgrader/upgrade/upgrade_leader.go
@@ -1,0 +1,49 @@
+package upgrade
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/kubermatic/kubeone/pkg/config"
+	"github.com/kubermatic/kubeone/pkg/installer/util"
+	"github.com/kubermatic/kubeone/pkg/ssh"
+)
+
+func upgradeLeader(ctx *util.Context) error {
+	return ctx.RunTaskOnLeader(upgradeLeaderExecutor)
+}
+
+func upgradeLeaderExecutor(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+	logger := ctx.Logger.WithField("node", node.PublicAddress)
+
+	logger.Infoln("Labeling leader control plane…")
+	err := labelNode(ctx.Clientset.CoreV1().Nodes(), node)
+	if err != nil {
+		return errors.Wrap(err, "failed to label leader control plane node")
+	}
+
+	logger.Infoln("Upgrading kubeadm on leader control plane…")
+	err = upgradeKubeadm(ctx, node)
+	if err != nil {
+		return errors.Wrap(err, "failed to upgrade kubeadm on leader control plane")
+	}
+
+	logger.Infoln("Running 'kubeadm upgrade' on leader control plane node…")
+	err = upgradeLeaderControlPlane(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to run 'kubeadm upgrade' on leader control plane")
+	}
+
+	logger.Infoln("Upgrading kubelet on leader control plane…")
+	err = upgradeKubelet(ctx, node)
+	if err != nil {
+		return errors.Wrap(err, "failed to upgrade kubelet on leader control plane")
+	}
+
+	logger.Infoln("Unlabeling leader control plane…")
+	err = unlabelNode(ctx.Clientset.CoreV1().Nodes(), node)
+	if err != nil {
+		return errors.Wrap(err, "failed to unlabel leader control plane node")
+	}
+
+	return nil
+}

--- a/pkg/upgrader/upgrade/util.go
+++ b/pkg/upgrader/upgrade/util.go
@@ -1,0 +1,80 @@
+package upgrade
+
+import (
+	"github.com/kubermatic/kubeone/pkg/config"
+	"github.com/kubermatic/kubeone/pkg/installer/util"
+	"github.com/kubermatic/kubeone/pkg/ssh"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1types "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func determineHostname(ctx *util.Context) error {
+	ctx.Logger.Infoln("Determine hostname…")
+	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+		stdout, _, err := ctx.Runner.Run("hostname -f", nil)
+		if err != nil {
+			return err
+		}
+
+		node.Hostname = stdout
+		return nil
+	}, true)
+}
+
+func determineOS(ctx *util.Context) error {
+	ctx.Logger.Infoln("Determine operating system…")
+	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+		osID, _, err := ctx.Runner.Run("source /etc/os-release && echo -n $ID", nil)
+		if err != nil {
+			return err
+		}
+
+		node.OperatingSystem = osID
+		return nil
+	}, true)
+}
+
+func labelNode(nodeClient corev1types.NodeInterface, host *config.HostConfig) error {
+	node, err := nodeClient.Get(host.Hostname, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	var modified bool
+	label := map[string]string{
+		labelUpgradeLock: "",
+	}
+	mergeStringMap(&modified, &node.ObjectMeta.Labels, label)
+	if !modified {
+		return nil
+	}
+
+	_, err = nodeClient.Update(node)
+	return err
+}
+
+func unlabelNode(nodeClient corev1types.NodeInterface, host *config.HostConfig) error {
+	node, err := nodeClient.Get(host.Hostname, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	delete(node.ObjectMeta.Labels, labelUpgradeLock)
+	_, err = nodeClient.Update(node)
+	return err
+}
+
+// mergeStringMap merges two string maps into destination string map
+func mergeStringMap(modified *bool, destination *map[string]string, required map[string]string) {
+	if *destination == nil {
+		*destination = map[string]string{}
+	}
+
+	for k, v := range required {
+		if destinationV, ok := (*destination)[k]; !ok || destinationV != v {
+			(*destination)[k] = v
+			*modified = true
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

* implement scripts for upgrading `kubeadm` and `kubelet` (#198),
* implements scripts for invoking `kubeadm upgrade` on both leader and follower nodes (#198),
* applies `kubeone.io/upgrade-in-progress` label before starting the upgrade process,
* removes `kubeone.io/upgrade-in-progress` label after successfully finishing the upgrade process,
* adds function for determining the hostname (ported from installer),
* slightly refactors the code to changes made in #210 

**Breaking changes:** I propose to rename the `kubeone.io/upgrading-in-process` label to `kubeone.io/upgrade-in-progress` because that seems more grammatically correct.

This PR is supposed to be merged once we have scripts for upgrading packages in the place, until then
/hold

This PR is based on the Kubernetes documentation: [Upgrading kubeadm HA clusters from v1.12 to v1.13](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha-1-13/).

**Questions for reviewers (check review comments for other questions):**

* ~Do we need to run `kubeadm plan`? To my understanding, it basically does nothing beside showing what will be changed. This can be useful with verbose, but not beside that. I done some testing and it even doesn't error if you put non-existing version or something similar.~ (see https://github.com/kubermatic/kubeone/pull/211#issuecomment-466386728)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #198

**Release note**:
```release-note
NONE
```

/assign @kron4eg 