### PR TITLE
Increase E2E tests timeouts

### DIFF
--- a/hack/run_ci_e2e_test.sh
+++ b/hack/run_ci_e2e_test.sh
@@ -128,8 +128,8 @@ make install
 # Start the tests
 echo "Running E2E tests ..."
 if [[ $TEST_SET == "conformance" ]]; then
-  go test -race -tags=e2e -v -timeout 30m -run TestClusterConformance ./test/e2e/... -identifier=$BUILD_ID -provider=$PROVIDER -cluster-version=$TEST_CLUSTER_TARGET_VERSION
+  go test -race -tags=e2e -v -timeout 60m -run TestClusterConformance ./test/e2e/... -identifier=$BUILD_ID -provider=$PROVIDER -cluster-version=$TEST_CLUSTER_TARGET_VERSION
 fi
 if [[ $TEST_SET == "upgrades" ]]; then
-  go test -race -tags=e2e -v -timeout 60m -run TestClusterUpgrade ./test/e2e/... -identifier=$BUILD_ID -provider=$PROVIDER -cluster-version=$TEST_CLUSTER_TARGET_VERSION
+  go test -race -tags=e2e -v -timeout 120m -run TestClusterUpgrade ./test/e2e/... -identifier=$BUILD_ID -provider=$PROVIDER -cluster-version=$TEST_CLUSTER_TARGET_VERSION
 fi

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -65,7 +65,7 @@ func setupTearDown(p Provisioner, k Kubeone) func(t *testing.T) {
 }
 
 func waitForNodesReady(client dynclient.Client, expectedNumberOfNodes int) error {
-	return wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
+	return wait.Poll(5*time.Second, 10*time.Minute, func() (bool, error) {
 		nodes := corev1.NodeList{}
 		nodeListOpts := dynclient.ListOptions{}
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -194,7 +194,7 @@ func waitForNodesUpgraded(client dynclient.Client, targetVersion string) error {
 		return errors.Wrap(err, "desired version is invalid")
 	}
 
-	return wait.Poll(5*time.Second, 10*time.Minute, func() (bool, error) {
+	return wait.Poll(5*time.Second, 20*time.Minute, func() (bool, error) {
 		nodes := corev1.NodeList{}
 		err := client.List(context.Background(), &dynclient.ListOptions{}, &nodes)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

* Waiting for nodes to become ready timeout increased to 10 minutes from 5 minutes
* Waiting for nodes to be upgraded timeout increased to 20 minutes from 10 minutes
* Conformance E2E tests timeout increased to 1 hour from 30 minutes
* Upgrades E2E tests timeout increased to 2 hours from 1 hour

This should reduce the number of flakes we encounter in the CI tests.

**Release note**:
```release-note
NONE
```

/assign @kron4eg 
