### PR TITLE
Parse all supported digitalocean params

### DIFF
--- a/examples/terraform/digitalocean/output.tf
+++ b/examples/terraform/digitalocean/output.tf
@@ -41,10 +41,19 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     fra1-1 = {
       replicas        = 3
-      operatingSystem = "ubuntu"
-      droplet_size    = "${var.droplet_size}"
-      region          = "${var.region}"
       sshPublicKeys   = ["${digitalocean_ssh_key.deployer.public_key}"]
+      operatingSystem = "ubuntu"
+
+      operatingSystemSpec = {
+        distUpgradeOnBoot = false
+      }
+
+      region             = "${var.region}"
+      size               = "${var.droplet_size}"
+      private_networking = true
+      backups            = false
+      ipv6               = false
+      monitoring         = false
     }
   }
 }

--- a/test/e2e/testdata/config_aws_1.13.5.yaml
+++ b/test/e2e/testdata/config_aws_1.13.5.yaml
@@ -15,5 +15,3 @@ versions:
   kubernetes: '1.13.5'
 provider:
   name: 'aws'
-features:
-  enable_pod_security_policy: false

--- a/test/e2e/testdata/config_aws_1.14.1.yaml
+++ b/test/e2e/testdata/config_aws_1.14.1.yaml
@@ -15,5 +15,3 @@ versions:
   kubernetes: '1.14.1'
 provider:
   name: 'aws'
-features:
-  enable_pod_security_policy: false

--- a/test/e2e/testdata/config_do_1.13.5.yaml
+++ b/test/e2e/testdata/config_do_1.13.5.yaml
@@ -15,17 +15,3 @@ versions:
   kubernetes: '1.13.5'
 provider:
   name: 'digitalocean'
-features:
-  enable_pod_security_policy: false
-workers:
-- name: fra1-1
-  replicas: 3
-  config:
-    cloudProviderSpec:
-      backups: false
-      ipv6: false
-      private_networking: true
-      monitoring: false
-    operatingSystem: 'ubuntu'
-    operatingSystemSpec:
-      distUpgradeOnBoot: true

--- a/test/e2e/testdata/config_do_1.13.5.yaml
+++ b/test/e2e/testdata/config_do_1.13.5.yaml
@@ -15,3 +15,4 @@ versions:
   kubernetes: '1.13.5'
 provider:
   name: 'digitalocean'
+  external: true

--- a/test/e2e/testdata/config_do_1.14.1.yaml
+++ b/test/e2e/testdata/config_do_1.14.1.yaml
@@ -15,17 +15,3 @@ versions:
   kubernetes: '1.14.1'
 provider:
   name: 'digitalocean'
-features:
-  enable_pod_security_policy: false
-workers:
-- name: fra1-1
-  replicas: 3
-  config:
-    cloudProviderSpec:
-      backups: false
-      ipv6: false
-      private_networking: true
-      monitoring: false
-    operatingSystem: 'ubuntu'
-    operatingSystemSpec:
-      distUpgradeOnBoot: true

--- a/test/e2e/testdata/config_do_1.14.1.yaml
+++ b/test/e2e/testdata/config_do_1.14.1.yaml
@@ -15,3 +15,4 @@ versions:
   kubernetes: '1.14.1'
 provider:
   name: 'digitalocean'
+  external: true

--- a/test/e2e/testdata/config_hetzner_1.13.5.yaml
+++ b/test/e2e/testdata/config_hetzner_1.13.5.yaml
@@ -15,3 +15,4 @@ versions:
   kubernetes: '1.13.5'
 provider:
   name: 'hetzner'
+  external: true

--- a/test/e2e/testdata/config_hetzner_1.13.5.yaml
+++ b/test/e2e/testdata/config_hetzner_1.13.5.yaml
@@ -15,5 +15,3 @@ versions:
   kubernetes: '1.13.5'
 provider:
   name: 'hetzner'
-features:
-  enable_pod_security_policy: false

--- a/test/e2e/testdata/config_hetzner_1.14.1.yaml
+++ b/test/e2e/testdata/config_hetzner_1.14.1.yaml
@@ -15,3 +15,4 @@ versions:
   kubernetes: '1.14.1'
 provider:
   name: 'hetzner'
+  external: true

--- a/test/e2e/testdata/config_hetzner_1.14.1.yaml
+++ b/test/e2e/testdata/config_hetzner_1.14.1.yaml
@@ -15,5 +15,3 @@ versions:
   kubernetes: '1.14.1'
 provider:
   name: 'hetzner'
-features:
-  enable_pod_security_policy: false


### PR DESCRIPTION
* cleanup testdata cluster configs
* remove what's already providede by terraform
* remove default options
* speed-up DO tests (by avoiding upgrade on boot)

```release-note
Digitalocean params are fully supported in terraform config
```

Fixes #176