### PR TITLE
kubeone reset --destroy-workers default  true

### DIFF
--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -46,7 +46,7 @@ It's possible to source information about hosts from Terraform output, using the
 		},
 	}
 
-	cmd.Flags().BoolVarP(&ropts.DestroyWorkers, "destroy-workers", "", false, "destroy all worker machines before resetting cluster")
+	cmd.Flags().BoolVarP(&ropts.DestroyWorkers, "destroy-workers", "", true, "destroy all worker machines before resetting the cluster")
 
 	return cmd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleanup workers in reset clusters

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #250 

```release-note
kubeone reset will destroy workers by default
```
