### PR TITLE
Add build options to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ lint:
 	golangci-lint run ./pkg/... ./test/...
 
 .PHONY: verify-licence
+verify-licence: GOFLAGS = -mod=readonly
 verify-licence: vendor
 	wwhrd check
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ dist/kubeone: buildenv
 	go build -ldflags='$(GOLDFLAGS)' -v -o $@ .
 
 .PHONY: generate-internal-groups
+generate-internal-groups: GOFLAGS = -mod=readonly
 generate-internal-groups: vendor
 	./hack/update-codegen.sh
 
@@ -70,6 +71,7 @@ verify-licence: vendor
 	wwhrd check
 
 .PHONY: verify-codegen
+verify-codegen: GOFLAGS = -mod=readonly
 verify-codegen: vendor
 	./hack/verify-codegen.sh
 

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ export GOPATH?=$(shell go env GOPATH)
 export CGO_ENABLED=0
 export GOPROXY=https://proxy.golang.org
 export GO111MODULE=on
-export GOFLAGS?=-mod=readonly
+export GOFLAGS?=-mod=readonly -trimpath
 
 BUILD_DATE=$(shell if hash gdate 2>/dev/null; then gdate --rfc-3339=seconds | sed 's/ /T/'; else date --rfc-3339=seconds | sed 's/ /T/'; fi)
 GITCOMMIT=$(shell git log -1 --pretty=format:"%H")
 GITTAG=$(shell git describe --tags --always)
-GOLDFLAGS?=-s -w -X github.com/kubermatic/kubeone/pkg/cmd.version=$(GITTAG) -X github.com/kubermatic/kubeone/pkg/cmd.commit=$(GITCOMMIT) -X github.com/kubermatic/kubeone/pkg/cmd.date=$(BUILD_DATE)
+GOLDFLAGS?=-extldflags=-zrelro -extldflags=-znow -s -w -X github.com/kubermatic/kubeone/pkg/cmd.version=$(GITTAG) -X github.com/kubermatic/kubeone/pkg/cmd.commit=$(GITCOMMIT) -X github.com/kubermatic/kubeone/pkg/cmd.date=$(BUILD_DATE)
 
 .PHONY: all
 all: install


### PR DESCRIPTION
The path is trimmed from binaries to make builds more reproducible.
Disable lazy binding and make global offset table read only to
harden binary a bit.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Enhances security of builds and makes them more reproducible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
