### PR TITLE
configure-cloud-routes = false on AWS

### DIFF
--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -175,7 +175,10 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		nodeRegistration.KubeletExtraArgs["cloud-provider"] = provider
 		nodeRegistration.KubeletExtraArgs["cloud-config"] = renderedCloudConfig
 
-		if cluster.CloudProvider.Name == kubeoneapi.CloudProviderNameAzure {
+		switch cluster.CloudProvider.Name {
+		case kubeoneapi.CloudProviderNameAzure:
+			clusterConfig.ControllerManager.ExtraArgs["configure-cloud-routes"] = "false"
+		case kubeoneapi.CloudProviderNameAWS:
 			clusterConfig.ControllerManager.ExtraArgs["configure-cloud-routes"] = "false"
 		}
 	}

--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -175,7 +175,10 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		nodeRegistration.KubeletExtraArgs["cloud-provider"] = provider
 		nodeRegistration.KubeletExtraArgs["cloud-config"] = renderedCloudConfig
 
-		if cluster.CloudProvider.Name == kubeoneapi.CloudProviderNameAzure {
+		switch cluster.CloudProvider.Name {
+		case kubeoneapi.CloudProviderNameAzure:
+			clusterConfig.ControllerManager.ExtraArgs["configure-cloud-routes"] = "false"
+		case kubeoneapi.CloudProviderNameAWS:
 			clusterConfig.ControllerManager.ExtraArgs["configure-cloud-routes"] = "false"
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes log spamming regarding cloud-routes on AWS

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #627 

```release-note
Fix AWS configure-cloud-routes bug
```
