### PR TITLE
Fix load balancer reference in vSphere Terraform example

### DIFF
--- a/examples/terraform/vsphere/main.tf
+++ b/examples/terraform/vsphere/main.tf
@@ -154,7 +154,7 @@ locals {
 resource "null_resource" "lb_config" {
   triggers = {
     cluster_instance_ids = join(",", vsphere_virtual_machine.control_plane.*.id)
-    config               = rendered_lb_config
+    config               = local.rendered_lb_config
   }
 
   connection {
@@ -163,7 +163,7 @@ resource "null_resource" "lb_config" {
   }
 
   provisioner "file" {
-    content     = rendered_lb_config
+    content     = local.rendered_lb_config
     destination = "/tmp/gobetween.toml"
   }
 


### PR DESCRIPTION
Signed-off-by: Christoph Kleineweber <christoph.kleineweber@loodse.com>

**What this PR does / why we need it**:

Terraform example for vSphere was broken due to an invalid reference to the LB config.

**Release note**:
```release-note
NONE
```