### PR TITLE
Add support for custom OS in E2E tests for AWS

### DIFF
--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -98,6 +98,14 @@ func TestClusterConformance(t *testing.T) {
 			if testProvider != tc.provider {
 				t.SkipNow()
 			}
+			if err := ValidateOperatingSystem(testOSControlPlane); err != nil {
+				t.Fatal(err)
+			}
+			if err := ValidateOperatingSystem(testOSWorkers); err != nil {
+				t.Fatal(err)
+			}
+			osControlPlane := OperatingSystem(testOSControlPlane)
+			osWorkers := OperatingSystem(testOSWorkers)
 			t.Logf("Running conformance tests for Kubernetes v%s…", testTargetVersion)
 
 			// Create provisioner
@@ -134,6 +142,16 @@ func TestClusterConformance(t *testing.T) {
 			// Create infrastructure
 			t.Log("Provisioning infrastructure using Terraform…")
 			args := []string{}
+			if osControlPlane != OperatingSystemDefault {
+				img, err := DiscoverControlPlaneOSImage(tc.provider, osControlPlane)
+				if err != nil {
+					t.Fatalf("failed to discover control plane os image: %v", err)
+				}
+				args = append(args, "-var", img)
+			}
+			if osWorkers != OperatingSystemDefault {
+				args = append(args, "-var", fmt.Sprintf("worker_os=%s", osWorkers))
+			}
 			if tc.provider == provisioner.GCE {
 				args = []string{"-var", "control_plane_target_pool_members_count=1"}
 			}
@@ -159,7 +177,18 @@ func TestClusterConformance(t *testing.T) {
 			// Run Terraform again for GCE to add nodes to the load balancer
 			if tc.provider == provisioner.GCE {
 				t.Log("Adding other control plane nodes to the load balancer…")
-				tf, err = pr.Provision()
+				args = []string{}
+				if osControlPlane != OperatingSystemDefault {
+					img, err := DiscoverControlPlaneOSImage(tc.provider, osControlPlane)
+					if err != nil {
+						t.Fatalf("failed to discover control plane os image: %v", err)
+					}
+					args = append(args, "-var", img)
+				}
+				if osWorkers != OperatingSystemDefault {
+					args = append(args, "-var", fmt.Sprintf("worker_os=%s", osWorkers))
+				}
+				tf, err = pr.Provision(args...)
 				if err != nil {
 					t.Fatalf("failed to provision the infrastructure: %v", err)
 				}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -42,6 +42,8 @@ var (
 	testInitialVersion string
 	testTargetVersion  string
 	testProvider       string
+	testOSControlPlane string
+	testOSWorkers      string
 )
 
 func init() {
@@ -49,6 +51,8 @@ func init() {
 	flag.StringVar(&testProvider, "provider", "", "Provider to run tests on")
 	flag.StringVar(&testInitialVersion, "initial-version", "", "Cluster version to provision for tests")
 	flag.StringVar(&testTargetVersion, "target-version", "", "Cluster version to provision for tests")
+	flag.StringVar(&testOSControlPlane, "os-control-plane", "", "Operating system to use for control plane nodes")
+	flag.StringVar(&testOSWorkers, "os-workers", "", "Operating system to use for worker nodes")
 	flag.Parse()
 }
 

--- a/test/e2e/os.go
+++ b/test/e2e/os.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kubermatic/kubeone/test/e2e/provisioner"
+)
+
+type OperatingSystem string
+
+const (
+	OperatingSystemUbuntu  OperatingSystem = "ubuntu"
+	OperatingSystemCentOS  OperatingSystem = "centos"
+	OperatingSystemCoreOS  OperatingSystem = "coreos"
+	OperatingSystemDefault OperatingSystem = ""
+)
+
+func ValidateOperatingSystem(osName string) error {
+	switch OperatingSystem(osName) {
+	case OperatingSystemUbuntu, OperatingSystemCentOS, OperatingSystemCoreOS, OperatingSystemDefault:
+		return nil
+	}
+	return errors.New("failed to validate operating system")
+}
+
+// DiscoverControlPlaneOSImage returns Terraform flag with the image to be used for provisioning
+func DiscoverControlPlaneOSImage(provider string, osName OperatingSystem) (string, error) {
+	if provider == provisioner.AWS {
+		img, err := discoverAWSImage(osName)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("ami=%s", img), nil
+	}
+	return "", errors.New("custom operating system is not supported for selected provider")
+}
+
+func discoverAWSImage(osName OperatingSystem) (string, error) {
+	switch osName {
+	case OperatingSystemUbuntu:
+		return "ami-0119667e27598718e", nil
+	case OperatingSystemCentOS:
+		return "ami-0e1ab783dc9489f34", nil
+	case OperatingSystemCoreOS:
+		return "ami-04de4c2943ebaa320", nil
+	}
+	return "", errors.New("operating system not matched")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for custom OS in E2E tests for AWS. Other providers are to follow up if this is okay and it works.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially addresses #553

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 