### PR TITLE
Update machine-controller to v1.5.2

### DIFF
--- a/pkg/templates/machinecontroller/cloudprovider_specs.go
+++ b/pkg/templates/machinecontroller/cloudprovider_specs.go
@@ -91,17 +91,16 @@ type PacketSpec struct {
 
 // VSphereSpec holds cloudprovider spec for vSphere
 type VSphereSpec struct {
-	AllowInsecure   bool   `json:"allowInsecure"`
-	Cluster         string `json:"cluster"`
-	CPUs            int    `json:"cpus"`
-	Datacenter      string `json:"datacenter"`
-	Datastore       string `json:"datastore"`
-	DiskSizeGB      *int   `json:"diskSizeGB,omitempty"`
-	Folder          string `json:"folder"`
-	MemoryMB        int    `json:"memoryMB"`
-	TemplateNetName string `json:"templateNetName,omitempty"`
-	TemplateVMName  string `json:"templateVMName"`
-	VMNetName       string `json:"vmNetName,omitempty"`
+	AllowInsecure  bool   `json:"allowInsecure"`
+	Cluster        string `json:"cluster"`
+	CPUs           int    `json:"cpus"`
+	Datacenter     string `json:"datacenter"`
+	Datastore      string `json:"datastore"`
+	DiskSizeGB     *int   `json:"diskSizeGB,omitempty"`
+	Folder         string `json:"folder"`
+	MemoryMB       int    `json:"memoryMB"`
+	TemplateVMName string `json:"templateVMName"`
+	VMNetName      string `json:"vmNetName,omitempty"`
 }
 
 // AzureSpec holds cloudprovider spec for Azure

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -47,7 +47,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.5.1"
+	MachineControllerTag           = "v1.5.2"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -397,7 +397,6 @@ func (c *Config) updateVSphereWorkerset(existingWorkerSet *kubeonev1alpha1.Worke
 		{key: "diskSizeGB", value: vsphereConfig.DiskSizeGB},
 		{key: "folder", value: vsphereConfig.Folder},
 		{key: "memoryMB", value: vsphereConfig.MemoryMB},
-		{key: "templateNetName", value: vsphereConfig.TemplateNetName},
 		{key: "templateVMName", value: vsphereConfig.TemplateVMName},
 		{key: "vmNetName", value: vsphereConfig.VMNetName},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates machine-controller to v1.5.2.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.5.2
```

/assign @kron4eg 