### PR TITLE
Update the upgrades proposal status

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,4 @@
 * [Environment variables used by KubeOne](environment_variables.md)
 * [Adding support for provider](adding_provider_support.md)
 * [Proposals](./proposals)
-  * [Cluster Upgrades](./proposals/0002-upgrades.md)
+  * [Cluster Upgrades](./proposals/20190211-upgrades.md)

--- a/docs/proposals/20190211-upgrades.md
+++ b/docs/proposals/20190211-upgrades.md
@@ -1,7 +1,7 @@
 # kubeone upgrade
 
 **Author**: Artiom Diomin (@kron4eg)  
-**Status**: Draft proposal
+**Status**: Implemented in [v0.3.0](https://github.com/kubermatic/kubeone/releases/tag/v0.3.0)
 
 ## Motivation and Background
 The point of `kubeone` project since the beginning was to provide full cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the upgrades proposal status to implemented in v0.3.0.

This PR also proposes to change proposals' file names to `date-proposal-name.md` instead of using proposal numbers. This way we keep information about when the proposal was created, we have all proposals sorted, but we don't need to coordinate proposal numbers across multiple PRs and keep them up to date.

**Release note**:
```release-note
NONE
```
/assign @kron4eg 