### PR TITLE
Remove pod2daemon-flexvol and volume definition from canal manifest

### DIFF
--- a/pkg/templates/canal/canal.go
+++ b/pkg/templates/canal/canal.go
@@ -31,10 +31,9 @@ import (
 )
 
 const (
-	installCNIImage    = "calico/cni:v3.10.0"
-	flexVolDriverImage = "calico/pod2daemon-flexvol:v3.10.0"
-	calicoImage        = "calico/node:v3.10.0"
-	flannelImage       = "quay.io/coreos/flannel:v0.11.0"
+	installCNIImage = "calico/cni:v3.10.0"
+	calicoImage     = "calico/node:v3.10.0"
+	flannelImage    = "quay.io/coreos/flannel:v0.11.0"
 
 	// cniNetworkConfig configures installation on the each node. The special values in this config will be
 	// automatically populated

--- a/pkg/templates/canal/daemonset.go
+++ b/pkg/templates/canal/daemonset.go
@@ -182,19 +182,6 @@ func daemonSet(ifacePatch bool) *appsv1.DaemonSet {
 								},
 							},
 						},
-						{
-							// Adds a Flex Volume Driver that creates a per-pod
-							// Unix Domain Socket to allow Dikastes to communicate
-							// with Felix over the Policy Sync API
-							Name:  "flexvol-driver",
-							Image: flexVolDriverImage,
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "flexvol-driver-host",
-									MountPath: "/host/driver",
-								},
-							},
-						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -428,15 +415,6 @@ func daemonSet(ifacePatch bool) *appsv1.DaemonSet {
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: "/var/run/nodeagent",
-									Type: &directoryOrCreate,
-								},
-							},
-						},
-						{
-							Name: "flexvol-driver-host",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds",
 									Type: &directoryOrCreate,
 								},
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:
This volume causes problems on CoreOS

**Special notes for your reviewer**:
https://github.com/projectcalico/calico/issues/2712


**Does this PR introduce a user-facing change?**:
```release-note
removed flexvolume support from canal
```
