### PR TITLE
Update DigitalOcean Cloud Controller Manager to v0.1.21

### DIFF
--- a/pkg/templates/externalccm/digitalocean.go
+++ b/pkg/templates/externalccm/digitalocean.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	digitaloceanCCMVersion     = "v0.1.16"
+	digitaloceanCCMVersion     = "v0.1.21"
 	digitaloceanSAName         = "cloud-controller-manager"
 	digitaloceanDeploymentName = "digitalocean-cloud-controller-manager"
 )
@@ -174,6 +174,7 @@ func doDeployment() *appsv1.Deployment {
 					},
 				},
 				Spec: corev1.PodSpec{
+					DNSPolicy:          corev1.DNSDefault,
 					ServiceAccountName: digitaloceanSAName,
 					Tolerations: []corev1.Toleration{
 						{


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the DigitalOcean Cloud Controller Manager to v0.1.21.

**Does this PR introduce a user-facing change?**:
```release-note
Update the DigitalOcean Cloud Controller Manager to v0.1.21.
```

/assign @kron4eg 