### PR TITLE
Convert terraform example files to be v0.12 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,19 @@ New KubeOne release will be done for each minor Kubernetes version. Usually, a
 new release is targeted 2-3 weeks after Kubernetes release, depending on number
 of changes needed to support a new version.
 
-In the following table you can find what are supported Kubernetes versions for
-each KubeOne version. KubeOne versions that are crossed out are not supported.
-It's highly recommended to use the latest version whenever possible.
+Since some terraform releases introduces incompatibilities to previuos versions,
+only a specific version range is supported with each KubeOne release.
 
-| KubeOne version | 1.14 | 1.13 | Supported providers                                                |
-|-----------------|------|------|--------------------------------------------------------------------|
-| v0.9.0+         | +    | +    | AWS, DigitalOcean, GCE, Hetzner, Packet, OpenStack, vSphere, Azure |
-| v0.8.0+         | +    | +    | AWS, DigitalOcean, GCE, Hetzner, Packet, OpenStack, vSphere        |
-| v0.6.0+         | +    | +    | AWS, DigitalOcean, GCE, Hetzner, Packet, OpenStack                 |
-| v0.5.0          | +    | +    | AWS, DigitalOcean, GCE, Hetzner, OpenStack                         |
+In the following table you can find what are supported Kubernetes and Terraform
+versions for each KubeOne version. KubeOne versions that are crossed out are not
+supported. It's highly recommended to use the latest version whenever possible.
+
+| KubeOne version | 1.14 | 1.13 | Terraform | Supported providers                                                |
+|-----------------|------|------|-----------|--------------------------------------------------------------------|
+| v0.9.0+         | +    | +    | v0.12+    | AWS, DigitalOcean, GCE, Hetzner, Packet, OpenStack, vSphere, Azure |
+| v0.8.0+         | +    | +    | v0.11     | AWS, DigitalOcean, GCE, Hetzner, Packet, OpenStack, vSphere        |
+| v0.6.0+         | +    | +    | v0.11     | AWS, DigitalOcean, GCE, Hetzner, Packet, OpenStack                 |
+| v0.5.0          | +    | +    | v0.11     | AWS, DigitalOcean, GCE, Hetzner, OpenStack                         |
 
 ## Getting Started
 

--- a/docs/quickstart-aws.md
+++ b/docs/quickstart-aws.md
@@ -8,10 +8,8 @@ As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.8.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
-* `terraform` v0.11 installed. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
-
-**Note:** Due to breaking changes made in Terraform v0.12, it's currently not possible to use example Terraform scripts with Terraform v0.12.
+* `kubeone` v0.9.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials
 

--- a/docs/quickstart-azure.md
+++ b/docs/quickstart-azure.md
@@ -12,13 +12,8 @@ three control plane nodes and two worker nodes.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.8.0 or newer installed, which can be
-  done by following the `Installing KubeOne` section of [the README][1],
-* `terraform` v0.11 installed. The binaries for `terraform` can be found on the
-  [Terraform website][2]
-
-**Note:** Due to breaking changes made in Terraform v0.12, it's currently not
-possible to use example Terraform scripts with Terraform v0.12.
+* `kubeone` v0.9.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials
 

--- a/docs/quickstart-digitalocean.md
+++ b/docs/quickstart-digitalocean.md
@@ -8,10 +8,8 @@ As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.8.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
-* `terraform` v0.11 installed. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
-
-**Note:** Due to breaking changes made in Terraform v0.12, it's currently not possible to use example Terraform scripts with Terraform v0.12.
+* `kubeone` v0.9.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials
 

--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -12,13 +12,8 @@ three control plane nodes and two worker nodes.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.8.0 or newer installed, which can be done by following the `Installing KubeOne`
-  section of [the
-  README](https://github.com/kubermatic/kubeone/blob/master/README.md),
-* `terraform` v0.11 installed. The binaries for `terraform` can be found on the
-  [Terraform website](https://www.terraform.io/downloads.html)
-
-**Note:** Due to breaking changes made in Terraform v0.12, it's currently not possible to use example Terraform scripts with Terraform v0.12.
+* `kubeone` v0.9.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials
 

--- a/docs/quickstart-hetzner.md
+++ b/docs/quickstart-hetzner.md
@@ -8,10 +8,8 @@ As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.8.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
-* `terraform` v0.11 installed. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
-
-**Note:** Due to breaking changes made in Terraform v0.12, it's currently not possible to use example Terraform scripts with Terraform v0.12.
+* `kubeone` v0.9.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials
 

--- a/docs/quickstart-openstack.md
+++ b/docs/quickstart-openstack.md
@@ -8,10 +8,8 @@ As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.8.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
-* `terraform` v0.11 installed. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
-
-**Note:** Due to breaking changes made in Terraform v0.12, it's currently not possible to use example Terraform scripts with Terraform v0.12.
+* `kubeone` v0.9.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials
 

--- a/docs/quickstart-packet.md
+++ b/docs/quickstart-packet.md
@@ -12,12 +12,8 @@ three control plane nodes and one worker node (which can be easily scaled).
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.8.0 or newer installed, which can be done by following the
-  `Installing KubeOne` section of [the README][main_readme],
-* `terraform` v0.11 installed. The binaries for `terraform` can be found on the
-  [Terraform website][terraform_website]
-
-**Note:** Due to breaking changes made in Terraform v0.12, it's currently not possible to use example Terraform scripts with Terraform v0.12.
+* `kubeone` v0.9.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials
 
@@ -135,7 +131,7 @@ will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
 To get started you can use the following configuration. It'll install Kubernetes
-1.14.2, create 1 worker node and deploy the 
+1.14.2, create 1 worker node and deploy the
 [external cloud controller manager][packet_ccm]. The external cloud controller
 manager takes care of providing correct information about nodes from the Packet
 API. KubeOne automatically populates information about the worker nodes from the

--- a/docs/quickstart-vsphere.md
+++ b/docs/quickstart-vsphere.md
@@ -12,13 +12,8 @@ three control plane nodes and two worker nodes.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.8.0 or newer installed, which can be
-  done by following the `Installing KubeOne` section of [the README][1],
-* `terraform` v0.11 installed. The binaries for `terraform` can be found on the
-  [Terraform website][2]
-
-**Note:** Due to breaking changes made in Terraform v0.12, it's currently not
-possible to use example Terraform scripts with Terraform v0.12.
+* `kubeone` v0.9.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials
 

--- a/examples/terraform/aws-private/output.tf
+++ b/examples/terraform/aws-private/output.tf
@@ -18,12 +18,12 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = "${aws_lb.control_plane.dns_name}"
+    endpoint = aws_lb.control_plane.dns_name
   }
 }
 
 output "kubeone_bastion" {
-  value = "${aws_instance.bastion.0.public_ip}"
+  value = aws_instance.bastion.public_ip
 }
 
 output "kubeone_hosts" {
@@ -31,13 +31,13 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = "${var.cluster_name}"
+      cluster_name         = var.cluster_name
       cloud_provider       = "aws"
-      private_address      = "${aws_instance.control_plane.*.private_ip}"
-      ssh_agent_socket     = "${var.ssh_agent_socket}"
-      ssh_port             = "${var.ssh_port}"
-      ssh_private_key_file = "${var.ssh_private_key_file}"
-      ssh_user             = "${var.ssh_username}"
+      private_address      = aws_instance.control_plane.*.private_ip
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
     }
   }
 }
