### PR TITLE
Add v0.4.0 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ However, running of the master branch introduces potential risks as the project 
 
 Alternatively, you can obtain KubeOne via [GitHub Releases](https://github.com/kubermatic/kubeone/releases):
 ```bash
-curl -LO https://github.com/kubermatic/kubeone/releases/download/v0.3.0/kubeone_0.3.0_linux_amd64.zip
-unzip kubeone_0.3.0_linux_amd64.zip
+curl -LO https://github.com/kubermatic/kubeone/releases/download/v0.4.0/kubeone_0.4.0_linux_amd64.zip
+unzip kubeone_0.4.0_linux_amd64.zip
 sudo mv kubeone /usr/local/bin
 ```
 
@@ -53,6 +53,7 @@ In the following table you can find what are supported Kubernetes versions for e
 
 | KubeOne version | 1.14 | 1.13 | 1.12 |
 |-----------------|------|------|------|
+| v0.4.0 | - | + | - |
 | v0.3.0 | - | + | - |
 | <s>v0.2.0</s> | - | + | - |
 | <s>v0.1.0-beta0</s> | - | + | +


### PR DESCRIPTION
This PR updates links to use v0.4.0 and adds v0.4.0 to the release compatibility table.

**Release note**:
```release-note
NONE
```

/assign @kron4eg 
