### PR TITLE
Fix DestroyWorkers not retrying operations

### DIFF
--- a/pkg/installer/installation/reset.go
+++ b/pkg/installer/installation/reset.go
@@ -55,24 +55,49 @@ func Reset(s *state.State) error {
 }
 
 func destroyWorkers(s *state.State) error {
+	var lastErr error
 	s.Logger.Infoln("Destroying worker nodes…")
 
-	waitErr := wait.ExponentialBackoff(defaultRetryBackoff(3), func() (bool, error) {
-		err := kubeconfig.BuildKubernetesClientset(s)
-		return err == nil, errors.Wrap(err, "unable to build kubernetes clientset")
+	_ = wait.ExponentialBackoff(defaultRetryBackoff(3), func() (bool, error) {
+		lastErr = kubeconfig.BuildKubernetesClientset(s)
+		if lastErr != nil {
+			s.Logger.Warn("Unable to connect to the control plane API. Retrying…")
+			return false, nil
+		}
+		return true, nil
+
 	})
-	if waitErr != nil {
+	if lastErr != nil {
 		s.Logger.Warn("Unable to connect to the control plane API and destroy worker nodes")
 		s.Logger.Warn("You can skip destroying worker nodes and destroy them manually using `--destroy-workers=false`")
-		return waitErr
+		return errors.Wrap(lastErr, "unable to build kubernetes clientset")
 	}
 
-	waitErr = wait.ExponentialBackoff(defaultRetryBackoff(3), func() (bool, error) {
-		err := machinecontroller.DestroyWorkers(s)
-		return err == nil, errors.Wrap(err, "unable to delete all worker nodes")
+	_ = wait.ExponentialBackoff(defaultRetryBackoff(3), func() (bool, error) {
+		lastErr = machinecontroller.DestroyWorkers(s)
+		if lastErr != nil {
+			s.Logger.Warn("Unable to destroy worker nodes. Retrying…")
+			return false, nil
+		}
+		return true, nil
 	})
+	if lastErr != nil {
+		return errors.Wrap(lastErr, "unable to delete all worker nodes")
+	}
 
-	return waitErr
+	_ = wait.ExponentialBackoff(defaultRetryBackoff(3), func() (bool, error) {
+		lastErr = machinecontroller.WaitDestroy(s)
+		if lastErr != nil {
+			s.Logger.Warn("Waiting for all machines to be deleted…")
+			return false, nil
+		}
+		return true, nil
+	})
+	if lastErr != nil {
+		return errors.Wrap(lastErr, "error waiting for machines to be deleted")
+	}
+
+	return nil
 }
 
 func resetNode(s *state.State, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -160,8 +160,14 @@ func DestroyWorkers(s *state.State) error {
 		}
 	}
 
-	// Wait for all Machines to be deleted
+	return nil
+}
+
+// WaitDestroy waits for all Machines to be deleted
+func WaitDestroy(s *state.State) error {
 	s.Logger.Info("Waiting for all machines to get deleted…")
+
+	bgCtx := context.Background()
 	return wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
 		list := &clusterv1alpha1.MachineList{}
 		if err := s.DynamicClient.List(bgCtx, dynclient.InNamespace(MachineControllerNamespace), list); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

When an error is returned in the function of `wait.ExponentialBackoff`, it doesn't retry the operation again, but instead just fails. This PR is supposed to fix this by remembering the last error and parsing it outside of the `wait.ExponentialBackoff` function.

This could be helpful when KubeOne is waiting for all machines to be deleted. Recently, the AWS E2E tests were failing because it takes more time for worker machines to be deleted and as we haven't repeated the operation, it just failed after the first few minutes. This PR should eventually improve the stability of our tests.

**Does this PR introduce a user-facing change?**:
```release-note
Ensure operations related to deleting worker nodes are retried properly
```

/assign @kron4eg 