### PR TITLE
Propagate signals in E2E tests script

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -18,6 +18,9 @@
 # It installs dependencies and starts the tests
 
 set -euo pipefail
+# Required for signal propagation to work so the cleanup trap
+# gets executed when the script receives a SIGINT
+set -o monitor
 
 RUNNING_IN_CI=${JOB_NAME:-""}
 BUILD_ID=${BUILD_ID:-"${USER}-local"}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `set -o monitor` command to our E2E tests script, so the signals are propagated and the cleanup trap is executed on SIGINT. This could fix a bug causing resources not to be cleaned up when a new commit is pushed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 