### PR TITLE
update the machine-controller to v1.5.3

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -47,7 +47,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.5.2"
+	MachineControllerTag           = "v1.5.3"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the machine-controller to version v1.5.3.

**Does this PR introduce a user-facing change?**:
```release-note
Update the machine-controller to v1.5.3
```