@@ -50,29 +50,27 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     pool1 = {
       replicas        = 1
-      sshPublicKeys   = ["${aws_key_pair.deployer.public_key}"]
-      operatingSystem = "${var.worker_os}"
-
+      sshPublicKeys   = [aws_key_pair.deployer.public_key]
+      operatingSystem = var.worker_os
       operatingSystemSpec = {
         distUpgradeOnBoot = false
       }
-
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
-
-      region           = "${var.aws_region}"
-      ami              = "${local.ami}"
-      availabilityZone = "${data.aws_availability_zones.available.names[0]}"
-      instanceProfile  = "${aws_iam_instance_profile.workers.name}"
-      securityGroupIDs = ["${aws_security_group.common.id}"]
-      vpcId            = "${data.aws_vpc.selected.id}"
-      subnetId         = "${aws_subnet.private.0.id}"
-      instanceType     = "${var.worker_type}"
+      region           = var.aws_region
+      ami              = local.ami
+      availabilityZone = data.aws_availability_zones.available.names[0]
+      instanceProfile  = aws_iam_instance_profile.workers.name
+      securityGroupIDs = [aws_security_group.common.id]
+      vpcId            = data.aws_vpc.selected.id
+      subnetId         = aws_subnet.private[0].id
+      instanceType     = var.worker_type
       diskSize         = 100
-      tags = "${map(
-        "kubeone", "pool1",
-      )}"
+      tags = {
+        "kubeone" = "pool1"
+      }
     }
   }
+  # provider specific fields:
+  # see example under `cloudProviderSpec` section at: 
+  # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
 }
+

--- a/examples/terraform/aws-private/variables.tf
+++ b/examples/terraform/aws-private/variables.tf
@@ -89,3 +89,4 @@ variable "ami" {
   default     = ""
   description = "AMI ID, use it to fixate control-plane AMI in order to avoid force-recreation it at later times"
 }
+

--- a/examples/terraform/aws-private/versions.tf
+++ b/examples/terraform/aws-private/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -15,21 +15,22 @@ limitations under the License.
 */
 
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 locals {
-  az_count         = "${length(data.aws_availability_zones.available.names)}"
+  az_count         = length(data.aws_availability_zones.available.names)
   az_a             = "${var.aws_region}a"
   az_b             = "${var.aws_region}b"
   az_c             = "${var.aws_region}c"
   kube_cluster_tag = "kubernetes.io/cluster/${var.cluster_name}"
-  vpc_id           = "${var.vpc_id == "default" ? aws_default_vpc.default.id : var.vpc_id}"
+  vpc_id           = var.vpc_id == "default" ? aws_default_vpc.default.id : var.vpc_id
 
-  ami = "${var.ami == "" ? data.aws_ami.ubuntu.id : var.ami}"
+  ami = var.ami == "" ? data.aws_ami.ubuntu.id : var.ami
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
 
 data "aws_ami" "ubuntu" {
   most_recent = true
@@ -48,47 +49,46 @@ data "aws_ami" "ubuntu" {
 }
 
 data "aws_subnet_ids" "default" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 data "aws_subnet" "az_a" {
-  availability_zone = "${local.az_a}"
-  vpc_id            = "${local.vpc_id}"
+  availability_zone = local.az_a
+  vpc_id            = local.vpc_id
 }
 
 data "aws_subnet" "az_b" {
-  availability_zone = "${local.az_b}"
-  vpc_id            = "${local.vpc_id}"
+  availability_zone = local.az_b
+  vpc_id            = local.vpc_id
 }
 
 data "aws_subnet" "az_c" {
-  availability_zone = "${local.az_c}"
-  vpc_id            = "${local.vpc_id}"
+  availability_zone = local.az_c
+  vpc_id            = local.vpc_id
 }
 
 locals {
-  all_subnets = ["${data.aws_subnet.az_a.id}", "${data.aws_subnet.az_b.id}", "${data.aws_subnet.az_c.id}"]
+  all_subnets = [data.aws_subnet.az_a.id, data.aws_subnet.az_b.id, data.aws_subnet.az_c.id]
 }
 
-resource "aws_default_vpc" "default" {}
+resource "aws_default_vpc" "default" {
+}
 
 resource "aws_key_pair" "deployer" {
   key_name   = "${var.cluster_name}-deployer-key"
-  public_key = "${file("${var.ssh_public_key_file}")}"
+  public_key = file(var.ssh_public_key_file)
 }
 
 resource "aws_security_group" "common" {
   name        = "${var.cluster_name}-common"
   description = "cluster common rules"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags = "${map(
-    "${local.kube_cluster_tag}", "shared",
-  )}"
+  tags = map(local.kube_cluster_tag, "shared")
 
   ingress {
-    from_port   = "${var.ssh_port}"
-    to_port     = "${var.ssh_port}"
+    from_port   = var.ssh_port
+    to_port     = var.ssh_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -111,11 +111,9 @@ resource "aws_security_group" "common" {
 resource "aws_security_group" "control_plane" {
   name        = "${var.cluster_name}-control_planes"
   description = "cluster control_planes"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags = "${map(
-    "${local.kube_cluster_tag}", "shared",
-  )}"
+  tags = map(local.kube_cluster_tag, "shared")
 
   ingress {
     from_port   = 6443
@@ -143,16 +141,17 @@ resource "aws_iam_role" "role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_instance_profile" "profile" {
   name = "${var.cluster_name}-host"
-  role = "${aws_iam_role.role.name}"
+  role = aws_iam_role.role.name
 }
 
 resource "aws_iam_role_policy" "policy" {
   name = "${var.cluster_name}-host"
-  role = "${aws_iam_role.role.id}"
+  role = aws_iam_role.role.id
 
   policy = <<EOF
 {
@@ -171,65 +170,60 @@ resource "aws_iam_role_policy" "policy" {
   ]
 }
 EOF
+
 }
 
 resource "aws_lb" "control_plane" {
   name               = "${var.cluster_name}-api-lb"
   internal           = false
   load_balancer_type = "network"
-  subnets            = ["${local.all_subnets}"]
+  subnets = local.all_subnets
 
-  tags = "${map(
-    "Cluster", "${var.cluster_name}",
-    "${local.kube_cluster_tag}", "shared",
-  )}"
+  tags = map("Cluster", var.cluster_name, local.kube_cluster_tag, "shared")
 }
 
 resource "aws_lb_target_group" "control_plane_api" {
   name     = "${var.cluster_name}-api"
   port     = 6443
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 }
 
 resource "aws_lb_listener" "control_plane_api" {
-  load_balancer_arn = "${aws_lb.control_plane.arn}"
+  load_balancer_arn = aws_lb.control_plane.arn
   port              = 6443
   protocol          = "TCP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.control_plane_api.arn}"
+    target_group_arn = aws_lb_target_group.control_plane_api.arn
     type             = "forward"
   }
 }
 
 resource "aws_lb_target_group_attachment" "control_plane_api" {
   count            = 3
-  target_group_arn = "${aws_lb_target_group.control_plane_api.arn}"
-  target_id        = "${element(aws_instance.control_plane.*.id, count.index)}"
+  target_group_arn = aws_lb_target_group.control_plane_api.arn
+  target_id        = element(aws_instance.control_plane.*.id, count.index)
   port             = 6443
 }
 
 resource "aws_instance" "control_plane" {
   count = 3
 
-  tags = "${map(
-    "Name", "${var.cluster_name}-control_plane-${count.index + 1}",
-    "${local.kube_cluster_tag}", "shared",
-  )}"
+  tags = map("Name", "${var.cluster_name}-control_plane-${count.index + 1}", local.kube_cluster_tag, "shared")
 
