### PR TITLE
Bump default Kubernetes version to v1.16.1

### DIFF
--- a/docs/quickstart-aws.md
+++ b/docs/quickstart-aws.md
@@ -2,7 +2,7 @@
 
 In this quick start we're going to show how to get started with KubeOne on AWS. We'll cover how to create the needed infrastructure using our example Terraform scripts and then install Kubernetes. Finally, we're going to show how to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with three control plane nodes and two worker nodes.
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and two worker nodes.
 
 ### Prerequisites
 
@@ -98,14 +98,13 @@ Before you start you'll need a configuration file that defines how Kubernetes
 will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
-To get started you can use the following configuration. It'll install Kubernetes 1.14.2 and create 3 worker nodes. KubeOne automatically populates all needed information about worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/ec8bf305446ac22529e9683fd4ce3c9abf753d1e/examples/terraform/aws/output.tf#L38-L87). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [AWS example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml) for available options.
+To get started you can use the following configuration. It'll install Kubernetes 1.16.1 and create one worker node. KubeOne automatically populates all needed information about worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/ec8bf305446ac22529e9683fd4ce3c9abf753d1e/examples/terraform/aws/output.tf#L38-L87). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [AWS example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml) for available options.
 
 ```yaml
 apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
-name: demo
 versions:
-  kubernetes: '1.14.2'
+  kubernetes: '1.16.1'
 cloudProvider:
   name: 'aws'
 ```
