### PR TITLE
Deploy machine-controller even on uninitialized nodes

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -808,6 +808,15 @@ func machineControllerDeployment(cluster *config.Cluster) (*appsv1.Deployment, e
 							Operator: corev1.TolerationOpExists,
 							Effect:   corev1.TaintEffectNoSchedule,
 						},
+						{
+							Key:    "node.cloudprovider.kubernetes.io/uninitialized",
+							Value:  "true",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+						{
+							Key:      "CriticalAddonsOnly",
+							Operator: corev1.TolerationOpExists,
+						},
 					},
 					Containers: []corev1.Container{
 						{

--- a/pkg/templates/machinecontroller/webhook.go
+++ b/pkg/templates/machinecontroller/webhook.go
@@ -144,6 +144,15 @@ func webhookDeployment(cluster *config.Cluster) *appsv1.Deployment {
 			Operator: corev1.TolerationOpExists,
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
+		{
+			Key:    "node.cloudprovider.kubernetes.io/uninitialized",
+			Value:  "true",
+			Effect: corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: corev1.TolerationOpExists,
+		},
 	}
 
 	dep.Spec.Template.Spec.Containers = []corev1.Container{


### PR DESCRIPTION
**What this PR does / why we need it**:
Setting `provider.external: true` makes kubeone fail, because it's impossible to deploy machine-controller.

```release-note
NONE
```