-  instance_type          = "${var.control_plane_type}"
-  iam_instance_profile   = "${aws_iam_instance_profile.profile.name}"
-  ami                    = "${local.ami}"
-  key_name               = "${aws_key_pair.deployer.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.common.id}", "${aws_security_group.control_plane.id}"]
-  availability_zone      = "${data.aws_availability_zones.available.names[count.index % local.az_count]}"
-  subnet_id              = "${local.all_subnets[count.index % local.az_count]}"
+  instance_type          = var.control_plane_type
+  iam_instance_profile   = aws_iam_instance_profile.profile.name
+  ami                    = local.ami
+  key_name               = aws_key_pair.deployer.key_name
+  vpc_security_group_ids = [aws_security_group.common.id, aws_security_group.control_plane.id]
+  availability_zone      = data.aws_availability_zones.available.names[count.index % local.az_count]
+  subnet_id              = local.all_subnets[count.index % local.az_count]
 
   ebs_optimized = true
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = "${var.control_plane_volume_size}"
+    volume_size = var.control_plane_volume_size
   }
 }

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = "${aws_lb.control_plane.dns_name}"
+    endpoint = aws_lb.control_plane.dns_name
   }
 }
 
@@ -27,14 +27,14 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = "${var.cluster_name}"
+      cluster_name         = var.cluster_name
       cloud_provider       = "aws"
-      private_address      = "${aws_instance.control_plane.*.private_ip}"
-      public_address       = "${aws_instance.control_plane.*.public_ip}"
-      ssh_agent_socket     = "${var.ssh_agent_socket}"
-      ssh_port             = "${var.ssh_port}"
-      ssh_private_key_file = "${var.ssh_private_key_file}"
-      ssh_user             = "${var.ssh_username}"
+      private_address      = aws_instance.control_plane.*.private_ip
+      public_address       = aws_instance.control_plane.*.public_ip
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
     }
   }
 }
@@ -47,29 +47,27 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     pool1 = {
       replicas        = 1
-      sshPublicKeys   = ["${aws_key_pair.deployer.public_key}"]
-      operatingSystem = "${var.worker_os}"
-
+      sshPublicKeys   = [aws_key_pair.deployer.public_key]
+      operatingSystem = var.worker_os
       operatingSystemSpec = {
         distUpgradeOnBoot = false
       }
-
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
-
-      region           = "${var.aws_region}"
-      ami              = "${local.ami}"
-      availabilityZone = "${local.az_a}"
-      instanceProfile  = "${aws_iam_instance_profile.profile.name}"
-      securityGroupIDs = ["${aws_security_group.common.id}"]
-      vpcId            = "${local.vpc_id}"
-      subnetId         = "${data.aws_subnet.az_a.id}"
-      instanceType     = "${var.worker_type}"
+      region           = var.aws_region
+      ami              = local.ami
+      availabilityZone = local.az_a
+      instanceProfile  = aws_iam_instance_profile.profile.name
+      securityGroupIDs = [aws_security_group.common.id]
+      vpcId            = local.vpc_id
+      subnetId         = data.aws_subnet.az_a.id
+      instanceType     = var.worker_type
       diskSize         = 50
-      tags = "${map(
-        "kubeone", "pool1",
-      )}"
+      tags = {
+        "kubeone" = "pool1"
+      }
     }
   }
+  # provider specific fields:
+  # see example under `cloudProviderSpec` section at: 
+  # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
 }
+

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -84,3 +84,4 @@ variable "ami" {
   default     = ""
   description = "AMI ID, use it to fixate control-plane AMI in order to avoid force-recreation it at later times"
 }
+

--- a/examples/terraform/aws/versions.tf
+++ b/examples/terraform/aws/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = "${azurerm_public_ip.lbip.ip_address}"
+    endpoint = azurerm_public_ip.lbip.ip_address
   }
 }
 
@@ -27,14 +27,14 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = "${var.cluster_name}"
+      cluster_name         = var.cluster_name
       cloud_provider       = "azure"
-      private_address      = "${azurerm_network_interface.control_plane.*.private_ip_address}"
-      public_address       = "${azurerm_public_ip.control_plane.*.ip_address}"
-      ssh_agent_socket     = "${var.ssh_agent_socket}"
-      ssh_port             = "${var.ssh_port}"
-      ssh_private_key_file = "${var.ssh_private_key_file}"
-      ssh_user             = "${var.ssh_username}"
+      private_address      = azurerm_network_interface.control_plane.*.private_ip_address
+      public_address       = azurerm_public_ip.control_plane.*.ip_address
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
     }
   }
 }
