### PR TITLE
Divert kube-api access via SSH tunnel

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
   - goconst
   - gocritic
   - gocyclo
+  - golint
   - gofmt
   - goimports
   - gosec
@@ -28,12 +29,15 @@ linters:
   - interfacer
   - misspell
   - nakedret
+  - scopelint
   - staticcheck
   - structcheck
   - stylecheck
   - unconvert
+  - unparam
   - unused
   - varcheck
+  - whitespace
 
 linters-settings:
   govet:
@@ -51,3 +55,4 @@ issues:
   - "func SetDefaults_KubeOneCluster should be SetDefaultsKubeOneCluster"
   - "func SetDefaults_MachineController should be SetDefaultsMachineController"
   - "func SetDefaults_SystemPackages should be SetDefaultsSystemPackages"
+  - "type name will be used as kubeone.KubeOneCluster by other packages"

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,6 @@ dist/kubeone: buildenv
 generate-internal-groups: vendor
 	./hack/update-codegen.sh
 
-.PHONY: verify-dependencies
-verify-dependencies: buildenv
-	go mod verify
-
 .PHONY: test
 test:
 	go test ./pkg/... ./test/...

--- a/examples/terraform/aws-private/main.tf
+++ b/examples/terraform/aws-private/main.tf
@@ -160,9 +160,9 @@ resource "aws_route_table_association" "private" {
 
 resource "aws_lb" "control_plane" {
   name               = "${var.cluster_name}-api-lb"
-  internal           = false
+  internal           = true
   load_balancer_type = "network"
-  subnets            = aws_subnet.public.*.id
+  subnets            = aws_subnet.private.*.id
 
   tags = map(
     "Name", "${var.cluster_name}-control_plane",
@@ -172,10 +172,11 @@ resource "aws_lb" "control_plane" {
 }
 
 resource "aws_lb_target_group" "control_plane_api" {
-  name     = "${var.cluster_name}-api"
-  port     = 6443
-  protocol = "TCP"
-  vpc_id   = data.aws_vpc.selected.id
+  name        = "${var.cluster_name}-api"
+  port        = 6443
+  protocol    = "TCP"
+  vpc_id      = data.aws_vpc.selected.id
+  target_type = "ip"
 }
 
 resource "aws_lb_listener" "control_plane_api" {
@@ -192,7 +193,7 @@ resource "aws_lb_listener" "control_plane_api" {
 resource "aws_lb_target_group_attachment" "control_plane_api" {
   count            = 3
   target_group_arn = aws_lb_target_group.control_plane_api.arn
-  target_id        = element(aws_instance.control_plane.*.id, count.index)
+  target_id        = element(aws_instance.control_plane.*.private_ip, count.index)
   port             = 6443
 }
 

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -18,6 +18,7 @@ package kubeone
 
 import (
 	"errors"
+	"math/rand"
 
 	"github.com/Masterminds/semver"
 )
@@ -31,6 +32,11 @@ func (c KubeOneCluster) Leader() (HostConfig, error) {
 		}
 	}
 	return HostConfig{}, errors.New("leader not found")
+}
+
+func (c KubeOneCluster) RandomHost() HostConfig {
+	n := rand.Int31n(int32(len(c.Hosts)))
+	return c.Hosts[n]
 }
 
 // Followers returns all but the first configured host. Only call

--- a/pkg/cmd/kubeconfig.go
+++ b/pkg/cmd/kubeconfig.go
@@ -25,6 +25,8 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/kubermatic/kubeone/pkg/kubeconfig"
+	"github.com/kubermatic/kubeone/pkg/ssh"
+	"github.com/kubermatic/kubeone/pkg/state"
 )
 
 type kubeconfigOptions struct {
@@ -78,7 +80,15 @@ func runKubeconfig(logger *logrus.Logger, kubeconfigOptions *kubeconfigOptions) 
 		return errors.Wrap(err, "failed to load cluster")
 	}
 
-	konfig, err := kubeconfig.Download(cluster)
+	s, err := state.New()
+	if err != nil {
+		return err
+	}
+
+	s.Cluster = cluster
+	s.Connector = ssh.NewConnector()
+
+	konfig, err := kubeconfig.Download(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/installer/installation/kubeconfig.go
+++ b/pkg/installer/installation/kubeconfig.go
@@ -49,7 +49,7 @@ sudo chown $(id -u):$(id -g) $HOME/.kube/config
 func saveKubeconfig(s *state.State) error {
 	s.Logger.Info("Downloading kubeconfig…")
 
-	kc, err := kubeconfig.Download(s.Cluster)
+	kc, err := kubeconfig.Download(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -19,8 +19,6 @@ package kubeconfig
 import (
 	"github.com/pkg/errors"
 
-	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
-	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/state"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -28,19 +26,17 @@ import (
 )
 
 // Download downloads Kubeconfig over SSH
-func Download(cluster *kubeoneapi.KubeOneCluster) ([]byte, error) {
-	// connect to leader
-	leader, err := cluster.Leader()
+func Download(s *state.State) ([]byte, error) {
+	// connect to host
+	host, err := s.Cluster.Leader()
 	if err != nil {
 		return nil, err
 	}
-	connector := ssh.NewConnector()
 
-	conn, err := connector.Connect(leader)
+	conn, err := s.Connector.Connect(host)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	// get the kubeconfig
 	konfig, _, _, err := conn.Exec("sudo cat /etc/kubernetes/admin.conf")
@@ -55,7 +51,7 @@ func Download(cluster *kubeoneapi.KubeOneCluster) ([]byte, error) {
 func BuildKubernetesClientset(s *state.State) error {
 	s.Logger.Infoln("Building Kubernetes clientset…")
 
-	kubeconfig, err := Download(s.Cluster)
+	kubeconfig, err := Download(s)
 	if err != nil {
 		return errors.Wrap(err, "unable to download kubeconfig")
 	}
@@ -65,8 +61,14 @@ func BuildKubernetesClientset(s *state.State) error {
 		return errors.Wrap(err, "unable to build config from kubeconfig bytes")
 	}
 
-	err = HackIssue321InitDynamicClient(s)
-	return errors.Wrap(err, "unable to build dynamic client")
+	tunn, err := s.Connector.Tunnel(s.Cluster.RandomHost())
+	if err != nil {
+		return errors.Wrap(err, "failed to get SSH tunnel")
+	}
+
+	s.RESTConfig.Dial = tunn.TunnelTo
+
+	return errors.WithStack(HackIssue321InitDynamicClient(s))
 }
 
 // HackIssue321InitDynamicClient initialize controller-runtime/client


### PR DESCRIPTION
**What this PR does / why we need it**:
KubeOne operator may create kube-API loabdalancer as internal, only accessible from inside the VPC or internal-perimeter, so KubeOne will divert all kube-API access over SSH tunnel from the leader node which guaranteed to have direct kube-api access (since kubelet need to communicate with it).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #659 

```release-note
kube-api communications are going via the SSH tunnel
```
