### PR TITLE
Add AUR badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
   </a>
   <a href="https://bestpractices.coreinfrastructure.org/projects/2934"><img src="https://bestpractices.coreinfrastructure.org/projects/2934/badge">
   </a>
+  <a href="https://aur.archlinux.org/packages/kubeone">
+    <img src="https://img.shields.io/aur/version/kubeone.svg" alt="AUR version" />
+  </a>
 </p>
 
 `kubeone` is a CLI tool and a Go library for installing, managing, and upgrading


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a badge to README.md displaying the current AUR version. This makes it easier for maintainers to verify that the AUR package installs the correct KubeOne version and users can access the AUR page directly by clicking on it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
Nope

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