@@ -47,29 +47,27 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     pool1 = {
       replicas        = 1
-      sshPublicKeys   = ["${file("${var.ssh_public_key_file}")}"]
-      operatingSystem = "${var.worker_os}"
-
+      sshPublicKeys   = [file(var.ssh_public_key_file)]
+      operatingSystem = var.worker_os
       operatingSystemSpec = {
         distUpgradeOnBoot = false
       }
-
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/azure-machinedeployment.yaml
-
       assignPublicIP    = true
-      availabilitySet   = "${azurerm_availability_set.avset.name}"
-      location          = "${var.location}"
-      resourceGroup     = "${azurerm_resource_group.rg.name}"
+      availabilitySet   = azurerm_availability_set.avset.name
+      location          = var.location
+      resourceGroup     = azurerm_resource_group.rg.name
       routeTableName    = ""
-      securityGroupName = "${azurerm_network_security_group.sg.name}"
-      subnetName        = "${azurerm_subnet.subnet.name}"
-      vmSize            = "${var.worker_vm_size}"
-      vnetName          = "${azurerm_virtual_network.vpc.name}"
-      tags = "${map(
-        "kubeone", "${var.cluster_name}",
-      )}"
+      securityGroupName = azurerm_network_security_group.sg.name
+      subnetName        = azurerm_subnet.subnet.name
+      vmSize            = var.worker_vm_size
+      vnetName          = azurerm_virtual_network.vpc.name
+      tags = {
+        "kubeone" = var.cluster_name
+      }
     }
   }
+  # provider specific fields:
+  # see example under `cloudProviderSpec` section at: 
+  # https://github.com/kubermatic/machine-controller/blob/master/examples/azure-machinedeployment.yaml
 }
+

--- a/examples/terraform/azure/variables.tf
+++ b/examples/terraform/azure/variables.tf
@@ -69,3 +69,4 @@ variable "worker_vm_size" {
   description = "VM Size for worker machines"
   default     = "Standard_B2s"
 }
+

--- a/examples/terraform/azure/versions.tf
+++ b/examples/terraform/azure/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/terraform/digitalocean/main.tf
+++ b/examples/terraform/digitalocean/main.tf
@@ -14,19 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-provider "digitalocean" {}
+provider "digitalocean" {
+}
 
 locals {
   kube_cluster_tag = "kubernetes-cluster:${var.cluster_name}"
 }
 
 resource "digitalocean_tag" "kube_cluster_tag" {
-  name = "${local.kube_cluster_tag}"
+  name = local.kube_cluster_tag
 }
 
 resource "digitalocean_ssh_key" "deployer" {
   name       = "${var.cluster_name}-deployer-key"
-  public_key = "${file("${var.ssh_public_key_file}")}"
+  public_key = file(var.ssh_public_key_file)
 }
 
 resource "digitalocean_droplet" "control_plane" {
@@ -34,25 +35,25 @@ resource "digitalocean_droplet" "control_plane" {
   name  = "${var.cluster_name}-control-plane-${count.index + 1}"
 
   tags = [
-    "${local.kube_cluster_tag}",
+    local.kube_cluster_tag,
     "kubeone",
   ]
 
-  image              = "${var.control_plane_droplet_image}"
-  region             = "${var.region}"
-  size               = "${var.control_plane_size}"
+  image              = var.control_plane_droplet_image
+  region             = var.region
+  size               = var.control_plane_size
   private_networking = true
   monitoring         = false
   ipv6               = false
 
   ssh_keys = [
-    "${digitalocean_ssh_key.deployer.id}",
+    digitalocean_ssh_key.deployer.id,
   ]
 }
 
 resource "digitalocean_loadbalancer" "control_plane" {
   name   = "${var.cluster_name}-lb"
-  region = "${var.region}"
+  region = var.region
 
   forwarding_rule {
     entry_port     = 6443
@@ -67,5 +68,6 @@ resource "digitalocean_loadbalancer" "control_plane" {
     protocol = "tcp"
   }
 
-  droplet_tag = "${local.kube_cluster_tag}"
+  droplet_tag = local.kube_cluster_tag
 }
+

--- a/examples/terraform/digitalocean/output.tf
+++ b/examples/terraform/digitalocean/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = "${digitalocean_loadbalancer.control_plane.ip}"
+    endpoint = digitalocean_loadbalancer.control_plane.ip
   }
 }
 
@@ -27,14 +27,14 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = "${var.cluster_name}"
+      cluster_name         = var.cluster_name
       cloud_provider       = "digitalocean"
-      private_address      = "${digitalocean_droplet.control_plane.*.ipv4_address_private}"
-      public_address       = "${digitalocean_droplet.control_plane.*.ipv4_address}"
-      ssh_agent_socket     = "${var.ssh_agent_socket}"
-      ssh_port             = "${var.ssh_port}"
-      ssh_private_key_file = "${var.ssh_private_key_file}"
-      ssh_user             = "${var.ssh_username}"
+      private_address      = digitalocean_droplet.control_plane.*.ipv4_address_private
+      public_address       = digitalocean_droplet.control_plane.*.ipv4_address
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
     }
   }
 }
@@ -47,27 +47,25 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     pool1 = {
       replicas        = 1
-      sshPublicKeys   = ["${digitalocean_ssh_key.deployer.public_key}"]
-      operatingSystem = "${var.worker_os}"
-
+      sshPublicKeys   = [digitalocean_ssh_key.deployer.public_key]
+      operatingSystem = var.worker_os
       operatingSystemSpec = {
         distUpgradeOnBoot = false
       }
-
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/digitalocean-machinedeployment.yaml
-
-      region             = "${var.region}"
-      size               = "${var.worker_size}"
+      region             = var.region
+      size               = var.worker_size
       private_networking = true
       backups            = false
       ipv6               = false
       monitoring         = false
       tags = [
-        "${local.kube_cluster_tag}",
+        local.kube_cluster_tag,
         "kubeone",
       ]
     }
   }
+  # provider specific fields:
+  # see example under `cloudProviderSpec` section at: 
+  # https://github.com/kubermatic/machine-controller/blob/master/examples/digitalocean-machinedeployment.yaml
 }
+

--- a/examples/terraform/digitalocean/variables.tf
+++ b/examples/terraform/digitalocean/variables.tf
@@ -74,3 +74,4 @@ variable "worker_size" {
   description = "Size of worker nodes"
   default     = "s-2vcpu-4gb"
 }
+

--- a/examples/terraform/digitalocean/versions.tf
+++ b/examples/terraform/digitalocean/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = "${google_compute_address.lb_ip.address}"
+    endpoint = google_compute_address.lb_ip.address
   }
 }
 
