### PR TITLE
Update E2E runner script to work with GCP

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -105,7 +105,7 @@ if [ -n "${RUNNING_IN_CI}" ]; then
     export TF_VAR_project_id=${PACKET_PROJECT_ID}
     ;;
   "gce")
-    export GOOGLE_CREDENTIALS=$(echo ${GOOGLE_SERVICE_ACCOUNT} | base64 -d)
+    export GOOGLE_CREDENTIALS=$(echo ${KUBEONE_GOOGLE_SERVICE_ACCOUNT} | base64 -d)
     ;;
   "openstack")
     export OS_AUTH_URL=${OS_AUTH_URL}


### PR DESCRIPTION
**What this PR does / why we need it**:

Update E2E runner script to work with GCP.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 
/hold
until CI is not ready