### PR TITLE
Prepare for the release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# [v0.6.1](https://github.com/kubermatic/kubeone/releases/tag/v0.6.1) - 2019-05-09
+
+## Changed
+
+* Provide the `--kubelet-preferred-address-types` flag to metrics-server, so it works on all providers ([#424](https://github.com/kubermatic/kubeone/pull/424))
+
 # [v0.6.0](https://github.com/kubermatic/kubeone/releases/tag/v0.6.0) - 2019-05-08
 
 We're excited to announce that as of this release KubeOne is in **beta**! We have the new

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ expected.
 Alternatively, you can obtain KubeOne via [GitHub Releases][9]:
 
 ```bash
-curl -LO https://github.com/kubermatic/kubeone/releases/download/v0.6.0/kubeone_0.6.0_linux_amd64.zip
-unzip kubeone_0.6.0_linux_amd64.zip
+curl -LO https://github.com/kubermatic/kubeone/releases/download/v0.6.1/kubeone_0.6.1_linux_amd64.zip
+unzip kubeone_0.6.1_linux_amd64.zip
 sudo mv kubeone /usr/local/bin
 ```
 
@@ -82,6 +82,7 @@ It's highly recommended to use the latest version whenever possible.
 
 | KubeOne version | 1.14 | 1.13 | 1.12 | Supported providers                                |
 |-----------------|------|------|------|----------------------------------------------------|
+| v0.6.1          | +    | +    | -    | AWS, DigitalOcean, GCE, Hetzner, Packet, OpenStack |
 | v0.6.0          | +    | +    | -    | AWS, DigitalOcean, GCE, Hetzner, Packet, OpenStack |
 | v0.5.0          | +    | +    | -    | AWS, DigitalOcean, GCE, Hetzner, OpenStack         |
 | ~~v0.4.1~~      | -    | +    | -    | AWS, DigitalOcean, Hetzner, OpenStack              |

--- a/docs/quickstart-aws.md
+++ b/docs/quickstart-aws.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.14.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.6.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.6.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` installed. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-digitalocean.md
+++ b/docs/quickstart-digitalocean.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.14.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.6.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.6.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` installed. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -12,7 +12,7 @@ three control plane nodes and two worker nodes.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.6.0 or newer installed, which can be done by following the `Installing KubeOne`
+* `kubeone` v0.6.1 or newer installed, which can be done by following the `Installing KubeOne`
   section of [the
   README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` installed. The binaries for `terraform` can be found on the

--- a/docs/quickstart-hetzner.md
+++ b/docs/quickstart-hetzner.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.14.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.6.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.6.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` installed. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-openstack.md
+++ b/docs/quickstart-openstack.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.14.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.6.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.6.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` installed. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-packet.md
+++ b/docs/quickstart-packet.md
@@ -12,7 +12,7 @@ three control plane nodes and one worker node (which can be easily scaled).
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.6.0 or newer installed, which can be done by following the
+* `kubeone` v0.6.1 or newer installed, which can be done by following the
   `Installing KubeOne` section of [the README][main_readme],
 * `terraform` installed. The binaries for `terraform` can be found on the
   [Terraform website][terraform_website]


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates documentation for release v0.6.1. Will be cherry-picked to the v0.6 branch once merged.

**Release note**:
```release-note
NONE
```

/assign @kron4eg 