### PR TITLE
Update the release process documentation

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -8,7 +8,7 @@ Please follow these steps to prepare your environment for releasing
 a new version of KubeOne.
 
 * Make sure your Go version is up-to-date
-  * On your computer, run `go version` to find out what
+  * On your computer run `go version` to find out what
   Go version you're using
   * If you're not using the latest Go version, go to
   [the official Go website][1] to grab the latest binaries
@@ -37,9 +37,9 @@ the latest version
 
 Add a new entry for the upcoming release to the [CHANGELOG.md][7] file.
 
-The changelog file contains only changes that are directly affecting
-the end-users, such as a new feature, a bug or security fix, a new
-version of a dependency and more. Changes such as changes to tests,
+The changelog file only lists changes that are directly affecting
+the end-users, such as a new feature, a bug or a security fix, a new
+version of a component and more. Changes such as changes to tests and
 refactors (as long as there are no behavior changes) are not documented.
 
 **Note:** Currently, we're generating the changelog manually.
@@ -51,42 +51,11 @@ following link:
 https://github.com/kubermatic/kubeone/compare/<commit>...master
 ```
 
-### Creating a PR
-
-**Warning:** This part is still work in progress!
-
-Once you have finished updating the documentation and the
-changelog, go ahead and create a PR with all changes.
-
-We're using this PR to run all tests and ensure that
-the upcoming version works correctly on all providers.
-
-Once the PR is created, hold it so it's not merged by
-Prow/Tide as soon as the required tests pass:
-```
-/hold
-```
-
-Then, run optional tests that tests KubeOne on providers
-other than AWS:
-```
-TBD
-```
-
-Finally, go to the Prow Dashboard to monitor the progress.
-Once all tests are green, unhold the PR:
-```
-/hold cancel
-```
-
-At this point, the documentation is updated and we ensured that
-KubeOne works correctly on all providers. You're ready
-to create a new KubeOne release.
-
 ## Releasing KubeOne
 
-Before running the release process, ensure your
-`master` branch is up-to-date:
+### Pushing a Git tag
+
+Before pushing a new Git tag, ensure your `master` branch is up-to-date:
 
 ```
 git checkout master
@@ -94,15 +63,20 @@ git fetch origin
 git reset --hard origin/master
 ```
 
-Create a release branch and push it:
+In case you are releasing a stable or RC release, create a release
+branch and push it:
 
 ```
 git checkout -b release/v0.x
 git push origin release/v0.x
 ```
 
+The alpha and beta releases are cut directly from the master branch,
+without creating the release branch. This ensures we don't have to
+cherry-pick each PR to the release branch.
+
 **Note:** Currently there's a bug with branch-protector that
-requires a new protection to be created for each release branch.
+requires a new protection rule to be created for each release branch.
 
 Create a tag for the new version and push it:
 
@@ -111,31 +85,53 @@ git tag -a v0.x.y -m "KubeOne version 0.x.y"
 git push origin --tags
 ```
 
-Once the tag is in the place, run GoReleaser from the KubeOne
-root directory which will create a GitHub Release and generate
-and upload binaries:
+Now that we have a Git tag, we can proceed to releasing KubeOne binaries.
+
+### Releasing binaries
+
+We're using [GoReleaser][8] to build and release binaries.
+
+As of v0.10.0-alpha.0, we're shipping the `examples` directory along with
+the binary. It is **strictly** required to reset the `examples` directory
+to prevent secrets from leaking and being released. You can do that such as:
 
 ```
-goreleaser
+mv examples ~/kubeone-examples
+git reset --hard origin/master
 ```
 
-As GoReleaser generates the release notes based on the list of
-all commits since the last release, we're going to change it
-to the changelog we generated earlier.
+After the release process is done, you can move back the old `examples` directory
+back.
 
-At the top, add the following links:
+Next, create a release notes file somewhere outside of the repo and
+fill it with the changelog for the release. The release notes file will be
+used to load custom release notes instead of using the list of commits.
+
+The release notes should look like:
 
 ```
 Check out the [documentation](https://github.com/kubermatic/kubeone/tree/v0.x.y/docs) for this release to find out how to get started with KubeOne.
-```
 
-Then, add the changelog and after the changelog add information
-about checksums:
+<changelog>
 
-```
 ### Checksums
 
 SHA256 checksums can be found in the `kubeone_0.x.y_checksums.txt` file.
+```
+
+Once this is done, create a snapshot of the release and ensure that everything
+is in the place as intended. Pay attention that there are no any leftover files,
+especially in the `examples` directory.
+
+```
+goreleaser release --rm-dist --release-notes=~/notes.md --snapshot
+```
+
+If you're sure that everything is as intended, you can proceed to releasing
+a new version:
+
+```
+goreleaser release --rm-dist --release-notes=~/notes.md
 ```
 
 [1]: https://golang.org/dl/
@@ -145,3 +141,4 @@ SHA256 checksums can be found in the `kubeone_0.x.y_checksums.txt` file.
 [5]: https://github.com/kubermatic/kubeone#kubernetes-versions-compatibility
 [6]: https://github.com/kubermatic/kubeone/tree/master/docs
 [7]: https://github.com/kubermatic/kubeone/blob/master/CHANGELOG.md
+[8]: https://goreleaser.com


### PR DESCRIPTION
**What this PR does / why we need it**:

As of v0.10.0-alpha.0 we made some changes to the release process. This PR updates the release process document to mention those changes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg @eqrx 