### PR TITLE
Add methods for parsing KubeOneCluster configuration and credentials

### DIFF
--- a/pkg/util/config/cluster.go
+++ b/pkg/util/config/cluster.go
@@ -27,7 +27,6 @@ import (
 	kubeonescheme "github.com/kubermatic/kubeone/pkg/apis/kubeone/scheme"
 	kubeonev1alpha1 "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
 	"github.com/kubermatic/kubeone/pkg/apis/kubeone/validation"
-	"github.com/kubermatic/kubeone/pkg/terraform"
 	"github.com/kubermatic/kubeone/pkg/util/credentials"
 )
 
@@ -56,29 +55,29 @@ func SetKubeOneClusterCredentials(cfg *kubeoneapi.KubeOneCluster) error {
 }
 
 // SourceKubeOneClusterFromTerraformOutput sources information about the cluster from the Terraform output
-func SourceKubeOneClusterFromTerraformOutput(terraformOutput []byte, cluster *kubeonev1alpha1.KubeOneCluster) error {
-	var (
-		tfConfig *terraform.Config
-		err      error
-	)
+// func SourceKubeOneClusterFromTerraformOutput(terraformOutput []byte, cluster *kubeonev1alpha1.KubeOneCluster) error {
+// 	var (
+// 		tfConfig *terraform.Config
+// 		err      error
+// 	)
 
-	if tfConfig, err = terraform.NewConfigFromJSON(terraformOutput); err != nil {
-		return errors.Wrap(err, "failed to parse Terraform config")
-	}
+// 	if tfConfig, err = terraform.NewConfigFromJSON(terraformOutput); err != nil {
+// 		return errors.Wrap(err, "failed to parse Terraform config")
+// 	}
 
-	return tfConfig.Apply(cluster)
-}
+// 	return tfConfig.Apply(cluster)
+// }
 
 // DefaultedKubeOneCluster takes a versioned KubeOneCluster object and optionally a Terraform output, and converts versioned object to the
 // internal API type, defaults and validates the object.
 func DefaultedKubeOneCluster(versionedCluster *kubeonev1alpha1.KubeOneCluster, tfOutput []byte) (*kubeoneapi.KubeOneCluster, error) {
 	internalCfg := &kubeoneapi.KubeOneCluster{}
 
-	if tfOutput != nil {
-		if err := SourceKubeOneClusterFromTerraformOutput(tfOutput, versionedCluster); err != nil {
-			return nil, errors.Wrap(err, "unable to source information about cluster from a given terraform output")
-		}
-	}
+	// if tfOutput != nil {
+	// 	if err := SourceKubeOneClusterFromTerraformOutput(tfOutput, versionedCluster); err != nil {
+	// 		return nil, errors.Wrap(err, "unable to source information about cluster from a given terraform output")
+	// 	}
+	// }
 
 	// Default and convert to the internal API type
 	kubeonescheme.Scheme.Default(versionedCluster)

--- a/pkg/util/config/cluster.go
+++ b/pkg/util/config/cluster.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
+	kubeonescheme "github.com/kubermatic/kubeone/pkg/apis/kubeone/scheme"
+	kubeonev1alpha1 "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
+	"github.com/kubermatic/kubeone/pkg/apis/kubeone/validation"
+	"github.com/kubermatic/kubeone/pkg/terraform"
+	"github.com/kubermatic/kubeone/pkg/util/credentials"
+)
+
+// SetKubeOneClusterDynamicDefaults sets the dynamic defaults for a given KubeOneCluster object
+func SetKubeOneClusterDynamicDefaults(cfg *kubeoneapi.KubeOneCluster) error {
+	if err := SetKubeOneClusterCredentials(cfg); err != nil {
+		return errors.Wrap(err, "unable to set dynamic defaults for a given KubeOneCluster object")
+	}
+	return nil
+}
+
+// SetKubeOneClusterCredentials populates credentials used for machine-controller and external CCM
+func SetKubeOneClusterCredentials(cfg *kubeoneapi.KubeOneCluster) error {
+	// Only populate credentials if machine-controller is deployed or cloud provider is external
+	if (cfg.MachineController != nil && !cfg.MachineController.Deploy) && !cfg.CloudProvider.External {
+		return nil
+	}
+
+	creds, err := credentials.ProviderCredentials(cfg.CloudProvider.Name)
+	if err != nil {
+		return errors.Wrap(err, "unable to fetch cloud provider credentials")
+	}
+	cfg.Credentials = creds
+
+	return nil
+}
+
+// SourceKubeOneClusterFromTerraformOutput sources information about the cluster from the Terraform output
+func SourceKubeOneClusterFromTerraformOutput(terraformOutput []byte, cluster *kubeonev1alpha1.KubeOneCluster) error {
+	var (
+		tfConfig *terraform.Config
+		err      error
+	)
+
+	if tfConfig, err = terraform.NewConfigFromJSON(terraformOutput); err != nil {
+		return errors.Wrap(err, "failed to parse Terraform config")
+	}
+
+	return tfConfig.Apply(cluster)
+}
+
+// DefaultedKubeOneCluster takes a versioned KubeOneCluster object and optionally a Terraform output, and converts versioned object to the
+// internal API type, defaults and validates the object.
+func DefaultedKubeOneCluster(versionedCluster *kubeonev1alpha1.KubeOneCluster, tfOutput []byte) (*kubeoneapi.KubeOneCluster, error) {
+	internalCfg := &kubeoneapi.KubeOneCluster{}
+
+	if tfOutput != nil {
+		if err := SourceKubeOneClusterFromTerraformOutput(tfOutput, versionedCluster); err != nil {
+			return nil, errors.Wrap(err, "unable to source information about cluster from a given terraform output")
+		}
+	}
+
+	// Default and convert to the internal API type
+	kubeonescheme.Scheme.Default(versionedCluster)
+	kubeonescheme.Scheme.Convert(versionedCluster, internalCfg, nil)
+
+	// Apply the dynamic defaults
+	if err := SetKubeOneClusterDynamicDefaults(internalCfg); err != nil {
+		return nil, err
+	}
+
+	// Validate the configuration
+	if err := validation.ValidateKubeOneCluster(*internalCfg).ToAggregate(); err != nil {
+		return nil, errors.Wrap(err, "unable to validate the given KubeOneCluster object")
+	}
+
+	return internalCfg, nil
+}
+
+// LoadKubeOneClusterFromFile parses the KubeOneCluster configuration file and returns a KubeOneCluster object
+func LoadKubeOneClusterFromFile(clusterCfgPath string) (*kubeoneapi.KubeOneCluster, error) {
+	if len(clusterCfgPath) == 0 {
+		return nil, errors.New("cluster configuration path not provided")
+	}
+
+	b, err := ioutil.ReadFile(clusterCfgPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read the given cluster configuration file")
+	}
+
+	return BytesToKubeOneCluster(b, nil)
+}
+
+// LoadKubeOneClusterFromTerraformOutput parses the KubeOneCluster configuration file and the Terraform output
+// and returns a KubeOneCluster object
+func LoadKubeOneClusterFromTerraformOutput(clusterCfgPath, tfOutputPath string) (*kubeoneapi.KubeOneCluster, error) {
+	if len(clusterCfgPath) == 0 {
+		return nil, errors.New("cluster configuration path not provided")
+	}
+	if len(tfOutputPath) == 0 {
+		return nil, errors.New("terraform output path not provided")
+	}
+
+	bCluster, err := ioutil.ReadFile(clusterCfgPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read the given cluster configuration file")
+	}
+	bTfOutput, err := ioutil.ReadFile(tfOutputPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read the given terraform output file")
+	}
+
+	return BytesToKubeOneCluster(bCluster, bTfOutput)
+}
+
+// BytesToKubeOneCluster parses the bytes slice of cluster configuration and optionally terraform output
+// and returns a KubeOneCluster object
+func BytesToKubeOneCluster(cluster, tf []byte) (*kubeoneapi.KubeOneCluster, error) {
+	initCfg := &kubeonev1alpha1.KubeOneCluster{}
+	if err := runtime.DecodeInto(kubeonescheme.Codecs.UniversalDecoder(), cluster, initCfg); err != nil {
+		return nil, err
+	}
+
+	return DefaultedKubeOneCluster(initCfg, tf)
+}

