### PR TITLE
Add license headers to other files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 export GOPATH?=$(shell go env GOPATH)
 export CGO_ENABLED=0
 export TFJSON?=

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -1,3 +1,17 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This file contains the configuration for installing a single Kubernetes
 # clusters using KubeOne. You can augment some options by providing
 # Terraform output at runtime, like explained in the documentation.

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 provider "aws" {
   region = "${var.aws_region}"
 }

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 output "kubeone_api" {
   value = {
     endpoint = "${aws_lb.control_plane.dns_name}"

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 variable "cluster_name" {
   description = "prefix for cloud resources"
 }

--- a/examples/terraform/digitalocean/main.tf
+++ b/examples/terraform/digitalocean/main.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 provider "digitalocean" {}
 
 locals {

--- a/examples/terraform/digitalocean/output.tf
+++ b/examples/terraform/digitalocean/output.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 output "kubeone_api" {
   value = {
     endpoint = "${digitalocean_loadbalancer.control_plane.ip}"

--- a/examples/terraform/digitalocean/variables.tf
+++ b/examples/terraform/digitalocean/variables.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 variable "cluster_name" {
   description = "Name of the cluster"
 }

--- a/examples/terraform/hetzner/main.tf
+++ b/examples/terraform/hetzner/main.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 resource "hcloud_ssh_key" "kubeone" {
   name       = "kubeone-${var.cluster_name}"
   public_key = "${file("${var.ssh_public_key_file}")}"

--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 output "kubeone_hosts" {
   value = {
     control_plane = {

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 variable "cluster_name" {
   description = "prefix for cloud resources"
 }

--- a/examples/terraform/openstack/datasources.tf
+++ b/examples/terraform/openstack/datasources.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 data "openstack_networking_network_v2" "external_network" {
   name     = "${var.external_network_name}"
   external = true

--- a/examples/terraform/openstack/main.tf
+++ b/examples/terraform/openstack/main.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 provider "openstack" {}
 
 resource "openstack_compute_keypair_v2" "deployer" {

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 output "kubeone_api" {
   value = {
     endpoint = "${openstack_networking_floatingip_v2.lb.address}"

--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 variable "cluster_name" {
   description = "prefix for cloud resources"
 }

--- a/hack/run_ci_e2e_test.sh
+++ b/hack/run_ci_e2e_test.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This script is mostly used in CI
 # It installs dependencies and starts the tests
 

--- a/test/e2e/testdata/aws_config.yaml
+++ b/test/e2e/testdata/aws_config.yaml
@@ -1,3 +1,16 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 versions:
   kubernetes: '1.13.1'
 provider:

--- a/test/e2e/testdata/do_config.yaml
+++ b/test/e2e/testdata/do_config.yaml
@@ -1,3 +1,16 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 versions:
   kubernetes: '1.13.1'
 provider:

--- a/test/e2e/testdata/upgrades_aws_1.13.1.yaml
+++ b/test/e2e/testdata/upgrades_aws_1.13.1.yaml
@@ -1,3 +1,16 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 versions:
   kubernetes: '1.13.1'
 provider:

--- a/test/e2e/testdata/upgrades_aws_1.13.3.yaml
+++ b/test/e2e/testdata/upgrades_aws_1.13.3.yaml
@@ -1,3 +1,16 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 versions:
   kubernetes: '1.13.3'
 provider:

--- a/test/e2e/testdata/upgrades_do_1.13.1.yaml
+++ b/test/e2e/testdata/upgrades_do_1.13.1.yaml
@@ -1,3 +1,16 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 versions:
   kubernetes: '1.13.1'
 provider:

--- a/test/e2e/testdata/upgrades_do_1.13.3.yaml
+++ b/test/e2e/testdata/upgrades_do_1.13.3.yaml
@@ -1,3 +1,16 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 versions:
   kubernetes: '1.13.3'
 provider:


### PR DESCRIPTION
**What this PR does / why we need it**:

In #289 we added the license headers to all Go files. This PR adds license headers to:
* YAML manifests (example KubeOne manifests and KubeOne manifests for E2E tests)
* Bash script (`hack/run_ci_e2e_test.sh`)
* Terraform scripts (`{main,output,variables}.tf` files)
* Makefile
* `config.yaml.dist`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #275

**Special notes for your reviewer**:

I'm not sure:

* is it okay that I added the license headers to all YAML manifest (including `config.yaml.dist`)?
* is it okay that I added the license headers to all Terraform scripts?
* should I add the license headers to the config YAML manifests (e.g. `.golangci.yml`)?
* anything else missing?

**Release note**:
```release-note
NONE
```

/assign @kron4eg
/cc @scheeles