### PR TITLE
Fix DynamicAuditLog feature

### DIFF
--- a/pkg/features/dynamic_audit_log.go
+++ b/pkg/features/dynamic_audit_log.go
@@ -23,8 +23,10 @@ import (
 
 const (
 	auditDynamicConfigurationFlag = "audit-dynamic-configuration"
-	runtimeConfigFlag             = "runtime-config"
 	auditRegistrationAPI          = "auditregistration.k8s.io/v1alpha1=true"
+	auditFeatureGate              = "DynamicAuditing=true"
+	runtimeConfigFlag             = "runtime-config"
+	featureGatesFlag              = "feature-gates"
 )
 
 func activateKubeadmDynamicAuditLogs(feature *kubeoneapi.DynamicAuditLog, args *kubeadmargs.Args) {
@@ -34,5 +36,5 @@ func activateKubeadmDynamicAuditLogs(feature *kubeoneapi.DynamicAuditLog, args *
 
 	args.APIServer.ExtraArgs[auditDynamicConfigurationFlag] = "true"
 	args.APIServer.AppendMapStringStringExtraArg(runtimeConfigFlag, auditRegistrationAPI)
-	args.FeatureGates["DynamicAuditing"] = true
+	args.APIServer.AppendMapStringStringExtraArg(featureGatesFlag, auditFeatureGate)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

As per the official [Dynamic Audit Backend](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#dynamic-backend) documentation, we are required to set two flags and enable the feature gate on the API server. However, we were trying to enable the feature gate on all components (using `.clusterConfiguration.FeatureGates`), which made `kubeadm` to fail to provision the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #628 

**Does this PR introduce a user-facing change?**:
```release-note
Fix DynamicAuditLog feature
```

/assign @kron4eg @eqrx 