### PR TITLE
Migrate to the KubeOneCluster API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/installer/util"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -23,30 +23,28 @@ versions:
   kubernetes: "1.14.1"
 
 clusterNetwork:
-  # the subnet used for pods (flannel);
-  # leave it empty for default: 10.244.0.0/16
+  # the subnet used for pods (default: 10.244.0.0/16)
   podSubnet: ""
-  # the subnet used for services;
-  # leave it empty for default: 10.96.0.0/12
+  # the subnet used for services (default: 10.96.0.0/12)
   serviceSubnet: ""
-  # a nodePort range to reserve for services;
-  # leave it empty for default: 30000-32767
+  # the domain name used for services (default: cluster.local)
+  serviceDomainName: ""
+  # a nodePort range to reserve for services (default: 30000-32767)
   nodePortRange: ""
 
-provider:
+cloudProvider:
   # Supported cloud provider names:
   # * aws
   # * digitalocean
   # * hetzner
-  # * none
   # * openstack
   # * vsphere
+  # * none
   name: ""
-  # Set kubelet flag --cloud-provider=external, to be used with external
-  # Cloud Controller Managers (CCM).
+  # Set the kubelet flag '--cloud-provider=external' and deploy the external CCM for supported providers
   external: false
-  # Path to file that will be uploaded and used as custom --cloud-config file.
-  cloud_config: ""
+  # Path to file that will be uploaded and used as custom '--cloud-config' file.
+  cloudConfig: ""
 
 features:
   # Enables PodSecurityPolicy admission plugin in API server, as well as creates
@@ -122,17 +120,19 @@ features:
 #   sshAgentSocket: 'env:SSH_AUTH_SOCK'
 
 # The API server can also be overwritten by Terraform. Provide the
-# external address of your load balancer or the public address of
-# your first node.
+# external address of your load balancer or the public addresses of
+# your control plane nodes.
 # apiEndpoints:
-#   - host: '1.2.3.4'
-#     port: 6443
+# - host: '1.2.3.4'
+#   port: 6443
 
 # If the cluster runs on bare metal or an unsupported cloud provider,
 # you can disable the machine-controller deployment entirely. In this
 # case, anything you configure in your "workers" sections is ignored.
-#machineController:
+# machineController:
 #  deploy: false
+#  # Defines for what provider the machine-controller will be configured (defaults to cloudProvider.Name)
+#  provider: ""
 
 # Proxy is used to configure HTTP_PROXY, HTTPS_PROXY and NO_PROXY
 # for Docker daemon and kubelet, and to be used when provisioning cluster
@@ -145,55 +145,55 @@ features:
 # KubeOne can automatically create MachineDeployments to create
 # worker nodes in your cluster. Each element in this "workers"
 # list is a single deployment and must have a unique name.
-#workers:
-#- name: fra1-a
-#  replicas: 1
-#  config:
-#    labels:
-#      mylabel: 'fra1-a'
-#    # SSH keys can be inferred from Terraform if this list is empty
-#    # and your tf output contains a "ssh_public_keys" field.
-#    # sshPublicKeys:
-#    # - 'ssh-rsa ......'
-#    # cloudProviderSpec corresponds `provider.name` config
-#    cloudProviderSpec:
-#      ### the following params could be inferred by kubeone from terraform
-#      ### output JSON:
-#      # ami: 'ami-0332a5c40cf835528',
-#      # availabilityZone: 'eu-central-1a',
-#      # instanceProfile: 'mycool-profile',
-#      # region: 'eu-central-1',
-#      # securityGroupIDs: ['sg-01f34ffd8447e70c0']
-#      # subnetId: 'subnet-2bff4f43',
-#      # vpcId: 'vpc-819f62e9'
-#      ### end of terraform inferred kubeone params
-#      instanceType: 't3.medium'
-#      diskSize: 50
-#      diskType: 'gp2'
-#    operatingSystem: 'ubuntu'
-#    operatingSystemSpec:
-#      distUpgradeOnBoot: true
-#- name: fra1-b
-#  replicas: 1
-#  config:
-#    labels:
-#      mylabel: 'fra1-b'
-#    cloudProviderSpec:
-#      instanceType: 't3.medium'
-#      diskSize: 50
-#      diskType: 'gp2'
-#    operatingSystem: 'ubuntu'
-#    operatingSystemSpec:
-#      distUpgradeOnBoot: true
-#- name: fra1-c
-#  replicas: 1
-#  config:
-#    labels:
-#      mylabel: 'fra1-c'
-#    cloudProviderSpec:
-#      instanceType: 't3.medium'
-#      diskSize: 50
-#      diskType: 'gp2'
-#    operatingSystem: 'ubuntu'
-#    operatingSystemSpec:
-#      distUpgradeOnBoot: true
+# workers:
+# - name: fra1-a
+#   replicas: 1
+#   providerSpec:
+#     labels:
+#       mylabel: 'fra1-a'
+#     # SSH keys can be inferred from Terraform if this list is empty
+#     # and your tf output contains a "ssh_public_keys" field.
+#     # sshPublicKeys:
+#     # - 'ssh-rsa ......'
+#     # cloudProviderSpec corresponds `provider.name` config
+#     cloudProviderSpec:
+#       ### the following params could be inferred by kubeone from terraform
+#       ### output JSON:
+#       # ami: 'ami-0332a5c40cf835528',
+#       # availabilityZone: 'eu-central-1a',
+#       # instanceProfile: 'mycool-profile',
+#       # region: 'eu-central-1',
+#       # securityGroupIDs: ['sg-01f34ffd8447e70c0']
+#       # subnetId: 'subnet-2bff4f43',
+#       # vpcId: 'vpc-819f62e9'
+#       ### end of terraform inferred kubeone params
+#       instanceType: 't3.medium'
+#       diskSize: 50
+#       diskType: 'gp2'
+#     operatingSystem: 'ubuntu'
+#     operatingSystemSpec:
+#       distUpgradeOnBoot: true
+# - name: fra1-b
+#   replicas: 1
+#   providerSpec:
+#     labels:
+#       mylabel: 'fra1-b'
+#     cloudProviderSpec:
+#       instanceType: 't3.medium'
+#       diskSize: 50
+#       diskType: 'gp2'
+#     operatingSystem: 'ubuntu'
+#     operatingSystemSpec:
+#       distUpgradeOnBoot: true
+# - name: fra1-c
+#   replicas: 1
+#   providerSpec:
+#     labels:
+#       mylabel: 'fra1-c'
+#     cloudProviderSpec:
+#       instanceType: 't3.medium'
+#       diskSize: 50
+#       diskType: 'gp2'
+#     operatingSystem: 'ubuntu'
+#     operatingSystemSpec:
+#       distUpgradeOnBoot: true

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -15,24 +15,23 @@
 # This file contains the configuration for installing a single Kubernetes
 # clusters using KubeOne. You can augment some options by providing
 # Terraform output at runtime, like explained in the documentation.
-
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 name: my-demo-cluster
 
 versions:
   kubernetes: "1.14.1"
 
-network:
+clusterNetwork:
   # the subnet used for pods (flannel);
   # leave it empty for default: 10.244.0.0/16
-  pod_subnet: ""
-
+  podSubnet: ""
   # the subnet used for services;
   # leave it empty for default: 10.96.0.0/12
-  service_subnet: ""
-
+  serviceSubnet: ""
   # a nodePort range to reserve for services;
   # leave it empty for default: 30000-32767
-  node_port_range: ""
+  nodePortRange: ""
 
 provider:
   # Supported cloud provider names:
@@ -43,11 +42,9 @@ provider:
   # * openstack
   # * vsphere
   name: ""
-
   # Set kubelet flag --cloud-provider=external, to be used with external
   # Cloud Controller Managers (CCM).
   external: false
-
   # Path to file that will be uploaded and used as custom --cloud-config file.
   cloud_config: ""
 
@@ -55,107 +52,95 @@ features:
   # Enables PodSecurityPolicy admission plugin in API server, as well as creates
   # default `privileged` PodSecurityPolicy, plus RBAC rules to authorize
   # `kube-system` namespace pods to `use` it.
-  pod_security_policy:
+  podSecurityPolicy:
     enable: false
-
   # Enables dynamic audit logs.
   # After enablig this, operator should create auditregistration.k8s.io/v1alpha1
   # AuditSink object.
   # More info: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#dynamic-backend
-  dynamic_audit_log:
+  dynamicAuditLog:
     enable: false
-
   # Opt-out from deploying metrics-server
   # more info: https://github.com/kubernetes-incubator/metrics-server
-  metrics_server:
+  metricsServer:
     # enabled by default
     enable: true
-
   # Enable OpenID-Connect support in API server
   # More info: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
-  openid_connect:
+  openidConnect:
     enable: false
-
     config:
       # The URL of the OpenID issuer, only HTTPS scheme will be accepted. If
       # set, it will be used to verify the OIDC JSON Web Token (JWT).
-      issuer_url: ""
-
+      issuerUrl: ""
       # The client ID for the OpenID Connect client, must be set if
       # issuer_url is set.
-      client_id: "kubernetes"
-
+      clientId: "kubernetes"
       # The OpenID claim to use as the user name. Note that claims other than
       # the default ('sub') is not guaranteed to be unique and immutable. This
       # flag is experimental in kubernetes, please see the kubernetes
       # authentication documentation for further details.
-      username_claim: "sub"
-
+      usernameClaim: "sub"
       # If provided, all usernames will be prefixed with this value. If not
       # provided, username claims other than 'email' are prefixed by the issuer
       # URL to avoid clashes. To skip any prefixing, provide the value '-'.
-      username_prefix: "oidc:"
-
+      usernamePrefix: "oidc:"
       # If provided, the name of a custom OpenID Connect claim for specifying
       # user groups. The claim value is expected to be a string or array of
       # strings. This flag is experimental in kubernetes, please see the
       # kubernetes authentication documentation for further details.
-      groups_claim: "groups"
-
+      groupsClaim: "groups"
       # If provided, all groups will be prefixed with this value to prevent
       # conflicts with other authentication strategies.
-      groups_prefix: "oidc:"
-
+      groupsPrefix: "oidc:"
       # Comma-separated list of allowed JOSE asymmetric signing algorithms. JWTs
       # with a 'alg' header value not in this list will be rejected. Values are
       # defined by RFC 7518 https://tools.ietf.org/html/rfc7518#section-3.1.
-      signing_algs: "RS256"
-
+      signingAlgs: "RS256"
       # A key=value pair that describes a required claim in the ID Token. If
       # set, the claim is verified to be present in the ID Token with a matching
       # value. Only single pair is currently supported.
-      required_claim: ""
-
+      requiredClaim: ""
       # If set, the OpenID server's certificate will be verified by one of the
       # authorities in the oidc-ca-file, otherwise the host's root CA set will
       # be used.
-      ca_file: ""
+      caFile: ""
 
 # The list of nodes can be overwritten by providing Terraform output.
 # You are strongly encouraged to provide an odd number of nodes and
 # have at least three of them.
 # Remember to only specify your *master* nodes.
 # hosts:
-# - public_address: '1.2.3.4'
-#   private_address: '172.18.0.1'
-#   ssh_port: 22 # can be left out if using the default (22)
-#   ssh_username: ubuntu
-
-#   # Uou usually want to configure either a private key OR an
+# - publicAddress: '1.2.3.4'
+#   privateAddress: '172.18.0.1'
+#   sshPort: 22 # can be left out if using the default (22)
+#   sshUsername: ubuntu
+#   # You usually want to configure either a private key OR an
 #   # agent socket, but never both. The socket value can be
 #   # prefixed with "env:" to refer to an environment variable.
-#   ssh_private_key_file: '/home/me/.ssh/id_rsa'
-#   ssh_agent_socket: 'env:SSH_AUTH_SOCK'
+#   sshPrivateKeyFile: '/home/me/.ssh/id_rsa'
+#   sshAgentSocket: 'env:SSH_AUTH_SOCK'
 
 # The API server can also be overwritten by Terraform. Provide the
 # external address of your load balancer or the public address of
 # your first node.
-# apiserver:
-#   address: '1.2.3.4'
+# apiEndpoints:
+#   - host: '1.2.3.4'
+#     port: 6443
 
 # If the cluster runs on bare metal or an unsupported cloud provider,
 # you can disable the machine-controller deployment entirely. In this
 # case, anything you configure in your "workers" sections is ignored.
-#machine_controller:
+#machineController:
 #  deploy: false
 
 # Proxy is used to configure HTTP_PROXY, HTTPS_PROXY and NO_PROXY
 # for Docker daemon and kubelet, and to be used when provisioning cluster
 # (e.g. for curl, apt-get..).
 # proxy:
-#  http_proxy: 'http://1.2.3.4'
-#  https_proxy: 'https://1.2.3.4'
-#  no_proxy: '1.2.3.4'
+#  http: 'http://1.2.3.4'
+#  https: 'https://1.2.3.4'
+#  noProxy: '1.2.3.4'
 
 # KubeOne can automatically create MachineDeployments to create
 # worker nodes in your cluster. Each element in this "workers"

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -121,9 +121,9 @@ features:
 
 # The API server can also be overwritten by Terraform. Provide the
 # external address of your load balancer or the public addresses of
