### PR TITLE
Add deprecation note to the old API

### DIFF
--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package config implements the KubeOne configuration API.
+// Deprecated: This API is deprecated and is used only for migration purposes.
+// The config package will be removed after 2019-08-12.
 package config
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the deprecation note to the old API package, so users know it will be removed at some point. As per the backwards compatibility policy I picked 2019-08-12 as the deprecation date (3 months from now), but we can pick some other date if there are objections. 

**Release note**:
```release-note
NONE
```

/assign @kron4eg 