### PR TITLE
Update README files in examples/terraform

### DIFF
--- a/examples/terraform/aws-private/README.md
+++ b/examples/terraform/aws-private/README.md
@@ -1,3 +1,8 @@
+# AWS with Private VPC Quickstart Terraform scripts
+
+:warning: **Experimental: The following setup is experimental and can't be used with KubeOne out-of-box.
+Follow the [issue #337](https://github.com/kubermatic/kubeone/issues/337) for more details about progress.** :warning:
+
 ## Assumptions
 
 * VPC (default or custom) with attached internet gateway exists

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -4,6 +4,8 @@ The AWS Quickstart Terraform scripts can be used to create the needed infrastruc
 Check out the following [AWS getting started walkthrough][aws-quickstart] to learn more about how to use the
 scripts and how to provision a Kubernetes cluster using KubeOne.
 
+[aws-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-aws.md
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -27,5 +29,3 @@ scripts and how to provision a Kubernetes cluster using KubeOne.
 | kubeone\_api |  |
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
-
-[aws-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-aws.md

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -1,9 +1,8 @@
-```
-$ terraform init
-$ terraform plan
-$ terraform apply
-$ terraform output -json > tf.json
-```
+# AWS Quickstart Terraform scripts
+
+The AWS Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
+Check out the following [AWS getting started walkthrough][aws-quickstart] to learn more about how to use the
+scripts and how to provision a Kubernetes cluster using KubeOne.
 
 ## Inputs
 
@@ -28,3 +27,5 @@ $ terraform output -json > tf.json
 | kubeone\_api |  |
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
+
+[aws-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-aws.md

--- a/examples/terraform/digitalocean/README.md
+++ b/examples/terraform/digitalocean/README.md
@@ -1,9 +1,9 @@
-```
-$ terraform init
-$ terraform plan
-$ terraform apply
-$ terraform output -json > tf.json
-```
+# DigitalOcean Quickstart Terraform scripts
+
+The DigitalOcean Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
+Check out the following [DigitalOcean getting started walkthrough][do-quickstart] to learn more about how to use the
+scripts and how to provision a Kubernetes cluster using KubeOne.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -30,3 +30,4 @@ $ terraform output -json > tf.json
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
 
+[do-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-digitalocean.md

--- a/examples/terraform/digitalocean/README.md
+++ b/examples/terraform/digitalocean/README.md
@@ -4,6 +4,8 @@ The DigitalOcean Quickstart Terraform scripts can be used to create the needed i
 Check out the following [DigitalOcean getting started walkthrough][do-quickstart] to learn more about how to use the
 scripts and how to provision a Kubernetes cluster using KubeOne.
 
+[do-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-digitalocean.md
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -29,5 +31,3 @@ scripts and how to provision a Kubernetes cluster using KubeOne.
 | kubeone\_api |  |
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
-
-[do-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-digitalocean.md

--- a/examples/terraform/gce/README.md
+++ b/examples/terraform/gce/README.md
@@ -4,6 +4,8 @@ The GCE Quickstart Terraform scripts can be used to create the needed infrastruc
 Check out the following [GCE getting started walkthrough][gce-quickstart] to learn more about how to use the
 scripts and how to provision a Kubernetes cluster using KubeOne.
 
+[gce-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-gce.md
+
 ## GCE Provider configuration
 
 ### Credentials
@@ -42,5 +44,3 @@ ether of the following ENV variables should be accessible:
 | kubeone\_api | kubernetes API loadbalancer |
 | kubeone\_hosts | control plain nodes |
 | kubeone\_workers | workers definitions translated into MachineDeployment ClusterAPI objects |
-
-[gce-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-gce.md

--- a/examples/terraform/gce/README.md
+++ b/examples/terraform/gce/README.md
@@ -1,4 +1,8 @@
-# Terraform
+# GCE Quickstart Terraform scripts
+
+The GCE Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
+Check out the following [GCE getting started walkthrough][gce-quickstart] to learn more about how to use the
+scripts and how to provision a Kubernetes cluster using KubeOne.
 
 ## GCE Provider configuration
 
@@ -39,3 +43,4 @@ ether of the following ENV variables should be accessible:
 | kubeone\_hosts | control plain nodes |
 | kubeone\_workers | workers definitions translated into MachineDeployment ClusterAPI objects |
 
+[gce-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-gce.md

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -4,6 +4,8 @@ The Hetzner Quickstart Terraform scripts can be used to create the needed infras
 Check out the following [Hetzner getting started walkthrough][hetzner-quickstart] to learn more about how to use the
 scripts and how to provision a Kubernetes cluster using KubeOne.
 
+[hetzner-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-hetzner.md
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -22,5 +24,3 @@ scripts and how to provision a Kubernetes cluster using KubeOne.
 |------|-------------|
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
-
-[hetzner-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-hetzner.md

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -1,3 +1,9 @@
+# Hetzner Quickstart Terraform scripts
+
+The Hetzner Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
+Check out the following [Hetzner getting started walkthrough][hetzner-quickstart] to learn more about how to use the
+scripts and how to provision a Kubernetes cluster using KubeOne.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -17,3 +23,4 @@
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
 
+[hetzner-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-hetzner.md

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -4,6 +4,8 @@ The OpenStack Quickstart Terraform scripts can be used to create the needed infr
 Check out the following [OpenStack getting started walkthrough][os-quickstart] to learn more about how to use the
 scripts and how to provision a Kubernetes cluster using KubeOne.
 
+[os-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-openstack.md
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -30,5 +32,3 @@ scripts and how to provision a Kubernetes cluster using KubeOne.
 | kubeone\_api |  |
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
-
-[os-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-openstack.md

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -1,37 +1,8 @@
-# OpenStack
+# OpenStack Quickstart Terraform scripts
 
-## Environment variables
-
-So Terraform can communicate with the OpenStack API it is necessary that the required environment variables are set correctly.
-Example
-```bash
-export OS_AUTH_URL="https://some-keystone-endpoint:5000/v3"
-export OS_IDENTITY_API_VERSION=3
-export OS_USERNAME="some-username"
-export OS_PASSWORD="some-password"
-export OS_REGION_NAME="region1"
-export OS_INTERFACE=public
-export OS_ENDPOINT_TYPE=public
-export OS_USER_DOMAIN_NAME="Default"
-export OS_PROJECT_ID="some-project-id"
-```
-
-## Terraform
-
-```
-$ terraform init
-$ terraform plan
-$ terraform apply
-$ terraform output -json > tf.json
-```
-
-## KubeOne
-
-Create a config.yaml and make sure you specify `.provider.cloud_config`.
-
-```bash
-kubeone install --tfjson tf.json config.yaml
-```
+The OpenStack Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
+Check out the following [OpenStack getting started walkthrough][os-quickstart] to learn more about how to use the
+scripts and how to provision a Kubernetes cluster using KubeOne.
 
 ## Inputs
 
@@ -60,3 +31,4 @@ kubeone install --tfjson tf.json config.yaml
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
 
+[os-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-openstack.md

--- a/examples/terraform/packet/README.md
+++ b/examples/terraform/packet/README.md
@@ -1,3 +1,9 @@
+# Packet Quickstart Terraform scripts
+
+The Packet Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
+Check out the following [Packet getting started walkthrough][packet-quickstart] to learn more about how to use the
+scripts and how to provision a Kubernetes cluster using KubeOne.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -23,3 +29,4 @@
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
 
+[packet-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-packet.md

--- a/examples/terraform/packet/README.md
+++ b/examples/terraform/packet/README.md
@@ -4,6 +4,8 @@ The Packet Quickstart Terraform scripts can be used to create the needed infrast
 Check out the following [Packet getting started walkthrough][packet-quickstart] to learn more about how to use the
 scripts and how to provision a Kubernetes cluster using KubeOne.
 
+[packet-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-packet.md
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -28,5 +30,3 @@ scripts and how to provision a Kubernetes cluster using KubeOne.
 | kubeone\_api |  |
 | kubeone\_hosts |  |
 | kubeone\_workers |  |
-
-[packet-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-packet.md


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the README files in `examples/terraform` subdirectories.

* Add a description and a link to the quickstart for each provider,
* Add the experimental warning for the `aws-private` script,
* Remove details about getting started on OpenStack as the quickstart already covers everything

**Release note**:
```release-note
NONE
```

/assign @kron4eg 