### PR TITLE
Address None provider and machine-controller bugs

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -71,7 +71,7 @@ func runInstall(logger *logrus.Logger, installOptions *installOptions) error {
 	}
 
 	if err = applyTerraform(installOptions.TerraformState, cluster); err != nil {
-		return errors.Wrap(err, "failed to setup PKI backup")
+		return errors.Wrap(err, "failed to apply Terraform options")
 	}
 
 	if err = cluster.DefaultAndValidate(); err != nil {

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -868,14 +868,14 @@ func machineControllerCredentialsSecret(cluster *config.Cluster) *corev1.Secret 
 			Namespace: MachineControllerNamespace,
 		},
 		Type:       corev1.SecretTypeOpaque,
-		StringData: cluster.Provider.Credentials,
+		StringData: cluster.MachineController.Credentials,
 	}
 }
 
 func getEnvVarCredentials(cluster *config.Cluster) []corev1.EnvVar {
 	env := make([]corev1.EnvVar, 0)
 
-	for k := range cluster.Provider.Credentials {
+	for k := range cluster.MachineController.Credentials {
 		env = append(env, corev1.EnvVar{
 			Name: k,
 			ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
**What this PR does / why we need it**:

* Cloud Provider functionality remains unchanged
* Add MachineController.Provider API field which is used to configure machine-controller to use the specified provider
* If Cloud Provider is set to None and MachineController Provider is set, deploy machine-controller and deploy workers if they're defined
* If Cloud Provider is set to None and MachineController Provider is non-set or set to none, fail.
* If MachineController.Deploy is set to false, skip deployment and skip all validation and defaulting.

Breaking API changes:
* Provider.Credentials is moved to MachineController.Credentials

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #222

**Special notes for your reviewer**:

To do:
* Populate CloudProvider in the workerset spec with MachineController.Provider
* Consider renaming Provider to CloudProvider

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Move Provider.Credentials to MachineController.Credentials.
Introduce MachineController.Provider to be used for configuring machine-controller if Provider is set to None.
Provider None is now working as expected.
```
