### PR TITLE
Make reset a bit more robust

### DIFF
--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -146,7 +146,9 @@ func DestroyWorkers(ctx *util.Context) error {
 	}
 	for i := range msList.Items {
 		if err := ctx.DynamicClient.Delete(bgCtx, &msList.Items[i]); err != nil {
-			return errors.Wrapf(err, "unable to delete machineset object %s", msList.Items[i].Name)
+			if !errorsutil.IsNotFound(err) {
+				return errors.Wrapf(err, "unable to delete machineset object %s", msList.Items[i].Name)
+			}
 		}
 	}
 
@@ -160,7 +162,9 @@ func DestroyWorkers(ctx *util.Context) error {
 	}
 	for i := range mList.Items {
 		if err := ctx.DynamicClient.Delete(bgCtx, &mList.Items[i]); err != nil {
-			return errors.Wrapf(err, "unable to delete machine object %s", mList.Items[i].Name)
+			if !errorsutil.IsNotFound(err) {
+				return errors.Wrapf(err, "unable to delete machine object %s", mList.Items[i].Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
* Retry failed operations
* Don't error out on not found some of the objects that can be deleted by controllers (avoid race-condition)
* Log a message to try to use --destroy-workers=false flag

Fixes #474  

```release-note
kubeone reset more robust
```
