### PR TITLE
[BREAKING]: terraform outputs directly unmarshaled to kubeone API strucures

### DIFF
--- a/examples/terraform/aws-private/output.tf
+++ b/examples/terraform/aws-private/output.tf
@@ -49,29 +49,33 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas        = 1
-      sshPublicKeys   = [aws_key_pair.deployer.public_key]
-      operatingSystem = var.worker_os
-      operatingSystemSpec = {
-        distUpgradeOnBoot = false
-      }
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
-      region           = var.aws_region
-      ami              = local.ami
-      availabilityZone = data.aws_availability_zones.available.names[0]
-      instanceProfile  = aws_iam_instance_profile.workers.name
-      securityGroupIDs = [aws_security_group.common.id]
-      vpcId            = data.aws_vpc.selected.id
-      subnetId         = aws_subnet.private[0].id
-      instanceType     = var.worker_type
-      diskSize         = 100
-      diskType         = "gp2"
-      ## Only application if diskType = io1
-      diskIops         = 500
-      tags = {
-        "kubeone" = "pool1"
+      replicas = 1
+      providerSpec = {
+        sshPublicKeys   = [aws_key_pair.deployer.public_key]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at:
+          # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
+          region           = var.aws_region
+          ami              = local.ami
+          availabilityZone = data.aws_availability_zones.available.names[0]
+          instanceProfile  = aws_iam_instance_profile.workers.name
+          securityGroupIDs = [aws_security_group.common.id]
+          vpcId            = data.aws_vpc.selected.id
+          subnetId         = aws_subnet.private[0].id
+          instanceType     = var.worker_type
+          diskSize         = 100
+          diskType         = "gp2"
+          ## Only application if diskType = io1
+          diskIops = 500
+          tags = {
+            "${var.cluster_name}-workers" = "pool1"
+          }
+        }
       }
     }
   }

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -177,7 +177,7 @@ resource "aws_lb" "control_plane" {
   name               = "${var.cluster_name}-api-lb"
   internal           = false
   load_balancer_type = "network"
-  subnets = local.all_subnets
+  subnets            = local.all_subnets
 
   tags = map("Cluster", var.cluster_name, local.kube_cluster_tag, "shared")
 }

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -46,29 +46,33 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas        = 1
-      sshPublicKeys   = [aws_key_pair.deployer.public_key]
-      operatingSystem = var.worker_os
-      operatingSystemSpec = {
-        distUpgradeOnBoot = false
-      }
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
-      region           = var.aws_region
-      ami              = local.ami
-      availabilityZone = local.az_a
-      instanceProfile  = aws_iam_instance_profile.profile.name
-      securityGroupIDs = [aws_security_group.common.id]
-      vpcId            = local.vpc_id
-      subnetId         = data.aws_subnet.az_a.id
-      instanceType     = var.worker_type
-      diskSize         = 50
-      diskType         = "gp2"
-      ## Only application if diskType = io1
-      diskIops         = 500
-      tags = {
-        "kubeone" = "pool1"
+      replicas = 1
+      providerSpec = {
+        sshPublicKeys   = [aws_key_pair.deployer.public_key]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at:
+          # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
+          region           = var.aws_region
+          ami              = local.ami
+          availabilityZone = local.az_a
+          instanceProfile  = aws_iam_instance_profile.profile.name
+          securityGroupIDs = [aws_security_group.common.id]
+          vpcId            = local.vpc_id
+          subnetId         = data.aws_subnet.az_a.id
+          instanceType     = var.worker_type
+          diskSize         = 50
+          diskType         = "gp2"
+          ## Only applicable if diskType = io1
+          diskIops = 500
+          tags = {
+            "${var.cluster_name}-workers" = "pool1"
+          }
+        }
       }
     }
   }

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -46,26 +46,30 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas        = 1
-      sshPublicKeys   = [file(var.ssh_public_key_file)]
-      operatingSystem = var.worker_os
-      operatingSystemSpec = {
-        distUpgradeOnBoot = false
-      }
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/azure-machinedeployment.yaml
-      assignPublicIP    = true
-      availabilitySet   = azurerm_availability_set.avset.name
-      location          = var.location
-      resourceGroup     = azurerm_resource_group.rg.name
-      routeTableName    = ""
-      securityGroupName = azurerm_network_security_group.sg.name
-      subnetName        = azurerm_subnet.subnet.name
-      vmSize            = var.worker_vm_size
-      vnetName          = azurerm_virtual_network.vpc.name
-      tags = {
-        "kubeone" = var.cluster_name
+      replicas = 1
+      providerSpec = {
+        sshPublicKeys   = [file(var.ssh_public_key_file)]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at: 
+          # https://github.com/kubermatic/machine-controller/blob/master/examples/azure-machinedeployment.yaml
+          assignPublicIP    = true
+          availabilitySet   = azurerm_availability_set.avset.name
+          location          = var.location
+          resourceGroup     = azurerm_resource_group.rg.name
+          routeTableName    = ""
+          securityGroupName = azurerm_network_security_group.sg.name
+          subnetName        = azurerm_subnet.subnet.name
+          vmSize            = var.worker_vm_size
+          vnetName          = azurerm_virtual_network.vpc.name
+          tags = {
+            "${var.cluster_name}-workers" = "pool1"
+          }
+        }
       }
     }
   }

