### PR TITLE
Pass proxy environment to machine-controller.

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -700,6 +700,16 @@ func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster, credentials
 	}
 
 	envVar, err := credentials.EnvVarBindings(cluster.CloudProvider.Name, credentialsFilePath)
+	envVar = append(envVar,
+		corev1.EnvVar{
+			Name:  "HTTPS_PROXY",
+			Value: cluster.Proxy.HTTPS,
+		},
+		corev1.EnvVar{
+			Name:  "NO_PROXY",
+			Value: cluster.Proxy.NoProxy,
+		},
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get env var bindings for a secret")
 	}

--- a/pkg/templates/machinecontroller/webhook.go
+++ b/pkg/templates/machinecontroller/webhook.go
@@ -132,6 +132,16 @@ func webhookDeployment(cluster *kubeoneapi.KubeOneCluster, credentialsFilePath s
 	var replicas int32 = 1
 
 	envVar, err := credentials.EnvVarBindings(cluster.CloudProvider.Name, credentialsFilePath)
+	envVar = append(envVar,
+		corev1.EnvVar{
+			Name:  "HTTPS_PROXY",
+			Value: cluster.Proxy.HTTPS,
+		},
+		corev1.EnvVar{
+			Name:  "NO_PROXY",
+			Value: cluster.Proxy.NoProxy,
+		},
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get env var bindings for a secret")
 	}


### PR DESCRIPTION
* machine-controller and its webhook get HTTPS_PROXY and NO_PROXY

Fixes #656 

**Special notes for your review
```release-note
machine-controller can now work in proxy environments.
```
