### PR TITLE
Correct manifest examples in quickstart guides

### DIFF
--- a/docs/quickstart-aws.md
+++ b/docs/quickstart-aws.md
@@ -98,6 +98,8 @@ Before you start you'll need a configuration file that defines how Kubernetes wi
 To get started you can use the following configuration. It'll install Kubernetes 1.14.1 and create 3 worker nodes. KubeOne automatically populates all needed information about worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/ec8bf305446ac22529e9683fd4ce3c9abf753d1e/examples/terraform/aws/output.tf#L38-L87). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [AWS example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml) for available options.
 
 ```yaml
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 name: demo
 versions:
   kubernetes: '1.14.1'

--- a/docs/quickstart-digitalocean.md
+++ b/docs/quickstart-digitalocean.md
@@ -95,6 +95,8 @@ Before you start you'll need a configuration file that defines how Kubernetes wi
 To get started you can use the following configuration. It'll install Kubernetes 1.14.1, create 3 worker nodes and deploy the [external cloud controller manager](https://github.com/digitalocean/digitalocean-cloud-controller-manager). The external cloud controller manager takes care of providing correct information about nodes from the DigitalOcean API and allows you to use the `type: LoadBalancer` services. KubeOne automatically populates information about the worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/ec8bf305446ac22529e9683fd4ce3c9abf753d1e/examples/terraform/digitalocean/output.tf#L38-L59). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [DigitalOcean example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/digitalocean-machinedeployment.yaml) for available options.
 
 ```yaml
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 name: demo
 versions:
   kubernetes: '1.14.1'

--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -149,6 +149,8 @@ manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/
 for available options.
 
 ```yaml
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 name: demo
 versions:
   kubernetes: '1.14.1'

--- a/docs/quickstart-hetzner.md
+++ b/docs/quickstart-hetzner.md
@@ -88,6 +88,8 @@ Before you start you'll need a configuration file that defines how Kubernetes wi
 To get started you can use the following configuration. It'll install Kubernetes 1.14.1, create 3 worker nodes and deploy the [external cloud controller manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager). The external cloud controller manager takes care of providing correct information about the nodes. KubeOne automatically populates all needed information about worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/a874fd5913ca2a86c3b8136982c2a00e835c2f62/examples/terraform/hetzner/output.tf#L26-L36). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes see [Hetzner example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/hetzner-machinedeployment.yaml) for available options.
 
 ```yaml
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 name: demo
 versions:
   kubernetes: '1.14.1'

--- a/docs/quickstart-openstack.md
+++ b/docs/quickstart-openstack.md
@@ -112,6 +112,8 @@ To get started you can use the following configuration. It'll install Kubernetes
 For OpenStack you also need to provide a `cloud-config` file containing credentials, so OpenStack Cloud Controller Manager works as expected. Make sure to replace sample values with real values.
 
 ```yaml
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
 name: demo
 versions:
   kubernetes: '1.14.1'


### PR DESCRIPTION
**What this PR does / why we need it**:

The manifest examples in quickstart guides were missing `apiVersion` and `kind`.

**Release note**:
```release-note
NONE
```

/assign @kron4eg 