### PR TITLE
Decouple credentials secret creation from machine-controller

### DIFF
--- a/pkg/installer/installation/install.go
+++ b/pkg/installer/installation/install.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubermatic/kubeone/pkg/templates/externalccm"
 	"github.com/kubermatic/kubeone/pkg/templates/machinecontroller"
 	"github.com/kubermatic/kubeone/pkg/util"
+	"github.com/kubermatic/kubeone/pkg/util/credentials"
 )
 
 // Install performs all the steps required to install Kubernetes on
@@ -43,6 +44,7 @@ func Install(ctx *util.Context) error {
 		{Fn: saveKubeconfig, ErrMsg: "unable to save kubeconfig to the local machine", Retries: 3},
 		{Fn: util.BuildKubernetesClientset, ErrMsg: "unable to build kubernetes clientset", Retries: 3},
 		{Fn: features.Activate, ErrMsg: "unable to activate features"},
+		{Fn: credentials.Ensure, ErrMsg: "unable to ensure credentials secret"},
 		{Fn: externalccm.Ensure, ErrMsg: "failed to install external CCM"},
 		{Fn: patchCoreDNS, ErrMsg: "failed to patch CoreDNS", Retries: 3},
 		{Fn: applyCanalCNI, ErrMsg: "failed to install cni plugin canal", Retries: 3},

--- a/pkg/templates/externalccm/digitalocean.go
+++ b/pkg/templates/externalccm/digitalocean.go
@@ -239,7 +239,7 @@ func doDeployment() *appsv1.Deployment {
 									ValueFrom: &corev1.EnvVarSource{
 										SecretKeyRef: &corev1.SecretKeySelector{
 											LocalObjectReference: corev1.LocalObjectReference{
-												Name: credentials.CredentialsSecretName,
+												Name: credentials.SecretName,
 											},
 											Key: credentials.DigitalOceanTokenKey,
 										},

--- a/pkg/templates/externalccm/digitalocean.go
+++ b/pkg/templates/externalccm/digitalocean.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/templates/machinecontroller"
 	"github.com/kubermatic/kubeone/pkg/util"
 	"github.com/kubermatic/kubeone/pkg/util/credentials"
 
@@ -240,7 +239,7 @@ func doDeployment() *appsv1.Deployment {
 									ValueFrom: &corev1.EnvVarSource{
 										SecretKeyRef: &corev1.SecretKeySelector{
 											LocalObjectReference: corev1.LocalObjectReference{
-												Name: machinecontroller.MachineControllerCredentialsSecretName,
+												Name: credentials.CredentialsSecretName,
 											},
 											Key: credentials.DigitalOceanTokenKey,
 										},

--- a/pkg/templates/externalccm/hetzner.go
+++ b/pkg/templates/externalccm/hetzner.go
@@ -187,7 +187,7 @@ func hetznerDeployment() *appsv1.Deployment {
 									ValueFrom: &corev1.EnvVarSource{
 										SecretKeyRef: &corev1.SecretKeySelector{
 											LocalObjectReference: corev1.LocalObjectReference{
-												Name: credentials.CredentialsSecretName,
+												Name: credentials.SecretName,
 											},
 											Key: credentials.HetznerTokenKey,
 										},

--- a/pkg/templates/externalccm/hetzner.go
+++ b/pkg/templates/externalccm/hetzner.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 
-	"github.com/kubermatic/kubeone/pkg/templates/machinecontroller"
 	"github.com/kubermatic/kubeone/pkg/util"
 	"github.com/kubermatic/kubeone/pkg/util/credentials"
 
@@ -188,7 +187,7 @@ func hetznerDeployment() *appsv1.Deployment {
 									ValueFrom: &corev1.EnvVarSource{
 										SecretKeyRef: &corev1.SecretKeySelector{
 											LocalObjectReference: corev1.LocalObjectReference{
-												Name: machinecontroller.MachineControllerCredentialsSecretName,
+												Name: credentials.CredentialsSecretName,
 											},
 											Key: credentials.HetznerTokenKey,
 										},

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -897,7 +897,7 @@ func getEnvVarCredentials(cluster *kubeoneapi.KubeOneCluster) []corev1.EnvVar {
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: credentials.CredentialsSecretName,
+						Name: credentials.SecretName,
 					},
 					Key: k,
 				},

--- a/pkg/upgrader/upgrade/upgrade.go
+++ b/pkg/upgrader/upgrade/upgrade.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubermatic/kubeone/pkg/templates/externalccm"
 	"github.com/kubermatic/kubeone/pkg/templates/machinecontroller"
 	"github.com/kubermatic/kubeone/pkg/util"
+	"github.com/kubermatic/kubeone/pkg/util/credentials"
 )
 
 const (
@@ -53,6 +54,7 @@ func Upgrade(ctx *util.Context) error {
 		{Fn: upgradeFollower, ErrMsg: "unable to upgrade follower control plane", Retries: 3},
 		{Fn: features.Activate, ErrMsg: "unable to activate features"},
 		{Fn: certificate.DownloadCA, ErrMsg: "unable to download ca from leader", Retries: 3},
+		{Fn: credentials.Ensure, ErrMsg: "unable to ensure credentials secret"},
 		{Fn: externalccm.Ensure, ErrMsg: "failed to install external CCM"},
 		{Fn: machinecontroller.Ensure, ErrMsg: "failed to update machine-controller", Retries: 3},
 		{Fn: machinecontroller.WaitReady, ErrMsg: "failed to wait for machine-controller", Retries: 3},

--- a/pkg/util/credentials/secret.go
+++ b/pkg/util/credentials/secret.go
@@ -31,8 +31,10 @@ import (
 )
 
 const (
-	CredentialsSecretName      = "credentials"
-	CredentialsSecretNamespace = "kube-system"
+	// SecretName is name of the secret which contains the cloud provider credentials
+	SecretName = "credentials"
+	// SecretNamespace is namespace of the credentials secret
+	SecretNamespace = "kube-system"
 )
 
 func simpleCreateOrUpdate(ctx context.Context, client dynclient.Client, obj runtime.Object) error {
@@ -71,8 +73,8 @@ func credentialsSecret(credentials map[string]string) *corev1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      CredentialsSecretName,
-			Namespace: CredentialsSecretNamespace,
+			Name:      SecretName,
+			Namespace: SecretNamespace,
 		},
 		Type:       corev1.SecretTypeOpaque,
 		StringData: credentials,

--- a/pkg/util/credentials/secret.go
+++ b/pkg/util/credentials/secret.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// SecretName is name of the secret which contains the cloud provider credentials
-	SecretName = "credentials"
+	SecretName = "cloud-provider-credentials"
 	// SecretNamespace is namespace of the credentials secret
 	SecretNamespace = "kube-system"
 )

--- a/pkg/util/credentials/secret.go
+++ b/pkg/util/credentials/secret.go
@@ -19,8 +19,9 @@ package credentials
 import (
 	"context"
 
-	"github.com/kubermatic/kubeone/pkg/util"
 	"github.com/pkg/errors"
+
+	"github.com/kubermatic/kubeone/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
**What this PR does / why we need it**:

The credentials secret is used both by `machine-controller` and external CCM. The secret should be created even if `machine-controller` isn't deployed, but the external CCM is.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #366

**Release note**:
```release-note
Decouple the credentials secret creation from machine-controller
```

/assign @kron4eg 