### PR TITLE
Make login user of bastion host configurable

### DIFF
--- a/examples/ansible/kubeone/roles/kubeone_config/defaults/main.yml
+++ b/examples/ansible/kubeone/roles/kubeone_config/defaults/main.yml
@@ -48,6 +48,7 @@ kubeone_openidConnect_config_caFile: ""
 #   privateAddress: '172.18.0.1'
 #   bastion: '4.3.2.1'
 #   bastionPort: 22
+#   bastionUser: ubuntu
 #   sshPort: 22
 #   sshUsername: ubuntu
 #   sshPrivateKeyFile: '/home/me/.ssh/id_rsa'

--- a/examples/terraform/aws-private/README.md
+++ b/examples/terraform/aws-private/README.md
@@ -19,8 +19,9 @@ Follow the [issue #337](https://github.com/kubermatic/kubeone/issues/337) for mo
 | ssh\_port | SSH port to be used to provision instances | string | `"22"` | no |
 | ssh\_private\_key\_file | SSH private key file used to access instances | string | `""` | no |
 | ssh\_public\_key\_file | SSH public key file | string | `"~/.ssh/id_rsa.pub"` | no |
-| ssh\_username | SSH user, used only in output | string | `"root"` | no |
+| ssh\_username | SSH user, used only in output | string | `"ubuntu"` | no |
 | bastion\_port | Bastion SSH port | string | `"22"` | no |
+| bastion\_user | Bastion SSH username | string | `"ubuntu"` | no |
 | subnet\_netmask\_bits | default 8 bits in /16 CIDR, makes it /24 subnetworks | string | `"8"` | no |
 | subnet\_offset | subnet offset (from main VPC cidr_block) number to be cut | string | `"0"` | no |
 | vpc\_id | VPC to use ('default' for default VPC) | string | `"default"` | no |
@@ -35,4 +36,3 @@ Follow the [issue #337](https://github.com/kubermatic/kubeone/issues/337) for mo
 | kubeone\_bastion |  |
 | kubeone\_hosts | Control plane endpoints to SSH to |
 | kubeone\_workers | Workers definitions, that will be transformed into MachineDeployment object |
-

--- a/examples/terraform/aws-private/output.tf
+++ b/examples/terraform/aws-private/output.tf
@@ -42,6 +42,7 @@ output "kubeone_hosts" {
       ssh_user             = var.ssh_username
       bastion              = aws_instance.bastion.public_ip
       bastion_port         = var.bastion_port
+      bastion_user         = var.bastion_user
     }
   }
 }
@@ -147,4 +148,3 @@ output "kubeone_workers" {
     }
   }
 }
-

--- a/examples/terraform/aws-private/variables.tf
+++ b/examples/terraform/aws-private/variables.tf
@@ -58,6 +58,11 @@ variable "bastion_port" {
   default     = 22
 }
 
