### PR TITLE
Only show Retrying task message if there are retries left

### DIFF
--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -49,9 +49,12 @@ func (t *Task) Run(ctx *state.State) error {
 
 	var lastError error
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		if lastError != nil {
+			ctx.Logger.Warn("Retrying task…")
+		}
 		lastError = t.Fn(ctx)
 		if lastError != nil {
-			ctx.Logger.Warn("Task failed, retrying…")
+			ctx.Logger.Warn("Task failed…")
 			if ctx.Verbose {
 				ctx.Logger.Warnf("error was: %s", lastError)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Only show the "Retrying task..." message if there are retries left.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #673

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 