### PR TITLE
Update machine-controller to v1.5.8

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -47,7 +47,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.5.7"
+	MachineControllerTag           = "v1.5.8"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

Update machine-controller to v1.5.8.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.5.8
```

/assign @kron4eg 