### PR TITLE
Update machine-controller to v1.4.2 and add additional OpenStack field

### DIFF
--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -67,7 +67,7 @@ output "kubeone_workers" {
           # Otherwise, the rootDisk will be on ephemeral storage and its size will
           # be derived from the flavor
           rootDiskSizeGB = 50
-          # Optional: limit how much volumes can be attached to a node
+          # Optional: limit how many volumes can be attached to a node
           # nodeVolumeAttachLimit = 25
           tags = {
             "${var.cluster_name}-workers" = "pool1"

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -67,6 +67,8 @@ output "kubeone_workers" {
           # Otherwise, the rootDisk will be on ephemeral storage and its size will
           # be derived from the flavor
           rootDiskSizeGB = 50
+          # Optional: limit how much volumes can be attached to a node
+          # nodeVolumeAttachLimit = 25
           tags = {
             "${var.cluster_name}-workers" = "pool1"
           }

--- a/pkg/templates/machinecontroller/cloudprovider_specs.go
+++ b/pkg/templates/machinecontroller/cloudprovider_specs.go
@@ -45,15 +45,16 @@ type DigitalOceanSpec struct {
 
 // OpenStackSpec holds cloudprovider spec for OpenStack
 type OpenStackSpec struct {
-	Image            string            `json:"image"`
-	Flavor           string            `json:"flavor"`
-	SecurityGroups   []string          `json:"securityGroups"`
-	FloatingIPPool   string            `json:"floatingIPPool"`
-	AvailabilityZone string            `json:"availabilityZone"`
-	Network          string            `json:"network"`
-	Subnet           string            `json:"subnet"`
-	RootDiskSizeGB   *int              `json:"rootDiskSizeGB,omitempty"`
-	Tags             map[string]string `json:"tags"`
+	Image                 string            `json:"image"`
+	Flavor                string            `json:"flavor"`
+	SecurityGroups        []string          `json:"securityGroups"`
+	FloatingIPPool        string            `json:"floatingIPPool"`
+	AvailabilityZone      string            `json:"availabilityZone"`
+	Network               string            `json:"network"`
+	Subnet                string            `json:"subnet"`
+	RootDiskSizeGB        *int              `json:"rootDiskSizeGB,omitempty"`
+	NodeVolumeAttachLimit *uint             `json:"nodeVolumeAttachLimit,omitempty"`
+	Tags                  map[string]string `json:"tags"`
 }
 
 // GCESpec holds cloudprovider spec for GCE

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -45,7 +45,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.4.1"
+	MachineControllerTag           = "v1.4.2"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -345,6 +345,7 @@ func (c *Config) updateOpenStackWorkerset(existingWorkerSet *kubeonev1alpha1.Wor
 		{key: "network", value: openstackConfig.Network},
 		{key: "subnet", value: openstackConfig.Subnet},
 		{key: "rootDiskSizeGB", value: openstackConfig.RootDiskSizeGB},
+		{key: "nodeVolumeAttachLimit", value: openstackConfig.NodeVolumeAttachLimit},
 		{key: "tags", value: openstackConfig.Tags},
 	}
 
@@ -417,6 +418,10 @@ func setWorkersetFlag(w *kubeonev1alpha1.WorkerConfig, name string, value interf
 			return nil
 		}
 	case *int:
+		if s == nil {
+			return nil
+		}
+	case *uint:
 		if s == nil {
 			return nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates machine-controller to v1.4.2 and adds an optional OpenStack field `nodeVolumeAttachLimit`.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.4.2
Add `nodeVolumeAttachLimit` optional field to OpenStack worker spec
```

/assign @kron4eg 