### PR TITLE
Properly handle credentials if cloud provider is none

### DIFF
--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -139,6 +139,8 @@ func ProviderCredentials(p kubeone.CloudProviderName, credentialsFilePath string
 		// force scheme, as machine-controller requires it while terraform does not
 		vscreds[VSphereAddressMC] = "https://" + vscreds[VSphereAddressMC]
 		return vscreds, nil
+	case kubeone.CloudProviderNameNone:
+		return map[string]string{}, nil
 	}
 
 	return nil, errors.New("no provider matched")

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -38,6 +38,10 @@ const (
 
 // Ensure creates/updates the credentials secret
 func Ensure(s *state.State) error {
+	if s.Cluster.CloudProvider.Name == kubeoneapi.CloudProviderNameNone {
+		s.Logger.Info("Skipping creating credentials secret because cloud provider is none.")
+		return nil
+	}
 	if !s.Cluster.MachineController.Deploy && !s.Cluster.CloudProvider.External {
 		s.Logger.Info("Skipping creating credentials secret because both machine-controller and external CCM are disabled.")
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

If `.cloudProvider.Name` is `none`, KubeOne will still try to parse credentials. As function parsing credentials doesn't support `none` provider, cluster provisioning fails. This PR should fix this bug.

**Does this PR introduce a user-facing change?**:
```release-note
Properly handle credentials if cloud provider is none
```

/assign @kron4eg
