### PR TITLE
Update machine-controller to v1.5.7

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -47,7 +47,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.5.6"
+	MachineControllerTag           = "v1.5.7"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updated the `machine-controller` to v1.5.7. `machine-controller` v1.5.7 went out this morning to address the issue related to inconsistent applying of labels (#677) and taints (#678) on the Node object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #680

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.5.7
```

/assign @kron4eg 