### PR TITLE
Allow using of hostname instead of fqdn on kubeadm init/join for node…

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -33,8 +33,10 @@ import (
 
 type installOptions struct {
 	globalOptions
-	Manifest   string
-	BackupFile string
+	Manifest       string
+	BackupFile     string
+	NoFQDN         bool
+	EnableNodeName bool
 }
 
 // installCmd setups install command
@@ -72,6 +74,8 @@ It's possible to source information about hosts from Terraform output, using the
 	}
 
 	cmd.Flags().StringVarP(&iopts.BackupFile, "backup", "b", "", "path to where the PKI backup .tar.gz file should be placed (default: location of cluster config file)")
+	cmd.Flags().BoolVar(&iopts.NoFQDN, "no-fqdn", false, "use hostname instead of fqdn for node name")
+	cmd.Flags().BoolVar(&iopts.EnableNodeName, "enable-node-name", false, "set --node-name on kubeadm with node hostname")
 
 	return cmd
 }
@@ -125,5 +129,7 @@ func createInstallerOptions(clusterFile string, cluster *kubeoneapi.KubeOneClust
 		CredentialsFile: options.CredentialsFilePath,
 		BackupFile:      options.BackupFile,
 		Verbose:         options.Verbose,
+		NoFQDN:          options.NoFQDN,
+		EnableNodeName:  options.EnableNodeName,
 	}, nil
 }

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -32,6 +32,8 @@ type upgradeOptions struct {
 	ForceUpgrade              bool
 	Manifest                  string
 	UpgradeMachineDeployments bool
+	NoFQDN                    bool
+	EnableNodeName            bool
 }
 
 func upgradeCmd(rootFlags *pflag.FlagSet) *cobra.Command {
@@ -66,6 +68,8 @@ It's possible to source information about hosts from Terraform output, using the
 
 	cmd.Flags().BoolVarP(&uopts.ForceUpgrade, "force", "f", false, "force start upgrade process")
 	cmd.Flags().BoolVarP(&uopts.UpgradeMachineDeployments, "upgrade-machine-deployments", "", false, "upgrade MachineDeployments objects")
+	cmd.Flags().BoolVar(&uopts.NoFQDN, "no-fqdn", false, "use hostname instead of fqdn for node names")
+	cmd.Flags().BoolVar(&uopts.EnableNodeName, "enable-node-name", false, "set --node-name on kubeadm with node hostname")
 
 	return cmd
 }
@@ -93,5 +97,7 @@ func createUpgradeOptions(options *upgradeOptions) *upgrader.Options {
 		ForceUpgrade:              options.ForceUpgrade,
 		Verbose:                   options.Verbose,
 		UpgradeMachineDeployments: options.UpgradeMachineDeployments,
+		NoFQDN:                    options.NoFQDN,
+		EnableNodeName:            options.EnableNodeName,
 	}
 }

--- a/pkg/installer/installation/controlplane.go
+++ b/pkg/installer/installation/controlplane.go
@@ -43,10 +43,12 @@ func joinControlPlaneNodeInternal(s *state.State, node *kubeoneapi.HostConfig, c
 if [[ -f /etc/kubernetes/kubelet.conf ]]; then exit 0; fi
 
 sudo kubeadm join \
-	--config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
+	--config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml {{ if .ENABLE_NODE_NAME }} --node-name={{ .HOST }} {{ end }}
 `, runner.TemplateVariables{
-		"WORK_DIR": s.WorkDir,
-		"NODE_ID":  strconv.Itoa(node.ID),
+		"WORK_DIR":         s.WorkDir,
+		"NODE_ID":          strconv.Itoa(node.ID),
+		"HOST":             node.Hostname,
+		"ENABLE_NODE_NAME": s.EnableNodeName,
 	})
 	return err
 }

--- a/pkg/installer/installation/kubeadm_leader.go
+++ b/pkg/installer/installation/kubeadm_leader.go
@@ -35,7 +35,7 @@ sudo kubeadm init phase certs all --config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE
 `
 	kubeadmInitCommand = `
 if [[ -f /etc/kubernetes/admin.conf ]]; then exit 0; fi
-sudo kubeadm init --config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
+sudo kubeadm init --config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml {{ if .ENABLE_NODE_NAME }} --node-name={{ .HOST }} {{ end }}
 `
 )
 
