### PR TITLE
Support adding Taints on the worker nodes

### DIFF
--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -168,7 +168,7 @@ type WorkerConfig struct {
 type ProviderSpec struct {
 	CloudProviderSpec   json.RawMessage   `json:"cloudProviderSpec"`
 	Labels              map[string]string `json:"labels"`
-	Taints              []corev1.Taint    `json:"taints"`
+	Taints              []corev1.Taint    `json:"taints,omitempty"`
 	SSHPublicKeys       []string          `json:"sshPublicKeys"`
 	OperatingSystem     string            `json:"operatingSystem"`
 	OperatingSystemSpec json.RawMessage   `json:"operatingSystemSpec"`

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -19,6 +19,7 @@ package kubeone
 import (
 	"encoding/json"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -167,6 +168,7 @@ type WorkerConfig struct {
 type ProviderSpec struct {
 	CloudProviderSpec   json.RawMessage   `json:"cloudProviderSpec"`
 	Labels              map[string]string `json:"labels"`
+	Taints              []corev1.Taint    `json:"taints"`
 	SSHPublicKeys       []string          `json:"sshPublicKeys"`
 	OperatingSystem     string            `json:"operatingSystem"`
 	OperatingSystemSpec json.RawMessage   `json:"operatingSystemSpec"`

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -168,7 +168,7 @@ type WorkerConfig struct {
 type ProviderSpec struct {
 	CloudProviderSpec   json.RawMessage   `json:"cloudProviderSpec"`
 	Labels              map[string]string `json:"labels"`
-	Taints              []corev1.Taint    `json:"taints"`
+	Taints              []corev1.Taint    `json:"taints,omitempty"`
 	SSHPublicKeys       []string          `json:"sshPublicKeys"`
 	OperatingSystem     string            `json:"operatingSystem"`
 	OperatingSystemSpec json.RawMessage   `json:"operatingSystemSpec"`

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -167,6 +168,7 @@ type WorkerConfig struct {
 type ProviderSpec struct {
 	CloudProviderSpec   json.RawMessage   `json:"cloudProviderSpec"`
 	Labels              map[string]string `json:"labels"`
+	Taints              []corev1.Taint    `json:"taints"`
 	SSHPublicKeys       []string          `json:"sshPublicKeys"`
 	OperatingSystem     string            `json:"operatingSystem"`
 	OperatingSystemSpec json.RawMessage   `json:"operatingSystemSpec"`

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
@@ -25,6 +25,7 @@ import (
 	unsafe "unsafe"
 
 	kubeone "github.com/kubermatic/kubeone/pkg/apis/kubeone"
+	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -688,6 +689,7 @@ func Convert_kubeone_PodSecurityPolicy_To_v1alpha1_PodSecurityPolicy(in *kubeone
 func autoConvert_v1alpha1_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, out *kubeone.ProviderSpec, s conversion.Scope) error {
 	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
+	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
 	out.SSHPublicKeys = *(*[]string)(unsafe.Pointer(&in.SSHPublicKeys))
 	out.OperatingSystem = in.OperatingSystem
 	out.OperatingSystemSpec = *(*json.RawMessage)(unsafe.Pointer(&in.OperatingSystemSpec))
@@ -704,6 +706,7 @@ func Convert_v1alpha1_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, out
 func autoConvert_kubeone_ProviderSpec_To_v1alpha1_ProviderSpec(in *kubeone.ProviderSpec, out *ProviderSpec, s conversion.Scope) error {
 	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
+	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
 	out.SSHPublicKeys = *(*[]string)(unsafe.Pointer(&in.SSHPublicKeys))
 	out.OperatingSystem = in.OperatingSystem
 	out.OperatingSystemSpec = *(*json.RawMessage)(unsafe.Pointer(&in.OperatingSystemSpec))

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha1
 import (
 	json "encoding/json"
 
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -360,6 +361,13 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.Taints != nil {
+		in, out := &in.Taints, &out.Taints
+		*out = make([]v1.Taint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.SSHPublicKeys != nil {

--- a/pkg/apis/kubeone/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package kubeone
 import (
 	json "encoding/json"
 
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -360,6 +361,13 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.Taints != nil {
+		in, out := &in.Taints, &out.Taints
+		*out = make([]v1.Taint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.SSHPublicKeys != nil {

--- a/pkg/templates/machinecontroller/machines.go
+++ b/pkg/templates/machinecontroller/machines.go
@@ -133,6 +133,7 @@ func createMachineDeployment(cluster *kubeoneapi.KubeOneCluster, workerset kubeo
 					ProviderSpec: clusterv1alpha1.ProviderSpec{
 						Value: &runtime.RawExtension{Raw: encoded},
 					},
+					Taints: workerset.Config.Taints,
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for adding Taints on the worker nodes. Taints are added using the `.providerSpec.Taints` field.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevant to #662

**Does this PR introduce a user-facing change?**:
```release-note
Add support for adding Taints on the worker nodes
```

/assign @kron4eg 