@@ -208,6 +207,6 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
 
 [scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-azure.md
+++ b/docs/quickstart-azure.md
@@ -5,7 +5,7 @@ Azure. We'll cover how to create the needed infrastructure using our example
 Terraform scripts and then install Kubernetes. Finally, we're going to show how
 to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with
 three control plane nodes and two worker nodes.
 
 ### Prerequisites
@@ -134,7 +134,7 @@ will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
 To get started you can use the following configuration. It'll install Kubernetes
-1.14.2 and create 1 worker nodes. KubeOne automatically populates information
+1.16.1 and create one worker node. KubeOne automatically populates information
 about template, VM size and networking settings for worker nodes from the
 Terraform output. Alternatively, you can set those information manually. As
 KubeOne is using [Kubermatic `machine-controller`][7] for creating worker nodes,
@@ -147,9 +147,8 @@ values with real values.
 ```yaml
 apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
-
 versions:
-  kubernetes: '1.14.2'
+  kubernetes: '1.16.1'
 cloudProvider:
   name: 'azure'
   cloudConfig: |
@@ -274,7 +273,7 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three
 control plane nodes and two worker nodes. If you want to learn more about
 KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to
 check our [documentation][9].

--- a/docs/quickstart-digitalocean.md
+++ b/docs/quickstart-digitalocean.md
@@ -2,7 +2,7 @@
 
 In this quick start we're going to show how to get started with KubeOne on DigitalOcean. We'll cover how to create the needed infrastructure using our example Terraform scripts and then install Kubernetes. Finally, we're going to show how to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with three control plane nodes and two worker nodes.
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and two worker nodes.
 
 ### Prerequisites
 
@@ -94,14 +94,13 @@ Before you start you'll need a configuration file that defines how Kubernetes
 will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
-To get started you can use the following configuration. It'll install Kubernetes 1.14.2, create 3 worker nodes and deploy the [external cloud controller manager](https://github.com/digitalocean/digitalocean-cloud-controller-manager). The external cloud controller manager takes care of providing correct information about nodes from the DigitalOcean API and allows you to use the `type: LoadBalancer` services. KubeOne automatically populates information about the worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/ec8bf305446ac22529e9683fd4ce3c9abf753d1e/examples/terraform/digitalocean/output.tf#L38-L59). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [DigitalOcean example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/digitalocean-machinedeployment.yaml) for available options.
+To get started you can use the following configuration. It'll install Kubernetes 1.16.1, create one worker node and deploy the [external cloud controller manager](https://github.com/digitalocean/digitalocean-cloud-controller-manager). The external cloud controller manager takes care of providing correct information about nodes from the DigitalOcean API and allows you to use the `type: LoadBalancer` services. KubeOne automatically populates information about the worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/ec8bf305446ac22529e9683fd4ce3c9abf753d1e/examples/terraform/digitalocean/output.tf#L38-L59). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [DigitalOcean example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/digitalocean-machinedeployment.yaml) for available options.
 
 ```yaml
 apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
-name: demo
 versions:
-  kubernetes: '1.14.2'
+  kubernetes: '1.16.1'
 cloudProvider:
   name: 'digitalocean'
   external: true
@@ -207,6 +206,6 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
 
 [scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -5,7 +5,7 @@ We'll cover how to create the needed infrastructure using our example terraform
 configuration and then install Kubernetes. Finally, we're going to show how to
 destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with
 three control plane nodes and two worker nodes.
 
 ### Prerequisites
@@ -135,7 +135,7 @@ will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
 To get started you can use the following configuration. It'll install Kubernetes
-1.14.2 and create 3 worker nodes. KubeOne automatically populates information
+1.16.1 and create one worker node. KubeOne automatically populates information
 about worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/ec8bf305446ac22529e9683fd4ce3c9abf753d1e/examples/terraform/gce/output.tf#L41-L81).
 Alternatively, you can set those information manually. As KubeOne is using
 [Kubermatic
@@ -147,9 +147,8 @@ for available options.
 ```yaml
 apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
-name: demo
 versions:
-  kubernetes: '1.14.2'
+  kubernetes: '1.16.1'
 cloudProvider:
   name: 'gce'
 ```
@@ -253,7 +252,7 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three
 control plane nodes and three worker nodes. If you want to learn more about
 KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to
 check our

--- a/docs/quickstart-hetzner.md
+++ b/docs/quickstart-hetzner.md
@@ -2,7 +2,7 @@
 
 In this quick start we're going to show how to get started with KubeOne on Hetzner. We'll cover how to create the needed infrastructure using our example Terraform scripts and then install Kubernetes. Finally, we're going to show how to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with three control plane nodes and three worker nodes.
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and three worker nodes.
 
 ### Prerequisites
 
@@ -88,14 +88,13 @@ Before you start you'll need a configuration file that defines how Kubernetes
 will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
-To get started you can use the following configuration. It'll install Kubernetes 1.14.2, create 3 worker nodes and deploy the [external cloud controller manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager). The external cloud controller manager takes care of providing correct information about the nodes. KubeOne automatically populates all needed information about worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/a874fd5913ca2a86c3b8136982c2a00e835c2f62/examples/terraform/hetzner/output.tf#L26-L36). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes see [Hetzner example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/hetzner-machinedeployment.yaml) for available options.
+To get started you can use the following configuration. It'll install Kubernetes 1.16.1, create one worker node and deploy the [external cloud controller manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager). The external cloud controller manager takes care of providing correct information about the nodes. KubeOne automatically populates all needed information about worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/a874fd5913ca2a86c3b8136982c2a00e835c2f62/examples/terraform/hetzner/output.tf#L26-L36). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes see [Hetzner example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/hetzner-machinedeployment.yaml) for available options.
 
 ```yaml
 apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
-name: demo
 versions:
-  kubernetes: '1.14.2'
+  kubernetes: '1.16.1'
 cloudProvider:
   name: 'hetzner'
   external: true
@@ -199,6 +198,6 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
 
 [scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-openstack.md
+++ b/docs/quickstart-openstack.md
@@ -2,7 +2,7 @@
 
 In this quick start we're going to show how to get started with KubeOne on OpenStack. We'll cover how to create the needed infrastructure using our example Terraform scripts and then install Kubernetes. Finally, we're going to show how to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with three control plane nodes and two worker nodes.
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and two worker nodes.
 
 ### Prerequisites
 
@@ -110,16 +110,15 @@ Before you start you'll need a configuration file that defines how Kubernetes
 will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
-To get started you can use the following configuration. It'll install Kubernetes 1.14.2 and create 2 worker nodes. KubeOne automatically populates information about image, instance size and networking settings for worker nodes from the Terraform output. Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [OpenStack example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/openstack-machinedeployment.yaml) for available options.
+To get started you can use the following configuration. It'll install Kubernetes 1.16.1 and create one worker node. KubeOne automatically populates information about image, instance size and networking settings for worker nodes from the Terraform output. Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [OpenStack example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/openstack-machinedeployment.yaml) for available options.
 
 For OpenStack you also need to provide a `cloud-config` file containing credentials, so OpenStack Cloud Controller Manager works as expected. Make sure to replace sample values with real values.
 
 ```yaml
 apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
-name: demo
 versions:
-  kubernetes: '1.14.2'
+  kubernetes: '1.16.1'
 cloudProvider:
   name: 'openstack'
   cloudConfig: |
@@ -132,18 +131,6 @@ cloudProvider:
 
     [LoadBalancer]
     subnet-id=SUBNET_ID
-workers:
-- name: nodes1
-  replicas: 2
-  providerSpec:
-    labels:
-      mylabel: 'nodes1'
-    cloudProviderSpec:
-      tags:
-        tagKey: tagValue
-    operatingSystem: 'ubuntu'
-    operatingSystemSpec:
-      distUpgradeOnBoot: true
 ```
 
 Finally, we're going to install Kubernetes by using the `install` command and providing the configuration file and the Terraform output:
@@ -244,6 +231,6 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three control plane nodes and two worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and two worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
 
 [scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-packet.md
+++ b/docs/quickstart-packet.md
@@ -5,7 +5,7 @@ Packet. We'll cover how to create the needed infrastructure using our
 example Terraform scripts and then install Kubernetes. Finally, we're going to
 show how to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with
 three control plane nodes and one worker node (which can be easily scaled).
 
 ### Prerequisites
@@ -131,7 +131,7 @@ will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
 To get started you can use the following configuration. It'll install Kubernetes
-1.14.2, create 1 worker node and deploy the
+1.16.1, create one worker node and deploy the
 [external cloud controller manager][packet_ccm]. The external cloud controller
 manager takes care of providing correct information about nodes from the Packet
 API. KubeOne automatically populates information about the worker nodes from the
@@ -144,10 +144,9 @@ see [Packet example manifest][packet_mc_example] for available options.
 ```yaml
 apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
-name: demo
 
 versions:
-  kubernetes: "1.14.2"
+  kubernetes: "1.16.1"
 
 cloudProvider:
   name: "packet"
@@ -266,7 +265,7 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three
 control plane nodes and one worker node. If you want to learn more about KubeOne
 and its features, such as [upgrades](upgrading_cluster.md), make sure to check
 our [documentation][kubeone_docs].

--- a/docs/quickstart-vsphere.md
+++ b/docs/quickstart-vsphere.md
@@ -5,7 +5,7 @@ vSphere. We'll cover how to create the needed infrastructure using our example
 Terraform scripts and then install Kubernetes. Finally, we're going to show how
 to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.14.2 High-Available (HA) clusters with
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with
 three control plane nodes and two worker nodes.
 
 ### Prerequisites
@@ -137,7 +137,7 @@ will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
 To get started you can use the following configuration. It'll install Kubernetes
-1.14.2 and create 1 worker nodes. KubeOne automatically populates information
+1.16.1 and create one worker node. KubeOne automatically populates information
 about template, VM size and networking settings for worker nodes from the
 Terraform output. Alternatively, you can set those information manually. As
 KubeOne is using [Kubermatic `machine-controller`][7] for creating worker nodes,
@@ -150,9 +150,8 @@ to replace sample values with real values.
 ```yaml
 apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
-name: demo
 versions:
-  kubernetes: '1.14.2'
+  kubernetes: '1.16.1'
 cloudProvider:
   name: 'vsphere'
   cloudConfig: |
@@ -281,7 +280,7 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.14.2 HA cluster with three
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three
 control plane nodes and two worker nodes. If you want to learn more about
 KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to
 check our [documentation][9].

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	// defaultKubernetesVersion is default Kubernetes version for the example configuration file
-	defaultKubernetesVersion = "1.14.1"
+	defaultKubernetesVersion = "1.16.1"
 	// defaultCloudProviderName is cloud provider to build the example configuration file for
 	defaultCloudProviderName = "aws"
 )
@@ -107,7 +107,7 @@ Print an example configuration manifest. Using the appropriate flags you can cus
 For the full reference of the configuration manifest, run the print command with --full flag.
 `,
 		Args:    cobra.ExactArgs(0),
-		Example: `kubeone config print --provider digitalocean --kubernetes-version 1.14.1 --cluster-name example`,
+		Example: fmt.Sprintf("kubeone config print --provider digitalocean --kubernetes-version %s --cluster-name example", defaultKubernetesVersion),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runPrint(pOpts)
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump default Kubernetes version to v1.16.1.

**Does this PR introduce a user-facing change?**:
```release-note
Bump default Kubernetes version to v1.16.1
```

/assign @kron4eg 