### PR TITLE
Make E2E tests version-agnostic

### DIFF
--- a/hack/run_ci_e2e_test.sh
+++ b/hack/run_ci_e2e_test.sh
@@ -24,7 +24,8 @@ BUILD_ID=${BUILD_ID:-"${USER}-local"}
 PROVIDER=${PROVIDER:-"aws"}
 TERRAFORM_VERSION=${TERRAFORM_VERSION:-"0.12.2"}
 TEST_SET=${TEST_SET:-"conformance"}
-TEST_CLUSTER_TARGET_VERSION=${TEST_CLUSTER_VERSION:-"1.14.1"}
+TEST_CLUSTER_TARGET_VERSION=${TEST_CLUSTER_TARGET_VERSION:-""}
+TEST_CLUSTER_INITIAL_VERSION=${TEST_CLUSTER_INITIAL_VERSION:-""}
 export TF_VAR_cluster_name=${BUILD_ID}
 
 # Install dependencies
@@ -153,7 +154,8 @@ function runE2E() {
     ./test/e2e/... \
     -identifier=${BUILD_ID} \
     -provider=${PROVIDER} \
-    -cluster-version=${TEST_CLUSTER_TARGET_VERSION}
+    -target-version=${TEST_CLUSTER_TARGET_VERSION} \
+    -initial-version=${TEST_CLUSTER_INITIAL_VERSION}
 }
 
 # Start the tests

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -46,7 +46,7 @@ func TestClusterConformance(t *testing.T) {
 			provider:              provisioner.AWS,
 			providerExternal:      false,
 			scenario:              NodeConformance,
-			configFilePath:        "../../test/e2e/testdata/config_aws_1.14.3.yaml",
+			configFilePath:        "../../test/e2e/testdata/config_aws.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 worker
 		},
 		{
@@ -54,7 +54,7 @@ func TestClusterConformance(t *testing.T) {
 			provider:              provisioner.DigitalOcean,
 			providerExternal:      true,
 			scenario:              NodeConformance,
-			configFilePath:        "../../test/e2e/testdata/config_do_1.14.3.yaml",
+			configFilePath:        "../../test/e2e/testdata/config_do.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 worker
 		},
 		{
@@ -62,7 +62,7 @@ func TestClusterConformance(t *testing.T) {
 			provider:              provisioner.Hetzner,
 			providerExternal:      true,
 			scenario:              NodeConformance,
-			configFilePath:        "../../test/e2e/testdata/config_hetzner_1.14.3.yaml",
+			configFilePath:        "../../test/e2e/testdata/config_hetzner.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 worker
 		},
 		{
@@ -70,7 +70,7 @@ func TestClusterConformance(t *testing.T) {
 			provider:              provisioner.GCE,
 			providerExternal:      false,
 			scenario:              NodeConformance,
-			configFilePath:        "../../test/e2e/testdata/config_gce_1.14.3.yaml",
+			configFilePath:        "../../test/e2e/testdata/config_gce.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 worker
 		},
 		{
@@ -78,7 +78,7 @@ func TestClusterConformance(t *testing.T) {
 			provider:              provisioner.Packet,
 			providerExternal:      true,
 			scenario:              NodeConformance,
-			configFilePath:        "../../test/e2e/testdata/config_packet_1.14.3.yaml",
+			configFilePath:        "../../test/e2e/testdata/config_packet.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 worker
 		},
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -39,14 +39,16 @@ import (
 // testRunIdentifier aka. the build number, a unique identifier for the test run.
 var (
 	testRunIdentifier  string
-	testClusterVersion string
+	testInitialVersion string
+	testTargetVersion  string
 	testProvider       string
 )
 
 func init() {
 	flag.StringVar(&testRunIdentifier, "identifier", "", "The unique identifier for this test run")
-	flag.StringVar(&testClusterVersion, "cluster-version", "", "Cluster version to run tests for")
 	flag.StringVar(&testProvider, "provider", "", "Provider to run tests on")
+	flag.StringVar(&testInitialVersion, "initial-version", "", "Cluster version to provision for tests")
+	flag.StringVar(&testTargetVersion, "target-version", "", "Cluster version to provision for tests")
 	flag.Parse()
 }
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -49,58 +49,46 @@ func TestClusterUpgrade(t *testing.T) {
 		name                  string
 		provider              string
 		providerExternal      bool
-		initialVersion        string
-		targetVersion         string
 		initialConfigPath     string
 		targetConfigPath      string
 		expectedNumberOfNodes int
 	}{
 		{
-			name:                  "upgrade k8s 1.13.7 cluster to 1.14.3 on AWS",
+			name:                  "upgrade k8s cluster on AWS",
 			provider:              provisioner.AWS,
 			providerExternal:      false,
-			initialVersion:        "1.13.7",
-			targetVersion:         "1.14.3",
 			initialConfigPath:     "../../test/e2e/testdata/config_aws_1.13.7.yaml",
 			targetConfigPath:      "../../test/e2e/testdata/config_aws_1.14.3.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
 		},
 		{
-			name:                  "upgrade k8s 1.13.7 cluster to 1.14.3 on DO",
+			name:                  "upgrade k8s cluster on DO",
 			provider:              provisioner.DigitalOcean,
 			providerExternal:      true,
-			initialVersion:        "1.13.7",
-			targetVersion:         "1.14.3",
 			initialConfigPath:     "../../test/e2e/testdata/config_do_1.13.7.yaml",
 			targetConfigPath:      "../../test/e2e/testdata/config_do_1.14.3.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
 		},
 		{
-			name:                  "upgrade k8s 1.13.7 cluster to 1.14.3 on Hetzner",
+			name:                  "upgrade k8s cluster on Hetzner",
 			provider:              provisioner.Hetzner,
 			providerExternal:      true,
-			initialVersion:        "1.13.7",
-			targetVersion:         "1.14.3",
 			initialConfigPath:     "../../test/e2e/testdata/config_hetzner_1.13.7.yaml",
 			targetConfigPath:      "../../test/e2e/testdata/config_hetzner_1.14.3.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
 		},
 		{
-			name:                  "upgrade k8s 1.13.7 cluster to 1.14.3 on GCE",
+			name:                  "upgrade k8s cluster to 1.14.3 on GCE",
 			provider:              provisioner.GCE,
 			providerExternal:      false,
-			initialVersion:        "1.13.7",
-			targetVersion:         "1.14.3",
 			initialConfigPath:     "../../test/e2e/testdata/config_gce_1.13.7.yaml",
 			targetConfigPath:      "../../test/e2e/testdata/config_gce_1.14.3.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
 		},
 		{
-			name:                  "upgrade k8s 1.13.7 cluster to 1.14.3 on Packet",
+			name:                  "upgrade k8s cluster on Packet",
 			provider:              provisioner.Packet,
 			providerExternal:      true,
-			initialVersion:        "1.13.7",
-			targetVersion:         "1.14.3",
 			initialConfigPath:     "../../test/e2e/testdata/config_packet_1.13.7.yaml",
 			targetConfigPath:      "../../test/e2e/testdata/config_packet_1.14.3.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
@@ -116,12 +104,16 @@ func TestClusterUpgrade(t *testing.T) {
 			if len(testRunIdentifier) == 0 {
 				t.Fatalf("-identifier must be set")
 			}
+			if len(testInitialVersion) == 0 {
+				t.Fatal("-initial-version must be set")
+			}
+			if len(testTargetVersion) == 0 {
+				t.Fatal("-target-version must be set")
+			}
 			if testProvider != tc.provider {
 				t.SkipNow()
 			}
-			if testClusterVersion != tc.targetVersion {
-				t.SkipNow()
-			}
+			t.Logf("Running upgrade tests from Kubernetes v%s to v%s…", testInitialVersion, testTargetVersion)
 
 			// Create provisioner
 			testPath := fmt.Sprintf("../../_build/%s", testRunIdentifier)
@@ -142,7 +134,7 @@ func TestClusterUpgrade(t *testing.T) {
 
 			// Create configuration manifest
 			t.Log("Creating KubeOneCluster manifest…")
-			err = target.CreateConfig(tc.initialVersion, tc.provider, tc.providerExternal)
+			err = target.CreateConfig(testInitialVersion, tc.provider, tc.providerExternal)
 			if err != nil {
 				t.Fatalf("failed to create KubeOneCluster manifest: %v", err)
 			}
@@ -203,7 +195,7 @@ func TestClusterUpgrade(t *testing.T) {
 				t.Fatalf("nodes are not ready: %v", err)
 			}
 			t.Log("Verifying cluster version before running upgrade…")
-			err = verifyVersion(client, metav1.NamespaceSystem, tc.initialVersion)
+			err = verifyVersion(client, metav1.NamespaceSystem, testInitialVersion)
 			if err != nil {
 				t.Fatalf("version mismatch before running upgrade: %v", err)
 			}
@@ -217,7 +209,7 @@ func TestClusterUpgrade(t *testing.T) {
 
 			// Create new configuration manifest
 			t.Log("Creating KubeOneCluster manifest…")
-			err = target.CreateConfig(tc.targetVersion, tc.provider, tc.providerExternal)
+			err = target.CreateConfig(testTargetVersion, tc.provider, tc.providerExternal)
 			if err != nil {
 				t.Fatalf("failed to create KubeOneCluster manifest: %v", err)
 			}
@@ -236,12 +228,12 @@ func TestClusterUpgrade(t *testing.T) {
 				t.Fatalf("nodes are not ready: %v", err)
 			}
 			t.Log("Verifying cluster version after running upgrade…")
-			err = verifyVersion(client, metav1.NamespaceSystem, tc.targetVersion)
+			err = verifyVersion(client, metav1.NamespaceSystem, testTargetVersion)
 			if err != nil {
 				t.Fatalf("version mismatch before running upgrade: %v", err)
 			}
 			t.Log("Polling nodes to verify are all workers upgraded…")
-			err = waitForNodesUpgraded(client, tc.targetVersion)
+			err = waitForNodesUpgraded(client, testTargetVersion)
 			if err != nil {
 				t.Fatalf("nodes are not running the target version: %v", err)
 			}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -57,40 +57,40 @@ func TestClusterUpgrade(t *testing.T) {
 			name:                  "upgrade k8s cluster on AWS",
 			provider:              provisioner.AWS,
 			providerExternal:      false,
-			initialConfigPath:     "../../test/e2e/testdata/config_aws_1.13.7.yaml",
-			targetConfigPath:      "../../test/e2e/testdata/config_aws_1.14.3.yaml",
+			initialConfigPath:     "../../test/e2e/testdata/config_aws_initial.yaml",
+			targetConfigPath:      "../../test/e2e/testdata/config_aws_target.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
 		},
 		{
 			name:                  "upgrade k8s cluster on DO",
 			provider:              provisioner.DigitalOcean,
 			providerExternal:      true,
-			initialConfigPath:     "../../test/e2e/testdata/config_do_1.13.7.yaml",
-			targetConfigPath:      "../../test/e2e/testdata/config_do_1.14.3.yaml",
+			initialConfigPath:     "../../test/e2e/testdata/config_do_initial.yaml",
+			targetConfigPath:      "../../test/e2e/testdata/config_do_target.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
 		},
 		{
 			name:                  "upgrade k8s cluster on Hetzner",
 			provider:              provisioner.Hetzner,
 			providerExternal:      true,
-			initialConfigPath:     "../../test/e2e/testdata/config_hetzner_1.13.7.yaml",
-			targetConfigPath:      "../../test/e2e/testdata/config_hetzner_1.14.3.yaml",
+			initialConfigPath:     "../../test/e2e/testdata/config_hetzner_initial.yaml",
+			targetConfigPath:      "../../test/e2e/testdata/config_hetzner_target.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
 		},
 		{
-			name:                  "upgrade k8s cluster to 1.14.3 on GCE",
+			name:                  "upgrade k8s cluster on GCE",
 			provider:              provisioner.GCE,
 			providerExternal:      false,
-			initialConfigPath:     "../../test/e2e/testdata/config_gce_1.13.7.yaml",
-			targetConfigPath:      "../../test/e2e/testdata/config_gce_1.14.3.yaml",
+			initialConfigPath:     "../../test/e2e/testdata/config_gce_initial.yaml",
+			targetConfigPath:      "../../test/e2e/testdata/config_gce_target.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
 		},
 		{
 			name:                  "upgrade k8s cluster on Packet",
 			provider:              provisioner.Packet,
 			providerExternal:      true,
-			initialConfigPath:     "../../test/e2e/testdata/config_packet_1.13.7.yaml",
-			targetConfigPath:      "../../test/e2e/testdata/config_packet_1.14.3.yaml",
+			initialConfigPath:     "../../test/e2e/testdata/config_packet_initial.yaml",
+			targetConfigPath:      "../../test/e2e/testdata/config_packet_target.yaml",
 			expectedNumberOfNodes: 4, // 3 control planes + 1 workers
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Considering steps to run E2E tests are the same for each Kubernetes version, I think we should not create a test case for each version, but instead, just provide the version to be used as a flag.

This PR updates the E2E tests and the script used to start the tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #372

**Release note**:
```release-note
NONE
```

/assign @kron4eg