### PR TITLE
Rename API load balancer in Azure TF example.

### DIFF
--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -111,7 +111,7 @@ resource "azurerm_public_ip" "control_plane" {
 
 resource "azurerm_lb" "lb" {
   resource_group_name = azurerm_resource_group.rg.name
-  name                = "${var.cluster_name}-lb"
+  name                = "kubernetes"
   location            = var.location
 
   frontend_ip_configuration {


### PR DESCRIPTION
**What this PR does / why we need it**:

Azure allows only one load balancer of the same type (internal or
public) per availability set. Creating multiple LBs causes failures
while using other features like attaching volumes. By creating an LB
for the API server, no additional services of type LoadBalacer can be
used anymore within the cluster without causing errors.

As Azure LBs support multiple frontend IP configurations and backend
pools, we can use the "kubernetes" LB also for external API access.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
