### PR TITLE
Update e2e tests image to include 1.17 binaries

### DIFF
--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,9 +17,9 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.14"]="v1.14.8"
-full_versions["1.15"]="v1.15.5"
-full_versions["1.16"]="v1.16.2"
+full_versions["1.15"]="v1.15.6"
+full_versions["1.16"]="v1.16.3"
+full_versions["1.17"]="v1.17.0"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.4
+TAG=v0.1.5
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add binaries for Kubernetes 1.17.0
* Remove binaries for Kubernetes 1.14, since we don't test 1.14 anymore

**Special notes for your reviewer**:

```release-note
NONE
```

/assign @kron4eg 