### PR TITLE
Delete worker nodes using dynamic client and add an option to remove Kubernetes packages when resetting the cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ test:
 dep:
 	dep ensure -v
 
-
 .PHONY: licence-check
 licence-check:
 	wwhrd check
@@ -67,7 +66,7 @@ docker-make-install:
 		make install
 
 .PHONY: e2e_test
-e2e_test:
+e2e_test: build lint test dep
 	./hack/run_ci_e2e_test.sh
 
 dist/kubeone: $(shell find . -name '*.go')

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -29,7 +29,7 @@ type resetOptions struct {
 	globalOptions
 	Manifest       string
 	DestroyWorkers bool
-	RemovePackages bool
+	RemoveBinaries bool
 }
 
 // resetCmd setups reset command
@@ -64,7 +64,7 @@ It's possible to source information about hosts from Terraform output, using the
 	}
 
 	cmd.Flags().BoolVarP(&ropts.DestroyWorkers, "destroy-workers", "", true, "destroy all worker machines before resetting the cluster")
-	cmd.Flags().BoolVarP(&ropts.RemovePackages, "remove-packages", "", false, "remove kubernetes packages after resetting the cluster")
+	cmd.Flags().BoolVarP(&ropts.RemoveBinaries, "remove-binaries", "", false, "remove kubernetes binaries after resetting the cluster")
 
 	return cmd
 }
@@ -83,7 +83,7 @@ func runReset(logger *logrus.Logger, resetOptions *resetOptions) error {
 	options := &installer.Options{
 		Verbose:        resetOptions.Verbose,
 		DestroyWorkers: resetOptions.DestroyWorkers,
-		RemovePackages: resetOptions.RemovePackages,
+		RemoveBinaries: resetOptions.RemoveBinaries,
 	}
 
 	return installer.NewInstaller(cluster, logger).Reset(options)

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -29,6 +29,7 @@ type resetOptions struct {
 	globalOptions
 	Manifest       string
 	DestroyWorkers bool
+	RemovePackages bool
 }
 
 // resetCmd setups reset command
@@ -63,6 +64,7 @@ It's possible to source information about hosts from Terraform output, using the
 	}
 
 	cmd.Flags().BoolVarP(&ropts.DestroyWorkers, "destroy-workers", "", true, "destroy all worker machines before resetting the cluster")
+	cmd.Flags().BoolVarP(&ropts.RemovePackages, "remove-packages", "", false, "remove kubernetes packages after resetting the cluster")
 
 	return cmd
 }
