### PR TITLE
Implement proper support for external CCM and cloud-config 

### DIFF
--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -176,8 +176,9 @@ const (
 
 // ProviderConfig describes the cloud provider that is running the machines.
 type ProviderConfig struct {
-	Name        ProviderName `json:"name"`
-	CloudConfig string       `json:"cloud_config"`
+	Name                                 ProviderName `json:"name"`
+	EnableExternalCloudControllerManager bool         `json:"enable_external_cloud_controller_manager"`
+	CloudConfig                          string       `json:"cloud_config"`
 }
 
 // Validate checks the ProviderConfig for errors

--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -124,7 +124,7 @@ func NewConfig(ctx *util.Context, host *config.HostConfig) ([]runtime.Object, er
 		nodeRegistration.KubeletExtraArgs["cloud-config"] = renderedCloudConfig
 	}
 
-	if cluster.Provider.Name == "external" {
+	if cluster.Provider.EnableExternalCloudControllerManager {
 		clusterConfig.APIServer.ExtraArgs["cloud-provider"] = ""
 		clusterConfig.ControllerManager.ExtraArgs["cloud-provider"] = ""
 		nodeRegistration.KubeletExtraArgs["cloud-provider"] = "external"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves support for external CCM.

With this PR, external CCM is enabled by setting provider.EnableCCM option instead of setting provider.Name to `none`. This way user can still set provider.Name and we don't lose information about on what provider we deploy on. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #168 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add provider.EnableExternalCloudControllerManager API field for enabling external CCM instead of setting provider.Name to external 
```

/assign @kron4eg 