### PR TITLE
Fix GoReleaser deprecation warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,5 +10,6 @@ builds:
   - darwin
   goarch:
   - amd64
-archive:
-  format: zip
+archives:
+  - id: kubeone
+    format: zip


### PR DESCRIPTION
**What this PR does / why we need it**:

`goreleaser` shows the following deprecated warning when staging a release

```
• ARCHIVES         
            • DEPRECATED: `archive` should not be used anymore, check https://goreleaser.com/deprecations#archive for more info.
```

This PR fixes this by using `archives` instead of `archive`.

I haven't tested this, but I believe it should work the same way.

**Release note**:
```release-note
NONE
```

/assign @kron4eg 