### PR TITLE
Fix proxy-env for pre-requisite scripts

### DIFF
--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -60,14 +60,20 @@ cat <<EOF | sudo tee /etc/kubeone/proxy-env
 {{ if .HTTP_PROXY -}}
 HTTP_PROXY="{{ .HTTP_PROXY }}"
 http_proxy="{{ .HTTP_PROXY }}"
+export HTTP_PROXY http_proxy
+
 {{ end }}
 {{- if .HTTPS_PROXY -}}
 HTTPS_PROXY="{{ .HTTPS_PROXY }}"
 https_proxy="{{ .HTTPS_PROXY }}"
+export HTTPS_PROXY https_proxy
+
 {{ end }}
 {{- if .NO_PROXY -}}
 NO_PROXY="{{ .NO_PROXY }}"
 no_proxy="{{ .NO_PROXY }}"
+export NO_PROXY no_proxy
+
 {{ end }}
 EOF
 	`

--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -82,8 +82,8 @@ EOF
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 
-source /etc/os-release
-source /etc/kubeone/proxy-env
+. /etc/os-release
+. /etc/kubeone/proxy-env
 
 # Short-Circuit the installation if it was already executed
 if type docker &>/dev/null && type kubelet &>/dev/null; then exit 0; fi
@@ -145,7 +145,7 @@ sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
 sudo sed -i s/SELINUX=enforcing/SELINUX=permissive/g /etc/sysconfig/selinux
 
-source /etc/kubeone/proxy-env
+. /etc/kubeone/proxy-env
 
 # Short-Circuit the installation if it was already executed
 if type docker &>/dev/null && type kubelet &>/dev/null; then exit 0; fi
@@ -177,7 +177,7 @@ sudo systemctl enable --now kubelet
 `
 
 	kubeadmCoreOSScript = `
-source /etc/kubeone/proxy-env
+. /etc/kubeone/proxy-env
 
 # Short-Circuit the installation if it was already executed
 if type docker &>/dev/null && type kubelet &>/dev/null; then exit 0; fi
@@ -289,7 +289,7 @@ func installPrerequisitesOnNode(s *state.State, node *kubeoneapi.HostConfig, con
 }
 
 func determineOS(s *state.State) (string, error) {
-	osID, _, err := s.Runner.Run("source /etc/os-release && echo -n $ID", nil)
+	osID, _, err := s.Runner.Run(". /etc/os-release && echo -n $ID", nil)
 	return osID, err
 }
 

--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -199,7 +199,7 @@ RELEASE="v{{ .KUBERNETES_VERSION }}"
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
-sudo curl -L --remote-name-all \
+sudo -E curl -L --remote-name-all \
 	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
 sudo chmod +x {kubeadm,kubelet,kubectl}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`/etc/kubeone/proxy-env` is used for systemd unit files (`EnvironmentFile=/etc/kubeone/proxy-env`) and also in the pre-req shell scripts (`source /etc/kubeone/proxy-env`).

While this works fine for systemd's `EnvironmentFile` directive, it will have no effect on child processes in the pre-req script unless the variables get exported.
Actually adding a line export xxx_proxy XXX_PROXY behind each assignment would make it work in the shell and would be ignored by the systemd directive.

reference from systemd manual:
```
The text file should contain new-line-separated variable assignments. 
Empty lines, lines without an "=" separator, or lines starting with ; or # will be ignored[...]
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #649 

```release-note
Fix proxy-env use in prerequisite scripts.
```