@@ -27,14 +27,14 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = "${var.cluster_name}"
+      cluster_name         = var.cluster_name
       cloud_provider       = "gce"
-      private_address      = "${google_compute_instance.control_plane.*.network_interface.0.network_ip}"
-      public_address       = "${google_compute_instance.control_plane.*.network_interface.0.access_config.0.nat_ip}"
-      ssh_agent_socket     = "${var.ssh_agent_socket}"
-      ssh_port             = "${var.ssh_port}"
-      ssh_private_key_file = "${var.ssh_private_key_file}"
-      ssh_user             = "${var.ssh_username}"
+      private_address      = google_compute_instance.control_plane.*.network_interface.0.network_ip
+      public_address       = google_compute_instance.control_plane.*.network_interface.0.access_config.0.nat_ip
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
     }
   }
 }
@@ -47,30 +47,28 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     pool1 = {
       replicas        = 1
-      sshPublicKeys   = ["${file("${var.ssh_public_key_file}")}"]
-      operatingSystem = "${var.worker_os}"
-
+      sshPublicKeys   = [file(var.ssh_public_key_file)]
+      operatingSystem = var.worker_os
       operatingSystemSpec = {
         distUpgradeOnBoot = false
       }
-
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/gce-machinedeployment.yaml
-
       diskSize              = 50
       diskType              = "pd-ssd"
-      machineType           = "${var.workers_type}"
-      network               = "${google_compute_network.network.self_link}"
-      subnetwork            = "${google_compute_subnetwork.subnet.self_link}"
+      machineType           = var.workers_type
+      network               = google_compute_network.network.self_link
+      subnetwork            = google_compute_subnetwork.subnet.self_link
       zone                  = "${var.region}-a"
       preemptible           = false
       assignPublicIPAddress = true
-      labels = "${map(
-        "kubeone", "workers",
-      )}"
+      labels = {
+        "kubeone" = "workers"
+      }
       tags     = ["firewall", "targets"]
       regional = false
     }
   }
+  # provider specific fields:
+  # see example under `cloudProviderSpec` section at: 
+  # https://github.com/kubermatic/machine-controller/blob/master/examples/gce-machinedeployment.yaml
 }
+

--- a/examples/terraform/gce/variables.tf
+++ b/examples/terraform/gce/variables.tf
@@ -97,3 +97,4 @@ variable "cluster_network_cidr" {
   default     = "10.240.0.0/24"
   description = "Cluster network subnet cidr"
 }
+

--- a/examples/terraform/gce/versions.tf
+++ b/examples/terraform/gce/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = "${hcloud_server.lb.ipv4_address}"
+    endpoint = hcloud_server.lb.ipv4_address
   }
 }
 
@@ -27,14 +27,14 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = "${var.cluster_name}"
+      cluster_name         = var.cluster_name
       cloud_provider       = "hetzner"
-      private_address      = []                                              # hetzner doesn't provide private addressed
-      public_address       = "${hcloud_server.control_plane.*.ipv4_address}"
-      ssh_agent_socket     = "${var.ssh_agent_socket}"
-      ssh_port             = "${var.ssh_port}"
-      ssh_private_key_file = "${var.ssh_private_key_file}"
-      ssh_user             = "${var.ssh_username}"
+      private_address      = [] # hetzner doesn't provide private addressed
+      public_address       = hcloud_server.control_plane.*.ipv4_address
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
     }
   }
 }
@@ -47,19 +47,17 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     pool1 = {
       replicas        = 1
-      sshPublicKeys   = ["${file("${var.ssh_public_key_file}")}"]
-      operatingSystem = "${var.worker_os}"
-
+      sshPublicKeys   = [file(var.ssh_public_key_file)]
+      operatingSystem = var.worker_os
       operatingSystemSpec = {
         distUpgradeOnBoot = false
       }
-
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/hetzner-machinedeployment.yaml
-
-      serverType = "${var.worker_type}"
-      location   = "${var.datacenter}"
+      serverType = var.worker_type
+      location   = var.datacenter
     }
   }
+  # provider specific fields:
+  # see example under `cloudProviderSpec` section at: 
+  # https://github.com/kubermatic/machine-controller/blob/master/examples/hetzner-machinedeployment.yaml
 }
+

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -74,3 +74,4 @@ variable "datacenter" {
 variable "image" {
   default = "ubuntu-18.04"
 }
+

--- a/examples/terraform/hetzner/versions.tf
+++ b/examples/terraform/hetzner/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = "${openstack_networking_floatingip_v2.lb.address}"
+    endpoint = openstack_networking_floatingip_v2.lb.address
   }
 }
 
@@ -27,14 +27,14 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = "${var.cluster_name}"
+      cluster_name         = var.cluster_name
       cloud_provider       = "openstack"
-      private_address      = "${openstack_compute_instance_v2.control_plane.*.access_ip_v4}"
-      public_address       = "${openstack_networking_floatingip_v2.control_plane.*.address}"
-      ssh_agent_socket     = "${var.ssh_agent_socket}"
-      ssh_port             = "${var.ssh_port}"
-      ssh_private_key_file = "${var.ssh_private_key_file}"
-      ssh_user             = "${var.ssh_username}"
+      private_address      = openstack_compute_instance_v2.control_plane.*.access_ip_v4
+      public_address       = openstack_networking_floatingip_v2.control_plane.*.address
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
     }
   }
 }
@@ -47,26 +47,24 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     pool1 = {
       replicas        = 1
-      sshPublicKeys   = ["${file("${var.ssh_public_key_file}")}"]
-      operatingSystem = "${var.worker_os}"
-
+      sshPublicKeys   = [file(var.ssh_public_key_file)]
+      operatingSystem = var.worker_os
       operatingSystemSpec = {
         distUpgradeOnBoot = false
       }
-
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/openstack-machinedeployment.yaml
-
-      image          = "${var.image}"
-      flavor         = "${var.worker_flavor}"
-      securityGroups = ["${openstack_networking_secgroup_v2.securitygroup.name}"]
-      floatingIPPool = "${var.external_network_name}"
-      network        = "${openstack_networking_network_v2.network.name}"
-      subnet         = "${openstack_networking_subnet_v2.subnet.name}"
-      tags = "${map(
-        "kubeone", "worker",
-      )}"
+      image          = var.image
+      flavor         = var.worker_flavor
+      securityGroups = [openstack_networking_secgroup_v2.securitygroup.name]
+      floatingIPPool = var.external_network_name
+      network        = openstack_networking_network_v2.network.name
+      subnet         = openstack_networking_subnet_v2.subnet.name
+      tags = {
+        "kubeone" = "worker"
+      }
     }
   }
