### PR TITLE
Force non-interactive mode for dpkg via apt-get.

### DIFF
--- a/pkg/installer/installation/prerequisites.go
+++ b/pkg/installer/installation/prerequisites.go
@@ -81,6 +81,7 @@ envtmp=/tmp/k1-etc-environment
 grep -v '#kubeone$' /etc/environment > $envtmp || true
 set +o pipefail # grep exits non-zero without match
 grep = /etc/kubeone/proxy-env | sed 's/$/#kubeone/' >> $envtmp
+echo 'DEBIAN_FRONTEND=noninteractive#kubeone' >> $envtmp
 sudo tee /etc/environment < $envtmp
 `
 	kubeadmDebianScript = `
@@ -102,7 +103,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 EOF
 
 sudo apt-get update
-sudo apt-get install -y --no-install-recommends \
+sudo apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	apt-transport-https \
 	ca-certificates \
 	curl \
@@ -135,7 +136,7 @@ cni_ver=$(apt-cache madison kubernetes-cni | \
 	grep "{{ .CNI_VERSION }}" | head -1 | awk '{print $3}')
 
 sudo apt-mark unhold docker-ce kubelet kubeadm kubectl kubernetes-cni
-sudo apt-get install -y --no-install-recommends \
+sudo apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	docker-ce=${docker_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \

--- a/pkg/upgrader/upgrade/kubernetes_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_binaries.go
@@ -35,7 +35,7 @@ kube_ver=$(apt-cache madison kubelet | grep "{{ .KUBERNETES_VERSION }}" | head -
 cni_ver=$(apt-cache madison kubernetes-cni | grep "{{ .CNI_VERSION }}" | head -1 | awk '{print $3}')
 
 sudo apt-mark unhold kubeadm kubelet kubectl kubernetes-cni
-sudo apt-get install -y --no-install-recommends \
+sudo apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
      kubeadm=${kube_ver} \
      kubectl=${kube_ver} \
      kubelet=${kube_ver} \


### PR DESCRIPTION
This fixes ubuntu based `apt-get install` calls hanging for
some dpkg interactivity.
Upstream issue reference:
https://bugs.launchpad.net/ubuntu/+source/ansible/+bug/1833013

```release-note
Fix hanging ubuntu setup (make dpkg non-interactive).
```