-# your control plane nodes.
-# apiEndpoints:
-# - host: '1.2.3.4'
+# the first control plane nodes.
+# apiEndpoint:
+#   host: '1.2.3.4'
 #   port: 6443
 
 # If the cluster runs on bare metal or an unsupported cloud provider,

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -33,7 +33,7 @@ type KubeOneCluster struct {
 	// Hosts describes the control plane nodes and how to access them
 	Hosts []HostConfig `json:"hosts,omitempty"`
 	// APIEndpoints are pairs of address and port used to communicate with the Kubernetes API
-	APIEndpoints []APIEndpoint `json:"apiEndpoint,omitempty"`
+	APIEndpoints []APIEndpoint `json:"apiEndpoints,omitempty"`
 	// CloudProvider configures the cloud provider specific features
 	CloudProvider CloudProviderSpec `json:"cloudProvider,omitempty"`
 	// Versions defines which Kubernetes version will be installed

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -32,8 +32,8 @@ type KubeOneCluster struct {
 	Name string
 	// Hosts describes the control plane nodes and how to access them
 	Hosts []HostConfig `json:"hosts,omitempty"`
-	// APIEndpoints are pairs of address and port used to communicate with the Kubernetes API
-	APIEndpoints []APIEndpoint `json:"apiEndpoints,omitempty"`
+	// APIEndpoint are pairs of address and port used to communicate with the Kubernetes API
+	APIEndpoint APIEndpoint `json:"apiEndpoint,omitempty"`
 	// CloudProvider configures the cloud provider specific features
 	CloudProvider CloudProviderSpec `json:"cloudProvider,omitempty"`
 	// Versions defines which Kubernetes version will be installed

--- a/pkg/apis/kubeone/v1alpha1/defaults.go
+++ b/pkg/apis/kubeone/v1alpha1/defaults.go
@@ -61,32 +61,16 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 
 func SetDefaults_APIEndpoints(obj *KubeOneCluster) {
 	// If no API endpoint is provided, assume the public address is an endpoint
-	if len(obj.APIEndpoints) == 0 {
+	if len(obj.APIEndpoint.Host) == 0 {
 		if len(obj.Hosts) == 0 {
 			// No hosts, so can't default to the first one
 			return
 		}
-		obj.APIEndpoints = []APIEndpoint{
-			{
-				Host: obj.Hosts[0].PublicAddress,
-				Port: 6443,
-			},
-		}
-	} else {
-		// There's APIEndpoint provided, default host and port
-		for i := range obj.APIEndpoints {
-			if len(obj.APIEndpoints[i].Host) == 0 {
-				if len(obj.Hosts) > 0 {
-					// Can only default to the first host if it exists
-					obj.APIEndpoints[i].Host = obj.Hosts[0].PublicAddress
-				}
-			}
-			if obj.APIEndpoints[i].Port == 0 {
-				obj.APIEndpoints[i].Port = 6443
-			}
-		}
+		obj.APIEndpoint.Host = obj.Hosts[0].PublicAddress
 	}
-
+	if obj.APIEndpoint.Port == 0 {
+		obj.APIEndpoint.Port = 6443
+	}
 }
 
 func SetDefaults_ClusterNetwork(obj *KubeOneCluster) {

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -33,7 +33,7 @@ type KubeOneCluster struct {
 	// Hosts describes the control plane nodes and how to access them
 	Hosts []HostConfig `json:"hosts,omitempty"`
 	// APIEndpoints are pairs of address and port used to communicate with the Kubernetes API
-	APIEndpoints []APIEndpoint `json:"apiEndpoint,omitempty"`
+	APIEndpoints []APIEndpoint `json:"apiEndpoints,omitempty"`
 	// CloudProvider configures the cloud provider specific features
 	CloudProvider CloudProviderSpec `json:"cloudProvider,omitempty"`
 	// Versions defines which Kubernetes version will be installed

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -32,8 +32,8 @@ type KubeOneCluster struct {
 	Name string
 	// Hosts describes the control plane nodes and how to access them
 	Hosts []HostConfig `json:"hosts,omitempty"`
-	// APIEndpoints are pairs of address and port used to communicate with the Kubernetes API
-	APIEndpoints []APIEndpoint `json:"apiEndpoints,omitempty"`
+	// APIEndpoint are pairs of address and port used to communicate with the Kubernetes API
+	APIEndpoint APIEndpoint `json:"apiEndpoint,omitempty"`
 	// CloudProvider configures the cloud provider specific features
 	CloudProvider CloudProviderSpec `json:"cloudProvider,omitempty"`
 	// Versions defines which Kubernetes version will be installed

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
@@ -358,7 +358,9 @@ func Convert_kubeone_HostConfig_To_v1alpha1_HostConfig(in *kubeone.HostConfig, o
 func autoConvert_v1alpha1_KubeOneCluster_To_kubeone_KubeOneCluster(in *KubeOneCluster, out *kubeone.KubeOneCluster, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Hosts = *(*[]kubeone.HostConfig)(unsafe.Pointer(&in.Hosts))
-	out.APIEndpoints = *(*[]kubeone.APIEndpoint)(unsafe.Pointer(&in.APIEndpoints))
+	if err := Convert_v1alpha1_APIEndpoint_To_kubeone_APIEndpoint(&in.APIEndpoint, &out.APIEndpoint, s); err != nil {
+		return err
+	}
 	if err := Convert_v1alpha1_CloudProviderSpec_To_kubeone_CloudProviderSpec(&in.CloudProvider, &out.CloudProvider, s); err != nil {
 		return err
 	}
@@ -388,7 +390,9 @@ func Convert_v1alpha1_KubeOneCluster_To_kubeone_KubeOneCluster(in *KubeOneCluste
 func autoConvert_kubeone_KubeOneCluster_To_v1alpha1_KubeOneCluster(in *kubeone.KubeOneCluster, out *KubeOneCluster, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Hosts = *(*[]HostConfig)(unsafe.Pointer(&in.Hosts))
-	out.APIEndpoints = *(*[]APIEndpoint)(unsafe.Pointer(&in.APIEndpoints))
+	if err := Convert_kubeone_APIEndpoint_To_v1alpha1_APIEndpoint(&in.APIEndpoint, &out.APIEndpoint, s); err != nil {
+		return err
+	}
 	if err := Convert_kubeone_CloudProviderSpec_To_v1alpha1_CloudProviderSpec(&in.CloudProvider, &out.CloudProvider, s); err != nil {
 		return err
 	}

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.deepcopy.go
@@ -151,11 +151,7 @@ func (in *KubeOneCluster) DeepCopyInto(out *KubeOneCluster) {
 		*out = make([]HostConfig, len(*in))
 		copy(*out, *in)
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make([]APIEndpoint, len(*in))
-		copy(*out, *in)
-	}
+	out.APIEndpoint = in.APIEndpoint
 	out.CloudProvider = in.CloudProvider
 	out.Versions = in.Versions
 	out.ClusterNetwork = in.ClusterNetwork

--- a/pkg/apis/kubeone/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/zz_generated.deepcopy.go
@@ -151,11 +151,7 @@ func (in *KubeOneCluster) DeepCopyInto(out *KubeOneCluster) {
 		*out = make([]HostConfig, len(*in))
 		copy(*out, *in)
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make([]APIEndpoint, len(*in))
-		copy(*out, *in)
-	}
+	out.APIEndpoint = in.APIEndpoint
 	out.CloudProvider = in.CloudProvider
 	out.Versions = in.Versions
 	out.ClusterNetwork = in.ClusterNetwork

--- a/pkg/certificate/ca.go
+++ b/pkg/certificate/ca.go
@@ -26,7 +26,7 @@ import (
 
 // DownloadCA grabs CA certs/keys from leader host
 func DownloadCA(ctx *util.Context) error {
-	return ctx.RunTaskOnLeader(func(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
+	return ctx.RunTaskOnLeader(func(ctx *util.Context, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {
 		_, _, err := ctx.Runner.Run(`
 mkdir -p ./{{ .WORK_DIR }}/pki/etcd
 sudo cp /etc/kubernetes/pki/ca.crt ./{{ .WORK_DIR }}/pki/

--- a/pkg/certificate/ca.go
+++ b/pkg/certificate/ca.go
@@ -19,14 +19,14 @@ package certificate
 import (
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
 
 // DownloadCA grabs CA certs/keys from leader host
 func DownloadCA(ctx *util.Context) error {
-	return ctx.RunTaskOnLeader(func(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
+	return ctx.RunTaskOnLeader(func(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
 		_, _, err := ctx.Runner.Run(`
 mkdir -p ./{{ .WORK_DIR }}/pki/etcd
 sudo cp /etc/kubernetes/pki/ca.crt ./{{ .WORK_DIR }}/pki/

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/installer"
 )
 
@@ -76,7 +76,7 @@ It's possible to source information about hosts from Terraform output, using the
 
 // runInstall provisions Kubernetes on the provided machines
 func runInstall(logger *logrus.Logger, installOptions *installOptions) error {
-	cluster, err := loadClusterConfig(installOptions.Manifest)
+	cluster, err := loadClusterConfig(installOptions.Manifest, installOptions.TerraformState)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}
@@ -86,22 +86,13 @@ func runInstall(logger *logrus.Logger, installOptions *installOptions) error {
 		return errors.Wrap(err, "failed to create installer options")
 	}
 
-	if err = applyTerraform(installOptions.TerraformState, cluster); err != nil {
-		return errors.Wrap(err, "failed to apply Terraform options")
-	}
-
-	if err = cluster.DefaultAndValidate(); err != nil {
-		return err
-	}
-
 	return installer.NewInstaller(cluster, logger).Install(options)
 }
 
-func createInstallerOptions(clusterFile string, cluster *config.Cluster, options *installOptions) (*installer.Options, error) {
+func createInstallerOptions(clusterFile string, cluster *kubeoneapi.KubeOneCluster, options *installOptions) (*installer.Options, error) {
 	if len(options.BackupFile) == 0 {
 		fullPath, _ := filepath.Abs(clusterFile)
 		clusterName := cluster.Name
-
 		options.BackupFile = filepath.Join(filepath.Dir(fullPath), fmt.Sprintf("%s.tar.gz", clusterName))
 	}
 

--- a/pkg/cmd/kubeconfig.go
+++ b/pkg/cmd/kubeconfig.go
@@ -70,18 +70,9 @@ func runKubeconfig(kubeconfigOptions *kubeconfigOptions) error {
 		return errors.New("no cluster config file given")
 	}
 
-	cluster, err := loadClusterConfig(kubeconfigOptions.Manifest)
+	cluster, err := loadClusterConfig(kubeconfigOptions.Manifest, kubeconfigOptions.TerraformState)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
-	}
-
-	// apply terraform
-	if err = applyTerraform(kubeconfigOptions.TerraformState, cluster); err != nil {
-		return err
-	}
-
-	if err = cluster.DefaultAndValidate(); err != nil {
-		return err
 	}
 
 	kubeconfig, err := util.DownloadKubeconfig(cluster)

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -73,17 +73,9 @@ func runReset(logger *logrus.Logger, resetOptions *resetOptions) error {
 		return errors.New("no cluster config file given")
 	}
 
-	cluster, err := loadClusterConfig(resetOptions.Manifest)
+	cluster, err := loadClusterConfig(resetOptions.Manifest, resetOptions.TerraformState)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
-	}
-
-	if err = applyTerraform(resetOptions.TerraformState, cluster); err != nil {
-		return err
-	}
-
-	if err = cluster.DefaultAndValidate(); err != nil {
-		return err
 	}
 
 	options := &installer.Options{

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -17,16 +17,12 @@ limitations under the License.
 package cmd
 
 import (
-	"io/ioutil"
-	"os"
-
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
-	"github.com/kubermatic/kubeone/pkg/config"
-	"github.com/kubermatic/kubeone/pkg/terraform"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
+	"github.com/kubermatic/kubeone/pkg/util/config"
 )
 
 const (
@@ -73,44 +69,11 @@ func initLogger(verbose bool) *logrus.Logger {
 	return logger
 }
 
-func loadClusterConfig(filename string) (*config.Cluster, error) {
-	content, err := ioutil.ReadFile(filename)
+func loadClusterConfig(filename, terraformOutputPath string) (*kubeoneapi.KubeOneCluster, error) {
+	a, err := config.LoadKubeOneCluster(filename, terraformOutputPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read file")
+		return nil, errors.Wrap(err, "unable to load a given KubeOneCluster object")
 	}
 
-	cluster := config.Cluster{}
-	if err := yaml.Unmarshal(content, &cluster); err != nil {
-		return nil, errors.Wrap(err, "failed to decode file as JSON")
-	}
-
-	return &cluster, nil
-}
-
-func applyTerraform(tf string, cluster *config.Cluster) error {
-	if tf == "" {
-		return nil
-	}
-
-	var (
-		tfJSON []byte
-		err    error
-	)
-
-	if tf == "-" {
-		if tfJSON, err = ioutil.ReadAll(os.Stdin); err != nil {
-			return errors.Wrap(err, "unable to load Terraform output from stdin")
-		}
-	} else {
-		if tfJSON, err = ioutil.ReadFile(tf); err != nil {
-			return errors.Wrap(err, "unable to load Terraform output from file")
-		}
-	}
-
-	var tfConfig *terraform.Config
-	if tfConfig, err = terraform.NewConfigFromJSON(tfJSON); err != nil {
-		return errors.Wrap(err, "failed to parse Terraform config")
-	}
-
-	return tfConfig.Apply(cluster)
+	return a, nil
 }

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -71,21 +71,12 @@ It's possible to source information about hosts from Terraform output, using the
 
 // runUpgrade upgrades Kubernetes on the provided machines
 func runUpgrade(logger *logrus.Logger, upgradeOptions *upgradeOptions) error {
-	cluster, err := loadClusterConfig(upgradeOptions.Manifest)
+	cluster, err := loadClusterConfig(upgradeOptions.Manifest, upgradeOptions.TerraformState)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}
 
 	options := createUpgradeOptions(upgradeOptions)
-
-	if err = applyTerraform(upgradeOptions.TerraformState, cluster); err != nil {
-		return errors.Wrap(err, "failed to parse terraform state")
-	}
-
-	if err = cluster.DefaultAndValidate(); err != nil {
-		return err
-	}
-
 	return upgrader.NewUpgrader(cluster, logger).Upgrade(options)
 }
 

--- a/pkg/features/activate.go
+++ b/pkg/features/activate.go
@@ -20,14 +20,14 @@ import (
 	"github.com/pkg/errors"
 
 	kubeadmv1beta1 "github.com/kubermatic/kubeone/pkg/apis/kubeadm/v1beta1"
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
 
 // Activate configured features.
 // Installing CRDs, creating policies and so on
 func Activate(ctx *util.Context) error {
-	if err := installKubeSystemPSP(ctx.Cluster.Features.PodSecurityPolicy.Enable, ctx); err != nil {
+	if err := installKubeSystemPSP(ctx.Cluster.Features.PodSecurityPolicy, ctx); err != nil {
 		return errors.Wrap(err, "failed to install PodSecurityPolicy")
 	}
 
@@ -40,7 +40,7 @@ func Activate(ctx *util.Context) error {
 
 // UpdateKubeadmClusterConfiguration update additional config options in the kubeadm's
 // v1beta1.ClusterConfiguration according to enabled features
-func UpdateKubeadmClusterConfiguration(featuresCfg config.Features, clusterConfig *kubeadmv1beta1.ClusterConfiguration) {
+func UpdateKubeadmClusterConfiguration(featuresCfg kubeoneapi.Features, clusterConfig *kubeadmv1beta1.ClusterConfiguration) {
 	activateKubeadmPSP(featuresCfg.PodSecurityPolicy, clusterConfig)
 	activateKubeadmDynamicAuditLogs(featuresCfg.DynamicAuditLog, clusterConfig)
 	activateKubeadmOIDC(featuresCfg.OpenIDConnect, clusterConfig)

--- a/pkg/features/dynamic_audit_log.go
+++ b/pkg/features/dynamic_audit_log.go
@@ -18,7 +18,7 @@ package features
 
 import (
 	kubeadmv1beta1 "github.com/kubermatic/kubeone/pkg/apis/kubeadm/v1beta1"
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 )
 
 const (
@@ -27,8 +27,8 @@ const (
 	auditRegistrationAPI          = "auditregistration.k8s.io/v1alpha1=true"
 )
 
-func activateKubeadmDynamicAuditLogs(feature config.DynamicAuditLog, clusterConfig *kubeadmv1beta1.ClusterConfiguration) {
-	if feature.Enable == nil || !*feature.Enable {
+func activateKubeadmDynamicAuditLogs(feature *kubeoneapi.DynamicAuditLog, clusterConfig *kubeadmv1beta1.ClusterConfiguration) {
+	if feature == nil || !feature.Enable {
 		return
 	}
 

--- a/pkg/features/metrics-server.go
+++ b/pkg/features/metrics-server.go
@@ -21,8 +21,8 @@ import (
 	"github.com/kubermatic/kubeone/pkg/util"
 )
 
-func installMetricsServer(activate *bool, ctx *util.Context) error {
-	if activate != nil && !*activate {
+func installMetricsServer(activate bool, ctx *util.Context) error {
+	if !activate {
 		return nil
 	}
 

--- a/pkg/features/oidc.go
+++ b/pkg/features/oidc.go
@@ -18,11 +18,11 @@ package features
 
 import (
 	kubeadmv1beta1 "github.com/kubermatic/kubeone/pkg/apis/kubeadm/v1beta1"
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 )
 
-func activateKubeadmOIDC(feature config.OpenIDConnect, cfg *kubeadmv1beta1.ClusterConfiguration) {
-	if !feature.Enable {
+func activateKubeadmOIDC(feature *kubeoneapi.OpenIDConnect, cfg *kubeadmv1beta1.ClusterConfiguration) {
+	if feature == nil || !feature.Enable {
 		return
 	}
 

--- a/pkg/features/psp.go
+++ b/pkg/features/psp.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	kubeadmv1beta1 "github.com/kubermatic/kubeone/pkg/apis/kubeadm/v1beta1"
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -55,8 +55,8 @@ var (
 	}
 )
 
-func activateKubeadmPSP(feature config.PodSecurityPolicy, clusterConfig *kubeadmv1beta1.ClusterConfiguration) {
-	if feature.Enable == nil || !*feature.Enable {
+func activateKubeadmPSP(feature *kubeoneapi.PodSecurityPolicy, clusterConfig *kubeadmv1beta1.ClusterConfiguration) {
+	if feature == nil || !feature.Enable {
 		return
 	}
 
@@ -71,8 +71,8 @@ func activateKubeadmPSP(feature config.PodSecurityPolicy, clusterConfig *kubeadm
 	}
 }
 
-func installKubeSystemPSP(activate *bool, ctx *util.Context) error {
-	if activate == nil || !*activate {
+func installKubeSystemPSP(psp *kubeoneapi.PodSecurityPolicy, ctx *util.Context) error {
+	if psp == nil || !psp.Enable {
 		return nil
 	}
 

--- a/pkg/installer/installation/certs.go
+++ b/pkg/installer/installation/certs.go
@@ -27,7 +27,7 @@ func deployCA(ctx *util.Context) error {
 	return ctx.RunTaskOnFollowers(deployCAOnNode, true)
 }
 
-func deployCAOnNode(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
+func deployCAOnNode(ctx *util.Context, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Uploading files…")
 	return ctx.Configuration.UploadTo(conn, ctx.WorkDir)
 }

--- a/pkg/installer/installation/certs.go
+++ b/pkg/installer/installation/certs.go
@@ -17,7 +17,7 @@ limitations under the License.
 package installation
 
 import (
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
@@ -27,7 +27,7 @@ func deployCA(ctx *util.Context) error {
 	return ctx.RunTaskOnFollowers(deployCAOnNode, true)
 }
 
-func deployCAOnNode(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+func deployCAOnNode(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Uploading files…")
 	return ctx.Configuration.UploadTo(conn, ctx.WorkDir)
 }

--- a/pkg/installer/installation/controlplane.go
+++ b/pkg/installer/installation/controlplane.go
@@ -19,7 +19,7 @@ package installation
 import (
 	"strconv"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
@@ -29,7 +29,7 @@ func joinControlplaneNode(ctx *util.Context) error {
 	return ctx.RunTaskOnFollowers(joinControlPlaneNodeInternal, false)
 }
 
-func joinControlPlaneNodeInternal(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+func joinControlPlaneNodeInternal(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
 	_, _, err := ctx.Runner.Run(`
 if [[ -f /etc/kubernetes/kubelet.conf ]]; then exit 0; fi
 

--- a/pkg/installer/installation/controlplane.go
+++ b/pkg/installer/installation/controlplane.go
@@ -29,7 +29,7 @@ func joinControlplaneNode(ctx *util.Context) error {
 	return ctx.RunTaskOnFollowers(joinControlPlaneNodeInternal, false)
 }
 
-func joinControlPlaneNodeInternal(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
+func joinControlPlaneNodeInternal(ctx *util.Context, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	_, _, err := ctx.Runner.Run(`
 if [[ -f /etc/kubernetes/kubelet.conf ]]; then exit 0; fi
 

--- a/pkg/installer/installation/coredns.go
+++ b/pkg/installer/installation/coredns.go
@@ -30,7 +30,7 @@ import (
 )
 
 func patchCoreDNS(ctx *util.Context) error {
-	if !ctx.Cluster.Provider.External {
+	if !ctx.Cluster.CloudProvider.External {
 		return nil
 	}
 

--- a/pkg/installer/installation/kubeadm_config.go
+++ b/pkg/installer/installation/kubeadm_config.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/templates/kubeadm"
 	"github.com/kubermatic/kubeone/pkg/util"
@@ -42,6 +42,6 @@ func generateKubeadm(ctx *util.Context) error {
 	return ctx.RunTaskOnAllNodes(generateKubeadmOnNode, true)
 }
 
-func generateKubeadmOnNode(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
+func generateKubeadmOnNode(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
 	return errors.Wrap(ctx.Configuration.UploadTo(conn, ctx.WorkDir), "failed to upload")
 }

--- a/pkg/installer/installation/kubeadm_config.go
+++ b/pkg/installer/installation/kubeadm_config.go
@@ -42,6 +42,6 @@ func generateKubeadm(ctx *util.Context) error {
 	return ctx.RunTaskOnAllNodes(generateKubeadmOnNode, true)
 }
 
-func generateKubeadmOnNode(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
+func generateKubeadmOnNode(ctx *util.Context, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	return errors.Wrap(ctx.Configuration.UploadTo(conn, ctx.WorkDir), "failed to upload")
 }

--- a/pkg/installer/installation/kubeadm_leader.go
+++ b/pkg/installer/installation/kubeadm_leader.go
@@ -19,7 +19,7 @@ package installation
 import (
 	"strconv"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
@@ -48,7 +48,7 @@ func kubeadmCertsOnFollower(ctx *util.Context) error {
 	return ctx.RunTaskOnFollowers(kubeadmCertsExecutor, true)
 }
 
-func kubeadmCertsExecutor(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+func kubeadmCertsExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
 
 	ctx.Logger.Infoln("Ensuring Certificates…")
 	_, _, err := ctx.Runner.Run(kubeadmCertCommand, util.TemplateVariables{
@@ -61,7 +61,7 @@ func kubeadmCertsExecutor(ctx *util.Context, node *config.HostConfig, conn ssh.C
 func initKubernetesLeader(ctx *util.Context) error {
 	ctx.Logger.Infoln("Initializing Kubernetes on leader…")
 
-	return ctx.RunTaskOnLeader(func(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+	return ctx.RunTaskOnLeader(func(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Running kubeadm…")
 
 		_, _, err := ctx.Runner.Run(kubeadmInitCommand, util.TemplateVariables{

--- a/pkg/installer/installation/kubeadm_leader.go
+++ b/pkg/installer/installation/kubeadm_leader.go
@@ -48,7 +48,7 @@ func kubeadmCertsOnFollower(ctx *util.Context) error {
 	return ctx.RunTaskOnFollowers(kubeadmCertsExecutor, true)
 }
 
-func kubeadmCertsExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
+func kubeadmCertsExecutor(ctx *util.Context, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 
 	ctx.Logger.Infoln("Ensuring Certificates…")
 	_, _, err := ctx.Runner.Run(kubeadmCertCommand, util.TemplateVariables{
@@ -61,7 +61,7 @@ func kubeadmCertsExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn ss
 func initKubernetesLeader(ctx *util.Context) error {
 	ctx.Logger.Infoln("Initializing Kubernetes on leader…")
 
-	return ctx.RunTaskOnLeader(func(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
+	return ctx.RunTaskOnLeader(func(ctx *util.Context, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Running kubeadm…")
 
 		_, _, err := ctx.Runner.Run(kubeadmInitCommand, util.TemplateVariables{

--- a/pkg/installer/installation/kubeconfig.go
+++ b/pkg/installer/installation/kubeconfig.go
@@ -28,7 +28,7 @@ import (
 )
 
 func copyKubeconfig(ctx *util.Context) error {
-	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
+	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Copying Kubeconfig to home directory…")
 
 		_, _, err := ctx.Runner.Run(`

--- a/pkg/installer/installation/kubeconfig.go
+++ b/pkg/installer/installation/kubeconfig.go
@@ -22,13 +22,13 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
 
 func copyKubeconfig(ctx *util.Context) error {
-	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
+	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
 		ctx.Logger.Infoln("Copying Kubeconfig to home directory…")
 
 		_, _, err := ctx.Runner.Run(`

--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -82,6 +82,7 @@ func installPrerequisitesOnNode(ctx *util.Context, node kubeoneapi.HostConfig, c
 		return errors.Wrap(err, "failed to upload configuration files")
 	}
 
+	// TODO(xmudrii): Remove the hack
 	for idx := range ctx.Cluster.Hosts {
 		if ctx.Cluster.Hosts[idx].ID == node.ID {
 			ctx.Cluster.Hosts[idx] = node

--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -82,6 +82,13 @@ func installPrerequisitesOnNode(ctx *util.Context, node kubeoneapi.HostConfig, c
 		return errors.Wrap(err, "failed to upload configuration files")
 	}
 
+	for idx := range ctx.Cluster.Hosts {
+		if ctx.Cluster.Hosts[idx].ID == node.ID {
+			ctx.Cluster.Hosts[idx] = node
+			break
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
@@ -37,17 +37,17 @@ func installPrerequisites(ctx *util.Context) error {
 }
 
 func generateConfigurationFiles(ctx *util.Context) {
-	ctx.Configuration.AddFile("cfg/cloud-config", ctx.Cluster.Provider.CloudConfig)
+	ctx.Configuration.AddFile("cfg/cloud-config", ctx.Cluster.CloudProvider.CloudConfig)
 }
 
-func installPrerequisitesOnNode(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+func installPrerequisitesOnNode(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Determine operating system…")
 	os, err := determineOS(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to determine operating system")
 	}
 
-	node.OperatingSystem = os
+	node.SetOperatingSystem(os)
 
 	ctx.Logger.Infoln("Determine hostname…")
 	hostname, err := determineHostname(ctx, node)
@@ -61,7 +61,7 @@ func installPrerequisitesOnNode(ctx *util.Context, node *config.HostConfig, conn
 		return errors.Wrap(err, "failed to create environment file")
 	}
 
-	node.Hostname = hostname
+	node.SetHostname(hostname)
 
 	logger := ctx.Logger.WithField("os", os)
 
@@ -90,7 +90,7 @@ func determineOS(ctx *util.Context) (string, error) {
 	return osID, err
 }
 
-func determineHostname(ctx *util.Context, _ *config.HostConfig) (string, error) {
+func determineHostname(ctx *util.Context, _ kubeoneapi.HostConfig) (string, error) {
 	stdout, _, err := ctx.Runner.Run("hostname -f", nil)
 
 	return stdout, err
@@ -98,8 +98,8 @@ func determineHostname(ctx *util.Context, _ *config.HostConfig) (string, error) 
 
 func createEnvironmentFile(ctx *util.Context) error {
 	_, _, err := ctx.Runner.Run(environmentFileCommand, util.TemplateVariables{
-		"HTTP_PROXY":  ctx.Cluster.Proxy.HTTPProxy,
-		"HTTPS_PROXY": ctx.Cluster.Proxy.HTTPSProxy,
+		"HTTP_PROXY":  ctx.Cluster.Proxy.HTTP,
+		"HTTPS_PROXY": ctx.Cluster.Proxy.HTTPS,
 		"NO_PROXY":    ctx.Cluster.Proxy.NoProxy,
 	})
 
@@ -124,7 +124,7 @@ no_proxy="{{ .NO_PROXY }}"
 EOF
 `
 
-func installKubeadm(ctx *util.Context, node *config.HostConfig) error {
+func installKubeadm(ctx *util.Context, node kubeoneapi.HostConfig) error {
 	var err error
 
 	switch node.OperatingSystem {
@@ -307,7 +307,7 @@ sudo chmod 600 /etc/kubernetes/cloud-config
 }
 
 func configureDockerDaemonProxy(ctx *util.Context) error {
-	if ctx.Cluster.Proxy.HTTPProxy == "" && ctx.Cluster.Proxy.HTTPSProxy == "" && ctx.Cluster.Proxy.NoProxy == "" {
+	if ctx.Cluster.Proxy.HTTP == "" && ctx.Cluster.Proxy.HTTPS == "" && ctx.Cluster.Proxy.NoProxy == "" {
 		return nil
 	}
 

--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -40,7 +40,7 @@ func generateConfigurationFiles(ctx *util.Context) {
 	ctx.Configuration.AddFile("cfg/cloud-config", ctx.Cluster.CloudProvider.CloudConfig)
 }
 
-func installPrerequisitesOnNode(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
+func installPrerequisitesOnNode(ctx *util.Context, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Determine operating system…")
 	os, err := determineOS(ctx)
 	if err != nil {
@@ -50,7 +50,7 @@ func installPrerequisitesOnNode(ctx *util.Context, node kubeoneapi.HostConfig, c
 	node.SetOperatingSystem(os)
 
 	ctx.Logger.Infoln("Determine hostname…")
-	hostname, err := determineHostname(ctx, node)
+	hostname, err := determineHostname(ctx, *node)
 	if err != nil {
 		return errors.Wrap(err, "failed to determine hostname")
 	}
@@ -66,7 +66,7 @@ func installPrerequisitesOnNode(ctx *util.Context, node kubeoneapi.HostConfig, c
 	logger := ctx.Logger.WithField("os", os)
 
 	logger.Infoln("Installing kubeadm…")
-	err = installKubeadm(ctx, node)
+	err = installKubeadm(ctx, *node)
 	if err != nil {
 		return errors.Wrap(err, "failed to install kubeadm")
 	}
@@ -80,14 +80,6 @@ func installPrerequisitesOnNode(ctx *util.Context, node kubeoneapi.HostConfig, c
 	err = deployConfigurationFiles(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to upload configuration files")
-	}
-
-	// TODO(xmudrii): Remove the hack
-	for idx := range ctx.Cluster.Hosts {
-		if ctx.Cluster.Hosts[idx].ID == node.ID {
-			ctx.Cluster.Hosts[idx] = node
-			break
-		}
 	}
 
 	return nil

--- a/pkg/installer/installation/reset.go
+++ b/pkg/installer/installation/reset.go
@@ -36,7 +36,7 @@ func Reset(ctx *util.Context) error {
 	return ctx.RunTaskOnAllNodes(resetNode, true)
 }
 
-func destroyWorkers(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
+func destroyWorkers(ctx *util.Context, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Destroying worker nodes…")
 
 	_, _, err := ctx.Runner.Run(destroyScript, util.TemplateVariables{
@@ -47,7 +47,7 @@ func destroyWorkers(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connect
 	return err
 }
 
-func resetNode(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
+func resetNode(ctx *util.Context, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Resetting node…")
 
 	_, _, err := ctx.Runner.Run(resetScript, util.TemplateVariables{

--- a/pkg/installer/installation/reset.go
+++ b/pkg/installer/installation/reset.go
@@ -17,7 +17,7 @@ limitations under the License.
 package installation
 
 import (
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/templates/machinecontroller"
 	"github.com/kubermatic/kubeone/pkg/util"
@@ -36,7 +36,7 @@ func Reset(ctx *util.Context) error {
 	return ctx.RunTaskOnAllNodes(resetNode, true)
 }
 
-func destroyWorkers(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
+func destroyWorkers(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Destroying worker nodes…")
 
 	_, _, err := ctx.Runner.Run(destroyScript, util.TemplateVariables{
@@ -47,7 +47,7 @@ func destroyWorkers(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection
 	return err
 }
 
-func resetNode(ctx *util.Context, _ *config.HostConfig, conn ssh.Connection) error {
+func resetNode(ctx *util.Context, _ kubeoneapi.HostConfig, conn ssh.Connection) error {
 	ctx.Logger.Infoln("Resetting node…")
 
 	_, _, err := ctx.Runner.Run(resetScript, util.TemplateVariables{

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -19,7 +19,7 @@ package installer
 import (
 	"github.com/sirupsen/logrus"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/installer/installation"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
@@ -35,13 +35,13 @@ type Options struct {
 
 // Installer is entrypoint for installation process
 type Installer struct {
-	cluster *config.Cluster
+	cluster *kubeoneapi.KubeOneCluster
 	logger  *logrus.Logger
 }
 
 // NewInstaller returns a new installer, responsible for dispatching
 // between the different supported Kubernetes versions and running the
-func NewInstaller(cluster *config.Cluster, logger *logrus.Logger) *Installer {
+func NewInstaller(cluster *kubeoneapi.KubeOneCluster, logger *logrus.Logger) *Installer {
 	return &Installer{
 		cluster: cluster,
 		logger:  logger,

--- a/pkg/ssh/connector.go
+++ b/pkg/ssh/connector.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 )
 
 // Connector holds a map of Connections
@@ -37,7 +37,7 @@ func NewConnector() *Connector {
 }
 
 // Connect to the node
-func (c *Connector) Connect(node config.HostConfig) (Connection, error) {
+func (c *Connector) Connect(node kubeoneapi.HostConfig) (Connection, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	var err error

--- a/pkg/templates/canal/canal.go
+++ b/pkg/templates/canal/canal.go
@@ -89,7 +89,7 @@ func Deploy(ctx *util.Context) error {
 	}
 
 	variables := map[string]interface{}{
-		"POD_SUBNET": ctx.Cluster.Network.PodSubnet(),
+		"POD_SUBNET": ctx.Cluster.ClusterNetwork.PodSubnet,
 	}
 
 	buf := bytes.Buffer{}

--- a/pkg/templates/externalccm/ccm.go
+++ b/pkg/templates/externalccm/ccm.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -34,19 +34,19 @@ import (
 
 // Ensure external CCM deployen if Provider.External
 func Ensure(ctx *util.Context) error {
-	if !ctx.Cluster.Provider.External {
+	if !ctx.Cluster.CloudProvider.External {
 		return nil
 	}
 
 	ctx.Logger.Info("Ensure external CCM is up to date")
 
-	switch ctx.Cluster.Provider.Name {
-	case config.ProviderNameHetzner:
+	switch ctx.Cluster.CloudProvider.Name {
+	case kubeoneapi.CloudProviderNameHetzner:
 		return ensureHetzner(ctx)
-	case config.ProviderNameDigitalOcean:
+	case kubeoneapi.CloudProviderNameDigitalOcean:
 		return ensureDigitalOcean(ctx)
 	default:
-		ctx.Logger.Infof("External CCM for %q not yet supported, skipping", ctx.Cluster.Provider.Name)
+		ctx.Logger.Infof("External CCM for %q not yet supported, skipping", ctx.Cluster.CloudProvider.Name)
 		return nil
 	}
 }

--- a/pkg/templates/externalccm/digitalocean.go
+++ b/pkg/templates/externalccm/digitalocean.go
@@ -22,9 +22,9 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
 	"github.com/kubermatic/kubeone/pkg/templates/machinecontroller"
 	"github.com/kubermatic/kubeone/pkg/util"
+	"github.com/kubermatic/kubeone/pkg/util/credentials"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -242,7 +242,7 @@ func doDeployment() *appsv1.Deployment {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: machinecontroller.MachineControllerCredentialsSecretName,
 											},
-											Key: config.DigitalOceanTokenKey,
+											Key: credentials.DigitalOceanTokenKey,
 										},
 									},
 								},

--- a/pkg/templates/externalccm/hetzner.go
+++ b/pkg/templates/externalccm/hetzner.go
@@ -22,9 +22,9 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
 	"github.com/kubermatic/kubeone/pkg/templates/machinecontroller"
 	"github.com/kubermatic/kubeone/pkg/util"
+	"github.com/kubermatic/kubeone/pkg/util/credentials"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -190,7 +190,7 @@ func hetznerDeployment() *appsv1.Deployment {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: machinecontroller.MachineControllerCredentialsSecretName,
 											},
-											Key: config.HetznerTokenKey,
+											Key: credentials.HetznerTokenKey,
 										},
 									},
 								},

--- a/pkg/templates/kubeadm/kubeadm.go
+++ b/pkg/templates/kubeadm/kubeadm.go
@@ -19,14 +19,14 @@ package kubeadm
 import (
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/templates"
 	"github.com/kubermatic/kubeone/pkg/templates/kubeadm/v1beta1"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
 
 // Config returns appropriate version of kubeadm config as YAML
-func Config(ctx *util.Context, instance *config.HostConfig) (string, error) {
+func Config(ctx *util.Context, instance kubeoneapi.HostConfig) (string, error) {
 	cluster := ctx.Cluster
 	masterNodes := cluster.Hosts
 	if len(masterNodes) == 0 {

--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -53,8 +53,7 @@ func NewConfig(ctx *util.Context, host kubeoneapi.HostConfig) ([]runtime.Object,
 		return nil, err
 	}
 
-	// TODO(xmudrii): Support more than one API endpoint
-	controlPlaneEndpoint := fmt.Sprintf("%s:%d", cluster.APIEndpoints[0].Host, cluster.APIEndpoints[0].Port)
+	controlPlaneEndpoint := fmt.Sprintf("%s:%d", cluster.APIEndpoint.Host, cluster.APIEndpoint.Port)
 	hostAdvertiseAddress := host.PrivateAddress
 	if hostAdvertiseAddress == "" {
 		hostAdvertiseAddress = host.PublicAddress
@@ -110,8 +109,7 @@ func NewConfig(ctx *util.Context, host kubeoneapi.HostConfig) ([]runtime.Object,
 				},
 				ExtraVolumes: []kubeadmv1beta1.HostPathMount{},
 			},
-			// TODO(xmudrii): Support more than one API endpoint
-			CertSANs: []string{strings.ToLower(cluster.APIEndpoints[0].Host)},
+			CertSANs: []string{strings.ToLower(cluster.APIEndpoint.Host)},
 		},
 		ControllerManager: kubeadmv1beta1.ControlPlaneComponent{
 			ExtraArgs:    map[string]string{},

--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -98,6 +98,7 @@ func NewConfig(ctx *util.Context, host kubeoneapi.HostConfig) ([]runtime.Object,
 		Networking: kubeadmv1beta1.Networking{
 			PodSubnet:     cluster.ClusterNetwork.PodSubnet,
 			ServiceSubnet: cluster.ClusterNetwork.ServiceSubnet,
+			DNSDomain:     cluster.ClusterNetwork.ServiceDomainName,
 		},
 		KubernetesVersion:    cluster.Versions.Kubernetes,
 		ControlPlaneEndpoint: controlPlaneEndpoint,

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -57,7 +57,7 @@ func Ensure(ctx *util.Context) error {
 
 // WaitReady waits for machine-controller and its webhook to became ready
 func WaitReady(ctx *util.Context) error {
-	if !*ctx.Cluster.MachineController.Deploy {
+	if !ctx.Cluster.MachineController.Deploy {
 		return nil
 	}
 

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -37,7 +37,7 @@ func simpleCreateOrUpdate(ctx context.Context, client dynclient.Client, obj runt
 
 // Ensure install/update machine-controller
 func Ensure(ctx *util.Context) error {
-	if !*ctx.Cluster.MachineController.Deploy {
+	if !ctx.Cluster.MachineController.Deploy {
 		ctx.Logger.Info("Skipping machine-controller deployment because it was disabled in configuration.")
 		return nil
 	}

--- a/pkg/templates/machinecontroller/machines.go
+++ b/pkg/templates/machinecontroller/machines.go
@@ -147,7 +147,8 @@ func machineSpec(cluster *kubeoneapi.KubeOneCluster, workerset kubeoneapi.Worker
 		return nil, errors.New("could't find cloudProviderSpec")
 	}
 	spec := make(map[string]interface{})
-	if err := json.Unmarshal(specRaw, &spec); err != nil {
+	err = json.Unmarshal(specRaw, &spec)
+	if err != nil {
 		return nil, errors.Wrap(err, "unable to parse the workerset spec")
 	}
 
@@ -155,6 +156,7 @@ func machineSpec(cluster *kubeoneapi.KubeOneCluster, workerset kubeoneapi.Worker
 	if provider == kubeoneapi.CloudProviderNameAWS {
 		tagName := fmt.Sprintf("kubernetes.io/cluster/%s", cluster.Name)
 		tagValue := "shared"
+
 		spec, err = addMapTag(spec, tagName, tagValue)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not parse tags for worker machines")

--- a/pkg/templates/machinecontroller/machines.go
+++ b/pkg/templates/machinecontroller/machines.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,11 +35,11 @@ import (
 )
 
 type providerSpec struct {
-	SSHPublicKeys       []string            `json:"sshPublicKeys"`
-	CloudProvider       config.ProviderName `json:"cloudProvider"`
-	CloudProviderSpec   interface{}         `json:"cloudProviderSpec"`
-	OperatingSystem     string              `json:"operatingSystem"`
-	OperatingSystemSpec interface{}         `json:"operatingSystemSpec"`
+	SSHPublicKeys       []string                     `json:"sshPublicKeys"`
+	CloudProvider       kubeoneapi.CloudProviderName `json:"cloudProvider"`
+	CloudProviderSpec   interface{}                  `json:"cloudProviderSpec"`
+	OperatingSystem     string                       `json:"operatingSystem"`
+	OperatingSystemSpec interface{}                  `json:"operatingSystemSpec"`
 }
 
 // DeployMachineDeployments deploys MachineDeployments that create appropriate machines
@@ -66,8 +66,8 @@ func DeployMachineDeployments(ctx *util.Context) error {
 	return nil
 }
 
-func createMachineDeployment(cluster *config.Cluster, workerset config.WorkerConfig) (*clusterv1alpha1.MachineDeployment, error) {
-	provider := cluster.Provider.Name
+func createMachineDeployment(cluster *kubeoneapi.KubeOneCluster, workerset kubeoneapi.WorkerConfig) (*clusterv1alpha1.MachineDeployment, error) {
+	provider := cluster.CloudProvider.Name
 
 	cloudProviderSpec, err := machineSpec(cluster, workerset, provider)
 	if err != nil {
@@ -139,16 +139,20 @@ func createMachineDeployment(cluster *config.Cluster, workerset config.WorkerCon
 	}, nil
 }
 
-func machineSpec(cluster *config.Cluster, workerset config.WorkerConfig, provider config.ProviderName) (map[string]interface{}, error) {
+func machineSpec(cluster *kubeoneapi.KubeOneCluster, workerset kubeoneapi.WorkerConfig, provider kubeoneapi.CloudProviderName) (map[string]interface{}, error) {
 	var err error
 
-	spec := workerset.Config.CloudProviderSpec
-	if spec == nil {
+	specRaw := workerset.Config.CloudProviderSpec
+	if specRaw == nil {
 		return nil, errors.New("could't find cloudProviderSpec")
+	}
+	spec := make(map[string]interface{})
+	if err := json.Unmarshal(specRaw, &spec); err != nil {
+		return nil, errors.Wrap(err, "unable to parse the workerset spec")
 	}
 
 	// We only need this tag for AWS because it is used to coordinate nodes in ASG
-	if provider == config.ProviderNameAWS {
+	if provider == kubeoneapi.CloudProviderNameAWS {
 		tagName := fmt.Sprintf("kubernetes.io/cluster/%s", cluster.Name)
 		tagValue := "shared"
 		spec, err = addMapTag(spec, tagName, tagValue)

--- a/pkg/templates/machinecontroller/webhook.go
+++ b/pkg/templates/machinecontroller/webhook.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/certificate"
-	"github.com/kubermatic/kubeone/pkg/config"
 	"github.com/kubermatic/kubeone/pkg/util"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -129,7 +129,7 @@ func WaitForWebhook(client dynclient.Client) error {
 }
 
 // webhookDeployment returns the deployment for the machine-controllers MutatignAdmissionWebhook
-func webhookDeployment(cluster *config.Cluster) *appsv1.Deployment {
+func webhookDeployment(cluster *kubeoneapi.KubeOneCluster) *appsv1.Deployment {
 	dep := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeonev1alpha1 "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
 )
 
 type controlPlane struct {
@@ -34,33 +34,6 @@ type controlPlane struct {
 	SSHPort           string   `json:"ssh_port"`
 	SSHPrivateKeyFile string   `json:"ssh_private_key_file"`
 	SSHAgentSocket    string   `json:"ssh_agent_socket"`
-}
-
-// Validate checks if the control plane conforms to our spec.
-func (c *controlPlane) Validate() error {
-	if len(c.PublicAddress) < 3 {
-		return errors.New("must specify a unique cluster name")
-	}
-
-	if len(c.PublicAddress) != len(c.PrivateAddress) {
-		return errors.New("number of public addresses must be equal to number of private addresses")
-	}
-
-	if len(c.PublicAddress) < 3 {
-		return errors.New("must specify at least three public addresses")
-	}
-
-	for i := 0; i < len(c.PublicAddress); i++ {
-		if len(c.PublicAddress[i]) == 0 {
-			return errors.Errorf("public address for host %d is empty", i+1)
-		}
-
-		if len(c.PrivateAddress[i]) == 0 {
-			return errors.Errorf("private address for host %d is empty", i+1)
-		}
-	}
-
-	return nil
 }
 
 type awsWorkerConfig struct {
@@ -75,7 +48,6 @@ type awsWorkerConfig struct {
 	DiskSize         *int     `json:"diskSize"`
 }
 
-// TODO: Add option for sourcing bool values (private networking, monitoring...)
 type doWorkerConfig struct {
 	Region            string   `json:"region"`
 	Size              string   `json:"size"`
@@ -143,9 +115,14 @@ func NewConfigFromJSON(j []byte) (c *Config, err error) {
 
 // Apply adds the terraform configuration options to the given
 // cluster config.
-func (c *Config) Apply(cluster *config.Cluster) error {
+func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 	if c.KubeOneAPI.Value.Endpoint != "" {
-		cluster.APIServer.Address = c.KubeOneAPI.Value.Endpoint
+		// TODO(xmudrii): Support more than one API endpoint
+		cluster.APIEndpoints = []kubeonev1alpha1.APIEndpoint{
+			{
+				Host: c.KubeOneAPI.Value.Endpoint,
+			},
+		}
 	}
 
 	if len(c.KubeOneHosts.Value.ControlPlane) == 0 {
@@ -155,7 +132,7 @@ func (c *Config) Apply(cluster *config.Cluster) error {
 	cp := c.KubeOneHosts.Value.ControlPlane[0]
 
 	if cp.CloudProvider != nil {
-		cluster.Provider.Name = config.ProviderName(*cp.CloudProvider)
+		cluster.CloudProvider.Name = kubeonev1alpha1.CloudProviderName(*cp.CloudProvider)
 	}
 
 	var sshPort int
@@ -170,14 +147,14 @@ func (c *Config) Apply(cluster *config.Cluster) error {
 	cluster.Name = cp.ClusterName
 
 	// build up a list of master nodes
-	hosts := make([]*config.HostConfig, 0)
+	hosts := make([]kubeonev1alpha1.HostConfig, 0)
 	for i, publicIP := range cp.PublicAddress {
 		privateIP := publicIP
 		if i < len(cp.PrivateAddress) {
 			privateIP = cp.PrivateAddress[i]
 		}
 
-		hosts = append(hosts, &config.HostConfig{
+		hosts = append(hosts, kubeonev1alpha1.HostConfig{
 			ID:                i,
 			PublicAddress:     publicIP,
 			PrivateAddress:    privateIP,
@@ -200,7 +177,7 @@ func (c *Config) Apply(cluster *config.Cluster) error {
 			continue
 		}
 
-		var existingWorkerSet *config.WorkerConfig
+		var existingWorkerSet *kubeonev1alpha1.WorkerConfig
 		for idx, workerset := range cluster.Workers {
 			if workerset.Name == workersetName {
 				existingWorkerSet = &cluster.Workers[idx]
@@ -210,25 +187,25 @@ func (c *Config) Apply(cluster *config.Cluster) error {
 		if existingWorkerSet == nil {
 			// Append copies the object when its a literal and not a pointer, hence
 			// we have to first append, then create a pointer to the appended object
-			cluster.Workers = append(cluster.Workers, config.WorkerConfig{Name: workersetName})
+			cluster.Workers = append(cluster.Workers, kubeonev1alpha1.WorkerConfig{Name: workersetName})
 			existingWorkerSet = &cluster.Workers[len(cluster.Workers)-1]
 		}
 
-		switch cluster.Provider.Name {
-		case config.ProviderNameAWS:
+		switch cluster.CloudProvider.Name {
+		case kubeonev1alpha1.CloudProviderNameAWS:
 			err = c.updateAWSWorkerset(existingWorkerSet, workersetValue[0])
-		case config.ProviderNameGCE:
+		case kubeonev1alpha1.CloudProviderNameGCE:
 			err = c.updateGCEWorkerset(existingWorkerSet, workersetValue[0])
-		case config.ProviderNameDigitalOcean:
+		case kubeonev1alpha1.CloudProviderNameDigitalOcean:
 			err = c.updateDigitalOceanWorkerset(existingWorkerSet, workersetValue[0])
-		case config.ProviderNameHetzner:
+		case kubeonev1alpha1.CloudProviderNameHetzner:
 			err = c.updateHetznerWorkerset(existingWorkerSet, workersetValue[0])
-		case config.ProviderNameOpenStack:
+		case kubeonev1alpha1.CloudProviderNameOpenStack:
 			err = c.updateOpenStackWorkerset(existingWorkerSet, workersetValue[0])
-		case config.ProviderNameVSphere:
+		case kubeonev1alpha1.CloudProviderNameVSphere:
 			err = c.updateVSphereWorkerset(existingWorkerSet, workersetValue[0])
 		default:
-			return errors.Errorf("unknown provider %v", cluster.Provider.Name)
+			return errors.Errorf("unknown provider %v", cluster.CloudProvider.Name)
 		}
 
 		if err != nil {
@@ -244,7 +221,7 @@ func (c *Config) Apply(cluster *config.Cluster) error {
 	return nil
 }
 
-func (c *Config) updateAWSWorkerset(workerset *config.WorkerConfig, cfg json.RawMessage) error {
+func (c *Config) updateAWSWorkerset(workerset *kubeonev1alpha1.WorkerConfig, cfg json.RawMessage) error {
 	var awsCloudConfig awsWorkerConfig
 	if err := json.Unmarshal(cfg, &awsCloudConfig); err != nil {
 		return errors.WithStack(err)
@@ -286,7 +263,7 @@ func (c *Config) updateAWSWorkerset(workerset *config.WorkerConfig, cfg json.Raw
 	return nil
 }
 
-func (c *Config) updateGCEWorkerset(workerset *config.WorkerConfig, cfg json.RawMessage) error {
+func (c *Config) updateGCEWorkerset(workerset *kubeonev1alpha1.WorkerConfig, cfg json.RawMessage) error {
 	var gceCloudConfig gceWorkerConfig
 	if err := json.Unmarshal(cfg, &gceCloudConfig); err != nil {
 		return errors.WithStack(err)
@@ -310,7 +287,7 @@ func (c *Config) updateGCEWorkerset(workerset *config.WorkerConfig, cfg json.Raw
 	return nil
 }
 
-func (c *Config) updateDigitalOceanWorkerset(workerset *config.WorkerConfig, cfg json.RawMessage) error {
+func (c *Config) updateDigitalOceanWorkerset(workerset *kubeonev1alpha1.WorkerConfig, cfg json.RawMessage) error {
 	var doCloudConfig doWorkerConfig
 	if err := json.Unmarshal(cfg, &doCloudConfig); err != nil {
 		return errors.WithStack(err)
@@ -334,7 +311,7 @@ func (c *Config) updateDigitalOceanWorkerset(workerset *config.WorkerConfig, cfg
 	return nil
 }
 
-func (c *Config) updateHetznerWorkerset(workerset *config.WorkerConfig, cfg json.RawMessage) error {
+func (c *Config) updateHetznerWorkerset(workerset *kubeonev1alpha1.WorkerConfig, cfg json.RawMessage) error {
 	var hetznerConfig hetznerWorkerConfig
 	if err := json.Unmarshal(cfg, &hetznerConfig); err != nil {
 		return err
@@ -355,7 +332,7 @@ func (c *Config) updateHetznerWorkerset(workerset *config.WorkerConfig, cfg json
 	return nil
 }
 
-func (c *Config) updateOpenStackWorkerset(workerset *config.WorkerConfig, cfg json.RawMessage) error {
+func (c *Config) updateOpenStackWorkerset(workerset *kubeonev1alpha1.WorkerConfig, cfg json.RawMessage) error {
 	var openstackConfig openStackWorkerConfig
 	if err := json.Unmarshal(cfg, &openstackConfig); err != nil {
 		return err
@@ -380,11 +357,11 @@ func (c *Config) updateOpenStackWorkerset(workerset *config.WorkerConfig, cfg js
 	return nil
 }
 
-func (c *Config) updateVSphereWorkerset(_ *config.WorkerConfig, _ json.RawMessage) error {
+func (c *Config) updateVSphereWorkerset(_ *kubeonev1alpha1.WorkerConfig, _ json.RawMessage) error {
 	return errors.New("cloudprovider VSphere is not implemented yet")
 }
 
-func setWorkersetFlag(w *config.WorkerConfig, name string, value interface{}) error {
+func setWorkersetFlag(w *kubeonev1alpha1.WorkerConfig, name string, value interface{}) error {
 	// ignore empty values (i.e. not set in terraform output)
 	switch s := value.(type) {
 	case int:
@@ -410,11 +387,21 @@ func setWorkersetFlag(w *config.WorkerConfig, name string, value interface{}) er
 
 	// update CloudProviderSpec ONLY IF given terraform output is absent in
 	// original CloudProviderSpec
-	if w.Config.CloudProviderSpec == nil {
-		w.Config.CloudProviderSpec = map[string]interface{}{}
+	jsonSpec := make(map[string]interface{})
+	if w.Config.CloudProviderSpec != nil {
+		if err := json.Unmarshal(w.Config.CloudProviderSpec, &jsonSpec); err != nil {
+			return errors.Wrap(err, "unable to parse the provided cloud provider")
+		}
 	}
-	if _, exists := w.Config.CloudProviderSpec[name]; !exists {
-		w.Config.CloudProviderSpec[name] = value
+
+	if _, exists := jsonSpec[name]; !exists {
+		jsonSpec[name] = value
+	}
+
+	var err error
+	w.Config.CloudProviderSpec, err = json.Marshal(jsonSpec)
+	if err != nil {
+		return errors.Wrap(err, "unable to update the cloud provider spec")
 	}
 
 	return nil
@@ -431,7 +418,7 @@ type operatingSystemSpec struct {
 	DistUpgradeOnBoot *bool `json:"distUpgradeOnBoot"`
 }
 
-func (c *Config) updateCommonWorkerConfig(workerset *config.WorkerConfig, cfg json.RawMessage) error {
+func (c *Config) updateCommonWorkerConfig(workerset *kubeonev1alpha1.WorkerConfig, cfg json.RawMessage) error {
 	var cc commonWorkerConfig
 	if err := json.Unmarshal(cfg, &cc); err != nil {
 		return errors.Wrap(err, "failed to unmarshal common worker config")
@@ -461,7 +448,11 @@ func (c *Config) updateCommonWorkerConfig(workerset *config.WorkerConfig, cfg js
 	}
 
 	if len(osSpecMap) > 0 {
-		workerset.Config.OperatingSystemSpec = osSpecMap
+		var err error
+		workerset.Config.OperatingSystemSpec, err = json.Marshal(osSpecMap)
+		if err != nil {
+			return errors.Wrap(err, "unable to update the cloud provider spec")
+		}
 	}
 
 	return nil

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -117,11 +117,8 @@ func NewConfigFromJSON(j []byte) (c *Config, err error) {
 // cluster config.
 func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 	if c.KubeOneAPI.Value.Endpoint != "" {
-		// TODO(xmudrii): Support more than one API endpoint
-		cluster.APIEndpoints = []kubeonev1alpha1.APIEndpoint{
-			{
-				Host: c.KubeOneAPI.Value.Endpoint,
-			},
+		cluster.APIEndpoint = kubeonev1alpha1.APIEndpoint{
+			Host: c.KubeOneAPI.Value.Endpoint,
 		}
 	}
 

--- a/pkg/upgrader/upgrade/kubeadm_config.go
+++ b/pkg/upgrader/upgrade/kubeadm_config.go
@@ -19,13 +19,13 @@ package upgrade
 import (
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/templates/kubeadm"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
 
-func generateKubeadmConfig(ctx *util.Context, node *config.HostConfig) error {
+func generateKubeadmConfig(ctx *util.Context, node kubeoneapi.HostConfig) error {
 	kubeadmConf, err := kubeadm.Config(ctx, node)
 	if err != nil {
 		return errors.Wrap(err, "failed to create kubeadm configuration")

--- a/pkg/upgrader/upgrade/kubernetes_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_binaries.go
@@ -19,7 +19,7 @@ package upgrade
 import (
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
 
@@ -76,7 +76,7 @@ curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/bu
 `
 )
 
-func upgradeKubernetesBinaries(ctx *util.Context, node *config.HostConfig) error {
+func upgradeKubernetesBinaries(ctx *util.Context, node kubeoneapi.HostConfig) error {
 	var err error
 
 	switch node.OperatingSystem {

--- a/pkg/upgrader/upgrade/preflight_checks.go
+++ b/pkg/upgrader/upgrade/preflight_checks.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 
@@ -101,7 +101,7 @@ func runPreflightChecks(ctx *util.Context) error {
 
 // checkPrerequisites checks are Docker, Kubelet, and Kubeadm installed on every machine in the cluster
 func checkPrerequisites(ctx *util.Context) error {
-	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, _ *config.HostConfig, _ ssh.Connection) error {
+	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, _ kubeoneapi.HostConfig, _ ssh.Connection) error {
 		ctx.Logger.Infoln("Checking are all prerequisites installed…")
 		_, _, err := ctx.Runner.Run(checkPrerequisitesCommand, util.TemplateVariables{})
 		return err
@@ -159,7 +159,7 @@ func verifyLabels(nodes *corev1.NodeList, verbose bool) error {
 }
 
 // verifyEndpoints verifies are IP addresses defined in the KubeOne manifest same as IP addresses of nodes
-func verifyEndpoints(nodes *corev1.NodeList, hosts []*config.HostConfig, verbose bool) error {
+func verifyEndpoints(nodes *corev1.NodeList, hosts []kubeoneapi.HostConfig, verbose bool) error {
 	for _, node := range nodes.Items {
 		for _, addr := range node.Status.Addresses {
 			switch addr.Type {

--- a/pkg/upgrader/upgrade/preflight_checks.go
+++ b/pkg/upgrader/upgrade/preflight_checks.go
@@ -101,7 +101,7 @@ func runPreflightChecks(ctx *util.Context) error {
 
 // checkPrerequisites checks are Docker, Kubelet, and Kubeadm installed on every machine in the cluster
 func checkPrerequisites(ctx *util.Context) error {
-	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, _ kubeoneapi.HostConfig, _ ssh.Connection) error {
+	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, _ *kubeoneapi.HostConfig, _ ssh.Connection) error {
 		ctx.Logger.Infoln("Checking are all prerequisites installed…")
 		_, _, err := ctx.Runner.Run(checkPrerequisitesCommand, util.TemplateVariables{})
 		return err

--- a/pkg/upgrader/upgrade/upgrade_follower.go
+++ b/pkg/upgrader/upgrade/upgrade_follower.go
@@ -30,7 +30,7 @@ func upgradeFollower(ctx *util.Context) error {
 	return ctx.RunTaskOnFollowers(upgradeFollowerExecutor, false)
 }
 
-func upgradeFollowerExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
+func upgradeFollowerExecutor(ctx *util.Context, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	logger := ctx.Logger.WithField("node", node.PublicAddress)
 
 	logger.Infoln("Labeling follower control plane…")
@@ -40,7 +40,7 @@ func upgradeFollowerExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn
 	}
 
 	logger.Infoln("Upgrading Kubernetes binaries on follower control plane…")
-	err = upgradeKubernetesBinaries(ctx, node)
+	err = upgradeKubernetesBinaries(ctx, *node)
 	if err != nil {
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on follower control plane")
 	}

--- a/pkg/upgrader/upgrade/upgrade_follower.go
+++ b/pkg/upgrader/upgrade/upgrade_follower.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
@@ -30,7 +30,7 @@ func upgradeFollower(ctx *util.Context) error {
 	return ctx.RunTaskOnFollowers(upgradeFollowerExecutor, false)
 }
 
-func upgradeFollowerExecutor(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+func upgradeFollowerExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
 	logger := ctx.Logger.WithField("node", node.PublicAddress)
 
 	logger.Infoln("Labeling follower control plane…")

--- a/pkg/upgrader/upgrade/upgrade_leader.go
+++ b/pkg/upgrader/upgrade/upgrade_leader.go
@@ -30,7 +30,7 @@ func upgradeLeader(ctx *util.Context) error {
 	return ctx.RunTaskOnLeader(upgradeLeaderExecutor)
 }
 
-func upgradeLeaderExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
+func upgradeLeaderExecutor(ctx *util.Context, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	logger := ctx.Logger.WithField("node", node.PublicAddress)
 
 	logger.Infoln("Labeling leader control plane…")
@@ -39,7 +39,7 @@ func upgradeLeaderExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn s
 	}
 
 	logger.Infoln("Upgrading Kubernetes binaries on leader control plane…")
-	if err := upgradeKubernetesBinaries(ctx, node); err != nil {
+	if err := upgradeKubernetesBinaries(ctx, *node); err != nil {
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on leader control plane")
 	}
 
@@ -47,7 +47,7 @@ func upgradeLeaderExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn s
 	time.Sleep(timeoutKubeletUpgrade)
 
 	logger.Infoln("Generating kubeadm config …")
-	if err := generateKubeadmConfig(ctx, node); err != nil {
+	if err := generateKubeadmConfig(ctx, *node); err != nil {
 		return errors.Wrap(err, "failed to generate kubeadm config")
 	}
 

--- a/pkg/upgrader/upgrade/upgrade_leader.go
+++ b/pkg/upgrader/upgrade/upgrade_leader.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 )
@@ -30,7 +30,7 @@ func upgradeLeader(ctx *util.Context) error {
 	return ctx.RunTaskOnLeader(upgradeLeaderExecutor)
 }
 
-func upgradeLeaderExecutor(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+func upgradeLeaderExecutor(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
 	logger := ctx.Logger.WithField("node", node.PublicAddress)
 
 	logger.Infoln("Labeling leader control plane…")

--- a/pkg/upgrader/upgrade/util.go
+++ b/pkg/upgrader/upgrade/util.go
@@ -19,7 +19,7 @@ package upgrade
 import (
 	"context"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/util"
 	"github.com/pkg/errors"
@@ -34,31 +34,31 @@ import (
 
 func determineHostname(ctx *util.Context) error {
 	ctx.Logger.Infoln("Determine hostname…")
-	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
 		stdout, _, err := ctx.Runner.Run("hostname -f", nil)
 		if err != nil {
 			return err
 		}
 
-		node.Hostname = stdout
+		node.SetHostname(stdout)
 		return nil
 	}, true)
 }
 
 func determineOS(ctx *util.Context) error {
 	ctx.Logger.Infoln("Determine operating system…")
-	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, node *config.HostConfig, conn ssh.Connection) error {
+	return ctx.RunTaskOnAllNodes(func(ctx *util.Context, node kubeoneapi.HostConfig, conn ssh.Connection) error {
 		osID, _, err := ctx.Runner.Run("source /etc/os-release && echo -n $ID", nil)
 		if err != nil {
 			return err
 		}
 
-		node.OperatingSystem = osID
+		node.SetOperatingSystem(osID)
 		return nil
 	}, true)
 }
 
-func labelNode(client dynclient.Client, host *config.HostConfig) error {
+func labelNode(client dynclient.Client, host kubeoneapi.HostConfig) error {
 	retErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		node := corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{Name: host.Hostname},
@@ -77,7 +77,7 @@ func labelNode(client dynclient.Client, host *config.HostConfig) error {
 	return errors.Wrapf(retErr, "failed to label node %q with label %q", host.Hostname, labelUpgradeLock)
 }
 
-func unlabelNode(client dynclient.Client, host *config.HostConfig) error {
+func unlabelNode(client dynclient.Client, host kubeoneapi.HostConfig) error {
 	retErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		node := corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{Name: host.Hostname},

--- a/pkg/upgrader/upgrade/util.go
+++ b/pkg/upgrader/upgrade/util.go
@@ -41,6 +41,14 @@ func determineHostname(ctx *util.Context) error {
 		}
 
 		node.SetHostname(stdout)
+
+		// TODO(xmudrii): Remove the hack
+		for idx := range ctx.Cluster.Hosts {
+			if ctx.Cluster.Hosts[idx].ID == node.ID {
+				ctx.Cluster.Hosts[idx] = node
+			}
+		}
+
 		return nil
 	}, true)
 }
@@ -54,6 +62,14 @@ func determineOS(ctx *util.Context) error {
 		}
 
 		node.SetOperatingSystem(osID)
+
+		// TODO(xmudrii): Remove the hack
+		for idx := range ctx.Cluster.Hosts {
+			if ctx.Cluster.Hosts[idx].ID == node.ID {
+				ctx.Cluster.Hosts[idx] = node
+			}
+		}
+
 		return nil
 	}, true)
 }

--- a/pkg/upgrader/upgrader.go
+++ b/pkg/upgrader/upgrader.go
@@ -19,7 +19,7 @@ package upgrader
 import (
 	"github.com/sirupsen/logrus"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/upgrader/upgrade"
 	"github.com/kubermatic/kubeone/pkg/util"
@@ -34,12 +34,12 @@ type Options struct {
 
 // Upgrader is entrypoint for the upgrade process
 type Upgrader struct {
-	cluster *config.Cluster
+	cluster *kubeoneapi.KubeOneCluster
 	logger  *logrus.Logger
 }
 
 // NewUpgrader returns a new upgrader, responsible for running the upgrade process
-func NewUpgrader(cluster *config.Cluster, logger *logrus.Logger) *Upgrader {
+func NewUpgrader(cluster *kubeoneapi.KubeOneCluster, logger *logrus.Logger) *Upgrader {
 	return &Upgrader{
 		cluster: cluster,
 		logger:  logger,

--- a/pkg/util/config/cluster.go
+++ b/pkg/util/config/cluster.go
@@ -70,11 +70,11 @@ func SourceKubeOneClusterFromTerraformOutput(terraformOutput []byte, cluster *ku
 func DefaultedKubeOneCluster(versionedCluster *kubeonev1alpha1.KubeOneCluster, tfOutput []byte) (*kubeoneapi.KubeOneCluster, error) {
 	internalCfg := &kubeoneapi.KubeOneCluster{}
 
-	// if tfOutput != nil {
-	// 	if err := SourceKubeOneClusterFromTerraformOutput(tfOutput, versionedCluster); err != nil {
-	// 		return nil, errors.Wrap(err, "unable to source information about cluster from a given terraform output")
-	// 	}
-	// }
+	if tfOutput != nil {
+		if err := SourceKubeOneClusterFromTerraformOutput(tfOutput, versionedCluster); err != nil {
+			return nil, errors.Wrap(err, "unable to source information about cluster from a given terraform output")
+		}
+	}
 
 	// Default and convert to the internal API type
 	kubeonescheme.Scheme.Default(versionedCluster)

--- a/pkg/util/config/cluster.go
+++ b/pkg/util/config/cluster.go
@@ -61,7 +61,6 @@ func SourceKubeOneClusterFromTerraformOutput(terraformOutput []byte, cluster *ku
 	if err != nil {
 		return errors.Wrap(err, "failed to parse Terraform config")
 	}
-
 	return tfConfig.Apply(cluster)
 }
 
@@ -71,11 +70,11 @@ func SourceKubeOneClusterFromTerraformOutput(terraformOutput []byte, cluster *ku
 func DefaultedKubeOneCluster(versionedCluster *kubeonev1alpha1.KubeOneCluster, tfOutput []byte) (*kubeoneapi.KubeOneCluster, error) {
 	internalCfg := &kubeoneapi.KubeOneCluster{}
 
-	if tfOutput != nil {
-		if err := SourceKubeOneClusterFromTerraformOutput(tfOutput, versionedCluster); err != nil {
-			return nil, errors.Wrap(err, "unable to source information about cluster from a given terraform output")
-		}
-	}
+	// if tfOutput != nil {
+	// 	if err := SourceKubeOneClusterFromTerraformOutput(tfOutput, versionedCluster); err != nil {
+	// 		return nil, errors.Wrap(err, "unable to source information about cluster from a given terraform output")
+	// 	}
+	// }
 
 	// Default and convert to the internal API type
 	kubeonescheme.Scheme.Default(versionedCluster)

--- a/pkg/util/config/cluster.go
+++ b/pkg/util/config/cluster.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
+	kubeonescheme "github.com/kubermatic/kubeone/pkg/apis/kubeone/scheme"
+	kubeonev1alpha1 "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
+	"github.com/kubermatic/kubeone/pkg/apis/kubeone/validation"
+	"github.com/kubermatic/kubeone/pkg/terraform"
+	"github.com/kubermatic/kubeone/pkg/util/credentials"
+)
+
+// SetKubeOneClusterDynamicDefaults sets the dynamic defaults for a given KubeOneCluster object
+func SetKubeOneClusterDynamicDefaults(cfg *kubeoneapi.KubeOneCluster) error {
+	if err := SetKubeOneClusterCredentials(cfg); err != nil {
+		return errors.Wrap(err, "unable to set dynamic defaults for a given KubeOneCluster object")
+	}
+	return nil
+}
+
+// SetKubeOneClusterCredentials populates credentials used for machine-controller and external CCM
+func SetKubeOneClusterCredentials(cfg *kubeoneapi.KubeOneCluster) error {
+	// Only populate credentials if machine-controller is deployed or cloud provider is external
+	if (cfg.MachineController != nil && !cfg.MachineController.Deploy) && !cfg.CloudProvider.External {
+		return nil
+	}
+
+	creds, err := credentials.ProviderCredentials(cfg.CloudProvider.Name)
+	if err != nil {
+		return errors.Wrap(err, "unable to fetch cloud provider credentials")
+	}
+	cfg.Credentials = creds
+
+	return nil
+}
+
+// SourceKubeOneClusterFromTerraformOutput sources information about the cluster from the Terraform output
+func SourceKubeOneClusterFromTerraformOutput(terraformOutput []byte, cluster *kubeonev1alpha1.KubeOneCluster) error {
+	tfConfig, err := terraform.NewConfigFromJSON(terraformOutput)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse Terraform config")
+	}
+
+	return tfConfig.Apply(cluster)
+}
+
+// DefaultedKubeOneCluster converts a versioned KubeOneCluster object to an internal representation of KubeOneCluster
+// object while sourcing information from Terraform output, applying default values and validating the KubeOneCluster
+// object
+func DefaultedKubeOneCluster(versionedCluster *kubeonev1alpha1.KubeOneCluster, tfOutput []byte) (*kubeoneapi.KubeOneCluster, error) {
+	internalCfg := &kubeoneapi.KubeOneCluster{}
+
+	if tfOutput != nil {
+		if err := SourceKubeOneClusterFromTerraformOutput(tfOutput, versionedCluster); err != nil {
+			return nil, errors.Wrap(err, "unable to source information about cluster from a given terraform output")
+		}
+	}
+
+	// Default and convert to the internal API type
+	kubeonescheme.Scheme.Default(versionedCluster)
+	if err := kubeonescheme.Scheme.Convert(versionedCluster, internalCfg, nil); err != nil {
+		return nil, errors.Wrap(err, "unable to convert versioned to internal cluster object")
+	}
+
+	// Apply the dynamic defaults
+	if err := SetKubeOneClusterDynamicDefaults(internalCfg); err != nil {
+		return nil, err
+	}
+
+	// Validate the configuration
+	if err := validation.ValidateKubeOneCluster(*internalCfg).ToAggregate(); err != nil {
+		return nil, errors.Wrap(err, "unable to validate the given KubeOneCluster object")
+	}
+
+	return internalCfg, nil
+}
+
+// LoadKubeOneCluster returns the KubeOneCluster object parsed from the KubeOneCluster configuration file and
+// optionally Terraform output
+func LoadKubeOneCluster(clusterCfgPath, tfOutputPath string) (*kubeoneapi.KubeOneCluster, error) {
+	if len(clusterCfgPath) == 0 {
+		return nil, errors.New("cluster configuration path not provided")
+	}
+
+	cluster, err := ioutil.ReadFile(clusterCfgPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read the given cluster configuration file")
+	}
+
+	var tfOutput []byte
+	if len(tfOutputPath) > 0 {
+		tfOutput, err = ioutil.ReadFile(tfOutputPath)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to read the given terraform output file")
+		}
+	}
+
+	return BytesToKubeOneCluster(cluster, tfOutput)
+}
+
+// BytesToKubeOneCluster returns the KubeOneCluster object parsed from the KubeOneCluster manifest and optionally
+// Terraform output
+func BytesToKubeOneCluster(cluster, tfOutput []byte) (*kubeoneapi.KubeOneCluster, error) {
+	initCfg := &kubeonev1alpha1.KubeOneCluster{}
+	if err := runtime.DecodeInto(kubeonescheme.Codecs.UniversalDecoder(), cluster, initCfg); err != nil {
+		return nil, err
+	}
+
+	return DefaultedKubeOneCluster(initCfg, tfOutput)
+}

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -19,7 +19,7 @@ package util
 import (
 	"github.com/sirupsen/logrus"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 
 	"k8s.io/client-go/rest"
@@ -29,7 +29,7 @@ import (
 // Context hold together currently test flags and parsed info, along with
 // utilities like logger
 type Context struct {
-	Cluster                   *config.Cluster
+	Cluster                   *kubeoneapi.KubeOneCluster
 	Logger                    logrus.FieldLogger
 	Connector                 *ssh.Connector
 	Configuration             *Configuration

--- a/pkg/util/credentials/credentials.go
+++ b/pkg/util/credentials/credentials.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"encoding/base64"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/pkg/errors"
+
+	"github.com/kubermatic/kubeone/pkg/apis/kubeone"
+)
+
+// The environment variable names with credential in them that machine-controller expects to see
+const (
+	AWSAccessKeyID          = "AWS_ACCESS_KEY_ID"
+	AWSSecretAccessKey      = "AWS_SECRET_ACCESS_KEY"
+	DigitalOceanTokenKey    = "DO_TOKEN"
+	GoogleServiceAccountKey = "GOOGLE_SERVICE_ACCOUNT"
+	HetznerTokenKey         = "HZ_TOKEN"
+	OpenStackAuthURL        = "OS_AUTH_URL"
+	OpenStackDomainName     = "OS_DOMAIN_NAME"
+	OpenStackPassword       = "OS_PASSWORD"
+	OpenStackTenantName     = "OS_TENANT_NAME"
+	OpenStackUserName       = "OS_USER_NAME"
+	VSphereAddress          = "VSPHERE_ADDRESS"
+	VSpherePasswords        = "VSPHERE_PASSWORD"
+	VSphereUsername         = "VSPHERE_USERNAME"
+)
+
+// ProviderEnvironmentVariable is used to match environment variable used by KubeOne to environment variable used by
+// machine-controller.
+type ProviderEnvironmentVariable struct {
+	Name                  string
+	MachineControllerName string
+}
+
+// ProviderCredentials match the cloudprovider and parses its credentials from environment
+func ProviderCredentials(p kubeone.CloudProviderName) (map[string]string, error) {
+	switch p {
+	case kubeone.CloudProviderNameAWS:
+		creds := make(map[string]string)
+		envCredsProvider := credentials.NewEnvCredentials()
+		envCreds, err := envCredsProvider.Get()
+		if err != nil {
+			return nil, err
+		}
+		if envCreds.AccessKeyID != "" && envCreds.SecretAccessKey != "" {
+			creds["AWS_ACCESS_KEY_ID"] = envCreds.AccessKeyID
+			creds["AWS_SECRET_ACCESS_KEY"] = envCreds.SecretAccessKey
+			return creds, nil
+		}
+
+		// If env fails resort to config file
+		configCredsProvider := credentials.NewSharedCredentials("", "")
+		configCreds, err := configCredsProvider.Get()
+		if err != nil {
+			return nil, err
+		}
+		if configCreds.AccessKeyID != "" && configCreds.SecretAccessKey != "" {
+			creds["AWS_ACCESS_KEY_ID"] = configCreds.AccessKeyID
+			creds["AWS_SECRET_ACCESS_KEY"] = configCreds.SecretAccessKey
+			return creds, nil
+		}
+
+		return nil, errors.New("error parsing aws credentials")
+	case kubeone.CloudProviderNameOpenStack:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "OS_AUTH_URL"},
+			{Name: "OS_USERNAME", MachineControllerName: "OS_USER_NAME"},
+			{Name: "OS_PASSWORD"},
+			{Name: "OS_DOMAIN_NAME"},
+			{Name: "OS_TENANT_NAME"},
+		})
+	case kubeone.CloudProviderNameHetzner:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "HCLOUD_TOKEN", MachineControllerName: "HZ_TOKEN"},
+		})
+	case kubeone.CloudProviderNameDigitalOcean:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "DIGITALOCEAN_TOKEN", MachineControllerName: "DO_TOKEN"},
+		})
+	case kubeone.CloudProviderNameGCE:
+		gsa, err := parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "GOOGLE_CREDENTIALS", MachineControllerName: "GOOGLE_SERVICE_ACCOUNT"},
+		})
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		// encode it before sending to secret to be consumed by
+		// machine-controller, as machine-controller assumes it will be double encoded
+		gsa["GOOGLE_SERVICE_ACCOUNT"] = base64.StdEncoding.EncodeToString([]byte(gsa["GOOGLE_SERVICE_ACCOUNT"]))
+		return gsa, nil
+	case kubeone.CloudProviderNameVSphere:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{
+			{Name: "VSPHERE_ADDRESS"},
+			{Name: "VSPHERE_USERNAME"},
+			{Name: "VSPHERE_PASSWORD"},
+		})
+	}
+
+	return nil, errors.New("no provider matched")
+}
+
+func parseCredentialVariables(envVars []ProviderEnvironmentVariable) (map[string]string, error) {
+	creds := make(map[string]string)
+	for _, env := range envVars {
+		if len(env.MachineControllerName) == 0 {
+			env.MachineControllerName = env.Name
+		}
+		creds[env.MachineControllerName] = strings.TrimSpace(os.Getenv(env.Name))
+		if creds[env.MachineControllerName] == "" {
+			return nil, errors.Errorf("environment variable %s is not set, but is required", env.Name)
+		}
+	}
+	return creds, nil
+}

--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -20,14 +20,14 @@ import (
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 // DownloadKubeconfig downloads Kubeconfig over SSH
-func DownloadKubeconfig(cluster *config.Cluster) ([]byte, error) {
+func DownloadKubeconfig(cluster *kubeoneapi.KubeOneCluster) ([]byte, error) {
 	// connect to leader
 	leader, err := cluster.Leader()
 	if err != nil {
@@ -35,7 +35,7 @@ func DownloadKubeconfig(cluster *config.Cluster) ([]byte, error) {
 	}
 	connector := ssh.NewConnector()
 
-	conn, err := connector.Connect(*leader)
+	conn, err := connector.Connect(leader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/task.go
+++ b/pkg/util/task.go
@@ -22,14 +22,14 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/config"
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 )
 
 // NodeTask is a task that is specifically tailored to run on a single node.
-type NodeTask func(ctx *Context, node *config.HostConfig, conn ssh.Connection) error
+type NodeTask func(ctx *Context, node kubeoneapi.HostConfig, conn ssh.Connection) error
 
-func (c *Context) runTask(node *config.HostConfig, task NodeTask, prefixed bool) error {
+func (c *Context) runTask(node kubeoneapi.HostConfig, task NodeTask, prefixed bool) error {
 	var (
 		err  error
 		conn ssh.Connection
@@ -37,7 +37,7 @@ func (c *Context) runTask(node *config.HostConfig, task NodeTask, prefixed bool)
 
 	// connect to the host (and do not close connection
 	// because we want to re-use it for future tasks)
-	conn, err = c.Connector.Connect(*node)
+	conn, err = c.Connector.Connect(node)
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect to %s", node.PublicAddress)
 	}
@@ -58,7 +58,7 @@ func (c *Context) runTask(node *config.HostConfig, task NodeTask, prefixed bool)
 }
 
 // RunTaskOnNodes runs the given task on the given selection of hosts.
-func (c *Context) RunTaskOnNodes(nodes []*config.HostConfig, task NodeTask, parallel bool) error {
+func (c *Context) RunTaskOnNodes(nodes []kubeoneapi.HostConfig, task NodeTask, parallel bool) error {
 	var err error
 
 	wg := sync.WaitGroup{}
@@ -70,7 +70,7 @@ func (c *Context) RunTaskOnNodes(nodes []*config.HostConfig, task NodeTask, para
 
 		if parallel {
 			wg.Add(1)
-			go func(ctx *Context, node *config.HostConfig) {
+			go func(ctx *Context, node kubeoneapi.HostConfig) {
 				err = ctx.runTask(node, task, parallel)
 				if err != nil {
 					ctx.Logger.Error(err)
@@ -107,7 +107,7 @@ func (c *Context) RunTaskOnLeader(task NodeTask) error {
 		return err
 	}
 
-	hosts := []*config.HostConfig{
+	hosts := []kubeoneapi.HostConfig{
 		leader,
 	}
 

--- a/test/e2e/testdata/config_aws_1.13.5.yaml
+++ b/test/e2e/testdata/config_aws_1.13.5.yaml
@@ -15,5 +15,5 @@ apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
 versions:
   kubernetes: '1.13.5'
-provider:
+cloudProvider:
   name: 'aws'

--- a/test/e2e/testdata/config_aws_1.13.5.yaml
+++ b/test/e2e/testdata/config_aws_1.13.5.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 versions:
   kubernetes: '1.13.5'
 provider:

--- a/test/e2e/testdata/config_aws_1.14.1.yaml
+++ b/test/e2e/testdata/config_aws_1.14.1.yaml
@@ -15,5 +15,5 @@ apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
 versions:
   kubernetes: '1.14.1'
-provider:
+cloudProvider:
   name: 'aws'

--- a/test/e2e/testdata/config_aws_1.14.1.yaml
+++ b/test/e2e/testdata/config_aws_1.14.1.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 versions:
   kubernetes: '1.14.1'
 provider:

--- a/test/e2e/testdata/config_do_1.13.5.yaml
+++ b/test/e2e/testdata/config_do_1.13.5.yaml
@@ -15,6 +15,6 @@ apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
 versions:
   kubernetes: '1.13.5'
-provider:
+cloudProvider:
   name: 'digitalocean'
   external: true

--- a/test/e2e/testdata/config_do_1.13.5.yaml
+++ b/test/e2e/testdata/config_do_1.13.5.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 versions:
   kubernetes: '1.13.5'
 provider:

--- a/test/e2e/testdata/config_do_1.14.1.yaml
+++ b/test/e2e/testdata/config_do_1.14.1.yaml
@@ -15,6 +15,6 @@ apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
 versions:
   kubernetes: '1.14.1'
-provider:
+cloudProvider:
   name: 'digitalocean'
   external: true

--- a/test/e2e/testdata/config_do_1.14.1.yaml
+++ b/test/e2e/testdata/config_do_1.14.1.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 versions:
   kubernetes: '1.14.1'
 provider:

--- a/test/e2e/testdata/config_hetzner_1.13.5.yaml
+++ b/test/e2e/testdata/config_hetzner_1.13.5.yaml
@@ -15,6 +15,6 @@ apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
 versions:
   kubernetes: '1.13.5'
-provider:
+cloudProvider:
   name: 'hetzner'
   external: true

--- a/test/e2e/testdata/config_hetzner_1.13.5.yaml
+++ b/test/e2e/testdata/config_hetzner_1.13.5.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 versions:
   kubernetes: '1.13.5'
 provider:

--- a/test/e2e/testdata/config_hetzner_1.14.1.yaml
+++ b/test/e2e/testdata/config_hetzner_1.14.1.yaml
@@ -15,6 +15,6 @@ apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
 versions:
   kubernetes: '1.14.1'
-provider:
+cloudProvider:
   name: 'hetzner'
   external: true

--- a/test/e2e/testdata/config_hetzner_1.14.1.yaml
+++ b/test/e2e/testdata/config_hetzner_1.14.1.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 versions:
   kubernetes: '1.14.1'
 provider:


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrate to the KubeOneCluster API implemented in #353 and proposed in [the following proposal](https://github.com/kubermatic/kubeone/blob/master/docs/proposals/20190409-kubeonecluster-api.md).

This PR brings **breaking changes** as some fields are removed or renamed. The new API is a Kubernetes-style API and supports API versioning, which allows us to make changes to the API without affecting the end users and breaking the backwards compatibility.

The new API is called `KubeOneCluster`, the API group is `kubeone.io` and the initial version is `v1alpha1`.

Once this PR is merged it will **not** be possible to create KubeOne clusters using the old configuration file and API. The following changes must be made in order to migrate to the new API:

* `apiVersion` and `kind` must be added at the top of the configuration file:
```yaml
apiVersion: kubeone.io/v1alpha1
kind: KubeOneCluster
```
* The following fields at the root level are renamed, so they follow the Kubernetes-style of naming fields and structures:
  * `apiserver` -> `apiEndpoints`
  * `provider` -> `cloudProvider`
  * `network` -> `clusterNetwork`
  * `machine_controller` -> `machineController`
* All `hosts` fields must be changed to the camel case:
  * `public_address` -> `publicAddress`
  * `private_address` -> `privateAddress`
  * `ssh_port` -> `sshPort`
  * `ssh_username` -> `sshUsername`
  * `ssh_private_key_file` -> `sshPrivateKeyFile`
  * `ssh_agent_socket` -> `sshAgentSocket`
* The `apiserver` structure is replaced with the `apiEndpoint` structure which contains the following fields:
  * `host` - address or hostname of the API endpoint (by default load balancer DNS)
  * `port` - port of the API (by default `6443`)
* All `cloudProvider` (prev. `provider`) fields must be changed to the camel case:
  * `cloud_config` -> `cloudConfig`
* The `network` structure is renamed to `clusterNetwork`, all existing fields are renamed to follow the camel case and a new field is added:
  * `pod_subnet` -> `podSubnet`
  * `service_subnet` -> `serviceSubnet`
  * `node_port_range` -> `nodePortRange`
  * [NEW] `serviceDomainName` -> isn't used currently
* `http_proxy` and `https_proxy` fields in the `proxy` structure are renamed to drop the `_proxy` suffix and `no_proxy` is renamed to follow the camel case:
  * `http_proxy` -> `http`
  * `https_proxy` -> `https`
  * `no_proxy` -> `noProxy`
* The `credentials` field from `machineController` structure (prev. `machine_controller`) is moved to the root level.
* All fields in the `features` structure are renamed to follow the camel case:
  * `pod_security_policy` -> `podSecurityPolicy`
  * `dynamic_audit_log` -> `dynamicAuditLog`
  * `metrics_server` -> `metricsServer`
  * `openid_connect` -> `openidConnect`
* All `openidConnect` fields are renamed to follow the camel case.
* `workers.Config` is renamed to `workers.providerSpec`.

Changes affecting using KubeOne as a Go library:

* Structures are renamed to follow the camel case and some structures are changed or removed (see above points for more details),
* `WorkerConfig.Config.CloudProviderSpec` and `WorkerConfig.Config.OperatingSystemSpec` are taking `json.RawMessage` instead of `map[string]interface{}`,
* All fields in the `Features` structure are now pointers. All fields for enabling the feature are called `Enable` and are type of bool (prev. pointer on bool),
* `MachineController` is now a pointer of `MachineControllerConfig` (prev. non-pointer `MachineControllerConfig`),
* `MachineController.Deploy` is now bool instead of pointer on bool.

The following changes should be considered before merging the PR:

* [x] Make `serviceDomainName` working.
* [ ] Support more than one API endpoint (a follow-up).
* [x] Is `openidConnect` a correct JSON tag or should it be `openIdConnect`?
* [x] Fix a typo in `apiEndpoint` (should be `apiEndpoints`).
* [x] Make sure that the cluster is updated after the hostname or operating system is changed.
* [x] ~Remove the old API (`pkg/config`) (a follow-up).~
* [ ] Build a migration tool for migrating from the old API to the new KubeOneCluster API (a follow-up).
* [ ] Update documentation and examples (a follow-up).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #259
The issue will be closed once the old API is removed. 

**Documentation**:

Documentation is up to be updated.

**Release note**:
```release-note
[BREAKING CHANGES] Migrate to the new KubeOneCluster API. Disable the old API.
```

/assign @kron4eg 
cc @scheeles 

/hold
until we don't agree on the final API structure