### PR TITLE
Update machine-controller to v1.1.5

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -43,7 +43,7 @@ const (
 	MachineControllerNamespace             = metav1.NamespaceSystem
 	MachineControllerAppLabelKey           = "app"
 	MachineControllerAppLabelValue         = "machine-controller"
-	MachineControllerTag                   = "v1.1.4"
+	MachineControllerTag                   = "v1.1.5"
 	MachineControllerCredentialsSecretName = "machine-controller-credentials"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `machine-controller` dependency to v1.1.5, which fixes a failing drain bug and adds support for Packet (see #376). There is no need to update the Cluster-API dependency as it has not been changed between v1.1.4 and v1.1.5.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #377 

**Release note**:
```release-note
Update the machine-controller dependency to v1.1.5
```

/cc @kron4eg 
/assign @kron4eg 