### PR TITLE
Bastion support

### DIFF
--- a/examples/terraform/aws-private/README.md
+++ b/examples/terraform/aws-private/README.md
@@ -20,6 +20,7 @@ Follow the [issue #337](https://github.com/kubermatic/kubeone/issues/337) for mo
 | ssh\_private\_key\_file | SSH private key file used to access instances | string | `""` | no |
 | ssh\_public\_key\_file | SSH public key file | string | `"~/.ssh/id_rsa.pub"` | no |
 | ssh\_username | SSH user, used only in output | string | `"root"` | no |
+| bastion\_port | Bastion SSH port | string | `"22"` | no |
 | subnet\_netmask\_bits | default 8 bits in /16 CIDR, makes it /24 subnetworks | string | `"8"` | no |
 | subnet\_offset | subnet offset (from main VPC cidr_block) number to be cut | string | `"0"` | no |
 | vpc\_id | VPC to use ('default' for default VPC) | string | `"default"` | no |

--- a/examples/terraform/aws-private/main.tf
+++ b/examples/terraform/aws-private/main.tf
@@ -147,7 +147,7 @@ resource "aws_lb" "control_plane" {
   name               = "${var.cluster_name}-api-lb"
   internal           = false
   load_balancer_type = "network"
-  subnets            = aws_subnet.private.*.id
+  subnets            = aws_subnet.public.*.id
 
   tags = map(
     "Name", "${var.cluster_name}-control_plane",

--- a/examples/terraform/aws-private/output.tf
+++ b/examples/terraform/aws-private/output.tf
@@ -22,10 +22,6 @@ output "kubeone_api" {
   }
 }
 
-output "kubeone_bastion" {
-  value = aws_instance.bastion.public_ip
-}
-
 output "kubeone_hosts" {
   description = "Control plane endpoints to SSH to"
 
@@ -38,6 +34,8 @@ output "kubeone_hosts" {
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file
       ssh_user             = var.ssh_username
+      bastion              = aws_instance.bastion.public_ip
+      bastion_port         = var.bastion_port
     }
   }
 }

--- a/examples/terraform/aws-private/output.tf
+++ b/examples/terraform/aws-private/output.tf
@@ -30,6 +30,7 @@ output "kubeone_hosts" {
       cluster_name         = var.cluster_name
       cloud_provider       = "aws"
       private_address      = aws_instance.control_plane.*.private_ip
+      hostnames            = aws_instance.control_plane.*.private_dns
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/examples/terraform/aws-private/variables.tf
+++ b/examples/terraform/aws-private/variables.tf
@@ -53,6 +53,11 @@ variable "ssh_agent_socket" {
   default     = "env:SSH_AUTH_SOCK"
 }
 
+variable "bastion_port" {
+  description = "Bastion SSH port"
+  default     = 22
+}
+
 # Provider specific settings
 
 variable "aws_region" {

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "aws"
       private_address      = aws_instance.control_plane.*.private_ip
       public_address       = aws_instance.control_plane.*.public_ip
+      hostnames            = aws_instance.control_plane.*.private_dns
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "azure"
       private_address      = azurerm_network_interface.control_plane.*.private_ip_address
       public_address       = azurerm_public_ip.control_plane.*.ip_address
+      hostnames            = formatlist("${var.cluster_name}-cp-%d", [0, 1, 2])
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/pkg/apis/kubeone/config/config.go
+++ b/pkg/apis/kubeone/config/config.go
@@ -24,14 +24,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	kubeonescheme "github.com/kubermatic/kubeone/pkg/apis/kubeone/scheme"
 	kubeonev1alpha1 "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
 	"github.com/kubermatic/kubeone/pkg/apis/kubeone/validation"
 	"github.com/kubermatic/kubeone/pkg/credentials"
 	"github.com/kubermatic/kubeone/pkg/terraform"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // SetKubeOneClusterDynamicDefaults sets the dynamic defaults for a given KubeOneCluster object

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -61,6 +61,8 @@ type HostConfig struct {
 	SSHUsername       string `json:"sshUsername"`
 	SSHPrivateKeyFile string `json:"sshPrivateKeyFile"`
 	SSHAgentSocket    string `json:"sshAgentSocket"`
+	Bastion           string `json:"bastion"`
+	BastionPort       int    `json:"bastionPort"`
 
 	// Information populated at the runtime
 	Hostname        string `json:"-"`

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -63,9 +63,9 @@ type HostConfig struct {
 	SSHAgentSocket    string `json:"sshAgentSocket"`
 	Bastion           string `json:"bastion"`
 	BastionPort       int    `json:"bastionPort"`
+	Hostname          string `json:"hostname"`
 
 	// Information populated at the runtime
-	Hostname        string `json:"-"`
 	OperatingSystem string `json:"-"`
 	IsLeader        bool   `json:"-"`
 }

--- a/pkg/apis/kubeone/v1alpha1/defaults.go
+++ b/pkg/apis/kubeone/v1alpha1/defaults.go
@@ -126,4 +126,10 @@ func defaultHostConfig(obj *HostConfig) {
 	if obj.SSHUsername == "" {
 		obj.SSHUsername = "root"
 	}
+	if obj.SSHPort == 0 {
+		obj.SSHPort = 22
+	}
+	if obj.BastionPort == 0 {
+		obj.BastionPort = 22
+	}
 }

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -61,6 +61,8 @@ type HostConfig struct {
 	SSHUsername       string `json:"sshUsername"`
 	SSHPrivateKeyFile string `json:"sshPrivateKeyFile"`
 	SSHAgentSocket    string `json:"sshAgentSocket"`
+	Bastion           string `json:"bastion"`
+	BastionPort       int    `json:"bastionPort"`
 
 	// Information populated at the runtime
 	Hostname        string `json:"-"`

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -63,9 +63,9 @@ type HostConfig struct {
 	SSHAgentSocket    string `json:"sshAgentSocket"`
 	Bastion           string `json:"bastion"`
 	BastionPort       int    `json:"bastionPort"`
+	Hostname          string `json:"hostname"`
 
 	// Information populated at the runtime
-	Hostname        string `json:"-"`
 	OperatingSystem string `json:"-"`
 	IsLeader        bool   `json:"-"`
 }

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
@@ -399,6 +399,8 @@ func autoConvert_v1alpha1_HostConfig_To_kubeone_HostConfig(in *HostConfig, out *
 	out.SSHUsername = in.SSHUsername
 	out.SSHPrivateKeyFile = in.SSHPrivateKeyFile
 	out.SSHAgentSocket = in.SSHAgentSocket
+	out.Bastion = in.Bastion
+	out.BastionPort = in.BastionPort
 	out.Hostname = in.Hostname
 	out.OperatingSystem = in.OperatingSystem
 	out.IsLeader = in.IsLeader
@@ -418,6 +420,8 @@ func autoConvert_kubeone_HostConfig_To_v1alpha1_HostConfig(in *kubeone.HostConfi
 	out.SSHUsername = in.SSHUsername
 	out.SSHPrivateKeyFile = in.SSHPrivateKeyFile
 	out.SSHAgentSocket = in.SSHAgentSocket
+	out.Bastion = in.Bastion
+	out.BastionPort = in.BastionPort
 	out.Hostname = in.Hostname
 	out.OperatingSystem = in.OperatingSystem
 	out.IsLeader = in.IsLeader

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -506,6 +506,8 @@ features:
 # hosts:
 # - publicAddress: '1.2.3.4'
 #   privateAddress: '172.18.0.1'
+#   bastion: '4.3.2.1'
+#   bastionPort: 22  # can be left out if using the default (22)
 #   sshPort: 22 # can be left out if using the default (22)
 #   sshUsername: ubuntu
 #   # You usually want to configure either a private key OR an

--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -234,9 +234,12 @@ func installPrerequisitesOnNode(s *state.State, node *kubeoneapi.HostConfig, con
 	node.SetOperatingSystem(os)
 
 	s.Logger.Infoln("Determine hostname…")
-	hostname, err := determineHostname(s, *node)
-	if err != nil {
-		return errors.Wrap(err, "failed to determine hostname")
+	if node.Hostname == "" {
+		hostname, hostnameErr := determineHostname(s, *node)
+		if hostnameErr != nil {
+			return errors.Wrap(hostnameErr, "failed to determine hostname")
+		}
+		node.SetHostname(hostname)
 	}
 
 	s.Logger.Infoln("Creating environment file…")
@@ -244,8 +247,6 @@ func installPrerequisitesOnNode(s *state.State, node *kubeoneapi.HostConfig, con
 	if err != nil {
 		return errors.Wrap(err, "failed to create environment file")
 	}
-
-	node.SetHostname(hostname)
 
 	logger := s.Logger.WithField("os", os)
 

--- a/pkg/ssh/connector.go
+++ b/pkg/ssh/connector.go
@@ -51,6 +51,8 @@ func (c *Connector) Connect(node kubeoneapi.HostConfig) (Connection, error) {
 			KeyFile:     node.SSHPrivateKeyFile,
 			AgentSocket: node.SSHAgentSocket,
 			Timeout:     10 * time.Second,
+			Bastion:     node.Bastion,
+			BastionPort: node.BastionPort,
 		}
 
 		conn, err = NewConnection(opts)

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -34,6 +34,8 @@ type controlPlane struct {
 	SSHPort           int      `json:"ssh_port"`
 	SSHPrivateKeyFile string   `json:"ssh_private_key_file"`
 	SSHAgentSocket    string   `json:"ssh_agent_socket"`
+	Bastion           string   `json:"bastion"`
+	BastionPort       int      `json:"bastion_port"`
 }
 
 // Config represents configuration in the terraform output format
@@ -101,6 +103,8 @@ func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 			SSHPort:           cp.SSHPort,
 			SSHPrivateKeyFile: cp.SSHPrivateKeyFile,
 			SSHAgentSocket:    cp.SSHAgentSocket,
+			Bastion:           cp.Bastion,
+			BastionPort:       cp.BastionPort,
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Provides bastion support

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #337 

**Special notes for your reviewer**:
Terraform config in aws-private requires pre-existing VPC provided via vars or alternatively var.subnet_offset/var.subnet_netmask_bits should be adjusted in order to avoid collision with existing subnets.

```release-note
Support for SSH over bastion host
```