### PR TITLE
Switch golangci-linter to whitelist mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,36 +1,53 @@
 run:
   issues-exit-code: 1
+  build-tags:
+  - e2e
   skip-dirs:
   - hack
   - vendor
+  - pkg/apis/kubeadm
+
+  skip-files:
+  - zz_generated.*.go
 
 linters:
-  enable-all: true
-  disable:
-  - funlen
+  disable-all: true
+  enable:
+  - bodyclose
+  - deadcode
+  - errcheck
+  - goconst
+  - gocritic
+  - gocyclo
+  - gofmt
+  - goimports
+  - gosec
+  - gosimple
+  - govet
+  - ineffassign
   - interfacer
-  - dupl
-  - maligned
-  - megacheck
-  - lll
-  - prealloc
-  - gochecknoinits
-  - gochecknoglobals
+  - misspell
+  - nakedret
+  - staticcheck
+  - structcheck
+  - stylecheck
+  - unconvert
+  - unused
+  - varcheck
 
 linters-settings:
   govet:
     check-shadowing: true
+  goimports:
+    local-prefixes: github.com/kubermatic/kubeone
 
 issues:
   exclude:
-    - "type name will be used as kubeone.KubeOneCluster by other packages, and that stutters; consider calling this Cluster"
-    - "don't use underscores in Go names; func SetDefaults_KubeOneCluster should be SetDefaultsKubeOneCluster"
-    - "don't use underscores in Go names; func SetDefaults_Hosts should be SetDefaultsHosts"
-    - "don't use underscores in Go names; func SetDefaults_APIEndpoints should be SetDefaultsAPIEndpoints"
-    - "don't use underscores in Go names; func SetDefaults_ClusterNetwork should be SetDefaultsClusterNetwork"
-    - "don't use underscores in Go names; func SetDefaults_Features should be SetDefaultsFeatures"
-    - "don't use underscores in Go names; func SetDefaults_MachineController should be SetDefaultsMachineController"
-    - "don't use underscores in Go names; func SetDefaults_SystemPackages should be SetDefaultsSystemPackages"
-    - "G101: Potential hardcoded credentials"
-    - "G106: Use of ssh InsecureIgnoreHostKey should be audited"
-    - "`defaultRetryBackoff` - `retries` always receives `3`"
+  - "`defaultRetryBackoff` - `retries` always receives `3`"
+  - "func SetDefaults_APIEndpoints should be SetDefaultsAPIEndpoints"
+  - "func SetDefaults_ClusterNetwork should be SetDefaultsClusterNetwork"
+  - "func SetDefaults_Features should be SetDefaultsFeatures"
+  - "func SetDefaults_Hosts should be SetDefaultsHosts"
+  - "func SetDefaults_KubeOneCluster should be SetDefaultsKubeOneCluster"
+  - "func SetDefaults_MachineController should be SetDefaultsMachineController"
+  - "func SetDefaults_SystemPackages should be SetDefaultsSystemPackages"

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -56,7 +56,7 @@ func (h *HostConfig) SetLeader(leader bool) {
 
 // CloudProviderInTree detects is there in-tree cloud provider implementation for specified provider.
 // List of in-tree provider can be found here: https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider
-func (p CloudProviderSpec) CloudProviderInTree() bool {
+func (p CloudProviderSpec) CloudProviderInTree() bool { //nolint:stylecheck
 	switch p.Name {
 	case CloudProviderNameAWS, CloudProviderNameGCE, CloudProviderNameOpenStack:
 		return true

--- a/pkg/apis/kubeone/scheme/scheme.go
+++ b/pkg/apis/kubeone/scheme/scheme.go
@@ -19,6 +19,7 @@ package scheme
 import (
 	"github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -209,7 +209,6 @@ func ValidateFeatures(f kubeone.Features, fldPath *field.Path) field.ErrorList {
 	if f.OpenIDConnect != nil && f.OpenIDConnect.Enable {
 		allErrs = append(allErrs, ValidateOIDCConfig(f.OpenIDConnect.Config, fldPath.Child("openidConnect"))...)
 	}
-	allErrs = append(allErrs)
 	return allErrs
 }
 

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -300,7 +300,6 @@ func createAndPrintManifest(printOptions *printOptions) error {
 	}
 	if printOptions.EnableOpenIDConnect {
 		cfg.Set(yamled.Path{"features", "openidConnect", "enable"}, printOptions.EnableOpenIDConnect)
-
 		cfg.Set(yamled.Path{"features", "openidConnect", "config", "issuerUrl"}, "")
 		cfg.Set(yamled.Path{"features", "openidConnect", "config", "clientId"}, "")
 		cfg.Set(yamled.Path{"features", "openidConnect", "config", "usernameClaim"}, "")

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -33,9 +33,9 @@ import (
 const (
 	// Variables that KubeOne (and Terraform) expect to see
 	AWSAccessKeyID          = "AWS_ACCESS_KEY_ID"
-	AWSSecretAccessKey      = "AWS_SECRET_ACCESS_KEY"
+	AWSSecretAccessKey      = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
 	AzureClientID           = "ARM_CLIENT_ID"
-	AzureClientSecret       = "ARM_CLIENT_SECRET"
+	AzureClientSecret       = "ARM_CLIENT_SECRET" //nolint:gosec
 	AzureTenantID           = "ARM_TENANT_ID"
 	AzureSubscribtionID     = "ARM_SUBSCRIPTION_ID"
 	DigitalOceanTokenKey    = "DIGITALOCEAN_TOKEN"
@@ -56,7 +56,7 @@ const (
 
 	// Variables that machine-controller expects
 	AzureClientIDMC           = "AZURE_CLIENT_ID"
-	AzureClientSecretMC       = "AZURE_CLIENT_SECRET"
+	AzureClientSecretMC       = "AZURE_CLIENT_SECRET" //nolint:gosec
 	AzureTenantIDMC           = "AZURE_TENANT_ID"
 	AzureSubscribtionIDMC     = "AZURE_SUBSCRIPTION_ID"
 	DigitalOceanTokenKeyMC    = "DO_TOKEN"

--- a/pkg/installer/installation/reset.go
+++ b/pkg/installer/installation/reset.go
@@ -65,7 +65,6 @@ func destroyWorkers(s *state.State) error {
 			return false, nil
 		}
 		return true, nil
-
 	})
 	if lastErr != nil {
 		s.Logger.Warn("Unable to connect to the control plane API and destroy worker nodes")

--- a/pkg/ssh/connection.go
+++ b/pkg/ssh/connection.go
@@ -161,7 +161,7 @@ func NewConnection(o Opts) (Connection, error) {
 		User:            o.Username,
 		Timeout:         o.Timeout,
 		Auth:            authMethods,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 	}
 
 	targetHost := o.Hostname

--- a/pkg/templates/machinecontroller/webhook.go
+++ b/pkg/templates/machinecontroller/webhook.go
@@ -18,7 +18,7 @@ package machinecontroller
 
 import (
 	"context"
-	"crypto/rsa"
+	"crypto"
 	"crypto/x509"
 	"fmt"
 	"time"
@@ -299,7 +299,7 @@ func getServingCertVolume() corev1.Volume {
 
 // tlsServingCertificate returns a secret with the machine-controller-webhook tls certificate
 // func tlsServingCertificate(ca *triple.KeyPair) (*corev1.Secret, error) {
-func tlsServingCertificate(caKey *rsa.PrivateKey, caCert *x509.Certificate) (*corev1.Secret, error) {
+func tlsServingCertificate(caKey crypto.Signer, caCert *x509.Certificate) (*corev1.Secret, error) {
 	commonName := fmt.Sprintf("%s.%s.svc.cluster.local.", WebhookName, WebhookNamespace)
 	altdnsNames := []string{
 		commonName,

--- a/pkg/upgrader/upgrade/kubernetes_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_binaries.go
@@ -94,13 +94,10 @@ func upgradeKubernetesBinaries(s *state.State, node kubeoneapi.HostConfig) error
 	switch node.OperatingSystem {
 	case "ubuntu", "debian":
 		err = upgradeKubernetesBinariesDebian(s)
-
 	case "coreos":
 		err = upgradeKubernetesBinariesCoreOS(s)
-
 	case "centos":
 		err = upgradeKubernetesBinariesCentOS(s)
-
 	default:
 		err = errors.Errorf("'%s' is not a supported operating system", node.OperatingSystem)
 	}

--- a/pkg/upgrader/upgrade/util.go
+++ b/pkg/upgrader/upgrade/util.go
@@ -19,10 +19,11 @@ package upgrade
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/state"
-	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/yamled/document_test.go
+++ b/pkg/yamled/document_test.go
@@ -250,7 +250,6 @@ func TestSetNewSubKey(t *testing.T) {
 }
 
 func TestSetNewDeepSubKey(t *testing.T) {
-
 	doc, expected := loadTestcase(t, "set-new-deep-sub-key.yaml")
 
 	doc.Set(Path{"root", "deep", "deeper", "reallyDeep", "newKey"}, "foo")

--- a/test/e2e/kubetest.go
+++ b/test/e2e/kubetest.go
@@ -46,7 +46,6 @@ func NewKubetest(k8sVersion, kubetestDir string, envVars map[string]string) Kube
 		kubernetesVersion: k8sVersion,
 		envVars:           envVars,
 	}
-
 }
 
 // Verify verifies the cluster
@@ -78,7 +77,6 @@ func (p *Kubetest) Verify(scenario string) error {
 
 // getK8sBinaries retrieves kubernetes binaries for version
 func getK8sBinaries(kubetestDir string, version string) error {
-
 	k8sPath := fmt.Sprintf("%s/kubernetes-%s", kubetestDir, version)
 	err := os.MkdirAll(k8sPath, 0755)
 	if err != nil {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -113,9 +113,9 @@ func verifyVersion(client dynclient.Client, namespace string, targetVersion stri
 
 	// Kubelet version check
 	for _, n := range nodes.Items {
-		kubeletVer, err := semver.NewVersion(n.Status.NodeInfo.KubeletVersion)
-		if err != nil {
-			return err
+		kubeletVer, errSemver := semver.NewVersion(n.Status.NodeInfo.KubeletVersion)
+		if errSemver != nil {
+			return errSemver
 		}
 		if reqVer.Compare(kubeletVer) != 0 {
 			return errors.Errorf("kubelet version mismatch: expected %v, got %v", reqVer.String(), kubeletVer.String())

--- a/test/e2e/testutil/testutil.go
+++ b/test/e2e/testutil/testutil.go
@@ -43,8 +43,10 @@ func IsCommandAvailable(name string) bool {
 
 // ExecuteCommand executes the given command
 func ExecuteCommand(path, name string, arg []string, additionalEnv map[string]string) (string, error) {
-	var stdoutBuf, stderrBuf bytes.Buffer
-	var errStdout, errStderr error
+	var (
+		stdoutBuf, stderrBuf bytes.Buffer
+		errStdout, errStderr error
+	)
 
 	cmd := exec.Command(name, arg...)
 	if len(path) > 0 {
@@ -74,7 +76,6 @@ func ExecuteCommand(path, name string, arg []string, additionalEnv map[string]st
 	go func() {
 		_, errStdout = io.Copy(stdout, stdoutIn)
 		doneStdout <- struct{}{}
-
 	}()
 
 	go func() {
@@ -95,7 +96,7 @@ func ExecuteCommand(path, name string, arg []string, additionalEnv map[string]st
 		return "", errStderr
 	}
 
-	outStr := string(stdoutBuf.Bytes())
+	outStr := stdoutBuf.String()
 	return outStr, nil
 }
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -195,7 +195,7 @@ func TestClusterUpgrade(t *testing.T) {
 			// Run Terraform again for GCE to add nodes to the load balancer
 			if tc.provider == provisioner.GCE {
 				t.Log("Adding other control plane nodes to the load balancer…")
-				tf, err = pr.Provision()
+				_, err = pr.Provision()
 				if err != nil {
 					t.Fatalf("failed to provision the infrastructure: %v", err)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
To avoid unnecessary frictions on every upgrade of golangci-linter now it's configured to operate under whitelist (of linters) mode.

Some additional configurations applied and identified problems are fixed.

```release-note
NONE
```
