### PR TITLE
Implement Retryable tasks

### DIFF
--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"time"
+
+	"github.com/kubermatic/kubeone/pkg/util"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// defaultRetryBackoff is backoff with with duration of 5 seconds and factor of 2.0
+func defaultRetryBackoff(retries int) wait.Backoff {
+	return wait.Backoff{
+		Steps:    retries,
+		Duration: 5 * time.Second,
+		Factor:   2.0,
+	}
+}
+
+// Task is a runnable task
+type Task struct {
+	Fn      func(*util.Context) error
+	ErrMsg  string
+	Retries int
+}
+
+// RunTask runs a task
+func (t *Task) Run(ctx *util.Context) error {
+	if t.Retries == 0 {
+		t.Retries = 1
+	}
+	backoff := defaultRetryBackoff(t.Retries)
+
+	var lastError error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		lastError = t.Fn(ctx)
+		if lastError != nil {
+			ctx.Logger.Warn("Task failed, retrying…")
+			return false, nil
+		}
+		return true, nil
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastError
+	}
+	return err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements retryable tasks. Some tasks are ran only once while some are ran 3 times. This package is based on the `k8s.io/apimachinery/util/wait` package and the `ExponentialBackoff` function.

This is required for proper upgrades support from 1.13 to 1.14 and to stabilize the CI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #269

**Release note**:
```release-note
NONE
```

/assign @kron4eg 