### PR TITLE
[WIP] Support sourcing AWS credentials from the AWS profiles file

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -34,6 +34,9 @@ type installOptions struct {
 	globalOptions
 	Manifest   string
 	BackupFile string
+
+	AWSProfilePath string
+	AWSProfileName string
 }
 
 // installCmd setups install command
@@ -70,6 +73,9 @@ It's possible to source information about hosts from Terraform output, using the
 	}
 
 	cmd.Flags().StringVarP(&iopts.BackupFile, "backup", "b", "", "path to where the PKI backup .tar.gz file should be placed (default: location of cluster config file)")
+
+	cmd.Flags().StringVarP(&iopts.AWSProfilePath, "aws-profile-path", "", "~/.aws/credentials", "path to the file where aws credentials are located")
+	cmd.Flags().StringVarP(&iopts.AWSProfileName, "aws-profile-name", "", "default", "name of the aws profile to be deployed on the cluster for machine-controller")
 
 	return cmd
 }
@@ -114,7 +120,9 @@ func createInstallerOptions(clusterFile string, cluster *kubeoneapi.KubeOneClust
 	defer f.Close()
 
 	return &installer.Options{
-		BackupFile: options.BackupFile,
-		Verbose:    options.Verbose,
+		BackupFile:     options.BackupFile,
+		Verbose:        options.Verbose,
+		AWSProfilePath: options.AWSProfilePath,
+		AWSProfileName: options.AWSProfileName,
 	}, nil
 }

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -82,7 +82,7 @@ It's possible to source information about hosts from Terraform output, using the
 
 // runInstall provisions Kubernetes on the provided machines
 func runInstall(logger *logrus.Logger, installOptions *installOptions) error {
-	cluster, err := loadClusterConfig(installOptions.Manifest, installOptions.TerraformState, logger)
+	cluster, err := loadClusterConfig(installOptions.Manifest, installOptions.TerraformState, logger, installOptions.AWSProfilePath, installOptions.AWSProfileName)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}

--- a/pkg/cmd/kubeconfig.go
+++ b/pkg/cmd/kubeconfig.go
@@ -72,7 +72,7 @@ func runKubeconfig(logger *logrus.Logger, kubeconfigOptions *kubeconfigOptions) 
 		return errors.New("no cluster config file given")
 	}
 
-	cluster, err := loadClusterConfig(kubeconfigOptions.Manifest, kubeconfigOptions.TerraformState, logger)
+	cluster, err := loadClusterConfig(kubeconfigOptions.Manifest, kubeconfigOptions.TerraformState, logger, "", "")
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -75,7 +75,7 @@ func runReset(logger *logrus.Logger, resetOptions *resetOptions) error {
 		return errors.New("no cluster config file given")
 	}
 
-	cluster, err := loadClusterConfig(resetOptions.Manifest, resetOptions.TerraformState, logger)
+	cluster, err := loadClusterConfig(resetOptions.Manifest, resetOptions.TerraformState, logger, "", "")
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -69,8 +69,8 @@ func initLogger(verbose bool) *logrus.Logger {
 	return logger
 }
 
-func loadClusterConfig(filename, terraformOutputPath string, logger *logrus.Logger) (*kubeoneapi.KubeOneCluster, error) {
-	a, err := config.LoadKubeOneCluster(filename, terraformOutputPath, logger)
+func loadClusterConfig(filename, terraformOutputPath string, logger *logrus.Logger, awsProfilePath, awsProfileName string) (*kubeoneapi.KubeOneCluster, error) {
+	a, err := config.LoadKubeOneCluster(filename, terraformOutputPath, logger, awsProfilePath, awsProfileName)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to load a given KubeOneCluster object")
 	}

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -71,7 +71,7 @@ It's possible to source information about hosts from Terraform output, using the
 
 // runUpgrade upgrades Kubernetes on the provided machines
 func runUpgrade(logger *logrus.Logger, upgradeOptions *upgradeOptions) error {
-	cluster, err := loadClusterConfig(upgradeOptions.Manifest, upgradeOptions.TerraformState, logger)
+	cluster, err := loadClusterConfig(upgradeOptions.Manifest, upgradeOptions.TerraformState, logger, "", "")
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -52,7 +52,7 @@ func Ensure(s *state.State) error {
 
 	s.Logger.Infoln("Creating credentials secret…")
 
-	creds, err := ProviderCredentials(s.Cluster.CloudProvider.Name)
+	creds, err := ProviderCredentials(s.Cluster.CloudProvider.Name, s.AWSProfilePath, s.AWSProfileName)
 	if err != nil {
 		return errors.Wrap(err, "unable to fetch cloud provider credentials")
 	}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -33,6 +33,8 @@ type Options struct {
 	BackupFile     string
 	DestroyWorkers bool
 	RemoveBinaries bool
+	AWSProfilePath string
+	AWSProfileName string
 }
 
 // Installer is entrypoint for installation process
@@ -77,5 +79,7 @@ func (i *Installer) createState(options *Options) *state.State {
 		BackupFile:     options.BackupFile,
 		DestroyWorkers: options.DestroyWorkers,
 		RemoveBinaries: options.RemoveBinaries,
+		AWSProfilePath: options.AWSProfilePath,
+		AWSProfileName: options.AWSProfileName,
 	}
 }

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -47,6 +47,8 @@ type State struct {
 	RemoveBinaries            bool
 	ForceUpgrade              bool
 	UpgradeMachineDeployments bool
+	AWSProfilePath            string
+	AWSProfileName            string
 }
 
 // Clone returns a shallow copy of the context.


### PR DESCRIPTION
**What this PR does / why we need it**:

Earlier we have added a function that sources AWS credentials from the profiles file, but actually, that function never worked. This PR fixes the behavior and ensures credentials can be sourced from the AWS profiles file.

Two new flags are added:

* `--aws-profile-path` - a path to the file where AWS profiles are located (default `~/.aws/credentials`)
* `--aws-profile-name` - a name of the profile that will be deployed on the cluster to be used by `machine-controller` (default `default`)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #501

**Does this PR introduce a user-facing change?**:
```release-note
Fix sourcing AWS credentials from the AWS profiles file
Add --aws-profile-path and --aws-profile-name flags
```

/assign @kron4eg 