### PR TITLE
Don't error in wait.Poll if error is expected

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -172,7 +172,7 @@ func waitForNodesReady(nodeClient corev1types.NodeInterface) error {
 		for _, n := range nodes.Items {
 			for _, c := range n.Status.Conditions {
 				if c.Type == corev1.NodeReady && c.Status != corev1.ConditionTrue {
-					return false, errors.Errorf("node %s is not running", n.ObjectMeta.Name)
+					return false, nil
 				}
 			}
 		}
@@ -200,7 +200,7 @@ func waitForNodesUpgraded(nodeClient corev1types.NodeInterface, targetVersion st
 				return false, err
 			}
 			if reqVer.Compare(kubeletVer) != 0 {
-				return false, errors.Errorf("kubelet version mismatch: expected %v, got %v", reqVer.String(), kubeletVer.String())
+				return false, nil
 			}
 		}
 		return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR doesn't return error if it's not fatal and it's supposed to retry the action. This should fix flakes we have with upgrade e2e tests.

**Release note**:
```release-note
NONE
```
