### PR TITLE
Allow sourcing cloudConfig from the credentials file

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -78,7 +78,7 @@ It's possible to source information about hosts from Terraform output, using the
 
 // runInstall provisions Kubernetes on the provided machines
 func runInstall(logger *logrus.Logger, installOptions *installOptions) error {
-	cluster, err := loadClusterConfig(installOptions.Manifest, installOptions.TerraformState, logger)
+	cluster, err := loadClusterConfig(installOptions.Manifest, installOptions.TerraformState, installOptions.CredentialsFilePath, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}

--- a/pkg/cmd/kubeconfig.go
+++ b/pkg/cmd/kubeconfig.go
@@ -53,6 +53,7 @@ It's possible to source information about hosts from Terraform output, using the
 			logger := initLogger(gopts.Verbose)
 			kopts.TerraformState = gopts.TerraformState
 			kopts.Verbose = gopts.Verbose
+			kopts.CredentialsFilePath = gopts.CredentialsFilePath
 
 			kopts.Manifest = args[0]
 			if kopts.Manifest == "" {
@@ -72,7 +73,7 @@ func runKubeconfig(logger *logrus.Logger, kubeconfigOptions *kubeconfigOptions) 
 		return errors.New("no cluster config file given")
 	}
 
-	cluster, err := loadClusterConfig(kubeconfigOptions.Manifest, kubeconfigOptions.TerraformState, logger)
+	cluster, err := loadClusterConfig(kubeconfigOptions.Manifest, kubeconfigOptions.TerraformState, kubeconfigOptions.CredentialsFilePath, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -53,6 +53,7 @@ It's possible to source information about hosts from Terraform output, using the
 			logger := initLogger(gopts.Verbose)
 			ropts.TerraformState = gopts.TerraformState
 			ropts.Verbose = gopts.Verbose
+			ropts.CredentialsFilePath = gopts.CredentialsFilePath
 
 			ropts.Manifest = args[0]
 			if ropts.Manifest == "" {
@@ -75,7 +76,7 @@ func runReset(logger *logrus.Logger, resetOptions *resetOptions) error {
 		return errors.New("no cluster config file given")
 	}
 
-	cluster, err := loadClusterConfig(resetOptions.Manifest, resetOptions.TerraformState, logger)
+	cluster, err := loadClusterConfig(resetOptions.Manifest, resetOptions.TerraformState, resetOptions.CredentialsFilePath, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -77,8 +77,8 @@ func initLogger(verbose bool) *logrus.Logger {
 	return logger
 }
 
-func loadClusterConfig(filename, terraformOutputPath string, logger *logrus.Logger) (*kubeoneapi.KubeOneCluster, error) {
-	a, err := config.LoadKubeOneCluster(filename, terraformOutputPath, logger)
+func loadClusterConfig(filename, terraformOutputPath, credentialsFilePath string, logger *logrus.Logger) (*kubeoneapi.KubeOneCluster, error) {
+	a, err := config.LoadKubeOneCluster(filename, terraformOutputPath, credentialsFilePath, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to load a given KubeOneCluster object")
 	}

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -72,7 +72,7 @@ It's possible to source information about hosts from Terraform output, using the
 
 // runUpgrade upgrades Kubernetes on the provided machines
 func runUpgrade(logger *logrus.Logger, upgradeOptions *upgradeOptions) error {
-	cluster, err := loadClusterConfig(upgradeOptions.Manifest, upgradeOptions.TerraformState, logger)
+	cluster, err := loadClusterConfig(upgradeOptions.Manifest, upgradeOptions.TerraformState, upgradeOptions.CredentialsFilePath, logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to load cluster")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an option to source cloudConfig from the credentials file. This is done by using the `cloudConfig` key.

Passing the credentials file path and the credentials bytes down the config functions is maybe not that elegant approach. The reason for doing this is that we want to be able to validate the cloudConfig using the API validation. An alternative approach would be to us the runtime validation, but it is prone to errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #492 

**Does this PR introduce a user-facing change?**:
```release-note
Add an option to source cloudConfig from the credentials file using the cloudConfig key
```

/assign @kron4eg 