+  # provider specific fields:
+  # see example under `cloudProviderSpec` section at: 
+  # https://github.com/kubermatic/machine-controller/blob/master/examples/openstack-machinedeployment.yaml
 }
+

--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -53,7 +53,6 @@ variable "ssh_agent_socket" {
   default     = "env:SSH_AUTH_SOCK"
 }
 
-
 # Provider specific settings
 
 variable "control_plane_flavor" {
@@ -72,7 +71,7 @@ variable "lb_flavor" {
 }
 
 variable "image" {
-  default = "Ubuntu 18.04"
+  default     = "Ubuntu 18.04"
   description = "image name to use"
 }
 
@@ -86,6 +85,7 @@ variable "external_network_name" {
 }
 
 variable "subnet_dns_servers" {
-  type    = "list"
+  type    = list(string)
   default = ["8.8.8.8", "8.8.4.4"]
 }
+

--- a/examples/terraform/openstack/versions.tf
+++ b/examples/terraform/openstack/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/terraform/packet/output.tf
+++ b/examples/terraform/packet/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = "${packet_device.lb.access_public_ipv4}"
+    endpoint = packet_device.lb.access_public_ipv4
   }
 }
 
@@ -27,14 +27,14 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = "${var.cluster_name}"
+      cluster_name         = var.cluster_name
       cloud_provider       = "packet"
-      private_address      = "${packet_device.control_plane.*.access_private_ipv4}"
-      public_address       = "${packet_device.control_plane.*.access_public_ipv4}"
-      ssh_agent_socket     = "${var.ssh_agent_socket}"
-      ssh_port             = "${var.ssh_port}"
-      ssh_private_key_file = "${var.ssh_private_key_file}"
-      ssh_user             = "${var.ssh_username}"
+      private_address      = packet_device.control_plane.*.access_private_ipv4
+      public_address       = packet_device.control_plane.*.access_public_ipv4
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
     }
   }
 }
@@ -47,20 +47,18 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     pool1 = {
       replicas        = 1
-      sshPublicKeys   = ["${file("${var.ssh_public_key_file}")}"]
-      operatingSystem = "${var.worker_os}"
-
+      sshPublicKeys   = [file(var.ssh_public_key_file)]
+      operatingSystem = var.worker_os
       operatingSystemSpec = {
         distUpgradeOnBoot = false
       }
-
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/packet-machinedeployment.yaml
-
-      projectID    = "${var.project_id}"
-      facilities   = ["${var.facility}"]
-      instanceType = "${var.device_type}"
+      projectID    = var.project_id
+      facilities   = [var.facility]
+      instanceType = var.device_type
     }
   }
+  # provider specific fields:
+  # see example under `cloudProviderSpec` section at: 
+  # https://github.com/kubermatic/machine-controller/blob/master/examples/packet-machinedeployment.yaml
 }
+

