### PR TITLE
pkg/cmd: Fix typo in help text of flag --tfjson

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -74,7 +74,7 @@ func newRoot() *cobra.Command {
 	fs := rootCmd.PersistentFlags()
 
 	fs.StringVarP(&opts.TerraformState, globalTerraformFlagName, "t", "",
-		"Source for terrafor output JSON. - to read from stdin. If path is file, contents will be used. If path is dictionary, `terraform output -json` is executed in this path")
+		"Source for terraform output in JSON - to read from stdin. If path is a file, contents will be used. If path is a dictionary, `terraform output -json` is executed in this path")
 	fs.StringVarP(&opts.CredentialsFilePath, globalCredentialsFlagName, "c", "", "File to source credentials and secrets from")
 	fs.BoolVarP(&opts.Verbose, globalVerboseFlagName, "v", false, "verbose")
 	fs.BoolVarP(&opts.Debug, globalDebugFlagName, "d", false, "debug")


### PR DESCRIPTION
This commit also improves the grammatic structure of the help text.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes a typo and improves the help text of the global flag `tfjson`.


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a typo and improve the help text of the global flag `tfjson`.
```
