### PR TITLE
Add changelog for release v0.10.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# [v0.10.0-alpha.3](https://github.com/kubermatic/kubeone/releases/tag/v0.10.0-alpha.3) - 2019-08-22
+
+## Changed
+
+* Update `machine-controller` to v1.5.3 ([#633](https://github.com/kubermatic/kubeone/pull/633))
+
 # [v0.10.0-alpha.2](https://github.com/kubermatic/kubeone/releases/tag/v0.10.0-alpha.2) - 2019-08-21
 
 ## Changed


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the changelog for the release v0.10.0-alpha.3.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 