### PR TITLE
Update machine-controller to v1.4.0 and add new OpenStackSpec fields

### DIFF
--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -63,6 +63,10 @@ output "kubeone_workers" {
           floatingIPPool = var.external_network_name
           network        = openstack_networking_network_v2.network.name
           subnet         = openstack_networking_subnet_v2.subnet.name
+          # Optional: If set, the rootDisk will be a volume. 
+          # Otherwise, the rootDisk will be on ephemeral storage and its size will
+          # be derived from the flavor
+          rootDiskSizeGB = 10
           tags = {
             "${var.cluster_name}-workers" = "pool1"
           }

--- a/pkg/templates/machinecontroller/cloudprovider_specs.go
+++ b/pkg/templates/machinecontroller/cloudprovider_specs.go
@@ -52,6 +52,7 @@ type OpenStackSpec struct {
 	AvailabilityZone string            `json:"availabilityZone"`
 	Network          string            `json:"network"`
 	Subnet           string            `json:"subnet"`
+	RootDiskSizeGB   *int              `json:"rootDiskSizeGB,omitempty"`
 	Tags             map[string]string `json:"tags"`
 }
 

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -44,7 +44,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.3.0"
+	MachineControllerTag           = "v1.4.0"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -312,6 +312,7 @@ func (c *Config) updateOpenStackWorkerset(existingWorkerSet *kubeonev1alpha1.Wor
 		{key: "availabilityZone", value: openstackConfig.AvailabilityZone},
 		{key: "network", value: openstackConfig.Network},
 		{key: "subnet", value: openstackConfig.Subnet},
+		{key: "rootDiskSizeGB", value: openstackConfig.RootDiskSizeGB},
 		{key: "tags", value: openstackConfig.Tags},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates `machine-controller` to v1.4.0 and adds the new `rootDiskSizeGB` field to the OpenStackSpec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #535

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.4.0
Add rootDiskSizeGB optional field to OpenStack worker spec
```

/assign @kron4eg 