### PR TITLE
Add changelog for the v0.11.0-beta.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+# [v0.11.0-beta.0](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0-beta.0) - 2019-11-28
+
+## Attention Needed
+
+* The AWS Terraform configuration has been refactored a in backward-incompatible way ([#729](https://github.com/kubermatic/kubeone/issues/729))
+  * Terraform now handles setting up subnets
+  * All resources are tagged ensuring all cluster features offered by AWS CCM are supported
+  * The security of the setup has been increased
+  * Access to nodes and the Kubernetes API is now going over a bastion host
+  * The `aws-private` configuration has been removed
+  * Check out the [new Terraform configuration](https://github.com/kubermatic/kubeone/tree/v0.11.0-beta.0/examples/terraform/aws) for more details
+
+## Added
+
+* Add the `kubeone status` command which checks the health of the cluster, API server and `etcd` ([#734](https://github.com/kubermatic/kubeone/issues/734))
+* Add support for NodeLocalDNSCache ([#704](https://github.com/kubermatic/kubeone/issues/704))
+* Add ability to divert access to the Kubernetes API over SSH tunnel ([#714](https://github.com/kubermatic/kubeone/issues/714))
+* Add support for sourcing proxy settings from Terraform output ([#698](https://github.com/kubermatic/kubeone/issues/698))
+
+## Changed
+
+### General
+
+* [Breaking] The AWS Terraform configuration has been refactored ([#729](https://github.com/kubermatic/kubeone/issues/729))
+* Make vSphere Cloud Controller Manager read credentials from a Secret instead from `cloud-config` ([#724](https://github.com/kubermatic/kubeone/issues/724))
+
+### Bug fixes
+
+* Fix credentials handling if `.cloudProvider.Name` is `none` ([#696](https://github.com/kubermatic/kubeone/issues/696))
+* Fix upgrades not determining hostname correctly causing upgrades to fail ([#708](https://github.com/kubermatic/kubeone/issues/708))
+* Fix `kubeone reset` failing to reset the cluster ([#727](https://github.com/kubermatic/kubeone/issues/727))
+* Fix `configure-cloud-routes` bug for AWS causing `kube-controller-manager` to log warnings ([#725](https://github.com/kubermatic/kubeone/issues/725))
+
+### Updates
+
+* Update machine-controller to v1.8.0 ([#736](https://github.com/kubermatic/kubeone/issues/736))
+* Update Canal CNI to v3.10 ([#718](https://github.com/kubermatic/kubeone/issues/718))
+* Update metrics-server to v0.3.6 ([#720](https://github.com/kubermatic/kubeone/issues/720))
+* Update DigitalOcean Cloud Controller Manager to v0.1.21 ([#722](https://github.com/kubermatic/kubeone/issues/722))
+* Update Hetzner Cloud Controller Manager to v1.5.0 ([#726](https://github.com/kubermatic/kubeone/issues/726))
+
+### Docs
+
+* GCE clusters must be configured as Regional to work properly ([#732](https://github.com/kubermatic/kubeone/issues/732))
+
 # [v0.10.0](https://github.com/kubermatic/kubeone/releases/tag/v0.10.0) - 2019-10-09
 
 ## Attention Needed


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds changelog for the `v0.11.0-beta.0` release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 