### PR TITLE
Fix install subcommand not running without terraform output

### DIFF
--- a/pkg/apis/kubeone/config/config.go
+++ b/pkg/apis/kubeone/config/config.go
@@ -124,7 +124,7 @@ func LoadKubeOneCluster(clusterCfgPath, tfOutputPath string, logger *logrus.Logg
 		if tfOutput, err = cmd.Output(); err != nil {
 			return nil, errors.Wrapf(err, "unable to read terraform output from the %q directory", tfOutputPath)
 		}
-	default:
+	case len(tfOutputPath) != 0:
 		if tfOutput, err = ioutil.ReadFile(tfOutputPath); err != nil {
 			return nil, errors.Wrap(err, "unable to read the given terraform output file")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix install subcommand not running without terraform output

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
