### PR TITLE
Fix validation printing workers object on error

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -44,7 +44,7 @@ func ValidateKubeOneCluster(c kubeone.KubeOneCluster) field.ErrorList {
 		allErrs = append(allErrs, ValidateMachineControllerConfig(c.MachineController, c.CloudProvider.Name, field.NewPath("machineController"))...)
 		allErrs = append(allErrs, ValidateWorkerConfig(c.Workers, field.NewPath("workers"))...)
 	} else if len(c.Workers) > 0 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("workers"), c.Workers, "machine-controller deployment is disabled, but configuration still contains worker definitions"))
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("workers"), "machine-controller deployment is disabled, but configuration still contains worker definitions"))
 	}
 
 	allErrs = append(allErrs, ValidateVersionConfig(c.Versions, field.NewPath("versions"))...)


### PR DESCRIPTION
**What this PR does / why we need it**:

We have a validation rule ensuring that if machine-controller is disabled, there must not be workers defined in the manifest or Terraform state. The validation marks the `workers` field as invalid and prints the whole object on stdout/stderr. The output is too long and may contain sensitive data, so we should not print it like that.

Instead, this PR updates the validation rule to mark the field as forbidden in such cases, which prevents validation from printing the whole object.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 