--- a/pkg/util/credentials/credentials.go
+++ b/pkg/util/credentials/credentials.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"encoding/base64"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/pkg/errors"
+
+	"github.com/kubermatic/kubeone/pkg/apis/kubeone"
+)
+
+// The environment variable names with credential in them that machine-controller expects to see
+const (
+	AWSAccessKeyID          = "AWS_ACCESS_KEY_ID"
+	AWSSecretAccessKey      = "AWS_SECRET_ACCESS_KEY"
+	DigitalOceanTokenKey    = "DO_TOKEN"
+	GoogleServiceAccountKey = "GOOGLE_SERVICE_ACCOUNT"
+	HetznerTokenKey         = "HZ_TOKEN"
+	OpenStackAuthURL        = "OS_AUTH_URL"
+	OpenStackDomainName     = "OS_DOMAIN_NAME"
+	OpenStackPassword       = "OS_PASSWORD"
+	OpenStackTenantName     = "OS_TENANT_NAME"
+	OpenStackUserName       = "OS_USER_NAME"
+	VSphereAddress          = "VSPHERE_ADDRESS"
+	VSpherePasswords        = "VSPHERE_PASSWORD"
+	VSphereUsername         = "VSPHERE_USERNAME"
+)
+
+// ProviderEnvironmentVariable is used to match environment variable used by KubeOne to environment variable used by
+// machine-controller.
+type ProviderEnvironmentVariable struct {
+	Name                  string
+	MachineControllerName string
+}
+
+// ProviderCredentials match the cloudprovider and parses its credentials from environment
+func ProviderCredentials(p kubeone.CloudProviderName) (map[string]string, error) {
+	switch p {
+	case kubeone.CloudProviderNameAWS:
+		creds := make(map[string]string)
+		envCredsProvider := credentials.NewEnvCredentials()
+		envCreds, err := envCredsProvider.Get()
+		if err != nil {
+			return nil, err
+		}
+		if envCreds.AccessKeyID != "" && envCreds.SecretAccessKey != "" {
+			creds["AWS_ACCESS_KEY_ID"] = envCreds.AccessKeyID
+			creds["AWS_SECRET_ACCESS_KEY"] = envCreds.SecretAccessKey
+			return creds, nil
+		}
+
+		// If env fails resort to config file
+		configCredsProvider := credentials.NewSharedCredentials("", "")
+		configCreds, err := configCredsProvider.Get()
+		if err != nil {
+			return nil, err
+		}
+		if configCreds.AccessKeyID != "" && configCreds.SecretAccessKey != "" {
+			creds["AWS_ACCESS_KEY_ID"] = configCreds.AccessKeyID
+			creds["AWS_SECRET_ACCESS_KEY"] = configCreds.SecretAccessKey
+			return creds, nil
+		}
+
+		return nil, errors.New("error parsing aws credentials")
+	case kubeone.CloudProviderNameOpenStack:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "OS_AUTH_URL"},
+			{Name: "OS_USERNAME", MachineControllerName: "OS_USER_NAME"},
+			{Name: "OS_PASSWORD"},
+			{Name: "OS_DOMAIN_NAME"},
+			{Name: "OS_TENANT_NAME"},
+		})
+	case kubeone.CloudProviderNameHetzner:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "HCLOUD_TOKEN", MachineControllerName: "HZ_TOKEN"},
+		})
+	case kubeone.CloudProviderNameDigitalOcean:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "DIGITALOCEAN_TOKEN", MachineControllerName: "DO_TOKEN"},
+		})
+	case kubeone.CloudProviderNameGCE:
+		gsa, err := parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "GOOGLE_CREDENTIALS", MachineControllerName: "GOOGLE_SERVICE_ACCOUNT"},
+		})
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		// encode it before sending to secret to be consumed by
+		// machine-controller, as machine-controller assumes it will be double encoded
+		gsa["GOOGLE_SERVICE_ACCOUNT"] = base64.StdEncoding.EncodeToString([]byte(gsa["GOOGLE_SERVICE_ACCOUNT"]))
+		return gsa, nil
+	case kubeone.CloudProviderNameVSphere:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "VSPHERE_ADDRESS"},
+			{Name: "VSPHERE_USERNAME"},
+			{Name: "VSPHERE_PASSWORD"},
+		})
+	}
+
+	return nil, errors.New("no provider matched")
+}
+
+func parseCredentialVariables(envVars []ProviderEnvironmentVariable) (map[string]string, error) {
+	creds := make(map[string]string)
+	for _, env := range envVars {
+		if len(env.MachineControllerName) == 0 {
+			env.MachineControllerName = env.Name
+		}
+		creds[env.MachineControllerName] = strings.TrimSpace(os.Getenv(env.Name))
+		if creds[env.MachineControllerName] == "" {
+			return nil, errors.Errorf("environment variable %s is not set, but is required", env.Name)
+		}
+	}
+	return creds, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add methods for parsing KubeOneCluster configuration
* Re-add method for parsing credentials

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #259 

**Special notes for your reviewer**:

The methods for parsing the configuration file could be improved and additional checks could be added (e.g. is version supported, strict verify, etc). This is going to be added in a follow-up.

**Release note**:
```release-note
NONE
```

/assign @kron4eg 
/cc @kron4eg 