### PR TITLE
Fix etcdstatus membership report in status command

### DIFF
--- a/pkg/scripts/discovery.go
+++ b/pkg/scripts/discovery.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scripts
+
+const (
+	hostnameCmd = `
+fqdn=$(hostname -f)
+[ "$fqdn" = localhost ] && fqdn=$(hostname)
+echo "$fqdn"
+`
+)
+
+func GetHostname() string {
+	return hostnameCmd
+}

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scripts
+
+import (
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+)
+
+// Render text template with given `variables` Render-context
+func Render(cmd string, variables map[string]interface{}) (string, error) {
+	tpl, err := template.New("base").Parse(cmd)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse script template")
+	}
+
+	var buf strings.Builder
+	buf.WriteString(`set -xeu pipefail`)
+	buf.WriteString("\n\n")
+	buf.WriteString(`export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"`)
+	buf.WriteString("\n\n")
+
+	if err := tpl.Execute(&buf, variables); err != nil {
+		return "", errors.Wrap(err, "failed to render script template")
+	}
+
+	return buf.String(), nil
+}

--- a/pkg/upgrader/upgrade/util.go
+++ b/pkg/upgrader/upgrade/util.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
+	"github.com/kubermatic/kubeone/pkg/scripts"
 	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/state"
 
@@ -32,14 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	hostnameScript = `
-fqdn=$(hostname -f)
-[ "$fqdn" = localhost ] && fqdn=$(hostname)
-echo "$fqdn"
-`
-)
-
 func determineHostname(s *state.State) error {
 	s.Logger.Infoln("Determine hostname…")
 	return s.RunTaskOnAllNodes(func(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
@@ -47,13 +40,13 @@ func determineHostname(s *state.State) error {
 			return nil
 		}
 
-		hostcmd := hostnameScript
+		hostnameCmd := scripts.GetHostname()
 
 		// on azure the name of the Node should == name of the VM
 		if s.Cluster.CloudProvider.Name == kubeoneapi.CloudProviderNameAzure {
-			hostcmd = `hostname`
+			hostnameCmd = `hostname`
 		}
-		stdout, _, err := s.Runner.Run(hostcmd, nil)
+		stdout, _, err := s.Runner.Run(hostnameCmd, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixed kubeone status in situation when hostname is not provided by terraform/config

**Special notes for your reviewer**:
There is new package `pkg/scripts`, where other scripts will be moved in the follow-up PRs. Containing and decoupling scripts rendering from scripts running (over ssh). This will allow us to:
* run scripts locally without ssh (to provision single node control-plane and master in one instance)
* have golden files with script renders, eventually leading to the better unit-test opportunities.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
🐛 Fix etcdstatus membership report in status command
```
