### PR TITLE
Allow open NodePorts in AWS terraform config

### DIFF
--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -104,3 +104,8 @@ variable "internal_api_lb" {
   default     = false
   description = "make kubernetes API loadbalancer internal (reachible only from inside the VPC)"
 }
+
+variable "open_nodeports" {
+  default     = false
+  description = "open NodePorts flag"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
To allow conformance tests to finish, we need to have open node ports on ExternalIPs, this is done by settings `terraform apply -var open_nodeports=true` (or any other way to set terraform variables).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
