### PR TITLE
Fix ClusterNetwork defaulting

### DIFF
--- a/pkg/apis/kubeone/v1alpha1/defaults.go
+++ b/pkg/apis/kubeone/v1alpha1/defaults.go
@@ -74,10 +74,18 @@ func SetDefaults_APIEndpoints(obj *KubeOneCluster) {
 }
 
 func SetDefaults_ClusterNetwork(obj *KubeOneCluster) {
-	obj.ClusterNetwork.PodSubnet = DefaultPodSubnet
-	obj.ClusterNetwork.ServiceSubnet = DefaultServiceSubnet
-	obj.ClusterNetwork.ServiceDomainName = DefaultServiceDNS
-	obj.ClusterNetwork.NodePortRange = DefaultNodePortRange
+	if len(obj.ClusterNetwork.PodSubnet) == 0 {
+		obj.ClusterNetwork.PodSubnet = DefaultPodSubnet
+	}
+	if len(obj.ClusterNetwork.ServiceSubnet) == 0 {
+		obj.ClusterNetwork.ServiceSubnet = DefaultServiceSubnet
+	}
+	if len(obj.ClusterNetwork.ServiceDomainName) == 0 {
+		obj.ClusterNetwork.ServiceDomainName = DefaultServiceDNS
+	}
+	if len(obj.ClusterNetwork.NodePortRange) == 0 {
+		obj.ClusterNetwork.NodePortRange = DefaultNodePortRange
+	}
 }
 
 func SetDefaults_MachineController(obj *KubeOneCluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug in defaulting for the `ClusterNetwork` structure which caused the user provided values to be overwritten with default values.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #259 

**Release note**:
```release-note
NONE
```

/assign @kron4eg 