### PR TITLE
Update machine-controller to v1.4.1 and add credentials validation

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -27,6 +27,7 @@ In the following table you can find all configuration variables with support for
 | `OS_USERNAME` | The username of the OpenStack user |
 | `OS_PASSWORD` | The password of the OpenStack user |
 | `OS_DOMAIN_NAME` | The name of the OpenStack domain |
+| `OS_TENANT_ID` | The ID of the OpenStack tenant |
 | `OS_TENANT_NAME` | The name of the OpenStack tenant |
 | | |
 | `PACKET_AUTH_TOKEN` | Packet auth token |

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -66,7 +66,7 @@ output "kubeone_workers" {
           # Optional: If set, the rootDisk will be a volume. 
           # Otherwise, the rootDisk will be on ephemeral storage and its size will
           # be derived from the flavor
-          rootDiskSizeGB = 10
+          rootDiskSizeGB = 50
           tags = {
             "${var.cluster_name}-workers" = "pool1"
           }

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -45,7 +45,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.4.0"
+	MachineControllerTag           = "v1.4.1"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates `machine-controller` to v1.4.1. The default root disk size in the Terraform script is increased to 50 GB.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.4.1
Add OS_TENANT_ID environment variable
```

/assign @kron4eg 