### PR TITLE
Fix E2E tests for Go 1.13

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -56,6 +56,14 @@ func init() {
 	flag.Parse()
 }
 
+// This is a workaround for a change in the testing framework
+// affecting Go 1.13 and newer.
+// More details: https://github.com/golang/go/issues/31859#issuecomment-489889428
+var _ = func() bool {
+	testing.Init()
+	return true
+}()
+
 func setupTearDown(p provisioner.Provisioner, k Kubeone) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Log("cleanup ....")


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a change in the testing framework that affects Go 1.13 and newer. Trying to run E2E tests with Go 1.13 returns an error such as:
```
flag provided but not defined: -test.timeout
Usage of /tmp/go-build670323133/b001/e2e.test:
  -identifier string
        The unique identifier for this test run
  -initial-version string
        Cluster version to provision for tests
  -os-control-plane string
        Operating system to use for control plane nodes
  -os-workers string
        Operating system to use for worker nodes
  -provider string
        Provider to run tests on
  -target-version string
        Cluster version to provision for tests
FAIL    github.com/kubermatic/kubeone/test/e2e  0.013s
?       github.com/kubermatic/kubeone/test/e2e/provisioner      [no test files]
?       github.com/kubermatic/kubeone/test/e2e/testutil [no test files]
FAIL
```

This workaround is supposed to fix this issue. In the CI we didn't encounter this problem because we are still using Go 1.12.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 