### PR TITLE
Update machine-controller to v1.1.0

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -43,7 +43,7 @@ const (
 	MachineControllerNamespace             = metav1.NamespaceSystem
 	MachineControllerAppLabelKey           = "app"
 	MachineControllerAppLabelValue         = "machine-controller"
-	MachineControllerTag                   = "v1.0.7"
+	MachineControllerTag                   = "v1.1.0"
 	MachineControllerCredentialsSecretName = "machine-controller-credentials"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the machine-controller template to deploy v1.1.0. 
v1.1.0 is using the same Cluster-API version as v1.0.7 so there's no need for updating the Cluster-API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #282

**Release note**:
```release-note
Update machine-controller to v1.1.0
```

/assign @kron4eg 