### PR TITLE
Reference new KubeOne channel on k8s Slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -7,5 +7,5 @@ labels: triage/support
 
 <!-- Please use this template if you need support using KubeOne or if you have any question.
 
-You can also ask us questions on the KubeOne channel on Kubermatic Slack: http://slack.kubermatic.io
+You can also ask us questions on the KubeOne channel on Kubernetes Slack: http://slack.k8s.io/
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ This part of the document explains how to get started with contributing, includi
 
 One of the most challenging part of contributing to the open source projects is finding what to work on. To make it easier, we're trying to label all issues that may be good for first time contributors using the [`good first issue`](https://github.com/kubermatic/kubeone/labels/good%20first%20issue) label. Another label you can take a look at is the [`help wanted`](https://github.com/kubermatic/kubeone/labels/help%20wanted) label, however there may be issue that can be harder to solve if you're not experienced with the code base.
 
-If you have any questions or need assistance, please feel free to comment on the appropriate issue, create a new issue or ping us on [Slack](http://slack.kubermatic.io/) or [`loodse-dev` mailing list](https://groups.google.com/forum/#!forum/loodse-dev)!
+If you have any questions or need assistance, please feel free to comment on the appropriate issue, create a new issue or ping us on [`#kubeone` channel on Kubernetes Slack](http://slack.k8s.io/) or [`loodse-dev` mailing list](https://groups.google.com/forum/#!forum/loodse-dev)!
 
 ### Submitting Feature Requests
 
@@ -193,7 +193,7 @@ import (
 
 ## Contact
 
-The KubeOne project currently uses the general [Loodse (`loodse-dev`) mailing list](https://groups.google.com/forum/#!forum/loodse-dev) and KubeOne Slack channel on [Kubermatic Slack](http://slack.kubermatic.io/). You can also ask questions by creating a new issue on GitHub, but using mailing list or Slack is preferred.
+The KubeOne project currently uses the general [Loodse (`loodse-dev`) mailing list](https://groups.google.com/forum/#!forum/loodse-dev) and [`#kubeone` Slack channel](https://kubernetes.slack.com/messages/CNEV2UMT7) on [Kubernetes Slack](http://slack.k8s.io/). You can also ask questions by creating a new issue on GitHub, but using mailing list or Slack is preferred.
 
 Please avoid emailing maintainers found in the MAINTAINERS file directly. They are very busy, but they often read the mailing list and the Slack channel.
 

--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ features, please create a new issue on GitHub or connect with us over the
 mailing list or Slack:
 
 * [loodse-dev mailing list][14]
-* [Kubermatic Slack][15]
+* [`#kubeone` channel][5] on [Kubernetes Slack][15]
 
 ## Reporting Bugs
 
 If you encounter issues, please [create a new issue on GitHub][1] or talk to us
-on the [#KubeOne Slack channel][5]. When reporting a bug please include the
+on the [`#kubeone` Slack channel][5]. When reporting a bug please include the
 following information:
 
 * KubeOne version or Git commit that you're running (`kubeone version`),
@@ -210,7 +210,7 @@ See [the list of releases][3] to find out about feature changes.
 [2]: https://github.com/kubermatic/KubeOne/blob/master/CONTRIBUTING.md
 [3]: https://github.com/kubermatic/KubeOne/releases
 [4]: https://github.com/kubermatic/KubeOne/blob/master/CODE_OF_CONDUCT.md
-[5]: https://kubermatic.slack.com/messages/KubeOne
+[5]: https://kubernetes.slack.com/messages/CNEV2UMT7
 [6]: ./docs/backwards_compatibility_policy.md
 [7]: https://github.com/kubernetes-sigs/cluster-api
 [8]: https://github.com/kubermatic/machine-controller
@@ -220,6 +220,6 @@ See [the list of releases][3] to find out about feature changes.
 [11]: ./docs/quickstart-aws.md
 [13]: https://github.com/kubermatic/kubeone#features
 [14]: https://groups.google.com/forum/#!forum/loodse-dev
-[15]: http://slack.kubermatic.io/
+[15]: http://slack.k8s.io/
 [16]: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#reporting-a-security-vulnerability
 [17]: https://github.com/kubermatic/kubeone/issues/471

--- a/docs/adding_provider_support.md
+++ b/docs/adding_provider_support.md
@@ -37,7 +37,8 @@ the output.
 The [Terraform documentation][3] has a document showing how to provision the
 infrastructure for each Terraform-supported provider. If there is no Terraform
 support for such provider, please create an issue in the KubeOne repository or
-contact us over [Kubermatic Slack][4] to discuss about potential alternatives.
+contact us on the [`#kubeone` channel on Kubernetes Slack][4] to discuss about
+potential alternatives.
 
 Once Terraform scripts are done, you should proceed to adding the needed API
 types to the KubeOneCluster API.
@@ -141,7 +142,7 @@ E2E tests for a newly-added provider in the CI pipeline.
 [1]: https://github.com/kubermatic/machine-controller
 [2]: https://github.com/kubermatic/kubeone/tree/19e5e6bf792ae47d65bd8adf75f390c74159e3de/examples/terraform
 [3]: https://www.terraform.io/docs/providers/
-[4]: http://slack.kubermatic.io/
+[4]: http://slack.k8s.io/
 [5]: https://github.com/kubermatic/kubeone/tree/19e5e6bf792ae47d65bd8adf75f390c74159e3de/pkg/apis/kubeone
 [6]: https://github.com/kubermatic/kubeone/blob/19e5e6bf792ae47d65bd8adf75f390c74159e3de/pkg/apis/kubeone/types.go#L83-L92
 [7]: https://github.com/kubermatic/kubeone/blob/19e5e6bf792ae47d65bd8adf75f390c74159e3de/pkg/apis/kubeone/v1alpha1/types.go#L83-L92

--- a/docs/frequently_asked_questions.md
+++ b/docs/frequently_asked_questions.md
@@ -2,7 +2,8 @@
 
 This document lists some commonly asked questions about KubeOne, what it does,
 and how it works. If you have any question not covered here, please create 
-[a new GitHub issue][1] or contact us on [the mailing list][2] or [Slack][3].
+[a new GitHub issue][1] or contact us on [the mailing list][2] or 
+on the [`#kubeone` channel on Kubernetes Slack][3].
 
 - [What is KubeOne?](#what-is-kubeone-)
 - [What cloud providers KubeOne does support?](#what-cloud-providers-kubeone-does-support-)
@@ -50,7 +51,8 @@ the infrastructure can be configured and what resources can be used. There are
 many possible setups and supporting each of them in most of cases isn't
 possible. Operators are free to define infrastructure how they prefer and then
 use KubeOne to provision the cluster. We're open to feedback, so if you have any
-suggestion or idea ping us on [the mailing list][6] or [Slack][3].
+suggestion or idea ping us on [the mailing list][6] or on the 
+[`#kubeone` channel on Kubernetes Slack][3].
 
 ## How KubeOne works?
 
@@ -102,7 +104,7 @@ Please check our [contributing guide](CONTRIBUTING.md).
 
 [1]: https://github.com/kubermatic/kubeone/issues
 [2]: https://groups.google.com/forum/#!forum/loodse-dev
-[3]: http://slack.kubermatic.io/
+[3]: http://slack.k8s.io/
 [4]: https://github.com/kubermatic/machine-controller
 [5]: http://github.com/kubermatic/kubeone/tree/master/examples/terraform
 [6]: https://groups.google.com/forum/#!forum/loodse-dev


### PR DESCRIPTION
**What this PR does / why we need it**:

As of recently, we have a new channel on Kubernetes Slack and we are planning to use that one for the communication. This PR updates the docs to mention the new channel instead of channel on Kubermatic Slack.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
