### PR TITLE
Allow sourcing secrets and authentication tokens from a file

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -59,6 +59,7 @@ It's possible to source information about hosts from Terraform output, using the
 			logger := initLogger(gopts.Verbose)
 			iopts.TerraformState = gopts.TerraformState
 			iopts.Verbose = gopts.Verbose
+			iopts.CredentialsFilePath = gopts.CredentialsFilePath
 
 			iopts.Manifest = args[0]
 			if iopts.Manifest == "" {
@@ -114,7 +115,8 @@ func createInstallerOptions(clusterFile string, cluster *kubeoneapi.KubeOneClust
 	defer f.Close()
 
 	return &installer.Options{
-		BackupFile: options.BackupFile,
-		Verbose:    options.Verbose,
+		CredentialsFile: options.CredentialsFilePath,
+		BackupFile:      options.BackupFile,
+		Verbose:         options.Verbose,
 	}, nil
 }

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/pflag"
 
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
+	"github.com/kubermatic/kubeone/pkg/credentials"
 	"github.com/kubermatic/kubeone/pkg/installer"
 )
 
@@ -85,6 +86,12 @@ func runInstall(logger *logrus.Logger, installOptions *installOptions) error {
 	options, err := createInstallerOptions(installOptions.Manifest, cluster, installOptions)
 	if err != nil {
 		return errors.Wrap(err, "failed to create installer options")
+	}
+
+	// Validate credentials
+	_, err = credentials.ProviderCredentials(cluster.CloudProvider.Name, installOptions.CredentialsFilePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to validate credentials")
 	}
 
 	return installer.NewInstaller(cluster, logger).Install(options)

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -81,9 +81,10 @@ func runReset(logger *logrus.Logger, resetOptions *resetOptions) error {
 	}
 
 	options := &installer.Options{
-		Verbose:        resetOptions.Verbose,
-		DestroyWorkers: resetOptions.DestroyWorkers,
-		RemoveBinaries: resetOptions.RemoveBinaries,
+		Verbose:         resetOptions.Verbose,
+		CredentialsFile: resetOptions.CredentialsFilePath,
+		DestroyWorkers:  resetOptions.DestroyWorkers,
+		RemoveBinaries:  resetOptions.RemoveBinaries,
 	}
 
 	return installer.NewInstaller(cluster, logger).Reset(options)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -75,6 +75,7 @@ func newRoot() *cobra.Command {
 
 	fs.StringVarP(&opts.TerraformState, globalTerraformFlagName, "t", "",
 		"Source for terrafor output JSON. - to read from stdin. If path is file, contents will be used. If path is dictionary, `terraform output -json` is executed in this path")
+	fs.StringVarP(&opts.CredentialsFilePath, globalCredentialsFlagName, "c", "", "File to source credentials and secrets from")
 	fs.BoolVarP(&opts.Verbose, globalVerboseFlagName, "v", false, "verbose")
 	fs.BoolVarP(&opts.Debug, globalDebugFlagName, "d", false, "debug")
 

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -26,16 +26,18 @@ import (
 )
 
 const (
-	globalTerraformFlagName = "tfjson"
-	globalVerboseFlagName   = "verbose"
-	globalDebugFlagName     = "debug"
+	globalTerraformFlagName   = "tfjson"
+	globalCredentialsFlagName = "credentials"
+	globalVerboseFlagName     = "verbose"
+	globalDebugFlagName       = "debug"
 )
 
 // globalOptions are global globalOptions same for all commands
 type globalOptions struct {
-	TerraformState string
-	Verbose        bool
-	Debug          bool
+	TerraformState      string
+	CredentialsFilePath string
+	Verbose             bool
+	Debug               bool
 }
 
 func persistentGlobalOptions(fs *pflag.FlagSet) (*globalOptions, error) {
@@ -49,9 +51,15 @@ func persistentGlobalOptions(fs *pflag.FlagSet) (*globalOptions, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	creds, err := fs.GetString(globalCredentialsFlagName)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
 	return &globalOptions{
-		Verbose:        verbose,
-		TerraformState: tfjson,
+		Verbose:             verbose,
+		TerraformState:      tfjson,
+		CredentialsFilePath: creds,
 	}, nil
 }
 

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/kubermatic/kubeone/pkg/credentials"
 	"github.com/kubermatic/kubeone/pkg/upgrader"
 )
 
@@ -74,6 +75,12 @@ func runUpgrade(logger *logrus.Logger, upgradeOptions *upgradeOptions) error {
 	cluster, err := loadClusterConfig(upgradeOptions.Manifest, upgradeOptions.TerraformState, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
+	}
+
+	// Validate credentials
+	_, err = credentials.ProviderCredentials(cluster.CloudProvider.Name, upgradeOptions.CredentialsFilePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to validate credentials")
 	}
 
 	options := createUpgradeOptions(upgradeOptions)

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -82,6 +82,7 @@ func runUpgrade(logger *logrus.Logger, upgradeOptions *upgradeOptions) error {
 
 func createUpgradeOptions(options *upgradeOptions) *upgrader.Options {
 	return &upgrader.Options{
+		CredentialsFile:           options.CredentialsFilePath,
 		ForceUpgrade:              options.ForceUpgrade,
 		Verbose:                   options.Verbose,
 		UpgradeMachineDeployments: options.UpgradeMachineDeployments,

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -29,10 +29,11 @@ import (
 // Options groups the various possible options for running
 // the Kubernetes installation.
 type Options struct {
-	Verbose        bool
-	BackupFile     string
-	DestroyWorkers bool
-	RemoveBinaries bool
+	Verbose         bool
+	CredentialsFile string
+	BackupFile      string
+	DestroyWorkers  bool
+	RemoveBinaries  bool
 }
 
 // Installer is entrypoint for installation process
@@ -68,14 +69,15 @@ func (i *Installer) Reset(options *Options) error {
 // structs for each task individually.
 func (i *Installer) createState(options *Options) *state.State {
 	return &state.State{
-		Cluster:        i.cluster,
-		Connector:      ssh.NewConnector(),
-		Configuration:  configupload.NewConfiguration(),
-		WorkDir:        "kubeone",
-		Logger:         i.logger,
-		Verbose:        options.Verbose,
-		BackupFile:     options.BackupFile,
-		DestroyWorkers: options.DestroyWorkers,
-		RemoveBinaries: options.RemoveBinaries,
+		Cluster:             i.cluster,
+		Connector:           ssh.NewConnector(),
+		Configuration:       configupload.NewConfiguration(),
+		WorkDir:             "kubeone",
+		Logger:              i.logger,
+		Verbose:             options.Verbose,
+		CredentialsFilePath: options.CredentialsFile,
+		BackupFile:          options.BackupFile,
+		DestroyWorkers:      options.DestroyWorkers,
+		RemoveBinaries:      options.RemoveBinaries,
 	}
 }

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -48,6 +48,7 @@ type State struct {
 	ForceUpgrade              bool
 	UpgradeMachineDeployments bool
 	PatchCNI                  bool
+	CredentialsFilePath       string
 }
 
 // Clone returns a shallow copy of the State.

--- a/pkg/templates/externalccm/digitalocean.go
+++ b/pkg/templates/externalccm/digitalocean.go
@@ -222,7 +222,7 @@ func doDeployment() *appsv1.Deployment {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: credentials.SecretName,
 											},
-											Key: credentials.DigitalOceanTokenKey,
+											Key: credentials.DigitalOceanTokenKeyMC,
 										},
 									},
 								},

--- a/pkg/templates/externalccm/hetzner.go
+++ b/pkg/templates/externalccm/hetzner.go
@@ -179,7 +179,7 @@ func hetznerDeployment() *appsv1.Deployment {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: credentials.SecretName,
 											},
-											Key: credentials.HetznerTokenKey,
+											Key: credentials.HetznerTokenKeyMC,
 										},
 									},
 								},

--- a/pkg/templates/externalccm/packet.go
+++ b/pkg/templates/externalccm/packet.go
@@ -223,7 +223,7 @@ func packetDeployment() *appsv1.Deployment {
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: credentials.SecretName,
 											},
-											Key: credentials.PacketAPIKey,
+											Key: credentials.PacketAPIKeyMC,
 										},
 									},
 								},

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -58,7 +58,7 @@ func Deploy(s *state.State) error {
 
 	ctx := context.Background()
 
-	deployment, err := machineControllerDeployment(s.Cluster)
+	deployment, err := machineControllerDeployment(s.Cluster, s.CredentialsFilePath)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate machine-controller deployment")
 	}
