### PR TITLE
Force docker start in ubuntu

### DIFF
--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -127,6 +127,7 @@ sudo apt-get install -y --no-install-recommends \
 	kubelet=${kube_ver} \
 	kubernetes-cni=${cni_ver}
 sudo apt-mark hold docker-ce kubelet kubeadm kubectl kubernetes-cni
+sudo systemctl enable --now docker
 `
 
 	kubeadmCentOSScript = `


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometime docker systemd service is not started automatically after install, so we force it (like in CentOS)

```release-note
Fix docker start issues
```