@@ -66,8 +66,10 @@ func initKubernetesLeader(s *state.State) error {
 		s.Logger.Infoln("Running kubeadm…")
 
 		_, _, err := s.Runner.Run(kubeadmInitCommand, runner.TemplateVariables{
-			"WORK_DIR": s.WorkDir,
-			"NODE_ID":  strconv.Itoa(node.ID),
+			"WORK_DIR":         s.WorkDir,
+			"NODE_ID":          strconv.Itoa(node.ID),
+			"HOST":             node.Hostname,
+			"ENABLE_NODE_NAME": s.EnableNodeName,
 		})
 
 		return err

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -32,6 +32,8 @@ type Options struct {
 	Verbose         bool
 	CredentialsFile string
 	BackupFile      string
+	NoFQDN          bool
+	EnableNodeName  bool
 	DestroyWorkers  bool
 	RemoveBinaries  bool
 }
@@ -79,5 +81,7 @@ func (i *Installer) createState(options *Options) *state.State {
 		BackupFile:          options.BackupFile,
 		DestroyWorkers:      options.DestroyWorkers,
 		RemoveBinaries:      options.RemoveBinaries,
+		NoFQDN:              options.NoFQDN,
+		EnableNodeName:      options.EnableNodeName,
 	}
 }

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -49,6 +49,8 @@ type State struct {
 	UpgradeMachineDeployments bool
 	PatchCNI                  bool
 	CredentialsFilePath       string
+	NoFQDN                    bool
+	EnableNodeName            bool
 }
 
 // Clone returns a shallow copy of the State.

--- a/pkg/upgrader/upgrade/util.go
+++ b/pkg/upgrader/upgrade/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
+	"github.com/kubermatic/kubeone/pkg/runner"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/state"
 	"github.com/pkg/errors"
@@ -35,7 +36,13 @@ import (
 func determineHostname(s *state.State) error {
 	s.Logger.Infoln("Determine hostname…")
 	return s.RunTaskOnAllNodes(func(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
-		stdout, _, err := s.Runner.Run("hostname -f", nil)
+		hostcmdSuffix := "-f"
+		if s.NoFQDN {
+			hostcmdSuffix = ""
+		}
+		stdout, _, err := s.Runner.Run("hostname {{.HOST_CMD_SUFFIX}}", runner.TemplateVariables{
+			"HOST_CMD_SUFFIX": hostcmdSuffix,
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/upgrader/upgrader.go
+++ b/pkg/upgrader/upgrader.go
@@ -32,6 +32,8 @@ type Options struct {
 	ForceUpgrade              bool
 	UpgradeMachineDeployments bool
 	Verbose                   bool
+	NoFQDN                    bool
+	EnableNodeName            bool
 }
 
 // Upgrader is entrypoint for the upgrade process
@@ -66,5 +68,7 @@ func (u *Upgrader) createState(options *Options) *state.State {
 		ForceUpgrade:              options.ForceUpgrade,
 		UpgradeMachineDeployments: options.UpgradeMachineDeployments,
 		CredentialsFilePath:       options.CredentialsFile,
+		NoFQDN:                    options.NoFQDN,
+		EnableNodeName:            options.EnableNodeName,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

During installation of the seed cluster for kubermatic we encountered a issue with kubeone.

Our setup:
* vsphere on premise 
* vsphere cloud provider
* custom ubuntu image (ubuntu + proxy settings)
* DHCP
  * `sh: hostname` -> vmname123
  * `sh: hostname -f` -> vmname123.domain.de


During installation of kubernetes with kubeone, kubeone hangs on `kubeadm init`.
After checking the log of kubectl, we see that the node uses the hostname `sh: hostname` instead of `sh: hostname -f` and can't finish the installation.

This PR adds a flag to use `hostname` instead of  `hostname -f` for the node names.

I added  `--node-name` , so that the --hostname-override is set, but this was not working with `hostname - f` as the node name. I think because of the following issue: https://github.com/kubernetes/kubernetes/issues/54482.

It worked only for us with `--node-name` and `hostname`

The Flags i added, are optional and everything should be backwards compatibly 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