@@ -672,7 +672,7 @@ func machineControllerMachineDeploymentCRD() *apiextensions.CustomResourceDefini
 	}
 }
 
-func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster) (*appsv1.Deployment, error) {
+func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster, credentialsFilePath string) (*appsv1.Deployment, error) {
 	var replicas int32 = 1
 
 	clusterDNS, err := clusterDNSIP(cluster)
@@ -697,6 +697,11 @@ func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster) (*appsv1.De
 
 	if cluster.CloudProvider.External {
 		args = append(args, "-external-cloud-provider")
+	}
+
+	envVar, err := credentials.EnvVarBindings(cluster.CloudProvider.Name, credentialsFilePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get env var bindings for a secret")
 	}
 
 	return &appsv1.Deployment{
@@ -763,7 +768,7 @@ func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster) (*appsv1.De
 							ImagePullPolicy:          corev1.PullIfNotPresent,
 							Command:                  []string{"/usr/local/bin/machine-controller"},
 							Args:                     args,
-							Env:                      getEnvVarCredentials(cluster),
+							Env:                      envVar,
 							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 							ReadinessProbe: &corev1.Probe{
@@ -797,26 +802,6 @@ func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster) (*appsv1.De
 			},
 		},
 	}, nil
-}
-
-func getEnvVarCredentials(cluster *kubeoneapi.KubeOneCluster) []corev1.EnvVar {
-	env := make([]corev1.EnvVar, 0)
-
-	for k := range cluster.Credentials {
-		env = append(env, corev1.EnvVar{
-			Name: k,
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: credentials.SecretName,
-					},
-					Key: k,
-				},
-			},
-		})
-	}
-
-	return env
 }
 
 // clusterDNSIP returns the IP address of ClusterDNS Service,

