### PR TITLE
Fix kubelet upgrade on Container Linux

### DIFF
--- a/pkg/upgrader/upgrade/kubernetes_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_binaries.go
@@ -59,14 +59,18 @@ curl -L "https://github.com/containernetworking/plugins/releases/download/{{ .CN
 
 RELEASE="v{{ .KUBERNETES_VERSION }}"
 
-sudo systemctl stop kubelet
+
+
+sudo mkdir -p /var/tmp/kube-binaries
+cd /var/tmp/kube-binaries
+sudo curl -L --remote-name-all \
+     https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
-
-
-sudo curl -L --remote-name-all \
-     https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+sudo systemctl stop kubelet
+sudo mv /var/tmp/kube-binaries/{kubeadm,kubelet,kubectl} .
 sudo chmod +x {kubeadm,kubelet,kubectl}
 
 curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | \

--- a/pkg/upgrader/upgrade/kubernetes_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_binaries.go
@@ -59,8 +59,12 @@ curl -L "https://github.com/containernetworking/plugins/releases/download/{{ .CN
 
 RELEASE="v{{ .KUBERNETES_VERSION }}"
 
+sudo systemctl stop kubelet
+
 sudo mkdir -p /opt/bin
 cd /opt/bin
+
+
 sudo curl -L --remote-name-all \
      https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
 sudo chmod +x {kubeadm,kubelet,kubectl}
@@ -72,7 +76,10 @@ curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/bu
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" | \
      sed "s:/usr/bin:/opt/bin:g" | \
-     sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+	 sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+	 
+sudo systemctl daemon-reload
+sudo systemctl start kubelet
 `
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

On Container Linux, kubelet locks itself, this patch stops kubelet
before downloading the new binaries and then starts it back up once
everything is ready.

```release-note
* Fix issue where kubelet wouldn't properly upgrade on Container Linux
```
