### PR TITLE
Fix GCE E2E cluster provisioning

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -29,7 +29,7 @@ TERRAFORM_VERSION=${TERRAFORM_VERSION:-"0.12.5"}
 TEST_SET=${TEST_SET:-"conformance"}
 TEST_CLUSTER_TARGET_VERSION=${TEST_CLUSTER_TARGET_VERSION:-""}
 TEST_CLUSTER_INITIAL_VERSION=${TEST_CLUSTER_INITIAL_VERSION:-""}
-export TF_VAR_cluster_name=${BUILD_ID}
+export TF_VAR_cluster_name=k1-${BUILD_ID}
 
 PATH=$PATH:$(go env GOPATH)/bin
 
@@ -103,7 +103,7 @@ if [ -n "${RUNNING_IN_CI}" ]; then
     export TF_VAR_project_id=${PACKET_PROJECT_ID}
     ;;
   "gce")
-    export GOOGLE_CREDENTIALS=${serviceAccount}
+    export GOOGLE_CREDENTIALS=$(echo ${GOOGLE_SERVICE_ACCOUNT} | base64 -d)
     ;;
   *)
     echo "unknown provider ${PROVIDER}"


### PR DESCRIPTION
**What this PR does / why we need it**:

* GCE credentials are fetched correctly
* All E2E test resources are now prefixed with the `k1-` prefix (applies to all providers)
  * This is required for GCE because all names must start with a letter
  * This is useful for other providers because we exactly know that those resources are from KubeOne
* E2E tests for GCE are now supposed to work

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```