### PR TITLE
Set Hetzner token when running E2E tests

### DIFF
--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -30,7 +30,7 @@ output "kubeone_workers" {
       location        = "${var.datacenter}"
       replicas        = 3
       sshPublicKeys   = ["${file("${var.ssh_public_key_file}")}"]
-      operatingSystem = "${var.image}"
+      operatingSystem = "ubuntu"
     }
   }
 }

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -32,7 +32,7 @@ variable "worker_type" {
 }
 
 variable "datacenter" {
-  default = "hel1"
+  default = "fsn1"
 }
 
 variable "ssh_public_key_file" {

--- a/hack/run_ci_e2e_test.sh
+++ b/hack/run_ci_e2e_test.sh
@@ -86,6 +86,9 @@ if [ -n "${RUNNING_IN_CI}" ]; then
  if [[ $PROVIDER == "digitalocean" ]]; then
   export DIGITALOCEAN_TOKEN=$DO_E2E_TESTS_TOKEN
  fi
+ if [[ $PROVIDER == "hetzner" ]]; then
+  export HCLOUD_TOKEN=$HZ_E2E_TOKEN
+ fi
  KUBE_TEST_DIR="/opt/kube-test"
  if [ -d "${KUBE_TEST_DIR}" ]; then
  KUBEONE_BUILD_DIR="$(go env GOPATH)/src/github.com/kubermatic/kubeone/_build"

--- a/hack/run_ci_e2e_test.sh
+++ b/hack/run_ci_e2e_test.sh
@@ -24,13 +24,13 @@ BUILD_ID=${BUILD_ID:-"${USER}-local"}
 PROVIDER=${PROVIDER:-"aws"}
 TEST_SET=${TEST_SET:-"conformance"}
 TEST_CLUSTER_TARGET_VERSION=${TEST_CLUSTER_VERSION:-"v1.14.0"}
-export TF_VAR_cluster_name=$BUILD_ID
+export TF_VAR_cluster_name=${BUILD_ID}
 
 # Install dependencies
 if ! [ -x "$(command -v terraform)" ]; then
   echo "Installing unzip"
   if ! [ -x "$(command -v unzip)" ]; then
-   apt update && apt install -y unzip
+    apt update && apt install -y unzip
   fi
   echo "Installing terraform"
   cd /tmp
@@ -49,22 +49,23 @@ if ! [ -x "$(command -v kubetest)" ]; then
 fi
 
 TERRAFORM_DIR="$(go env GOPATH)/src/github.com/kubermatic/kubeone/examples/terraform"
-function cleanup {
-set +e
-for try in {1..20}; do
-  cd $TERRAFORM_DIR/$PROVIDER
-  echo "Cleaning up terraform state, attempt ${try}"
-  # Upstream interpolation bug, but we dont care about the output
-  # at destroy time anyways: https://github.com/hashicorp/terraform/issues/17691
-  rm -f output.tf
-  terraform init --backend-config=key=$BUILD_ID
-  terraform destroy -auto-approve
-  if [[ $? == 0 ]]; then break; fi
-  echo "Sleeping for $try seconds"
-  sleep ${try}s
-done
+function cleanup() {
+  set +e
+  for try in {1..20}; do
+    cd ${TERRAFORM_DIR}/${PROVIDER}
+    echo "Cleaning up terraform state, attempt ${try}"
+    # Upstream interpolation bug, but we dont care about the output
+    # at destroy time anyways: https://github.com/hashicorp/terraform/issues/17691
+    rm -f output.tf
+    terraform init --backend-config=key=${BUILD_ID}
+    terraform destroy -auto-approve
+    if [[ $? == 0 ]]; then break; fi
+    echo "Sleeping for $try seconds"
+    sleep ${try}s
+  done
 }
 trap cleanup EXIT
+
 # If the following variable is set then this script is running in CI
 # and the assumption is that the image contains kubernetes binaries
 #
@@ -72,67 +73,93 @@ trap cleanup EXIT
 # kubetest assumes that the last part of that path contains "kubernetes", if not then it complains,
 # additionally the version must be in a very specific format.
 if [ -n "${RUNNING_IN_CI}" ]; then
- # set up terraform remote backend configuration
- for dir in ${TERRAFORM_DIR}/*; do
-     ln -s "$(go env GOPATH)/src/github.com/kubermatic/kubeone/test/e2e/testdata/s3_backend.tf" $dir/s3_backend.tf
- done
+  # set up terraform remote backend configuration
+  for dir in ${TERRAFORM_DIR}/*; do
+    ln -s "$(go env GOPATH)/src/github.com/kubermatic/kubeone/test/e2e/testdata/s3_backend.tf" $dir/s3_backend.tf
+  done
 
- # terraform expects to find AWS credentials in the following env variables
- if [[ $PROVIDER == "aws" ]]; then
-  export AWS_ACCESS_KEY_ID=$AWS_E2E_TESTS_KEY_ID
-  export AWS_SECRET_ACCESS_KEY=$AWS_E2E_TESTS_SECRET
- fi
- # terraform expects to find DigitalOcean credentials in the following env variables
- if [[ $PROVIDER == "digitalocean" ]]; then
-  export DIGITALOCEAN_TOKEN=$DO_E2E_TESTS_TOKEN
- fi
- if [[ $PROVIDER == "hetzner" ]]; then
-  export HCLOUD_TOKEN=$HZ_E2E_TOKEN
- fi
- KUBE_TEST_DIR="/opt/kube-test"
- if [ -d "${KUBE_TEST_DIR}" ]; then
- KUBEONE_BUILD_DIR="$(go env GOPATH)/src/github.com/kubermatic/kubeone/_build"
- mkdir -p ${KUBEONE_BUILD_DIR}
- for dir in ${KUBE_TEST_DIR}/*
-  do
-   VERSION_REG_EXP="^(\d+\.\d+\.\d+[\w.\-+]*)$"
-   KUBE_VERSION=$(basename $dir)
-   if ! [[ ${KUBE_VERSION} =~ ${VERSION_REG_EXP} ]]; then
-    KUBE_VERSION="${KUBE_VERSION}.0"
-   fi
-   KUBE_TEST_DST_DIR="${KUBEONE_BUILD_DIR}/kubernetes-v${KUBE_VERSION}/kubernetes"
-   mkdir -p "${KUBE_TEST_DST_DIR}"
-   ln -s $dir/* "${KUBE_TEST_DST_DIR}"
- done
- else
-  echo "The directory ${KUBE_TEST_DIR} does not exist, we need to download additional binaries for the tests. This might make the test to run longer."
- fi
- else
+  case ${PROVIDER} in
+  "aws")
+    export AWS_ACCESS_KEY_ID=${AWS_E2E_TESTS_KEY_ID}
+    export AWS_SECRET_ACCESS_KEY=${AWS_E2E_TESTS_SECRET}
+    ;;
+  "digitalocean")
+    export DIGITALOCEAN_TOKEN=${DO_E2E_TESTS_TOKEN}
+    ;;
+  "hetzner")
+    export HCLOUD_TOKEN=${HZ_E2E_TOKEN}
+    ;;
+  *)
+    echo "unknown provider ${PROVIDER}"
+    exit -1
+    ;;
+  esac
+
+  KUBE_TEST_DIR="/opt/kube-test"
+  if [ -d "${KUBE_TEST_DIR}" ]; then
+    KUBEONE_BUILD_DIR="$(go env GOPATH)/src/github.com/kubermatic/kubeone/_build"
+    mkdir -p ${KUBEONE_BUILD_DIR}
+    for dir in ${KUBE_TEST_DIR}/*; do
+      VERSION_REG_EXP="^(\d+\.\d+\.\d+[\w.\-+]*)$"
+      KUBE_VERSION=$(basename $dir)
+      if ! [[ ${KUBE_VERSION} =~ ${VERSION_REG_EXP} ]]; then
+        KUBE_VERSION="${KUBE_VERSION}.0"
+      fi
+      KUBE_TEST_DST_DIR="${KUBEONE_BUILD_DIR}/kubernetes-v${KUBE_VERSION}/kubernetes"
+      mkdir -p "${KUBE_TEST_DST_DIR}"
+      ln -s $dir/* "${KUBE_TEST_DST_DIR}"
+    done
+  else
+    echo "The directory ${KUBE_TEST_DIR} does not exist, we need to download additional binaries for the tests. This might make the test to run longer."
+  fi
+else
   echo "The script is not running in CI thus we need to download additional binaries for the tests. This might make the test to run longer."
 fi
 
-# Generate SSH key pair
-if [ ! -f "$HOME/.ssh/id_rsa_kubeone_e2e" ]; then
- echo "Generating SSH key pair"
- ssh-keygen -f $HOME/.ssh/id_rsa_kubeone_e2e -N ''
- SSH_PUBLIC_KEY_FILE="$HOME/.ssh/id_rsa_kubeone_e2e.pub"
- export TF_VAR_ssh_public_key_file=$SSH_PUBLIC_KEY_FILE
- SSH_PRIVATE_KEY_FILE="$HOME/.ssh/id_rsa_kubeone_e2e"
- export SSH_PUBLIC_KEY_FILE
- chmod 400 ${SSH_PRIVATE_KEY_FILE}
- eval `ssh-agent`
- ssh-add ${SSH_PRIVATE_KEY_FILE}
+SSH_PRIVATE_KEY_FILE="${HOME}/.ssh/id_rsa_kubeone_e2e"
+export SSH_PUBLIC_KEY_FILE="${SSH_PRIVATE_KEY_FILE}.pub"
+export TF_VAR_ssh_public_key_file=${SSH_PUBLIC_KEY_FILE}
+
+if [ ! -f "${SSH_PRIVATE_KEY_FILE}" ]; then
+  echo "Generating SSH key pair"
+  ssh-keygen -f ${SSH_PRIVATE_KEY_FILE} -N ''
+  chmod 400 ${SSH_PRIVATE_KEY_FILE}
+  eval $(ssh-agent)
+  ssh-add ${SSH_PRIVATE_KEY_FILE}
 fi
 
 # Build binaries
 echo "Building kubeone ..."
 make install
 
+function runE2E() {
+  local test_set=$1
+  local timeout=$2
+  set -x
+
+  go test \
+    -race \
+    -tags=e2e \
+    -v \
+    -timeout=${timeout} \
+    -run=${test_set} \
+    ./test/e2e/... \
+    -identifier=${BUILD_ID} \
+    -provider=${PROVIDER} \
+    -cluster-version=${TEST_CLUSTER_TARGET_VERSION}
+}
+
 # Start the tests
 echo "Running E2E tests ..."
-if [[ $TEST_SET == "conformance" ]]; then
-  go test -race -tags=e2e -v -timeout 60m -run TestClusterConformance ./test/e2e/... -identifier=$BUILD_ID -provider=$PROVIDER -cluster-version=$TEST_CLUSTER_TARGET_VERSION
-fi
-if [[ $TEST_SET == "upgrades" ]]; then
-  go test -race -tags=e2e -v -timeout 120m -run TestClusterUpgrade ./test/e2e/... -identifier=$BUILD_ID -provider=$PROVIDER -cluster-version=$TEST_CLUSTER_TARGET_VERSION
-fi
+case ${TEST_SET} in
+"conformance")
+  runE2E "TestClusterConformance" "60m"
+  ;;
+"upgrades")
+  runE2E "TestClusterUpgrade" "120m"
+  ;;
+*)
+  echo "unknown TEST_SET: ${TEST_SET}"
+  exit -1
+  ;;
+esac

--- a/test/e2e/kubeone.go
+++ b/test/e2e/kubeone.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"time"
 )
 
 // Kubeone structure
@@ -38,6 +39,8 @@ func NewKubeone(kubeoneDir, configurationFile string) Kubeone {
 
 // Install starts k8s cluster deployment
 func (p *Kubeone) Install(tfJSON string) error {
+	// deliberate delay, to give nodes time to start
+	time.Sleep(2 * time.Minute)
 
 	err := p.storeTFJson(tfJSON)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR correctly sets the Hetzner token when running E2E tests using the script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #165 

**Release note**:
```release-note
NONE
```

/assign @kron4eg 