### PR TITLE
Update release date for the v0.10.0-alpha.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# [v0.10.0-alpha.0](https://github.com/kubermatic/kubeone/releases/tag/v0.10.0-alpha.0) - 2019-07-15
+# [v0.10.0-alpha.0](https://github.com/kubermatic/kubeone/releases/tag/v0.10.0-alpha.0) - 2019-07-17
 
 ## Attention Needed
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the release date for the `v0.10.0-alpha.0` release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @eqrx 