### PR TITLE
Add an Ansible target for 'kubeone reset'

### DIFF
--- a/examples/ansible/kubeone-reset.yml
+++ b/examples/ansible/kubeone-reset.yml
@@ -1,0 +1,30 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Reset KubeOne cluster
+  hosts: localhost
+  connection: local
+  roles:
+    - kubeone-reset
+  vars:
+    kubeone_name: testcluster
+    kubeone_reset_destroyWorkers: true
+    kubeone_reset_removeBinaries: false
+    kubeone_cloudProvider_name: none
+    kubeone_machineController_deploy: false
+    kubeone_hosts:
+      - publicAddress: alpha.example.com
+        sshUsername: root
+      - publicAddress: beta.example.com
+        sshUsername: root

--- a/examples/ansible/roles/kubeone-reset/defaults/main.yml
+++ b/examples/ansible/roles/kubeone-reset/defaults/main.yml
@@ -1,0 +1,37 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kubeone_reset_destroyWorkers: true
+kubeone_reset_removeBinaries: false
+kubeone_versions_kubernetes: 1.14.1
+kubeone_clusterNetwork_podSubnet: 10.244.0.0/16
+kubeone_clusterNetwork_serviceSubnet: 10.96.0.0/12
+kubeone_clusterNetwork_serviceDomainName: cluster.local
+kubeone_clusterNetwork_nodePortRange: 30000-32767
+kubeone_clusterNetwork_cni_provider: canal
+kubeone_clusterNetwork_cni_encrypted: false
+kubeone_cloudProvider_name: aws
+kubeone_cloudProvider_external: false
+kubeone_cloudProvider_cloudconfig: ""
+kubeone_apiEndpoint_host: ""
+kubeone_apiEndpoint_port: 0
+kubeone_features_podSecurityPolicy_enable: false
+kubeone_features_dynamicAuditLog_enable: false
+kubeone_features_metricsServer_enable: true
+kubeone_machineController_deploy: true
+kubeone_machineController_provider: ""
+kubeone_proxy_http: ""
+kubeone_proxy_https: ""
+kubeone_proxy_noProxy: ""
+kubeone_hosts: []

--- a/examples/ansible/roles/kubeone-reset/tasks/main.yml
+++ b/examples/ansible/roles/kubeone-reset/tasks/main.yml
@@ -1,0 +1,29 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create temporary file for KubeOne config
+  tempfile:
+    state: file
+    suffix: kubeone_config
+  register: kubeone_config_tempfile
+
+- name: Create KubeOne configuration
+  template:
+    src: config.yaml.j2
+    dest: "{{ kubeone_config_tempfile.path }}"
+  when: kubeone_config_tempfile.path is defined
+
+- name: Reset KubeOne cluster
+  shell: kubeone reset "{{ kubeone_config_tempfile.path }}" --destroy-workers={{ kubeone_reset_destroyWorkers }} --remove-binaries={{ kubeone_reset_removeBinaries }}
+  when: kubeone_config_tempfile.path is defined

--- a/examples/ansible/roles/kubeone-reset/templates/config.yaml.j2
+++ b/examples/ansible/roles/kubeone-reset/templates/config.yaml.j2
@@ -1,0 +1,53 @@
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kubeone.io/v1alpha1
+kind: KubeOneCluster
+name: {{kubeone_name}}
+versions:
+  kubernetes: {{kubeone_versions_kubernetes}}
+clusterNetwork:
+  podSubnet: {{kubeone_clusterNetwork_podSubnet}}
+  serviceSubnet: {{ kubeone_clusterNetwork_serviceSubnet }}
+  serviceDomainName: {{ kubeone_clusterNetwork_serviceDomainName }}
+  nodePortRange: {{ kubeone_clusterNetwork_nodePortRange }}
+  cni:
+    provider: {{ kubeone_clusterNetwork_cni_provider }}
+    encrypted: {{ kubeone_clusterNetwork_cni_encrypted }}
+cloudProvider:
+  name: {{ kubeone_cloudProvider_name }}
+  external: {{ kubeone_cloudProvider_external }}
+  cloudConfig: {{ kubeone_cloudProvider_cloudconfig }}
+hosts:
+{% for host in kubeone_hosts %}
+  - publicAddress: {{ host.publicAddress }}
+    sshUsername: {{ host.sshUsername }}
+{% endfor %}
+apiEndpoint:
+  host: {{ kubeone_apiEndpoint_host }}
+  port: {{ kubeone_apiEndpoint_port }}
+features:
+  podSecurityPolicy:
+    enable: {{ kubeone_features_podSecurityPolicy_enable }}
+  dynamicAuditLog:
+    enable: {{ kubeone_features_dynamicAuditLog_enable }}
+  metricsServer:
+    enable: {{ kubeone_features_metricsServer_enable }}
+proxy:
+  http: {{ kubeone_proxy_http }}
+  https: {{ kubeone_proxy_https }}
+  noProxy: {{ kubeone_proxy_noProxy }}
+machineController:
+  deploy: {{ kubeone_machineController_deploy }}
+  provider: {{ kubeone_machineController_provider }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an Ansible target for the `kubeone reset` command.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @eqrx 