### PR TITLE
Update machine-controller to v1.1.4 and Cluster-API to c63bf6f

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -560,7 +560,7 @@
   version = "v1.13.1"
 
 [[projects]]
-  digest = "1:501f147af95df7681eeeabd516fec151ea6094beb4334ef790aa9d6396c439ab"
+  digest = "1:500ca96976d373a2242dab5c4597a2858458b6d26d8c3d3db8414525e6fc505f"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "pkg/apis/cluster/common",
@@ -568,7 +568,7 @@
     "pkg/client/clientset_generated/clientset/scheme",
   ]
   pruneopts = "NUT"
-  revision = "813b1fec840d79b37fe86778237b6db6d1cb959d"
+  revision = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
 
 [[projects]]
   digest = "1:d58a6193316103ee408ce0891398cf66b7977df81d2c40b75a3b1c92925fa76f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@ required = [
 
 [[constraint]]
   name = "sigs.k8s.io/cluster-api"
-  revision = "813b1fec840d79b37fe86778237b6db6d1cb959d"
+  revision = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
 
 [[constraint]]
   name = "sigs.k8s.io/controller-runtime"

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -43,7 +43,7 @@ const (
 	MachineControllerNamespace             = metav1.NamespaceSystem
 	MachineControllerAppLabelKey           = "app"
 	MachineControllerAppLabelValue         = "machine-controller"
-	MachineControllerTag                   = "v1.1.2"
+	MachineControllerTag                   = "v1.1.4"
 	MachineControllerCredentialsSecretName = "machine-controller-credentials"
 )
 

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/common/consts.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/common/consts.go
@@ -51,6 +51,13 @@ const (
 	// Example: timeout trying to connect to GCE.
 	CreateMachineError MachineStatusError = "CreateError"
 
+	// There was an error while trying to update a Node that this
+	// Machine represents. This may indicate a transient problem that will be
+	// fixed automatically with time, such as a service outage,
+	//
+	// Example: error updating load balancers
+	UpdateMachineError MachineStatusError = "UpdateError"
+
 	// An error was encountered while trying to delete the Node that this
 	// Machine represents. This could be a transient or terminal error, but
 	// will only be observable if the provider's Machine controller has

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -38,6 +38,8 @@ const (
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Machine status such as Terminating/Pending/Running/Failed etc"
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -57,9 +59,12 @@ type MachineSpec struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Taints is the full, authoritative list of taints to apply to the corresponding
-	// Node. This list will overwrite any modifications made to the Node on
-	// an ongoing basis.
+	// The list of the taints to be applied to the corresponding Node in additive
+	// manner. This list will not overwrite any other taints added to the Node on
+	// an ongoing basis by other entities. These taints should be actively reconciled
+	// e.g. if you ask the machine controller to apply a taint and then manually remove
+	// the taint the machine controller will put it back) but not have the machine controller
+	// remove any taints
 	// +optional
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
@@ -87,12 +92,12 @@ type MachineSpec struct {
 	// ProviderID is the identification ID of the machine provided by the provider.
 	// This field must match the provider ID as seen on the node object corresponding to this machine.
 	// This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
-	// with cluster-api as provider. Clean-up login in the autoscaler compares machines v/s nodes to find out
+	// with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
 	// machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
 	// generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
-	// able to have a provider view of the list of machines. Another list of nodes is queries from the k8s apiserver
-	// and then comparison is done to find out unregistered machines and are marked for delete.
-	// This field will be set by the actuators and consumed by higher level entities like autoscaler  who will
+	// able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+	// and then a comparison is done to find out unregistered machines and are marked for delete.
+	// This field will be set by the actuators and consumed by higher level entities like autoscaler that will
 	// be interfacing with cluster-api as generic provider.
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -58,6 +58,11 @@ type MachineSetSpec struct {
 	// +optional
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
 
+	// DeletePolicy defines the policy used to identify nodes to delete when downscaling.
+	// Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+	// +kubebuilder:validation:Enum=Random,Newest,Oldest
+	DeletePolicy string `json:"deletePolicy,omitempty"`
+
 	// Selector is a label query over machines that should match the replica count.
 	// Label keys and values that must match in order to be controlled by this MachineSet.
 	// It must match the machine template's labels.
@@ -69,6 +74,30 @@ type MachineSetSpec struct {
 	// +optional
 	Template MachineTemplateSpec `json:"template,omitempty"`
 }
+
+// MachineSetDeletePolicy defines how priority is assigned to nodes to delete when
+// downscaling a MachineSet. Defaults to "Random".
+type MachineSetDeletePolicy string
+
+const (
+	// RandomMachineSetDeletePolicy prioritizes both Machines that have the annotation
+	// "cluster.k8s.io/delete-machine=yes" and Machines that are unhealthy
+	// (Status.ErrorReason or Status.ErrorMessage are set to a non-empty value).
+	// Finally, it picks Machines at random to delete.
+	RandomMachineSetDeletePolicy MachineSetDeletePolicy = "Random"
+
+	// NewestMachineSetDeletePolicy prioritizes both Machines that have the annotation
+	// "cluster.k8s.io/delete-machine=yes" and Machines that are unhealthy
+	// (Status.ErrorReason or Status.ErrorMessage are set to a non-empty value).
+	// It then prioritizes the newest Machines for deletion based on the Machine's CreationTimestamp.
+	NewestMachineSetDeletePolicy MachineSetDeletePolicy = "Newest"
+
+	// OldestMachineSetDeletePolicy prioritizes both Machines that have the annotation
+	// "cluster.k8s.io/delete-machine=yes" and Machines that are unhealthy
+	// (Status.ErrorReason or Status.ErrorMessage are set to a non-empty value).
+	// It then prioritizes the oldest Machines for deletion based on the Machine's CreationTimestamp.
+	OldestMachineSetDeletePolicy MachineSetDeletePolicy = "Oldest"
+)
 
 /// [MachineSetSpec] // doxygen marker
 
@@ -169,6 +198,12 @@ func (m *MachineSet) Default() {
 
 	if len(m.Namespace) == 0 {
 		m.Namespace = metav1.NamespaceDefault
+	}
+
+	if m.Spec.DeletePolicy == "" {
+		randomPolicy := string(RandomMachineSetDeletePolicy)
+		log.Printf("Defaulting to %s\n", randomPolicy)
+		m.Spec.DeletePolicy = randomPolicy
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the `machine-controller` to [v1.1.4](https://github.com/kubermatic/machine-controller/releases/tag/v1.1.4) and Cluster-API to [`c63bf6f`](https://github.com/kubernetes-sigs/cluster-api/commit/c63bf6f67ab631a449b6eb76dfe29458441051e0).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #368 

**Release note**:
```release-note
Update the machine-controller to v1.1.4
```

/assign @kron4eg 
/cc @kron4eg 