--- a/examples/terraform/digitalocean/output.tf
+++ b/examples/terraform/digitalocean/output.tf
@@ -46,25 +46,29 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas        = 1
-      sshPublicKeys   = [digitalocean_ssh_key.deployer.public_key]
-      operatingSystem = var.worker_os
-      operatingSystemSpec = {
-        distUpgradeOnBoot = false
+      replicas = 1
+      providerSpec = {
+        sshPublicKeys   = [digitalocean_ssh_key.deployer.public_key]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at:
+          # https://github.com/kubermatic/machine-controller/blob/master/examples/digitalocean-machinedeployment.yaml
+          region             = var.region
+          size               = var.worker_size
+          private_networking = true
+          backups            = false
+          ipv6               = false
+          monitoring         = false
+          tags = [
+            local.kube_cluster_tag,
+            "${var.cluster_name}-workers-pool1"
+          ]
+        }
       }
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/digitalocean-machinedeployment.yaml
-      region             = var.region
-      size               = var.worker_size
-      private_networking = true
-      backups            = false
-      ipv6               = false
-      monitoring         = false
-      tags = [
-        local.kube_cluster_tag,
-        "kubeone",
-      ]
     }
   }
 }

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -46,28 +46,32 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas        = 1
-      sshPublicKeys   = [file(var.ssh_public_key_file)]
-      operatingSystem = var.worker_os
-      operatingSystemSpec = {
-        distUpgradeOnBoot = false
+      replicas = 1
+      providerSpec = {
+        sshPublicKeys   = [file(var.ssh_public_key_file)]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at:
+          # https://github.com/kubermatic/machine-controller/blob/master/examples/gce-machinedeployment.yaml
+          diskSize              = 50
+          diskType              = "pd-ssd"
+          machineType           = var.workers_type
+          network               = google_compute_network.network.self_link
+          subnetwork            = google_compute_subnetwork.subnet.self_link
+          zone                  = "${var.region}-a"
+          preemptible           = false
+          assignPublicIPAddress = true
+          labels = {
+            "${var.cluster_name}-workers" = "pool1"
+          }
+          tags     = ["firewall", "targets"]
+          regional = false
+        }
       }
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/gce-machinedeployment.yaml
-      diskSize              = 50
-      diskType              = "pd-ssd"
-      machineType           = var.workers_type
-      network               = google_compute_network.network.self_link
-      subnetwork            = google_compute_subnetwork.subnet.self_link
-      zone                  = "${var.region}-a"
-      preemptible           = false
-      assignPublicIPAddress = true
-      labels = {
-        "kubeone" = "workers"
-      }
-      tags     = ["firewall", "targets"]
-      regional = false
     }
   }
 }

--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -46,19 +46,23 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas        = 1
-      sshPublicKeys   = [file(var.ssh_public_key_file)]
-      operatingSystem = var.worker_os
-      operatingSystemSpec = {
-        distUpgradeOnBoot = false
-      }
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/hetzner-machinedeployment.yaml
-      serverType = var.worker_type
-      location   = var.datacenter
-      labels = {
-        "kubeone": "pool1"
+      replicas = 1
+      providerSpec = {
+        sshPublicKeys   = [file(var.ssh_public_key_file)]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at:
+          # https://github.com/kubermatic/machine-controller/blob/master/examples/hetzner-machinedeployment.yaml
+          serverType = var.worker_type
+          location   = var.datacenter
+          labels = {
+            "${var.cluster_name}-workers" = "pool1"
+          }
+        }
       }
     }
   }

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -46,23 +46,27 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas        = 1
-      sshPublicKeys   = [file(var.ssh_public_key_file)]
-      operatingSystem = var.worker_os
-      operatingSystemSpec = {
-        distUpgradeOnBoot = false
-      }
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/openstack-machinedeployment.yaml
-      image          = var.image
-      flavor         = var.worker_flavor
-      securityGroups = [openstack_networking_secgroup_v2.securitygroup.name]
-      floatingIPPool = var.external_network_name
-      network        = openstack_networking_network_v2.network.name
-      subnet         = openstack_networking_subnet_v2.subnet.name
-      tags = {
-        "kubeone" = "worker"
+      replicas = 1
+      providerSpec = {
+        sshPublicKeys   = [file(var.ssh_public_key_file)]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at:
+          # https://github.com/kubermatic/machine-controller/blob/master/examples/openstack-machinedeployment.yaml
+          image          = var.image
+          flavor         = var.worker_flavor
+          securityGroups = [openstack_networking_secgroup_v2.securitygroup.name]
+          floatingIPPool = var.external_network_name
+          network        = openstack_networking_network_v2.network.name
+          subnet         = openstack_networking_subnet_v2.subnet.name
+          tags = {
+            "${var.cluster_name}-workers" = "pool1"
+          }
+        }
       }
     }
   }

