### PR TITLE
Avoid curl via sudo, proper binary install.

### DIFF
--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -199,9 +199,13 @@ RELEASE="v{{ .KUBERNETES_VERSION }}"
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
-sudo -E curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
-sudo chmod +x {kubeadm,kubelet,kubectl}
+k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+for binary in kubeadm kubelet kubectl; do
+	curl -L --output /tmp/$binary \
+		$k8s_rel_baseurl/${RELEASE}/bin/linux/amd64/$binary
+	sudo install --owner=0 --group=0 --mode=0755 /tmp/$binary /opt/bin/$binary
+	rm /tmp/$binary
+done
 
 curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | \
 	sed "s:/usr/bin:/opt/bin:g" | \


### PR DESCRIPTION
This PR changes the curl invocation which downloads the kubeadm, kubelet, and kubectl binaries in way that it no longer requires sudo and also uses a proper binary installation.
Using sudo with curl had been problematic before with respect to proxy environment. While the `-E` keeps the environment with sudo, a least privilege approach like this should be preferred.
```release-note
NONE
```