### PR TITLE
Add Dockerfile and helper scripts for easier distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:latest
+
+RUN apk add --no-cache terraform
+
+COPY dist/kubeone /usr/bin/kubeone
+
+ENV SSH_AUTH_SOCK /run/ssh.sock
+WORKDIR /mnt

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PROVIDER=$(notdir $(wildcard ./terraform/*))
 CREATE_TARGETS=$(addsuffix -env,$(PROVIDER))
 DESTROY_TARGETS=$(addsuffix -env-cleanup,$(PROVIDER))
 
-.PHONY: all install-via-docker install build vendor download-dependencies
+.PHONY: all install-via-docker docker install build vendor download-dependencies
 .PHONY: generate-internal-groups verify-dependencies
 all: install
 
@@ -40,6 +40,10 @@ install-via-docker: docker-make-install
 		-w /go/src/github.com/kubermatic/kubeone \
 		$(BUILD_IMAGE) \
 		make install
+
+.PHONY: docker
+docker: dist/kubeone
+	docker build -t quay.io/kubermatic/kubeone:$(GITTAG) -f build/docker/Dockerfile .
 
 install:
 	go install $(GOBUILDFLAGS) -ldflags='$(GOLDFLAGS)' -v .

--- a/README.md
+++ b/README.md
@@ -106,6 +106,25 @@ Use your favorite method to build it on your system, for example by using
 `aurutils`:
 ```bash
 aur sync kubeone && pacman -S kubeone
+#### Docker
+
+We distribute a docker image that contains KubeOne and Terraform to use for your
+setup.
+
+##### Building
+
+```bash
+docker build -t kubeone:<Tag> .
+```
+
+##### Running
+
+To receive SSH credentials KubeOne needs to connect to the local SSH
+agent. This is done by mounting its UNIX socket. You can execute KubeOne and
+Terraform that way by running the following command line:
+
+```bash
+docker run --rm --user $(id -u) --name kubeone --mount type=bind,source="$SSH_AUTH_SOCK",target=/run/ssh.sock --mount type=bind,source="$(pwd)",target=/mnt -t kubeone:<Version> <Command>
 ```
 
 ### Shell completion and generating documentation


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds build instructions for a docker image that can be used to execute kubeone and terraform independently of the underlying distribution.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #473 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
