### PR TITLE
Use systemd cgroups driver on CoreOS and enable kubelet by default

### DIFF
--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -80,7 +80,7 @@ sudo sed -i '/.*swap.*/d' /etc/fstab
 source /etc/os-release
 source /etc/kubeone/proxy-env
 
-# Short-Circuit the installation if it was arleady executed
+# Short-Circuit the installation if it was already executed
 if type docker &>/dev/null && type kubelet &>/dev/null; then exit 0; fi
 
 sudo mkdir -p /etc/docker
@@ -131,6 +131,7 @@ sudo apt-get install -y --no-install-recommends \
 	kubernetes-cni=${cni_ver}
 sudo apt-mark hold docker-ce kubelet kubeadm kubectl kubernetes-cni
 sudo systemctl enable --now docker
+sudo systemctl enable --now kubelet
 `
 
 	kubeadmCentOSScript = `
@@ -141,7 +142,7 @@ sudo sed -i s/SELINUX=enforcing/SELINUX=permissive/g /etc/sysconfig/selinux
 
 source /etc/kubeone/proxy-env
 
-# Short-Circuit the installation if it was arleady executed
+# Short-Circuit the installation if it was already executed
 if type docker &>/dev/null && type kubelet &>/dev/null; then exit 0; fi
 
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
@@ -167,10 +168,23 @@ sudo yum install -y --disableexcludes=kubernetes \
 	kubectl-{{ .KUBERNETES_VERSION }}-0 \
 	kubernetes-cni-{{ .CNI_VERSION }}-0
 sudo systemctl enable --now docker
+sudo systemctl enable --now kubelet
 `
 
 	kubeadmCoreOSScript = `
 source /etc/kubeone/proxy-env
+
+# Short-Circuit the installation if it was already executed
+if type docker &>/dev/null && type kubelet &>/dev/null; then exit 0; fi
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": ["native.cgroupdriver=systemd"],
+	"storage-driver": "overlay2"
+}
+EOF
+sudo systemctl restart docker
 
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/{{ .CNI_VERSION }}/cni-plugins-amd64-{{ .CNI_VERSION }}.tgz" | \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR configures Docker on CoreOS to use `systemd` as a cgroups manager and `overlay2` as a storage driver. The installation script for CoreOS will now short-circuit if Docker and Kubelet are already present, like on Ubuntu and CentOS.

Lastly, Kubelet service is now enabled by default on Ubuntu and CentOS (it is already done on CoreOS). On Ubuntu it should have been like this by default, but not on CoreOS, causing `kubeadm` to complain.

Note that CoreOS still has 2 warnings that should be resolved, but those are not related to the `IsDockerSystemdCheck` warning.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #363 

**Does this PR introduce a user-facing change?**:
```release-note
Fix kubeadm warnings on CentOS and CoreOS
```

/assign @kron4eg 