### PR TITLE
Update default admission controllers for 1.16

### DIFF
--- a/pkg/kubeflags/data.go
+++ b/pkg/kubeflags/data.go
@@ -58,4 +58,20 @@ var (
 		"ValidatingAdmissionWebhook",
 		"ResourceQuota",
 	}
+
+	defaultAdmissionControllersv116x = []string{
+		"NamespaceLifecycle",
+		"LimitRanger",
+		"ServiceAccount",
+		"TaintNodesByCondition",
+		"Priority",
+		"DefaultTolerationSeconds",
+		"DefaultStorageClass",
+		"StorageObjectInUseProtection",
+		"PersistentVolumeClaimResize",
+		"MutatingAdmissionWebhook",
+		"ValidatingAdmissionWebhook",
+		"RuntimeClass",
+		"ResourceQuota",
+	}
 )

--- a/pkg/kubeflags/flags.go
+++ b/pkg/kubeflags/flags.go
@@ -26,6 +26,7 @@ var (
 	constrainv1130v1132 = mustConstraint(">= 1.13.0, < 1.13.3")
 	constrainv1133v114x = mustConstraint(">= 1.13.3, < 1.15.0")
 	constrainv115x      = mustConstraint("1.15.x")
+	constrainv116x      = mustConstraint("1.16.x")
 )
 
 // DefaultAdmissionControllers return list of default admission controllers for
@@ -38,10 +39,12 @@ func DefaultAdmissionControllers(kubeVersion *semver.Version) string {
 		return strings.Join(defaultAdmissionControllersv1133v114x, ",")
 	case constrainv115x.Check(kubeVersion):
 		return strings.Join(defaultAdmissionControllersv115x, ",")
+	case constrainv116x.Check(kubeVersion):
+		return strings.Join(defaultAdmissionControllersv116x, ",")
 	}
 
 	// return same as for last known release
-	return strings.Join(defaultAdmissionControllersv115x, ",")
+	return strings.Join(defaultAdmissionControllersv116x, ",")
 }
 
 func mustConstraint(c string) *semver.Constraints {


### PR DESCRIPTION
**What this PR does / why we need it**:

As per `kube-apiserver`, the `RuntimeClass` is a new admission controller that is enabled by default as of 1.16.

**Does this PR introduce a user-facing change?**:
```release-note
Enable the RuntimeClass admission controller by default for Kubernetes 1.16 clusters
```
