### PR TITLE
Fix the lint and misspell errors caught by the GoReportCard

### DIFF
--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -40,7 +40,7 @@ type Task struct {
 	Retries int
 }
 
-// RunTask runs a task
+// Run runs a task
 func (t *Task) Run(ctx *util.Context) error {
 	if t.Retries == 0 {
 		t.Retries = 1

--- a/pkg/templates/canal/daemonset.go
+++ b/pkg/templates/canal/daemonset.go
@@ -29,7 +29,7 @@ import (
 func daemonSet() *appsv1.DaemonSet {
 	maxUnavailable := intstr.FromInt(1)
 	terminationGracePeriodSeconds := int64(0)
-	priviliged := true
+	privileged := true
 	fileOrCreate := corev1.HostPathFileOrCreate
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -217,7 +217,7 @@ func daemonSet() *appsv1.DaemonSet {
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: &priviliged,
+								Privileged: &privileged,
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: map[corev1.ResourceName]resource.Quantity{
@@ -268,7 +268,7 @@ func daemonSet() *appsv1.DaemonSet {
 								"--kube-subnet-mgr",
 							},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: &priviliged,
+								Privileged: &privileged,
 							},
 							Env: []corev1.EnvVar{
 								{

--- a/test/e2e/kubeone.go
+++ b/test/e2e/kubeone.go
@@ -29,6 +29,7 @@ type Kubeone struct {
 	ConfigurationFile string
 }
 
+// NewKubeone creates and initializes the Kubeone structure
 func NewKubeone(kubeoneDir, configurationFile string) Kubeone {
 	return Kubeone{
 		KubeoneDir:        kubeoneDir,
@@ -50,6 +51,7 @@ func (p *Kubeone) Install(tfJSON string) error {
 	return nil
 }
 
+// Upgrade upgrades the cluster
 func (p *Kubeone) Upgrade() error {
 	_, err := executeCommand(p.KubeoneDir, "kubeone", []string{"upgrade", "--tfjson", "tf.json", "--upgrade-machine-deployments", p.ConfigurationFile}, nil)
 	if err != nil {
@@ -75,7 +77,7 @@ func (p *Kubeone) CreateKubeconfig() ([]byte, error) {
 	return []byte(rawKubeconfig), nil
 }
 
-// DestroyWorkers cleanup method
+// Reset resets and cleanups the cluster
 func (p *Kubeone) Reset() error {
 	_, err := executeCommand(p.KubeoneDir, "kubeone", []string{"-v", "reset", "--tfjson", "tf.json", "--destroy-workers", p.ConfigurationFile}, nil)
 	if err != nil {

--- a/test/e2e/kubetest.go
+++ b/test/e2e/kubetest.go
@@ -22,14 +22,13 @@ import (
 )
 
 const (
-	Pods            = "Pods"
 	NodeConformance = `\[NodeConformance\]`
 	Conformance     = `\[Conformance\]`
 )
 
 const skip = `Alpha|\[(Disruptive|Feature:[^\]]+|Flaky|Serial|Slow)\]`
 
-// Kubetest struct
+// Kubetest configures the Kubetest conformance tester
 type Kubetest struct {
 	kubetestDir       string
 	kubernetesVersion string
@@ -37,6 +36,7 @@ type Kubetest struct {
 	envVars map[string]string
 }
 
+// NewKubetest creates and provisions the Kubetest structure
 func NewKubetest(k8sVersion, kubetestDir string, envVars map[string]string) Kubetest {
 	return Kubetest{
 		kubetestDir:       kubetestDir,
@@ -46,7 +46,7 @@ func NewKubetest(k8sVersion, kubetestDir string, envVars map[string]string) Kube
 
 }
 
-// RunTests starts e2e tests
+// Verify verifies the cluster
 func (p *Kubetest) Verify(scenario string) error {
 	k8sVersionPath := fmt.Sprintf("%s/kubernetes-%s/kubernetes/version", p.kubetestDir, p.kubernetesVersion)
 	if _, err := os.Stat(k8sVersionPath); os.IsNotExist(err) {

--- a/test/e2e/provisioner.go
+++ b/test/e2e/provisioner.go
@@ -23,13 +23,17 @@ import (
 )
 
 const (
-	AWS          = "aws"
+	// AWS cloud provider
+	AWS = "aws"
+	// DigitalOcean cloud provider
 	DigitalOcean = "digitalocean"
-	Hetzner      = "hetzner"
+	// Hetzner cloud provider
+	Hetzner = "hetzner"
 
 	tfStateFileName = "terraform.tfstate"
 )
 
+// Provisioner provisions and cleanups the cluster
 type Provisioner interface {
 	Provision() (string, error)
 	Cleanup() error


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the lint and misspell errors caught by the [GoReportCard](https://goreportcard.com/report/github.com/kubermatic/kubeone).

**Release note**:
```release-note
NONE
```

/assign @kron4eg 