### PR TITLE
Use systemd cgroup manager for Docker on Ubuntu

### DIFF
--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -85,7 +85,10 @@ if type docker &>/dev/null && type kubelet &>/dev/null; then exit 0; fi
 
 sudo mkdir -p /etc/docker
 cat <<EOF | sudo tee /etc/docker/daemon.json
-{"storage-driver": "overlay2"}
+{
+	"exec-opts": ["native.cgroupdriver=systemd"],
+	"storage-driver": "overlay2"
+}
 EOF
 
 sudo apt-get update


### PR DESCRIPTION
**What this PR does / why we need it**:

When provisioning a cluster, `kubeadm` shows the following warning:

```
[WARNING IsDockerSystemdCheck]: detected "cgroupfs" as the Docker cgroup driver. The recommended driver is "systemd". Please follow the guide at https://kubernetes.io/docs/setup/cri/
```

By default, Docker uses `cgroupfs` for managing cgroups. This clashes on systems running `systemd` (e.g. Ubuntu) because they use `systemd` for managing cgroups. Because `systemd` and `cgroupfs` can see resources differently, that can cause a node to become unstable and fail.

A resolution is to tell Docker to use `systemd` for managing cgroups and this is what has been done by this PR. Note that it is not possible to change this for existing setups without rolling out the node. This fix only affects the installation process.

More details about this can be found in the [Kubernetes documentation related to CRI](https://kubernetes.io/docs/setup/production-environment/container-runtimes/).

In a follow-up, I'll confirm this for CentOS and CoreOS.

When running `kubeadm` with this fix, I don't see the warning anymore:

```
INFO[17:33:20 CEST] Running kubeadm…                              node=35.180.54.40
+ [[ -f /etc/kubernetes/admin.conf ]]
+ sudo kubeadm init --config=./kubeone/cfg/master_0.yaml
[config] WARNING: Ignored YAML document with GroupVersionKind kubeadm.k8s.io/v1beta1, Kind=JoinConfiguration
[init] Using Kubernetes version: v1.15.0
[preflight] Running pre-flight checks
[preflight] Pulling images required for setting up a Kubernetes cluster
[preflight] This might take a minute or two, depending on the speed of your internet connection
[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
[kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
[kubelet-start] Activating the kubelet service
[certs] Using certificateDir folder "/etc/kubernetes/pki"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #363

**Does this PR introduce a user-facing change?**:
```release-note
Fix IsDockerSystemdCheck warning for Ubuntu
```

/assign @kron4eg 