### PR TITLE
Add changelog for release v0.10.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Removed
 
+* Remove `TemplateNetName` field from the vSphere workers spec ([#624](https://github.com/kubermatic/kubeone/pull/624))
 * Remove the old KubeOne configuration API ([#626](https://github.com/kubermatic/kubeone/pull/626))
 
 # [v0.10.0-alpha.1](https://github.com/kubermatic/kubeone/releases/tag/v0.10.0-alpha.1) - 2019-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# [v0.10.0-alpha.2](https://github.com/kubermatic/kubeone/releases/tag/v0.10.0-alpha.2) - 2019-08-21
+
+## Changed
+
+* Fix cluster provisioning failures when DynamicAuditLog feature is enabled ([#630](https://github.com/kubermatic/kubeone/pull/630))
+* Update `machine-controller` to v1.5.2 ([#624](https://github.com/kubermatic/kubeone/pull/624))
+
+## Removed
+
+* Remove the old KubeOne configuration API ([#626](https://github.com/kubermatic/kubeone/pull/626))
+
 # [v0.10.0-alpha.1](https://github.com/kubermatic/kubeone/releases/tag/v0.10.0-alpha.1) - 2019-08-16
 
 ## Added


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a changelog for the upcoming v0.10.0-alpha.2 release, targeted for today.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 