### PR TITLE
Prefix v in the URL for CNI plugins.

### DIFF
--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -17,8 +17,6 @@ limitations under the License.
 package installation
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
@@ -187,7 +185,7 @@ EOF
 sudo systemctl restart docker
 
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/{{ .CNI_VERSION }}/cni-plugins-amd64-{{ .CNI_VERSION }}.tgz" | \
+curl -L "https://github.com/containernetworking/plugins/releases/download/v{{ .CNI_VERSION }}/cni-plugins-amd64-v{{ .CNI_VERSION }}.tgz" | \
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v{{ .KUBERNETES_VERSION }}"
@@ -338,7 +336,7 @@ func installKubeadmCentOS(ctx *util.Context) error {
 func installKubeadmCoreOS(ctx *util.Context) error {
 	_, _, err := ctx.Runner.Run(kubeadmCoreOSScript, util.TemplateVariables{
 		"KUBERNETES_VERSION": ctx.Cluster.Versions.Kubernetes,
-		"CNI_VERSION":        fmt.Sprintf("v%s", ctx.Cluster.Versions.KubernetesCNIVersion()),
+		"CNI_VERSION":        ctx.Cluster.Versions.KubernetesCNIVersion(),
 	})
 
 	return err

--- a/pkg/upgrader/upgrade/kubernetes_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_binaries.go
@@ -54,7 +54,7 @@ sudo yum install -y --disableexcludes=kubernetes \
 source /etc/kubeone/proxy-env
 
 sudo mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/{{ .CNI_VERSION }}/cni-plugins-amd64-{{ .CNI_VERSION }}.tgz" | \
+curl -L "https://github.com/containernetworking/plugins/releases/download/v{{ .CNI_VERSION }}/cni-plugins-amd64-v{{ .CNI_VERSION }}.tgz" | \
      sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v{{ .KUBERNETES_VERSION }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

This prefixes the `v` in front of the CNI version in the download URL.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #552 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Fix the URL for the CNI plugin when upgrading a cluster on Container Linux by CoreOS.
```
