### PR TITLE
Apply MachineDeployment labels on the Node object

### DIFF
--- a/pkg/templates/machinecontroller/machines.go
+++ b/pkg/templates/machinecontroller/machines.go
@@ -124,6 +124,9 @@ func createMachineDeployment(cluster *kubeoneapi.KubeOneCluster, workerset kubeo
 					Labels:    labels.Merge(workerset.Config.Labels, workersetNameLabels),
 				},
 				Spec: clusterv1alpha1.MachineSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels.Merge(workerset.Config.Labels, workersetNameLabels),
+					},
 					Versions: clusterv1alpha1.MachineVersionInfo{
 						Kubelet: cluster.Versions.Kubernetes,
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:

`machine-controller` supports applying labels on the Node object by providing them in the MachineDeployment object. This PR ensures this is done automatically when labels are defined using `.providerSpec.Labels`. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #662

**Does this PR introduce a user-facing change?**:
```release-note
Apply MachineDeployment labels on the Node object
```

/assign @kron4eg 