### PR TITLE
Add 2 minutes delay after installing before upgrade in E2E

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/master"
+	delayUpgrade          = 2 * time.Minute
 )
 
 func TestClusterUpgrade(t *testing.T) {
@@ -144,6 +145,9 @@ func TestClusterUpgrade(t *testing.T) {
 			if err != nil {
 				t.Fatalf("version mismatch before running upgrade: %v", err)
 			}
+
+			t.Logf("waiting %s for nodes to settle down", delayUpgrade.String())
+			time.Sleep(delayUpgrade)
 
 			// Create a new KubeOne provisioner pointing to the new configuration file
 			target = NewKubeone(testPath, tc.targetConfigPath)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a two minutes delay in E2E tests after installing and creating nodes to let nodes settle down for some time. This may resolve E2E flakes we have.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #269

**Release note**:
```release-note
NONE
```

/assign @kron4eg 