### PR TITLE
Add workers-pool name to tags for GCP loadbalancer creation

### DIFF
--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -68,7 +68,7 @@ output "kubeone_workers" {
           labels = {
             "${var.cluster_name}-workers" = "pool1"
           }
-          tags     = ["firewall", "targets"]
+          tags     = ["firewall", "targets", "${var.cluster_name}-pool1"]
           regional = false
         }
       }


### PR DESCRIPTION
**What this PR does / why we need it**:

Without the workers-pool name specified in the tags section of **_output.tf_** file, load balancer service type creation will be unsuccessful, sample error output:

```
Events:
  Type     Reason                      Age                From                Message
  ----     ------                      ----               ----                -------
  Normal   EnsuringLoadBalancer        16s (x2 over 30s)  service-controller  Ensuring load balancer
  Warning  CreatingLoadBalancerFailed  9s (x2 over 21s)   service-controller  Error creating load balancer (will retry): failed to ensure load balancer for service ingress-nginx/ingress-nginx: no node tags supplied and also failed to parse the given lists of hosts for tags. Abort creating firewall rule
```
Adding "${var.cluster_name}-pool1" to the list of tags in the  **_output.tf_** terraform file solves this.

```
tags     = ["firewall", "targets", "${var.cluster_name}-pool1"]
```

**Does this PR introduce a user-facing change?**:

```
NONE
```
