### PR TITLE
rename metrics_server.disable to metrics_server.enable

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -68,7 +68,8 @@ features:
   # Opt-out from deploying metrics-server
   # more info: https://github.com/kubernetes-incubator/metrics-server
   metrics_server:
-    disable: false
+    # enabled by default
+    enable: true
 
   # Enable OpenID-Connect support in API server
   # More info: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -348,17 +348,17 @@ type Features struct {
 
 // PodSecurityPolicy feature flag
 type PodSecurityPolicy struct {
-	Enable bool `json:"enable"`
+	Enable *bool `json:"enable,omitempty"`
 }
 
 // DynamicAuditLog feature flag
 type DynamicAuditLog struct {
-	Enable bool `json:"enable"`
+	Enable *bool `json:"enable,omitempty"`
 }
 
 // MetricsServer feature flag
 type MetricsServer struct {
-	Disable bool `json:"disable"`
+	Enable *bool `json:"enable,omitempty"`
 }
 
 // OpenIDConnect feature flag
@@ -382,6 +382,10 @@ type OpenIDConnectConfig struct {
 
 // Validate features config
 func (f *Features) Validate() error {
+	if f.MetricsServer.Enable == nil {
+		f.MetricsServer.Enable = boolPtr(true)
+	}
+
 	// Currently only validate OIDC config
 	if !f.OpenIDConnect.Enable {
 		return nil

--- a/pkg/features/activate.go
+++ b/pkg/features/activate.go
@@ -31,7 +31,7 @@ func Activate(ctx *util.Context) error {
 		return errors.Wrap(err, "failed to install PodSecurityPolicy")
 	}
 
-	if err := installMetricsServer(!ctx.Cluster.Features.MetricsServer.Disable, ctx); err != nil {
+	if err := installMetricsServer(ctx.Cluster.Features.MetricsServer.Enable, ctx); err != nil {
 		return errors.Wrap(err, "failed to install metrics-server")
 	}
 

--- a/pkg/features/dynamic_audit_log.go
+++ b/pkg/features/dynamic_audit_log.go
@@ -28,7 +28,7 @@ const (
 )
 
 func activateKubeadmDynamicAuditLogs(feature config.DynamicAuditLog, clusterConfig *kubeadmv1beta1.ClusterConfiguration) {
-	if !feature.Enable {
+	if feature.Enable == nil || !*feature.Enable {
 		return
 	}
 

--- a/pkg/features/metrics-server.go
+++ b/pkg/features/metrics-server.go
@@ -21,8 +21,8 @@ import (
 	"github.com/kubermatic/kubeone/pkg/util"
 )
 
-func installMetricsServer(activate bool, ctx *util.Context) error {
-	if !activate {
+func installMetricsServer(activate *bool, ctx *util.Context) error {
+	if activate != nil && !*activate {
 		return nil
 	}
 

--- a/pkg/features/psp.go
+++ b/pkg/features/psp.go
@@ -56,7 +56,7 @@ var (
 )
 
 func activateKubeadmPSP(feature config.PodSecurityPolicy, clusterConfig *kubeadmv1beta1.ClusterConfiguration) {
-	if !feature.Enable {
+	if feature.Enable == nil || !*feature.Enable {
 		return
 	}
 
@@ -71,8 +71,8 @@ func activateKubeadmPSP(feature config.PodSecurityPolicy, clusterConfig *kubeadm
 	}
 }
 
-func installKubeSystemPSP(activate bool, ctx *util.Context) error {
-	if !activate {
+func installKubeSystemPSP(activate *bool, ctx *util.Context) error {
+	if activate == nil || !*activate {
 		return nil
 	}
 


### PR DESCRIPTION
metrics_server.enable is enabled by default

```release-note
BREAKING: rename metrics_server.disable config to metrics_server.enable
```