### PR TITLE
Verify machine-controller CRDs before deleting workers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,3 +33,4 @@ issues:
     - "don't use underscores in Go names; func SetDefaults_SystemPackages should be SetDefaultsSystemPackages"
     - "G101: Potential hardcoded credentials"
     - "G106: Use of ssh InsecureIgnoreHostKey should be audited"
+    - "`defaultRetryBackoff` - `retries` always receives `3`"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug and brings an improvement:
* `kubeone reset` will not wait for workers to be deleted if CRDs are not deployed
* `kubeone reset` will now explicitly check are CRDs deployed instead of trying to delete a CR

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #681

**Does this PR introduce a user-facing change?**:
```release-note
kubeone reset doesn't wait for workers to be deleted if machine-controller CRDs are not deployed
```

/assign @kron4eg 