### PR TITLE
Set hostname for GCE instances in Terraform scripts

### DIFF
--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "gce"
       private_address      = google_compute_instance.control_plane.*.network_interface.0.network_ip
       public_address       = google_compute_instance.control_plane.*.network_interface.0.access_config.0.nat_ip
+      hostnames            = google_compute_instance.control_plane.*.name
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file


### PR DESCRIPTION
GCE now uses the instance name as a hostname, like AWS.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/hold