### PR TITLE
Fix that install subcommand requires credentials for none provider

### DIFF
--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -542,6 +542,8 @@ func (p ProviderName) ProviderCredentials() (map[string]string, error) {
 			{Name: VSphereUsername},
 			{Name: VSpherePasswords},
 		})
+	case ProviderNameNone:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{})
 	}
 
 	return nil, errors.New("no provider matched")

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -142,6 +142,8 @@ func ProviderCredentials(p kubeone.CloudProviderName) (map[string]string, error)
 		// force scheme, as machine-controller requires it while terraform does not
 		vscreds[VSphereAddress] = "https://" + vscreds[VSphereAddress]
 		return vscreds, nil
+	case kubeone.CloudProviderNameNone:
+		return parseCredentialVariables([]ProviderEnvironmentVariable{}, defaultValidationFunc)
 	}
 
 	return nil, errors.New("no provider matched")


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix that install subcommand requires credentials for none provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
