### PR TITLE
Update machine-controller to v1.1.7

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -44,7 +44,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.1.5"
+	MachineControllerTag           = "v1.1.7"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `machine-controller` to v1.1.7. The Cluster-API version is the same as for v1.1.5.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #416

**Release note**:
```release-note
Update machine-controller to v1.1.7
```

/assign @kron4eg 