### PR TITLE
vSphere credentials format that CCM would read

### DIFF
--- a/docs/quickstart-vsphere.md
+++ b/docs/quickstart-vsphere.md
@@ -141,18 +141,18 @@ see [vSphere example manifest][8] for available options.
 For vSphere you also need to provide a `cloud-config` file containing
 credentials, so vSphere Cloud Controller Manager works as expected. Make sure
 to replace sample values with real values. For example, to create a cluster with
-Kubernetes `1.16.1`, save the following to `config.yaml`:
+Kubernetes `1.16.2`, save the following to `config.yaml`:
 ```yaml
 apiVersion: kubeone.io/v1alpha1
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.16.1'
+  kubernetes: '1.16.2'
 cloudProvider:
   name: 'vsphere'
   cloudConfig: |
     [Global]
-    user = "<USERNAME>"
-    password = "<PASSWORD>"
+    secret-name = "cloud-provider-credentials"
+    secret-namespace = "kube-system"
     port = "443"
     insecure-flag = "0"
 
@@ -163,7 +163,6 @@ cloudProvider:
     datacenter = "dc-1"
     default-datastore="exsi-nas"
     resourcepool-path="kubeone"
-    folder = "kubeone"
 
     [Disk]
     scsicontrollertype = pvscsi

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -18,6 +18,7 @@ package credentials
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -138,6 +139,13 @@ func ProviderCredentials(p kubeone.CloudProviderName, credentialsFilePath string
 
 		// force scheme, as machine-controller requires it while terraform does not
 		vscreds[VSphereAddressMC] = "https://" + vscreds[VSphereAddressMC]
+
+		// Save credentials in Secret and configure vSphere cloud controller
+		// manager to read it, in replace of storing those in /etc/kubernates/cloud-config
+		// see more: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/k8s-secret.html
+		vcenterPrefix := vscreds[VSphereAddressMC]
+		vscreds[fmt.Sprintf("%s.username", vcenterPrefix)] = vscreds[VSphereUsernameMC]
+		vscreds[fmt.Sprintf("%s.password", vcenterPrefix)] = vscreds[VSpherePassword]
 		return vscreds, nil
 	case kubeone.CloudProviderNameNone:
 		return map[string]string{}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
According to https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/k8s-secret.html
it's possible to configure vSphere CCM to read credentials from the
Secret instead of plan-text /etc/kubernetes/cloud-config

Fixes #613 

```release-note
Added Secret object as a source for vSphere CCM credentials
```
