### PR TITLE
Implement E2E tests for Hetzner

### DIFF
--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -70,6 +70,22 @@ func TestClusterConformance(t *testing.T) {
 			configFilePath:        "../../test/e2e/testdata/config_do_1.14.0.yaml",
 			expectedNumberOfNodes: 6, // 3 control planes + 3 workers
 		},
+		{
+			name:                  "verify k8s 1.13.5 cluster deployment on Hetzner",
+			provider:              Hetzner,
+			kubernetesVersion:     "v1.13.5",
+			scenario:              NodeConformance,
+			configFilePath:        "../../test/e2e/testdata/config_hetzner_1.13.5.yaml",
+			expectedNumberOfNodes: 6, // 3 control planes + 3 workers
+		},
+		{
+			name:                  "verify k8s 1.14.0 cluster deployment on Hetzner",
+			provider:              Hetzner,
+			kubernetesVersion:     "v1.14.0",
+			scenario:              NodeConformance,
+			configFilePath:        "../../test/e2e/testdata/config_hetzner_1.14.0.yaml",
+			expectedNumberOfNodes: 6, // 3 control planes + 3 workers
+		},
 	}
 
 	for _, tc := range testcases {

--- a/test/e2e/helper.go
+++ b/test/e2e/helper.go
@@ -30,14 +30,16 @@ import (
 
 // CreateProvisioner returns interface for specific provisioner
 func CreateProvisioner(testPath string, identifier string, provider string) (Provisioner, error) {
-	if provider == AWS {
+	switch provider {
+	case AWS:
 		return NewAWSProvisioner(testPath, identifier)
-	}
-	if provider == DigitalOcean {
+	case DigitalOcean:
 		return NewDOProvisioner(testPath, identifier)
+	case Hetzner:
+		return NewHetznerProvisioner(testPath, identifier)
+	default:
+		return nil, fmt.Errorf("unsuported provider %v", provider)
 	}
-
-	return nil, fmt.Errorf("unsuported provider %v", provider)
 }
 
 // IsCommandAvailable checks if command is available OS

--- a/test/e2e/testdata/config_hetzner_1.13.5.yaml
+++ b/test/e2e/testdata/config_hetzner_1.13.5.yaml
@@ -1,0 +1,19 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+versions:
+  kubernetes: '1.13.5'
+provider:
+  name: 'hetzner'
+features:
+  enable_pod_security_policy: false

--- a/test/e2e/testdata/config_hetzner_1.14.0.yaml
+++ b/test/e2e/testdata/config_hetzner_1.14.0.yaml
@@ -1,0 +1,19 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+versions:
+  kubernetes: '1.14.0'
+provider:
+  name: 'hetzner'
+features:
+  enable_pod_security_policy: false

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -72,6 +72,16 @@ func TestClusterUpgrade(t *testing.T) {
 			expectedNumberOfNodes: 6, // 3 control planes + 3 workers
 			scenario:              NodeConformance,
 		},
+		{
+			name:                  "upgrade k8s 1.13.5 cluster to 1.14.0 on Hetzner",
+			provider:              Hetzner,
+			initialVersion:        "v1.13.5",
+			targetVersion:         "v1.14.0",
+			initialConfigPath:     "../../test/e2e/testdata/config_hetzner_1.13.5.yaml",
+			targetConfigPath:      "../../test/e2e/testdata/config_hetzner_1.14.0.yaml",
+			expectedNumberOfNodes: 6, // 3 control planes + 3 workers
+			scenario:              NodeConformance,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements the conformance and upgrades E2E tests for Hetzner. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #165 

**Release note**:
```release-note
NONE
```

/assign @kron4eg 