--- a/examples/terraform/packet/variables.tf
+++ b/examples/terraform/packet/variables.tf
@@ -78,3 +78,4 @@ variable "device_type" {
 variable "project_id" {
   description = "project ID"
 }
+

--- a/examples/terraform/packet/versions.tf
+++ b/examples/terraform/packet/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/terraform/vsphere/main.tf
+++ b/examples/terraform/vsphere/main.tf
@@ -22,49 +22,49 @@ provider "vsphere" {
 }
 
 data "vsphere_datacenter" "dc" {
-  name = "${var.dc_name}"
+  name = var.dc_name
 }
 
 data "vsphere_datastore" "datastore" {
-  name          = "${var.datastore_name}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.datastore_name
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_compute_cluster" "cluster" {
-  name          = "${var.compute_cluster_name}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.compute_cluster_name
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_network" "network" {
-  name          = "${var.network_name}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.network_name
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_virtual_machine" "template" {
-  name          = "${var.template_name}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.template_name
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 resource "vsphere_virtual_machine" "control_plane" {
   count            = 3
   name             = "${var.cluster_name}-cp-${count.index + 1}"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 2
   memory           = 2048
-  guest_id         = "${data.vsphere_virtual_machine.template.guest_id}"
-  scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
 
   network_interface {
-    network_id   = "${data.vsphere_network.network.id}"
-    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+    network_id   = data.vsphere_network.network.id
+    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
   }
 
   disk {
     label            = "disk0"
-    size             = "${var.disk_size}"
-    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
-    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+    size             = var.disk_size
+    thin_provisioned = data.vsphere_virtual_machine.template.disks[0].thin_provisioned
+    eagerly_scrub    = data.vsphere_virtual_machine.template.disks[0].eagerly_scrub
   }
 
   cdrom {
@@ -72,20 +72,20 @@ resource "vsphere_virtual_machine" "control_plane" {
   }
 
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    template_uuid = data.vsphere_virtual_machine.template.id
   }
 
   vapp {
-    properties {
+    properties = {
       hostname    = "${var.cluster_name}-cp-${count.index + 1}"
-      public-keys = "${file("${var.ssh_public_key_file}")}"
+      public-keys = file(var.ssh_public_key_file)
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "vapp.0.properties",
-      "tags",
+      vapp[0].properties,
+      tags,
     ]
   }
 }
@@ -93,23 +93,23 @@ resource "vsphere_virtual_machine" "control_plane" {
 resource "vsphere_virtual_machine" "lb" {
   count            = 1
   name             = "${var.cluster_name}-lb-${count.index + 1}"
-  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 1
   memory           = 1024
-  guest_id         = "${data.vsphere_virtual_machine.template.guest_id}"
-  scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
 
   network_interface {
-    network_id   = "${data.vsphere_network.network.id}"
-    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+    network_id   = data.vsphere_network.network.id
+    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
   }
 
   disk {
     label            = "disk0"
-    size             = "${var.disk_size}"
-    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
-    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+    size             = var.disk_size
+    thin_provisioned = data.vsphere_virtual_machine.template.disks[0].thin_provisioned
+    eagerly_scrub    = data.vsphere_virtual_machine.template.disks[0].eagerly_scrub
   }
 
   cdrom {
@@ -117,26 +117,27 @@ resource "vsphere_virtual_machine" "lb" {
   }
 
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    template_uuid = data.vsphere_virtual_machine.template.id
   }
 
   vapp {
-    properties {
+    properties = {
       hostname    = "${var.cluster_name}-lb-${count.index + 1}"
-      public-keys = "${file("${var.ssh_public_key_file}")}"
+      public-keys = file(var.ssh_public_key_file)
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "vapp.0.properties",
-      "tags",
+      vapp[0].properties,
+      tags,
     ]
   }
 
   connection {
-    host = "${self.default_ip_address}"
-    user = "${var.ssh_username}"
+    type = "ssh"
+    host = self.default_ip_address
+    user = var.ssh_username
   }
 
   provisioner "remote-exec" {
@@ -145,28 +146,28 @@ resource "vsphere_virtual_machine" "lb" {
 }
 
 data "template_file" "lbconfig" {
-  template = "${file("etc_gobetween.tpl")}"
+  template = file("etc_gobetween.tpl")
 
   vars = {
-    lb_target1 = "${vsphere_virtual_machine.control_plane.0.default_ip_address}"
-    lb_target2 = "${vsphere_virtual_machine.control_plane.1.default_ip_address}"
-    lb_target3 = "${vsphere_virtual_machine.control_plane.2.default_ip_address}"
+    lb_target1 = vsphere_virtual_machine.control_plane[0].default_ip_address
+    lb_target2 = vsphere_virtual_machine.control_plane[1].default_ip_address
+    lb_target3 = vsphere_virtual_machine.control_plane[2].default_ip_address
   }
 }
 
 resource "null_resource" "lb_config" {
   triggers = {
-    cluster_instance_ids = "${join(",", vsphere_virtual_machine.control_plane.*.id)}"
-    config               = "${data.template_file.lbconfig.rendered}"
+    cluster_instance_ids = join(",", vsphere_virtual_machine.control_plane.*.id)
+    config               = data.template_file.lbconfig.rendered
   }
 
   connection {
-    user = "${var.ssh_username}"
-    host = "${vsphere_virtual_machine.lb.default_ip_address}"
+    user = var.ssh_username
+    host = vsphere_virtual_machine.lb[0].default_ip_address
   }
 
   provisioner "file" {
-    content     = "${data.template_file.lbconfig.rendered}"
+    content     = data.template_file.lbconfig.rendered
     destination = "/tmp/gobetween.toml"
   }
 
@@ -177,3 +178,4 @@ resource "null_resource" "lb_config" {
     ]
   }
 }
+

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = "${vsphere_virtual_machine.lb.default_ip_address}"
+    endpoint = vsphere_virtual_machine.lb[0].default_ip_address
   }
 }
 
@@ -27,14 +27,14 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = "${var.cluster_name}"
+      cluster_name         = var.cluster_name
       cloud_provider       = "vsphere"
       private_address      = []
-      public_address       = "${vsphere_virtual_machine.control_plane.*.default_ip_address}"
-      ssh_agent_socket     = "${var.ssh_agent_socket}"
-      ssh_port             = "${var.ssh_port}"
-      ssh_private_key_file = "${var.ssh_private_key_file}"
-      ssh_user             = "${var.ssh_username}"
+      public_address       = vsphere_virtual_machine.control_plane.*.default_ip_address
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
     }
   }
 }
@@ -47,28 +47,26 @@ output "kubeone_workers" {
     # corresponding (by name) worker definition
     pool1 = {
       replicas        = 1
-      sshPublicKeys   = ["${file("${var.ssh_public_key_file}")}"]
-      operatingSystem = "${var.worker_os}"
-
+      sshPublicKeys   = [file(var.ssh_public_key_file)]
+      operatingSystem = var.worker_os
       operatingSystemSpec = {
         distUpgradeOnBoot = false
       }
-
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/vsphere-machinedeployment.yaml
-
-      allowInsecure  = false
-      cluster        = "${var.compute_cluster_name}"
-      cpus           = 2
-      datacenter     = "${var.dc_name}"
-      datastore      = "${var.datastore_name}"
+      allowInsecure = false
+      cluster       = var.compute_cluster_name
+      cpus          = 2
+      datacenter    = var.dc_name
+      datastore     = var.datastore_name
       # Optional: Resize the root disk to this size. Must be bigger than the existing size
       # Default is to leave the disk at the same size as the template
       diskSizeGB     = 10
       memoryMB       = 2048
-      templateVMName = "${var.template_name}"
-      vmNetName      = "${var.network_name}"
+      templateVMName = var.template_name
+      vmNetName      = var.network_name
     }
   }
+  # provider specific fields:
+  # see example under `cloudProviderSpec` section at: 
+  # https://github.com/kubermatic/machine-controller/blob/master/examples/vsphere-machinedeployment.yaml
 }
+

--- a/examples/terraform/vsphere/variables.tf
+++ b/examples/terraform/vsphere/variables.tf
@@ -84,3 +84,4 @@ variable "disk_size" {
   default     = 50
   description = "disk size"
 }
+

--- a/examples/terraform/vsphere/versions.tf
+++ b/examples/terraform/vsphere/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/hack/run_ci_e2e_test.sh
+++ b/hack/run_ci_e2e_test.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 RUNNING_IN_CI=${JOB_NAME:-""}
 BUILD_ID=${BUILD_ID:-"${USER}-local"}
 PROVIDER=${PROVIDER:-"aws"}
+TERRAFORM_VERSION=${TERRAFORM_VERSION:-"0.12.2"}
 TEST_SET=${TEST_SET:-"conformance"}
 TEST_CLUSTER_TARGET_VERSION=${TEST_CLUSTER_VERSION:-"1.14.1"}
 export TF_VAR_cluster_name=${BUILD_ID}
@@ -34,7 +35,7 @@ if ! [ -x "$(command -v terraform)" ]; then
   fi
   echo "Installing terraform"
   cd /tmp
-  curl https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip -Lo terraform.zip
+  curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -Lo terraform.zip
   unzip -n terraform.zip terraform
   chmod +x terraform
   mv terraform /usr/local/bin

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -18,7 +18,6 @@ package terraform
 
 import (
 	"encoding/json"
-	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -32,7 +31,7 @@ type controlPlane struct {
 	PublicAddress     []string `json:"public_address"`
 	PrivateAddress    []string `json:"private_address"`
 	SSHUser           string   `json:"ssh_user"`
-	SSHPort           string   `json:"ssh_port"`
+	SSHPort           int      `json:"ssh_port"`
 	SSHPrivateKeyFile string   `json:"ssh_private_key_file"`
 	SSHAgentSocket    string   `json:"ssh_agent_socket"`
 }
@@ -47,12 +46,12 @@ type Config struct {
 
 	KubeOneHosts struct {
 		Value struct {
-			ControlPlane []controlPlane `json:"control_plane"`
+			ControlPlane controlPlane `json:"control_plane"`
 		} `json:"value"`
 	} `json:"kubeone_hosts"`
 
 	KubeOneWorkers struct {
-		Value map[string][]json.RawMessage `json:"value"`
+		Value map[string]json.RawMessage `json:"value"`
 	} `json:"kubeone_workers"`
 }
 
@@ -76,24 +75,13 @@ func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 		}
 	}
 
