### PR TITLE
Add note about kubectl scale not working with kubectl 1.15

### DIFF
--- a/docs/quickstart-aws.md
+++ b/docs/quickstart-aws.md
@@ -176,6 +176,22 @@ or export the `KUBECONFIG` variable environment variable:
 export KUBECONFIG=$PWD/<cluster_name>-kubeconfig
 ```
 
+## Scaling Worker Nodes
+
+As worker nodes are managed by machine-controller, they can be scaled up and down
+(including to 0) using Kubernetes API.
+
+```bash
+kubectl --namespace kube-system scale machinedeployment/pool1-deployment --replicas=3
+```
+
+**Note:** The `kubectl scale` command is not working as expected with `kubectl` 1.15,
+returning an error such as:
+```
+The machinedeployments "pool1" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
+```
+For a workaround, please follow the steps described in the [issue 593][scale_issue].
+
 ## Deleting The Cluster
 
 Before deleting a cluster you should clean up all MachineDeployments, so all worker nodes are deleted. You can do it with the `kubeone reset` command:
@@ -193,3 +209,5 @@ terraform destroy
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
 Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+
+[scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-azure.md
+++ b/docs/quickstart-azure.md
@@ -240,6 +240,22 @@ or export the `KUBECONFIG` variable environment variable:
 export KUBECONFIG=$PWD/<cluster_name>-kubeconfig
 ```
 
+## Scaling Worker Nodes
+
+As worker nodes are managed by machine-controller, they can be scaled up and down
+(including to 0) using Kubernetes API.
+
+```bash
+kubectl --namespace kube-system scale machinedeployment/pool1-deployment --replicas=3
+```
+
+**Note:** The `kubectl scale` command is not working as expected with `kubectl` 1.15,
+returning an error such as:
+```
+The machinedeployments "pool1" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
+```
+For a workaround, please follow the steps described in the [issue 593][scale_issue].
+
 ## Deleting The Cluster
 
 Before deleting a cluster you should clean up all MachineDeployments, so all
@@ -271,3 +287,4 @@ check our [documentation][9].
 [7]: https://github.com/kubermatic/machine-controller
 [8]: https://github.com/kubermatic/machine-controller/blob/master/examples/azure-machinedeployment.yaml
 [9]: https://github.com/kubermatic/kubeone/tree/master/docs
