### PR TITLE
Wait 10 seconds before upgrading next node

### DIFF
--- a/pkg/upgrader/upgrade/upgrade_leader.go
+++ b/pkg/upgrader/upgrade/upgrade_leader.go
@@ -17,6 +17,8 @@ limitations under the License.
 package upgrade
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 
 	"github.com/kubermatic/kubeone/pkg/config"
@@ -60,6 +62,9 @@ func upgradeLeaderExecutor(ctx *util.Context, node *config.HostConfig, conn ssh.
 	if err := unlabelNode(ctx.DynamicClient, node); err != nil {
 		return errors.Wrap(err, "failed to unlabel leader control plane node")
 	}
+
+	logger.Infoln("Waiting 10 seconds to ensure all components are up…")
+	time.Sleep(10 * time.Second)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a delay of ten seconds before proceeding to the next node to ensure that all components have enough time to restart. This potentially fixes issues and flakes for upgrades on DigitalOcean.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #269

**Release note**:
```release-note
Add ten seconds delay before upgrading the next node.
```

/assign @kron4eg 
