### PR TITLE
Unconditionally add GOPATH/bin to PATH

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -31,6 +31,8 @@ TEST_CLUSTER_TARGET_VERSION=${TEST_CLUSTER_TARGET_VERSION:-""}
 TEST_CLUSTER_INITIAL_VERSION=${TEST_CLUSTER_INITIAL_VERSION:-""}
 export TF_VAR_cluster_name=${BUILD_ID}
 
+PATH=$PATH:$(go env GOPATH)/bin
+
 # Install dependencies
 if ! [ -x "$(command -v terraform)" ]; then
   echo "Installing unzip"
@@ -52,7 +54,6 @@ if ! [ -x "$(command -v kubetest)" ]; then
   pushd .
   cd /tmp
   go get k8s.io/test-infra/kubetest
-  PATH=$PATH:$(go env GOPATH)/bin
   popd
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes E2E tests script to unconditionally add `$(go env GOPATH)/bin` to `$PATH`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 