+[scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-digitalocean.md
+++ b/docs/quickstart-digitalocean.md
@@ -175,6 +175,22 @@ or export the `KUBECONFIG` variable environment variable:
 export KUBECONFIG=$PWD/<cluster_name>-kubeconfig
 ```
 
+## Scaling Worker Nodes
+
+As worker nodes are managed by machine-controller, they can be scaled up and down
+(including to 0) using Kubernetes API.
+
+```bash
+kubectl --namespace kube-system scale machinedeployment/pool1-deployment --replicas=3
+```
+
+**Note:** The `kubectl scale` command is not working as expected with `kubectl` 1.15,
+returning an error such as:
+```
+The machinedeployments "pool1" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
+```
+For a workaround, please follow the steps described in the [issue 593][scale_issue].
+
 ## Deleting The Cluster
 
 Before deleting a cluster you should clean up all MachineDeployments, so all worker nodes are deleted. You can do it with the `kubeone reset` command:
@@ -192,3 +208,5 @@ terraform destroy
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
 Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+
+[scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -219,6 +219,22 @@ environment variable:
 export KUBECONFIG=$PWD/cluster-name-kubeconfig
 ```
 
+## Scaling Worker Nodes
+
+As worker nodes are managed by machine-controller, they can be scaled up and down
+(including to 0) using Kubernetes API.
+
+```bash
+kubectl --namespace kube-system scale machinedeployment/pool1-deployment --replicas=3
+```
+
+**Note:** The `kubectl scale` command is not working as expected with `kubectl` 1.15,
+returning an error such as:
+```
+The machinedeployments "pool1" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
+```
+For a workaround, please follow the steps described in the [issue 593][scale_issue].
+
 ## Deleting The Cluster
 
 Before deleting a cluster you should clean up all MachineDeployments, so all
@@ -242,3 +258,5 @@ control plane nodes and three worker nodes. If you want to learn more about
 KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to
 check our
 [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+
+[scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-hetzner.md
+++ b/docs/quickstart-hetzner.md
@@ -167,6 +167,22 @@ or export the `KUBECONFIG` variable environment variable:
 export KUBECONFIG=$PWD/<cluster_name>-kubeconfig
 ```
 
+## Scaling Worker Nodes
+
+As worker nodes are managed by machine-controller, they can be scaled up and down
+(including to 0) using Kubernetes API.
+
+```bash
+kubectl --namespace kube-system scale machinedeployment/pool1-deployment --replicas=3
+```
+
+**Note:** The `kubectl scale` command is not working as expected with `kubectl` 1.15,
+returning an error such as:
+```
+The machinedeployments "pool1" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
+```
+For a workaround, please follow the steps described in the [issue 593][scale_issue].
+
 ## Deleting The Cluster
 
 Before deleting a cluster you should clean up all MachineDeployments, so all worker nodes are deleted. You can do it with the `kubeone reset` command:
@@ -184,3 +200,5 @@ terraform destroy
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
 Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+
+[scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-openstack.md
+++ b/docs/quickstart-openstack.md
@@ -212,6 +212,22 @@ or export the `KUBECONFIG` variable environment variable:
 export KUBECONFIG=$PWD/<cluster_name>-kubeconfig
 ```
 
+## Scaling Worker Nodes
+
+As worker nodes are managed by machine-controller, they can be scaled up and down
+(including to 0) using Kubernetes API.
+
+```bash
+kubectl --namespace kube-system scale machinedeployment/pool1-deployment --replicas=3
+```
+
+**Note:** The `kubectl scale` command is not working as expected with `kubectl` 1.15,
+returning an error such as:
+```
+The machinedeployments "pool1" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
+```
+For a workaround, please follow the steps described in the [issue 593][scale_issue].
+
 ## Deleting The Cluster
 
 Before deleting a cluster you should clean up all MachineDeployments, so all worker nodes are deleted. You can do it with the `kubeone reset` command:
@@ -229,3 +245,5 @@ terraform destroy
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
 Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three control plane nodes and two worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+
+[scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-packet.md
+++ b/docs/quickstart-packet.md
@@ -234,12 +234,19 @@ export KUBECONFIG=$PWD/<cluster_name>-kubeconfig
 
 ## Scaling Worker Nodes
 
-As worker nodes are managed by MachineController, they can be scaled up and down
+As worker nodes are managed by machine-controller, they can be scaled up and down
 (including to 0) using Kubernetes API.
 
 ```bash
 kubectl --namespace kube-system scale machinedeployment/pool1-deployment --replicas=3
 ```
+
+**Note:** The `kubectl scale` command is not working as expected with `kubectl` 1.15,
+returning an error such as:
+```
+The machinedeployments "pool1" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
+```
+For a workaround, please follow the steps described in the [issue 593][scale_issue].
 
 ## Deleting The Cluster
 
@@ -274,3 +281,4 @@ our [documentation][kubeone_docs].
 [machine_controller]: https://github.com/kubermatic/machine-controller
 [packet_mc_example]: https://github.com/kubermatic/machine-controller/blob/master/examples/packet-machinedeployment.yaml
 [kubeone_docs]: https://github.com/kubermatic/kubeone/tree/master/docs
+[scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-vsphere.md
+++ b/docs/quickstart-vsphere.md
@@ -247,6 +247,22 @@ or export the `KUBECONFIG` variable environment variable:
 export KUBECONFIG=$PWD/<cluster_name>-kubeconfig
 ```
 
+## Scaling Worker Nodes
+
+As worker nodes are managed by machine-controller, they can be scaled up and down
+(including to 0) using Kubernetes API.
+
+```bash
+kubectl --namespace kube-system scale machinedeployment/pool1-deployment --replicas=3
+```
+
+**Note:** The `kubectl scale` command is not working as expected with `kubectl` 1.15,
+returning an error such as:
+```
+The machinedeployments "pool1" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
+```
+For a workaround, please follow the steps described in the [issue 593][scale_issue].
+
 ## Deleting The Cluster
 
 Before deleting a cluster you should clean up all MachineDeployments, so all
@@ -279,3 +295,4 @@ check our [documentation][9].
 [7]: https://github.com/kubermatic/machine-controller
 [8]: https://github.com/kubermatic/machine-controller/blob/master/examples/vsphere-machinedeployment.yaml
 [9]: https://github.com/kubermatic/kubeone/tree/master/docs
+[scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds how to use the `kubectl scale` command to all quickstart guides, along with a note about `kubectl scale` command not working with `kubectl` 1.15.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #593

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 