-	if len(c.KubeOneHosts.Value.ControlPlane) == 0 {
-		return errors.New("no control plane hosts are given")
-	}
-
-	cp := c.KubeOneHosts.Value.ControlPlane[0]
+	cp := c.KubeOneHosts.Value.ControlPlane
 
 	if cp.CloudProvider != nil {
 		cluster.CloudProvider.Name = kubeonev1alpha1.CloudProviderName(*cp.CloudProvider)
 	}
 
-	var sshPort int
 	var err error
-	if cp.SSHPort != "" {
-		sshPort, err = strconv.Atoi(cp.SSHPort)
-		if err != nil {
-			return errors.Wrapf(err, "failed to convert ssh port string %q to int", cp.SSHPort)
-		}
-	}
 
 	cluster.Name = cp.ClusterName
 
@@ -110,7 +98,7 @@ func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 			PublicAddress:     publicIP,
 			PrivateAddress:    privateIP,
 			SSHUsername:       cp.SSHUser,
-			SSHPort:           sshPort,
+			SSHPort:           cp.SSHPort,
 			SSHPrivateKeyFile: cp.SSHPrivateKeyFile,
 			SSHAgentSocket:    cp.SSHAgentSocket,
 		})
@@ -123,11 +111,6 @@ func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 	// Walk through all configued workersets from terraform and apply their config
 	// by either merging it into an existing workerSet or creating a new one
 	for workersetName, workersetValue := range c.KubeOneWorkers.Value {
-		if len(workersetValue) != 1 {
-			// TODO: log warning? error?
-			continue
-		}
-
 		var existingWorkerSet *kubeonev1alpha1.WorkerConfig
 		for idx, workerset := range cluster.Workers {
 			if workerset.Name == workersetName {
@@ -144,21 +127,21 @@ func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 
 		switch cluster.CloudProvider.Name {
 		case kubeonev1alpha1.CloudProviderNameAWS:
-			err = c.updateAWSWorkerset(existingWorkerSet, workersetValue[0])
+			err = c.updateAWSWorkerset(existingWorkerSet, workersetValue)
 		case kubeonev1alpha1.CloudProviderNameAzure:
-			err = c.updateAzureWorkerset(existingWorkerSet, workersetValue[0])
+			err = c.updateAzureWorkerset(existingWorkerSet, workersetValue)
 		case kubeonev1alpha1.CloudProviderNameGCE:
-			err = c.updateGCEWorkerset(existingWorkerSet, workersetValue[0])
+			err = c.updateGCEWorkerset(existingWorkerSet, workersetValue)
 		case kubeonev1alpha1.CloudProviderNameDigitalOcean:
-			err = c.updateDigitalOceanWorkerset(existingWorkerSet, workersetValue[0])
+			err = c.updateDigitalOceanWorkerset(existingWorkerSet, workersetValue)
 		case kubeonev1alpha1.CloudProviderNameHetzner:
-			err = c.updateHetznerWorkerset(existingWorkerSet, workersetValue[0])
+			err = c.updateHetznerWorkerset(existingWorkerSet, workersetValue)
 		case kubeonev1alpha1.CloudProviderNameOpenStack:
-			err = c.updateOpenStackWorkerset(existingWorkerSet, workersetValue[0])
+			err = c.updateOpenStackWorkerset(existingWorkerSet, workersetValue)
 		case kubeonev1alpha1.CloudProviderNameVSphere:
-			err = c.updateVSphereWorkerset(existingWorkerSet, workersetValue[0])
+			err = c.updateVSphereWorkerset(existingWorkerSet, workersetValue)
 		case kubeonev1alpha1.CloudProviderNamePacket:
-			err = c.updatePacketWorkerset(existingWorkerSet, workersetValue[0])
+			err = c.updatePacketWorkerset(existingWorkerSet, workersetValue)
 		default:
 			return errors.Errorf("unknown provider %v", cluster.CloudProvider.Name)
 		}
@@ -168,7 +151,7 @@ func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 		}
 
 		// copy over common config
-		if err = c.updateCommonWorkerConfig(existingWorkerSet, workersetValue[0]); err != nil {
+		if err = c.updateCommonWorkerConfig(existingWorkerSet, workersetValue); err != nil {
 			return errors.Wrap(err, "failed to update common config from terraform config")
 		}
 	}
@@ -466,10 +449,10 @@ func setWorkersetFlag(w *kubeonev1alpha1.WorkerConfig, name string, value interf
 }
 
 type commonWorkerConfig struct {
-	SSHPublicKeys       []string              `json:"sshPublicKeys"`
-	Replicas            *int                  `json:"replicas"`
-	OperatingSystem     *string               `json:"operatingSystem"`
-	OperatingSystemSpec []operatingSystemSpec `json:"operatingSystemSpec"`
+	SSHPublicKeys       []string             `json:"sshPublicKeys"`
+	Replicas            *int                 `json:"replicas"`
+	OperatingSystem     *string              `json:"operatingSystem"`
+	OperatingSystemSpec *operatingSystemSpec `json:"operatingSystemSpec"`
 }
 
 type operatingSystemSpec struct {
@@ -499,10 +482,8 @@ func (c *Config) updateCommonWorkerConfig(workerset *kubeonev1alpha1.WorkerConfi
 	}
 
 	osSpecMap := make(map[string]interface{})
-	for _, v := range cc.OperatingSystemSpec {
-		if v.DistUpgradeOnBoot != nil {
-			osSpecMap["distUpgradeOnBoot"] = *v.DistUpgradeOnBoot
-		}
+	if cc.OperatingSystemSpec.DistUpgradeOnBoot != nil {
+		osSpecMap["distUpgradeOnBoot"] = *cc.OperatingSystemSpec.DistUpgradeOnBoot
 	}
 
 	if len(osSpecMap) > 0 {


### PR DESCRIPTION
Have done that by running `terraform 0.12upgrade` for each example

**What this PR does / why we need it**:
Terraform upstream version is 0.12 and we should support it. v0.12 introduces language breaking changes that make 0.12 and 0.11 incompatible with each other.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #463

**Special notes for your reviewer**:
None
 
**Documentation**:
Rewrote Docs to match version, added terraform version to compatibility matrix

**Release note**:
Since only examples are changes, does this require "action required"?
```release-note
Terraform examples are now written for version 0.12, but will not work with version 0.11 anymore.
```
