### PR TITLE
Fix the 'on-prem' typo in README and Frequently Asked Questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://goreportcard.com/report/github.com/kubermatic/kubeone"><img src="https://goreportcard.com/badge/github.com/kubermatic/kubeone" alt="Go Report Card"></img></a>
 </p>
 
-`kubeone` is a CLI tool and a Go library for installing, managing, and upgrading Kubernetes High-Available (HA) clusters. It can be used on any cloud provider, on-perm or bare-metal cluster.
+`kubeone` is a CLI tool and a Go library for installing, managing, and upgrading Kubernetes High-Available (HA) clusters. It can be used on any cloud provider, on-prem or bare-metal cluster.
 
 ## Project Status
 

--- a/docs/frequently_asked_questions.md
+++ b/docs/frequently_asked_questions.md
@@ -4,7 +4,7 @@ This document lists some commonly asked questions about KubeOne, what it does, a
 
 - [What is KubeOne?](#what-is-kubeone-)
 - [What cloud providers KubeOne does support?](#what-cloud-providers-kubeone-does-support-)
-- [Are on-perm and bare metal clusters supported?](#are-on-perm-and-bare-metal-clusters-supported-)
+- [Are on-prem and bare metal clusters supported?](#are-on-prem-and-bare-metal-clusters-supported-)
 - [Does KubeOne handles the infrastructure and cloud resources?](#does-kubeone-handles-the-infrastructure-and-cloud-resources-)
 - [How KubeOne works?](#how-kubeone-works-)
 - [How are commands executed on nodes?](#how-are-commands-executed-on-nodes-)
@@ -21,11 +21,11 @@ KubeOne is a CLI and a Go library for installing, maintaining and upgrading Kube
 
 ## What cloud providers KubeOne does support?
 
-KubeOne is supposed to work on any cloud provider, on-perm and bare-metal cluster, as long as there is no need for additional configuration. However, to utilize all features of KubeOne, such as Terraform integration and creating worker nodes, KubeOne and [Kubermatic machine-controller](https://github.com/kubermatic/machine-controller) need to support that provider.
+KubeOne is supposed to work on any cloud provider, on-prem and bare-metal cluster, as long as there is no need for additional configuration. However, to utilize all features of KubeOne, such as Terraform integration and creating worker nodes, KubeOne and [Kubermatic machine-controller](https://github.com/kubermatic/machine-controller) need to support that provider.
 
 Currently we support AWS, DigitalOcean, Google Compute Engine (GCE), Hetzner, and OpenStack.
 
-## Are on-perm and bare metal clusters supported?
+## Are on-prem and bare metal clusters supported?
 
 Yes. We support OpenStack, with support for vSphere coming soon.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the `on-prem` typo in README and the Frequently Asked Questions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #347 

**Release note**:
```release-note
NONE
```

/assign @kron4eg 