### PR TITLE
Add proxy env to /etc/environment

### DIFF
--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -76,8 +76,12 @@ export NO_PROXY no_proxy
 
 {{ end }}
 EOF
-	`
 
+envtmp=/tmp/k1-etc-environment
+grep -v '#kubeone$' /etc/environment > $envtmp
+grep = /etc/kubeone/proxy-env | sed 's/$/#kubeone/' >> $envtmp
+sudo tee /etc/environment < $envtmp
+`
 	kubeadmDebianScript = `
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab


### PR DESCRIPTION
Add proxy env to /etc/environment

`#kubeone` markers are used to allow reset and idempotency
**What this PR does / why we need it**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
