### PR TITLE
Run kubeadm without the --experimental-control-plane flag

### DIFF
--- a/pkg/installer/installation/controlplane.go
+++ b/pkg/installer/installation/controlplane.go
@@ -34,8 +34,7 @@ func joinControlPlaneNodeInternal(ctx *util.Context, node *config.HostConfig, co
 if [[ -f /etc/kubernetes/kubelet.conf ]]; then exit 0; fi
 
 sudo kubeadm join \
-	--config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml \
-	--experimental-control-plane
+	--config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
 `, util.TemplateVariables{
 		"WORK_DIR": ctx.WorkDir,
 		"NODE_ID":  strconv.Itoa(node.ID),


### PR DESCRIPTION
**What this PR does / why we need it**:

As of Kubernetes 1.14 it's not possible to run `kubeadm join` with both the config file and the `--experimental-control-plane` flag:

```
Error: unable to join other masters a cluster: + [[ -f /etc/kubernetes/kubelet.conf ]]
+ sudo kubeadm join --config=./kubeone/cfg/master_1.yaml --experimental-control-plane
can not mix '--config' with arguments [experimental-control-plane]: failed to exec command: export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
```

As per https://github.com/kubernetes/kubeadm/issues/1251, when using  [`JoinConfiguration.ControlPlane`](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#JoinControlPlane) the flag is not required. This change is compatible with Kubernetes 1.13.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #269

**Release note**:
```release-note
NONE
```