--- a/examples/terraform/packet/main.tf
+++ b/examples/terraform/packet/main.tf
@@ -36,7 +36,7 @@ resource "packet_device" "control_plane" {
   operating_system = var.control_plane_operating_system
   billing_cycle    = "hourly"
   project_id       = var.project_id
-  tags = [local.kube_cluster_tag]
+  tags             = [local.kube_cluster_tag]
 }
 
 resource "packet_device" "lb" {
@@ -48,7 +48,7 @@ resource "packet_device" "lb" {
   operating_system = var.lb_operating_system
   billing_cycle    = "hourly"
   project_id       = var.project_id
-  tags = [local.kube_cluster_tag]
+  tags             = [local.kube_cluster_tag]
 
   connection {
     type = "ssh"

--- a/examples/terraform/packet/output.tf
+++ b/examples/terraform/packet/output.tf
@@ -45,20 +45,23 @@ output "kubeone_workers" {
   value = {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
-    pool1 = {
-      replicas        = 1
-      sshPublicKeys   = [file(var.ssh_public_key_file)]
-      operatingSystem = var.worker_os
-      operatingSystemSpec = {
-        distUpgradeOnBoot = false
+    "${var.cluster_name}-pool1" = {
+      replicas = 1
+      providerSpec = {
+        sshPublicKeys   = [file(var.ssh_public_key_file)]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at: 
+          # https://github.com/kubermatic/machine-controller/blob/master/examples/packet-machinedeployment.yaml
+          projectID    = var.project_id
+          facilities   = [var.facility]
+          instanceType = var.device_type
+        }
       }
-      projectID    = var.project_id
-      facilities   = [var.facility]
-      instanceType = var.device_type
     }
   }
-  # provider specific fields:
-  # see example under `cloudProviderSpec` section at: 
-  # https://github.com/kubermatic/machine-controller/blob/master/examples/packet-machinedeployment.yaml
 }
-

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -46,26 +46,30 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas        = 1
-      sshPublicKeys   = [file(var.ssh_public_key_file)]
-      operatingSystem = var.worker_os
-      operatingSystemSpec = {
-        distUpgradeOnBoot = false
+      replicas = 1
+      providerSpec = {
+        sshPublicKeys   = [file(var.ssh_public_key_file)]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at:
+          # https://github.com/kubermatic/machine-controller/blob/master/examples/vsphere-machinedeployment.yaml
+          allowInsecure = false
+          cluster       = var.compute_cluster_name
+          cpus          = 2
+          datacenter    = var.dc_name
+          datastore     = var.datastore_name
+          # Optional: Resize the root disk to this size. Must be bigger than the existing size
+          # Default is to leave the disk at the same size as the template
+          diskSizeGB     = 10
+          memoryMB       = 2048
+          templateVMName = var.template_name
+          vmNetName      = var.network_name
+        }
       }
-      # provider specific fields:
-      # see example under `cloudProviderSpec` section at: 
-      # https://github.com/kubermatic/machine-controller/blob/master/examples/vsphere-machinedeployment.yaml
-      allowInsecure = false
-      cluster       = var.compute_cluster_name
-      cpus          = 2
-      datacenter    = var.dc_name
-      datastore     = var.datastore_name
-      # Optional: Resize the root disk to this size. Must be bigger than the existing size
-      # Default is to leave the disk at the same size as the template
-      diskSizeGB     = 10
-      memoryMB       = 2048
-      templateVMName = var.template_name
-      vmNetName      = var.network_name
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
To avoid collision with GCE `network`

```release-note
[BREAKING] terraform output to match config.yaml format 
```