@@ -81,6 +83,7 @@ func runReset(logger *logrus.Logger, resetOptions *resetOptions) error {
 	options := &installer.Options{
 		Verbose:        resetOptions.Verbose,
 		DestroyWorkers: resetOptions.DestroyWorkers,
+		RemovePackages: resetOptions.RemovePackages,
 	}
 
 	return installer.NewInstaller(cluster, logger).Reset(options)

--- a/pkg/installer/installation/reset.go
+++ b/pkg/installer/installation/reset.go
@@ -41,7 +41,7 @@ func Reset(ctx *util.Context) error {
 
 	if ctx.RemoveBinaries {
 		if err := ctx.RunTaskOnAllNodes(removeBinaries, true); err != nil {
-			return errors.Wrap(err, "unable to remove kubernetes packages")
+			return errors.Wrap(err, "unable to remove kubernetes binaries")
 		}
 	}
 
@@ -72,7 +72,7 @@ func resetNode(ctx *util.Context, _ *kubeoneapi.HostConfig, conn ssh.Connection)
 }
 
 func removeBinaries(ctx *util.Context, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
-	ctx.Logger.Infoln("Removing Kubernetes packages…")
+	ctx.Logger.Infoln("Removing Kubernetes binaries")
 
 	// Determine operating system
 	os, err := determineOS(ctx)
@@ -81,7 +81,7 @@ func removeBinaries(ctx *util.Context, node *kubeoneapi.HostConfig, conn ssh.Con
 	}
 	node.SetOperatingSystem(os)
 
-	// Remove Kubernetes packages
+	// Remove Kubernetes binaries
 	switch node.OperatingSystem {
 	case "ubuntu", "debian":
 		err = removeBinariesDebian(ctx)

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -31,7 +31,7 @@ type Options struct {
 	Verbose        bool
 	BackupFile     string
 	DestroyWorkers bool
-	RemovePackages bool
+	RemoveBinaries bool
 }
 
 // Installer is entrypoint for installation process
@@ -75,6 +75,6 @@ func (i *Installer) createContext(options *Options) *util.Context {
 		Verbose:        options.Verbose,
 		BackupFile:     options.BackupFile,
 		DestroyWorkers: options.DestroyWorkers,
-		RemovePackages: options.RemovePackages,
+		RemoveBinaries: options.RemoveBinaries,
 	}
 }

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -31,6 +31,7 @@ type Options struct {
 	Verbose        bool
 	BackupFile     string
 	DestroyWorkers bool
+	RemovePackages bool
 }
 
 // Installer is entrypoint for installation process
@@ -74,5 +75,6 @@ func (i *Installer) createContext(options *Options) *util.Context {
 		Verbose:        options.Verbose,
 		BackupFile:     options.BackupFile,
 		DestroyWorkers: options.DestroyWorkers,
+		RemovePackages: options.RemovePackages,
 	}
 }

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -79,7 +79,7 @@ func WaitReady(ctx *util.Context) error {
 	return nil
 }
 
-// DeleteAllMachines destory all MachineDeployment, MachineSet and Machine objects.
+// DeleteAllMachines deletes all MachineDeployment, MachineSet and Machine objects.
 func DeleteAllMachines(ctx *util.Context) error {
 	if !ctx.Cluster.MachineController.Deploy {
 		ctx.Logger.Info("Skipping deleting worker machines because machine-controller is disabled in configuration.")
@@ -100,8 +100,8 @@ func DeleteAllMachines(ctx *util.Context) error {
 		ctx.Logger.Info("Skipping deleting worker nodes because MachineDeployments CRD is not deployed")
 		return nil
 	}
-	for _, obj := range mdList.Items {
-		if err := ctx.DynamicClient.Delete(bgCtx, &obj); err != nil {
+	for i := range mdList.Items {
+		if err := ctx.DynamicClient.Delete(bgCtx, &mdList.Items[i]); err != nil {
 			return errors.Wrap(err, "unable to delete machinedeployment object")
 		}
 	}
@@ -111,8 +111,8 @@ func DeleteAllMachines(ctx *util.Context) error {
 	if err := ctx.DynamicClient.List(bgCtx, dynclient.InNamespace(MachineControllerNamespace), msList); err != nil {
 		return errors.Wrap(err, "unable to list machineset objects")
 	}
-	for _, obj := range msList.Items {
-		if err := ctx.DynamicClient.Delete(bgCtx, &obj); err != nil {
+	for i := range msList.Items {
+		if err := ctx.DynamicClient.Delete(bgCtx, &msList.Items[i]); err != nil {
 			return errors.Wrap(err, "unable to delete machineset object")
 		}
 	}
@@ -122,8 +122,8 @@ func DeleteAllMachines(ctx *util.Context) error {
 	if err := ctx.DynamicClient.List(bgCtx, dynclient.InNamespace(MachineControllerNamespace), mList); err != nil {
 		return errors.Wrap(err, "unable to list machine objects")
 	}
-	for _, obj := range mList.Items {
-		if err := ctx.DynamicClient.Delete(bgCtx, &obj); err != nil {
+	for i := range mList.Items {
+		if err := ctx.DynamicClient.Delete(bgCtx, &mList.Items[i]); err != nil {
 			return errors.Wrap(err, "unable to delete machine object")
 		}
 	}

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -112,7 +112,7 @@ func DestroyWorkers(ctx *util.Context) error {
 				n.Annotations = map[string]string{}
 			}
 			n.Annotations["kubermatic.io/skip-eviction"] = "true"
-			return errors.WithStack(ctx.DynamicClient.Update(bgCtx, &n))
+			return ctx.DynamicClient.Update(bgCtx, &n)
 		})
 
 		if retErr != nil {

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -166,7 +166,7 @@ func DestroyWorkers(ctx *util.Context) error {
 
 	// Wait for all Machines to be deleted
 	ctx.Logger.Info("Waiting for all machines to get deleted…")
-	return wait.Poll(5*time.Second, 3*time.Minute, func() (bool, error) {
+	return wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
 		list := &clusterv1alpha1.MachineList{}
 		if err := ctx.DynamicClient.List(bgCtx, dynclient.InNamespace(MachineControllerNamespace), list); err != nil {
 			return false, errors.Wrap(err, "unable to list machine objects")

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -140,7 +140,9 @@ func DestroyWorkers(ctx *util.Context) error {
 	ctx.Logger.Info("Deleting MachineSet objects…")
 	msList := &clusterv1alpha1.MachineSetList{}
 	if err := ctx.DynamicClient.List(bgCtx, dynclient.InNamespace(MachineControllerNamespace), msList); err != nil {
-		return errors.Wrap(err, "unable to list machineset objects")
+		if !errorsutil.IsNotFound(err) {
+			return errors.Wrap(err, "unable to list machineset objects")
+		}
 	}
 	for i := range msList.Items {
 		if err := ctx.DynamicClient.Delete(bgCtx, &msList.Items[i]); err != nil {
@@ -152,7 +154,9 @@ func DestroyWorkers(ctx *util.Context) error {
 	ctx.Logger.Info("Deleting Machine objects…")
 	mList := &clusterv1alpha1.MachineList{}
 	if err := ctx.DynamicClient.List(bgCtx, dynclient.InNamespace(MachineControllerNamespace), mList); err != nil {
-		return errors.Wrap(err, "unable to list machine objects")
+		if !errorsutil.IsNotFound(err) {
+			return errors.Wrap(err, "unable to list machine objects")
+		}
 	}
 	for i := range mList.Items {
 		if err := ctx.DynamicClient.Delete(bgCtx, &mList.Items[i]); err != nil {

--- a/pkg/upgrader/upgrade/upgrade_machine_deployments.go
+++ b/pkg/upgrader/upgrade/upgrade_machine_deployments.go
@@ -59,7 +59,7 @@ func upgradeMachineDeployments(ctx *util.Context) error {
 			}
 
 			machine.Spec.Template.Spec.Versions.Kubelet = ctx.Cluster.Versions.Kubernetes
-			return errors.WithStack(ctx.DynamicClient.Update(bg, &machine))
+			return ctx.DynamicClient.Update(bg, &machine)
 		})
 
 		if retErr != nil {

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -42,6 +42,7 @@ type Context struct {
 	Verbose                   bool
 	BackupFile                string
 	DestroyWorkers            bool
+	RemovePackages            bool
 	ForceUpgrade              bool
 	UpgradeMachineDeployments bool
 }

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -42,7 +42,7 @@ type Context struct {
 	Verbose                   bool
 	BackupFile                string
 	DestroyWorkers            bool
-	RemovePackages            bool
+	RemoveBinaries            bool
 	ForceUpgrade              bool
 	UpgradeMachineDeployments bool
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the `reset` command to use dynamic client instead of kubectl over SSH tunnel for deleting worker nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #447 
Fixes #397

**Release note**:
```release-note
Fix reset failures if there are no Machine objects or Cluster-API CRDs are not deployed
Add the --remove-binaries flag which removes Kubernetes binaries after resetting the cluster
```

/assign @kron4eg 