### PR TITLE
Add the Terraform workerset integration for Hetzner

### DIFF
--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -28,7 +28,7 @@ output "kubeone_workers" {
     pool1 = {
       serverType      = "${var.worker_type}"
       location        = "${var.datacenter}"
-      replicas        = 1
+      replicas        = 3
       sshPublicKeys   = ["${file("${var.ssh_public_key_file}")}"]
       operatingSystem = "${var.image}"
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the Terraform workerset integration for Hetzner. The following information about worker nodes can be sourced from Terraform:

* Server type
* Datacenter
* Location

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Required for #165 

**Release note**:
```release-note
Add the Terraform workerset integration for Hetzner
```

/assign @kron4eg 
