### PR TITLE
Make ams3 default DigitalOcean region

### DIFF
--- a/examples/terraform/digitalocean/variables.tf
+++ b/examples/terraform/digitalocean/variables.tf
@@ -57,7 +57,7 @@ variable "ssh_agent_socket" {
 
 variable "region" {
   description = "Region to speak to"
-  default     = "fra1"
+  default     = "ams3"
 }
 
 variable "control_plane_droplet_image" {


### PR DESCRIPTION
**What this PR does / why we need it**:

After some discussion, we decided to try to switch to another DO region to see is that going to decrease the number of E2E failures and flakes. For now, we'll try Amsterdam (`ams3`) region.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #372

**Release note**:
```release-note
NONE
```

/assign @kron4eg 