### PR TITLE
docs: enable multizone for GCE clusters

### DIFF
--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -148,7 +148,17 @@ versions:
   kubernetes: '1.16.1'
 cloudProvider:
   name: 'gce'
+  cloudConfig: |
+    [global]
+    multizone = true
 ```
+
+**Note:** If control plane nodes are created in multiple zones,
+you must configure `kube-controller-manager` to support multiple zones by
+setting `multizone` to `true`. Otherwise, `kube-controller-manager` will
+fail to create the needed routes and other cloud resources, without which
+the cluster can't function properly. The example Terraform configuration
+creates control plane nodes in multiple zones by default.
 
 Finally, we're going to install Kubernetes by using the `install` command and
 providing the configuration file and the Terraform output:

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -66,6 +66,8 @@ output "kubeone_workers" {
           zone                  = "${var.region}-a"
           preemptible           = false
           assignPublicIPAddress = true
+          # Enable support for multizone clusters
+          multizone             = true
           labels = {
             "${var.cluster_name}-workers" = "pool1"
           }


### PR DESCRIPTION
**What this PR does / why we need it**:

By default, we create control plane nodes on GCE in multiple zones. When multizone is not enabled, `kube-controller-manager` fails to create routes and other cloud resources. Without those resources, nodes have the `NetworkUnavailable` taint, pods can't be scheduled, and type LoadBalancer Services cannot be created.

With multizone enabled, all resources are created correctly and the cluster is fully functional.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevant to #627

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 
cc @toschneck 