### PR TITLE
Update GCE docs to configure clusters as regional

### DIFF
--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -150,12 +150,12 @@ cloudProvider:
   name: 'gce'
   cloudConfig: |
     [global]
-    multizone = true
+    regional = true
 ```
 
 **Note:** If control plane nodes are created in multiple zones,
-you must configure `kube-controller-manager` to support multiple zones by
-setting `multizone` to `true`. Otherwise, `kube-controller-manager` will
+you must configure `kube-controller-manager` to support regional clusters by
+setting `regional` to `true`. Otherwise, `kube-controller-manager` will
 fail to create the needed routes and other cloud resources, without which
 the cluster can't function properly. The example Terraform configuration
 creates control plane nodes in multiple zones by default.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates docs for GCE to configure clusters as regional by providing cloudConfig. More information about regional clusters can be found here: https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 