### PR TITLE
Make E2E tests pick right username

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ run:
 linters:
   enable-all: true
   disable:
+  - funlen
   - interfacer
   - dupl
   - maligned

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -143,11 +143,11 @@ func TestClusterConformance(t *testing.T) {
 			t.Log("Provisioning infrastructure using Terraform…")
 			args := []string{}
 			if osControlPlane != OperatingSystemDefault {
-				img, err := DiscoverControlPlaneOSImage(tc.provider, osControlPlane)
+				tfFlags, err := ControlPlaneImageFlags(tc.provider, osControlPlane)
 				if err != nil {
 					t.Fatalf("failed to discover control plane os image: %v", err)
 				}
-				args = append(args, "-var", img)
+				args = append(args, tfFlags...)
 			}
 			if osWorkers != OperatingSystemDefault {
 				args = append(args, "-var", fmt.Sprintf("worker_os=%s", osWorkers))
@@ -179,11 +179,11 @@ func TestClusterConformance(t *testing.T) {
 				t.Log("Adding other control plane nodes to the load balancer…")
 				args = []string{}
 				if osControlPlane != OperatingSystemDefault {
-					img, err := DiscoverControlPlaneOSImage(tc.provider, osControlPlane)
+					tfFlags, err := ControlPlaneImageFlags(tc.provider, osControlPlane)
 					if err != nil {
 						t.Fatalf("failed to discover control plane os image: %v", err)
 					}
-					args = append(args, "-var", img)
+					args = append(args, tfFlags...)
 				}
 				if osWorkers != OperatingSystemDefault {
 					args = append(args, "-var", fmt.Sprintf("worker_os=%s", osWorkers))

--- a/test/e2e/os.go
+++ b/test/e2e/os.go
@@ -40,26 +40,29 @@ func ValidateOperatingSystem(osName string) error {
 	return errors.New("failed to validate operating system")
 }
 
-// DiscoverControlPlaneOSImage returns Terraform flag with the image to be used for provisioning
-func DiscoverControlPlaneOSImage(provider string, osName OperatingSystem) (string, error) {
+// ControlPlaneImageFlags returns Terraform flags for control plane image and SSH username
+func ControlPlaneImageFlags(provider string, osName OperatingSystem) ([]string, error) {
 	if provider == provisioner.AWS {
-		img, err := discoverAWSImage(osName)
+		img, user, err := discoverAWSImage(osName)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return fmt.Sprintf("ami=%s", img), nil
+		return []string{
+			"-var", fmt.Sprintf("ami=%s", img),
+			"-var", fmt.Sprintf("ssh_username=%s", user),
+		}, nil
 	}
-	return "", errors.New("custom operating system is not supported for selected provider")
+	return nil, errors.New("custom operating system is not supported for selected provider")
 }
 
-func discoverAWSImage(osName OperatingSystem) (string, error) {
+func discoverAWSImage(osName OperatingSystem) (string, string, error) {
 	switch osName {
 	case OperatingSystemUbuntu:
-		return "ami-0119667e27598718e", nil
+		return "ami-0119667e27598718e", "ubuntu", nil
 	case OperatingSystemCentOS:
-		return "ami-0e1ab783dc9489f34", nil
+		return "ami-0e1ab783dc9489f34", "centos", nil
 	case OperatingSystemCoreOS:
-		return "ami-04de4c2943ebaa320", nil
+		return "ami-04de4c2943ebaa320", "core", nil
 	}
-	return "", errors.New("operating system not matched")
+	return "", "", errors.New("operating system not matched")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

By default, we use `ubuntu` as the SSH username, but it doesn't work for CentOS and CoreOS. This PR is supposed to fix this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevant to #553

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
