### PR TITLE
Run apt-get with -y and --no-install-recommends

### DIFF
--- a/pkg/upgrader/upgrade/kubeadm_package.go
+++ b/pkg/upgrader/upgrade/kubeadm_package.go
@@ -17,7 +17,7 @@ sudo apt-get update
 kube_ver=$(apt-cache madison kubelet | grep "{{ .KUBERNETES_VERSION }}" | head -1 | awk '{print $3}')
 
 sudo apt-mark unhold kubeadm
-sudo apt-get install kubeadm=${kube_ver}
+sudo apt-get install -y --no-install-recommends kubeadm=${kube_ver}
 sudo apt-mark hold kubeadm
 `
 	upgradeKubeadmCentOSCommand = `

--- a/pkg/upgrader/upgrade/kubelet_package.go
+++ b/pkg/upgrader/upgrade/kubelet_package.go
@@ -17,7 +17,7 @@ sudo apt-get update
 kube_ver=$(apt-cache madison kubelet | grep "{{ .KUBERNETES_VERSION }}" | head -1 | awk '{print $3}')
 
 sudo apt-mark unhold kubelet
-sudo apt-get install kubelet=${kube_ver}
+sudo apt-get install -y --no-install-recommends kubelet=${kube_ver}
 sudo apt-mark hold kubelet
 `
 	upgradeKubeletCentOSCommand = `


### PR DESCRIPTION
**What this PR does / why we need it**:

Without `-y` the upgrade process would fail because it's expected for a user to provide the input and as this isn't an interactive session, it's not possible. Therefore we have to use `apt-get -y` instead.

I added `--no-install-recommends` because we use it when installing prerequisites.

**Release note**:
```release-note
NONE
```

/assign @kron4eg 