+variable "bastion_user" {
+  description = "Bastion SSH username"
+  default     = "ubuntu"
+}
+
 variable "dist_upgrade_on_boot" {
   description = "run worker upgrade distribution on boot"
   default     = false
@@ -99,4 +104,3 @@ variable "ami" {
   default     = ""
   description = "AMI ID, use it to fixate control-plane AMI in order to avoid force-recreation it at later times"
 }
-

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -63,6 +63,7 @@ type HostConfig struct {
 	SSHAgentSocket    string `json:"sshAgentSocket"`
 	Bastion           string `json:"bastion"`
 	BastionPort       int    `json:"bastionPort"`
+	BastionUser       string `json:"bastionUser"`
 	Hostname          string `json:"hostname"`
 
 	// Information populated at the runtime

--- a/pkg/apis/kubeone/v1alpha1/defaults.go
+++ b/pkg/apis/kubeone/v1alpha1/defaults.go
@@ -150,4 +150,7 @@ func defaultHostConfig(obj *HostConfig) {
 	if obj.BastionPort == 0 {
 		obj.BastionPort = 22
 	}
+	if obj.BastionUser == "" {
+		obj.BastionUser = obj.SSHUsername
+	}
 }

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -63,6 +63,7 @@ type HostConfig struct {
 	SSHAgentSocket    string `json:"sshAgentSocket"`
 	Bastion           string `json:"bastion"`
 	BastionPort       int    `json:"bastionPort"`
+	BastionUser       string `json:"bastionUser"`
 	Hostname          string `json:"hostname"`
 
 	// Information populated at the runtime

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
@@ -423,6 +423,7 @@ func autoConvert_v1alpha1_HostConfig_To_kubeone_HostConfig(in *HostConfig, out *
 	out.SSHAgentSocket = in.SSHAgentSocket
 	out.Bastion = in.Bastion
 	out.BastionPort = in.BastionPort
+	out.BastionUser = in.BastionUser
 	out.Hostname = in.Hostname
 	out.OperatingSystem = in.OperatingSystem
 	out.IsLeader = in.IsLeader
@@ -444,6 +445,7 @@ func autoConvert_kubeone_HostConfig_To_v1alpha1_HostConfig(in *kubeone.HostConfi
 	out.SSHAgentSocket = in.SSHAgentSocket
 	out.Bastion = in.Bastion
 	out.BastionPort = in.BastionPort
+	out.BastionUser = in.BastionUser
 	out.Hostname = in.Hostname
 	out.OperatingSystem = in.OperatingSystem
 	out.IsLeader = in.IsLeader

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -450,7 +450,7 @@ features:
   podSecurityPolicy:
     enable: {{ .EnablePodSecurityPolicy }}
   # Enables and configures audit log backend.
-  # More info: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#log-backend  
+  # More info: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#log-backend
   staticAuditLog:
     enable: {{ .EnableStaticAuditLog }}
     config:
@@ -528,6 +528,7 @@ features:
 #   privateAddress: '172.18.0.1'
 #   bastion: '4.3.2.1'
 #   bastionPort: 22  # can be left out if using the default (22)
+#   bastionUser: 'root'  # can be left out if using the default ('root')
 #   sshPort: 22 # can be left out if using the default (22)
 #   sshUsername: ubuntu
 #   # You usually want to configure either a private key OR an

--- a/pkg/ssh/connection.go
+++ b/pkg/ssh/connection.go
@@ -56,6 +56,7 @@ type Opts struct {
 	Timeout     time.Duration
 	Bastion     string
 	BastionPort int
+	BastionUser string
 }
 
 func validateOptions(o Opts) (Opts, error) {
@@ -87,6 +88,10 @@ func validateOptions(o Opts) (Opts, error) {
 
 	if o.BastionPort <= 0 {
 		o.BastionPort = 22
+	}
+
+	if o.BastionUser == "" {
+		o.BastionUser = o.Username
 	}
 
 	if o.Timeout == 0 {
@@ -165,6 +170,7 @@ func NewConnection(o Opts) (Connection, error) {
 	if o.Bastion != "" {
 		targetHost = o.Bastion
 		targetPort = strconv.Itoa(o.BastionPort)
+		sshConfig.User = o.BastionUser
 	}
 
 	// do not use fmt.Sprintf() to allow proper IPv6 handling if hostname is an IP address
@@ -189,6 +195,7 @@ func NewConnection(o Opts) (Connection, error) {
 		return nil, errors.Wrapf(err, "could not establish connection to %s", endpointBehindBastion)
 	}
 
+	sshConfig.User = o.Username
 	ncc, chans, reqs, err := ssh.NewClientConn(conn, endpointBehindBastion, sshConfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not establish connection to %s", endpointBehindBastion)

--- a/pkg/ssh/connector.go
+++ b/pkg/ssh/connector.go
@@ -53,6 +53,7 @@ func (c *Connector) Connect(node kubeoneapi.HostConfig) (Connection, error) {
 			Timeout:     10 * time.Second,
 			Bastion:     node.Bastion,
 			BastionPort: node.BastionPort,
+			BastionUser: node.BastionUser,
 		}
 
 		conn, err = NewConnection(opts)

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -37,6 +37,7 @@ type controlPlane struct {
 	SSHAgentSocket    string   `json:"ssh_agent_socket"`
 	Bastion           string   `json:"bastion"`
 	BastionPort       int      `json:"bastion_port"`
+	BastionUser       string   `json:"bastion_user"`
 }
 
 // Config represents configuration in the terraform output format
@@ -186,6 +187,7 @@ func newHostConfig(id int, publicIP, privateIP, hostname string, cp controlPlane
 		SSHAgentSocket:    cp.SSHAgentSocket,
 		Bastion:           cp.Bastion,
 		BastionPort:       cp.BastionPort,
+		BastionUser:       cp.BastionUser,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Allows username of bastion host to be configurable

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
Some documentation states that "root" is the default SSH user, but its actually "ubuntu". Fixed that

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Made username for bastion host configurable
```
