### PR TITLE
Fix check-dependencies Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ licence-check:
 
 .PHONY: check-dependencies
 check-dependencies:
-	dep version || go get -u github.com/golang/dep/cmd/dep
 	dep check
 
 docker-make-install:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the `check-dependencies` Make target. This should make `pull-kubeone-dependencies` job faster.

**Release note**:
```release-note
NONE
```

/assign @kron4eg 