### PR TITLE
Upgrade machinecontroller to v1.2.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -594,7 +594,7 @@
   version = "v1.13.1"
 
 [[projects]]
-  digest = "1:500ca96976d373a2242dab5c4597a2858458b6d26d8c3d3db8414525e6fc505f"
+  digest = "1:8d33862c8f1b7b924332c7677ce204d383d1063653c8517b82154af7d0a5f940"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "pkg/apis/cluster/common",
@@ -602,7 +602,7 @@
     "pkg/client/clientset_generated/clientset/scheme",
   ]
   pruneopts = "NUT"
-  revision = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
+  revision = "2ec456177c0e8f0a903f4e746d44baaae54cc591"
 
 [[projects]]
   digest = "1:d58a6193316103ee408ce0891398cf66b7977df81d2c40b75a3b1c92925fa76f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@ required = [
 
 [[constraint]]
   name = "sigs.k8s.io/cluster-api"
-  revision = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
+  revision = "2ec456177c0e8f0a903f4e746d44baaae54cc591"
 
 [[constraint]]
   name = "sigs.k8s.io/controller-runtime"
@@ -74,6 +74,3 @@ required = [
   non-go = false
   go-tests = false
   unused-packages = false
-[[constraint]]
-  name = "github.com/cpuguy83/go-md2man"
-  revision = "691ee98543af2f262f35fbb54bdd42f00b9b9cc5"

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -532,6 +532,9 @@ machineController:
 # Proxy is used to configure HTTP_PROXY, HTTPS_PROXY and NO_PROXY
 # for Docker daemon and kubelet, and to be used when provisioning cluster
 # (e.g. for curl, apt-get..).
+# Also worker nodes managed by machine-controller will be configred according to
+# proxy settings here. The caveat is that only proxy.http and proxy.noProxy will
+# be used on worker machines.
 # proxy:
 #  http: '{{ .HTTPProxy }}'
 #  https: '{{ .HTTPSProxy }}'

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -44,7 +44,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.1.9"
+	MachineControllerTag           = "v1.2.0"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster
@@ -725,6 +725,14 @@ func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster) (*appsv1.De
 		"-v", "4",
 		"-internal-listen-address", "0.0.0.0:8085",
 		"-cluster-dns", clusterDNS.String(),
+	}
+
+	if cluster.Proxy.HTTP != "" {
+		args = append(args, "-node-http-proxy", cluster.Proxy.HTTP)
+	}
+
+	if cluster.Proxy.NoProxy != "" {
+		args = append(args, "-node-no-proxy", cluster.Proxy.NoProxy)
 	}
 
 	if cluster.CloudProvider.External {

--- a/vendor/sigs.k8s.io/cluster-api/logos/LICENSE.md
+++ b/vendor/sigs.k8s.io/cluster-api/logos/LICENSE.md
@@ -1,0 +1,13 @@
+All artwork in this repo is made available under the Linux Foundation trademark
+usage [guidelines](https://www.linuxfoundation.org/trademark-usage/).
+
+This text from those guidelines, and the correct and incorrect usage examples, are
+particularly helpful:
+
+> Certain marks of The Linux Foundation have been created to enable you to
+> communicate compatibility or interoperability of software or products.
+> In addition to the requirement that any use of a mark to make an assertion
+> of compatibility must, of course, be accurate, the use of these marks must
+> avoid confusion regarding The Linux Foundation’s association with the product.
+> The use of the mark cannot imply that The Linux Foundation or its projects are
+> sponsoring or endorsing the product.

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -31,6 +31,7 @@ const ClusterFinalizer = "cluster.cluster.k8s.io"
 /// [Cluster]
 // Cluster is the Schema for the clusters API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=cl
 // +kubebuilder:subresource:status
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -37,9 +37,11 @@ const (
 /// [Machine]
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=ma
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Machine status such as Terminating/Pending/Running/Failed etc"
+// +kubebuilder:printcolumn:name="NodeName",type="string",JSONPath=".status.nodeRef.name",description="Node name associated with this machine",priority=1
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineclass_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineclass_types.go
@@ -30,6 +30,7 @@ import (
 // across multiple Machines / MachineSets / MachineDeployments.
 // +k8s:openapi-gen=true
 // +resource:path=machineclasses
+// +kubebuilder:resource:shortName=mc
 type MachineClass struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -167,6 +167,7 @@ type MachineDeploymentStatus struct {
 /// [MachineDeployment]
 // MachineDeployment is the Schema for the machinedeployments API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=md
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 type MachineDeployment struct {

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -32,6 +32,7 @@ import (
 /// [MachineSet]
 // MachineSet ensures that a specified number of machines replicas are running at any given time.
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=ms
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 type MachineSet struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR brings proxy support for worker nodes

original PR: https://github.com/kubermatic/machine-controller/pull/559

```release-note
* Proxy support for worker nodes
```