### PR TITLE
Download kubeconfig automatically on install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tf.json
 *terraform.tfstate*
 .terraform
 terraform.tfvars
+*kubeconfig

--- a/pkg/installer/installation/install.go
+++ b/pkg/installer/installation/install.go
@@ -23,6 +23,7 @@ func Install(ctx *util.Context) error {
 		{fn: initKubernetesLeader, errMsg: "failed to init kubernetes on leader"},
 		{fn: joinControlplaneNode, errMsg: "unable to join other masters a cluster"},
 		{fn: copyKubeconfig, errMsg: "unable to copy kubeconfig to home directory"},
+		{fn: saveKubeconfig, errMsg: "unable to save kubeconfig to the local machine"},
 		{fn: util.BuildKubernetesClientset, errMsg: "unable to build kubernetes clientset"},
 		{fn: features.Activate, errMsg: "unable to activate features"},
 		{fn: applyCanalCNI, errMsg: "failed to install cni plugin canal"},

--- a/pkg/installer/installation/kubeconfig.go
+++ b/pkg/installer/installation/kubeconfig.go
@@ -1,6 +1,11 @@
 package installation
 
 import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+
 	"github.com/kubermatic/kubeone/pkg/config"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
@@ -21,4 +26,15 @@ sudo chown $(id -u):$(id -u) $HOME/.kube/config
 
 		return nil
 	}, true)
+}
+
+func saveKubeconfig(ctx *util.Context) error {
+	kubeconfig, err := util.DownloadKubeconfig(ctx.Cluster)
+	if err != nil {
+		return err
+	}
+
+	fileName := fmt.Sprintf("%s-kubeconfig", ctx.Cluster.Name)
+	err = ioutil.WriteFile(fileName, kubeconfig, 0644)
+	return errors.Wrap(err, "error saving kubeconfig file to the local machine")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `saveKubeconfig` install phase which saves the kubeconfig file named as `cluster-name-kubeconfig` to the local machine. The `*kubeconfig` files are added to the `.gitignore` file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #231

**Release note**:
```release-note
The kubeconfig file is now downloaded automatically on install
```

/assign @kron4eg