### PR TITLE
Prevent printing out usage if cmd line is correct but something else fails

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -62,9 +62,10 @@ func Execute() {
 func newRoot() *cobra.Command {
 	opts := &globalOptions{}
 	rootCmd := &cobra.Command{
-		Use:   "kubeone",
-		Short: "Kubernetes Cluster provisioning and maintaining tool",
-		Long:  "Provision and maintain Kubernetes High-Availability clusters with ease",
+		Use:          "kubeone",
+		Short:        "Kubernetes Cluster provisioning and maintaining tool",
+		Long:         "Provision and maintain Kubernetes High-Availability clusters with ease",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
KubeOne always prints outs the usage if any error happens. This is obtrusive beyond measure and makes it hard to debug.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
