### PR TITLE
Update GoReleaser settings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ builds:
   - "-s -w -X github.com/kubermatic/kubeone/pkg/cmd.version={{.Version}} -X github.com/kubermatic/kubeone/pkg/cmd.commit={{.FullCommit}} -X github.com/kubermatic/kubeone/pkg/cmd.date={{.Date}}"
   env:
   - "CGO_ENABLED=0"
-  - "GO111MODULE=off"
+  - "GO111MODULE=on"
   goos:
   - linux
   - darwin
@@ -13,3 +13,8 @@ builds:
 archives:
   - id: kubeone
     format: zip
+    files:
+      - README.md
+      - CHANGELOG.md
+      - LICENSE
+      - examples/**/*


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the GoReleaser settings to:

* Set `GO111MODULE` to `on` as we switched to Go modules
* Ship the `examples` directory along with the binary, `README.md`, `CHANGELOG.md` and `LICENSE` files

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @eqrx 