--- a/pkg/templates/machinecontroller/webhook.go
+++ b/pkg/templates/machinecontroller/webhook.go
@@ -28,6 +28,7 @@ import (
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/certificate"
 	"github.com/kubermatic/kubeone/pkg/clientutil"
+	"github.com/kubermatic/kubeone/pkg/credentials"
 	"github.com/kubermatic/kubeone/pkg/state"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -68,10 +69,15 @@ func DeployWebhookConfiguration(s *state.State) error {
 		return errors.Wrap(err, "failed to generate machine-controller webhook TLS secret")
 	}
 
+	deployment, err := webhookDeployment(s.Cluster, s.CredentialsFilePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate machine-controller webhook deployment")
+	}
+
 	ctx := context.Background()
 
 	k8sobjects := []runtime.Object{
-		webhookDeployment(s.Cluster),
+		deployment,
 		service(),
 		servingCert,
 		mutatingwebhookConfiguration(caCert),
@@ -122,8 +128,13 @@ func WaitForWebhook(client dynclient.Client) error {
 }
 
 // webhookDeployment returns the deployment for the machine-controllers MutatignAdmissionWebhook
-func webhookDeployment(cluster *kubeoneapi.KubeOneCluster) *appsv1.Deployment {
+func webhookDeployment(cluster *kubeoneapi.KubeOneCluster, credentialsFilePath string) (*appsv1.Deployment, error) {
 	var replicas int32 = 1
+
+	envVar, err := credentials.EnvVarBindings(cluster.CloudProvider.Name, credentialsFilePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get env var bindings for a secret")
+	}
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -190,7 +201,7 @@ func webhookDeployment(cluster *kubeoneapi.KubeOneCluster) *appsv1.Deployment {
 								"-v", "4",
 								"-listen-address", "0.0.0.0:9876",
 							},
-							Env:                      getEnvVarCredentials(cluster),
+							Env:                      envVar,
 							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 							ReadinessProbe: &corev1.Probe{
@@ -232,7 +243,7 @@ func webhookDeployment(cluster *kubeoneapi.KubeOneCluster) *appsv1.Deployment {
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 // service returns the internal service for the machine-controller webhook

--- a/pkg/upgrader/upgrader.go
+++ b/pkg/upgrader/upgrader.go
@@ -28,6 +28,7 @@ import (
 
 // Options groups the various possible options for running KubeOne upgrade
 type Options struct {
+	CredentialsFile           string
 	ForceUpgrade              bool
 	UpgradeMachineDeployments bool
 	Verbose                   bool
@@ -64,5 +65,6 @@ func (u *Upgrader) createState(options *Options) *state.State {
 		Verbose:                   options.Verbose,
 		ForceUpgrade:              options.ForceUpgrade,
 		UpgradeMachineDeployments: options.UpgradeMachineDeployments,
+		CredentialsFilePath:       options.CredentialsFile,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new flag called `--credentials` (shorthand `-c`) that allows users to specify a YAML file to source secrets and authentication tokens from.

The file is supposed to be formatted as a string key/value pairs YAML, e.g.
```
$ cat credentials.yaml
AWS_ACCESS_KEY_ID: ...
AWS_SECRET_ACCESS_KEY: ...
```

Besides that, this PR introduces some code quality improvements, such as correctly utilizing constants in the `credentials` package.

This PR only allows credentials to be sourced. In a follow-up, I'll extend this to add a possibility to source the cloud-config file from.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially addresses #492

**Does this PR introduce a user-facing change?**:
```release-note
Add --credentials flag to allow sourcing secrets and authentication tokens from a file
```
