### PR TITLE
Fix overwriting proxy settings

### DIFF
--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -19,6 +19,7 @@ package terraform
 import (
 	"encoding/json"
 
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 
 	kubeonev1alpha1 "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
@@ -126,7 +127,9 @@ func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 		cluster.Hosts = hosts
 	}
 
-	cluster.Proxy = c.Proxy.Value
+	if err = mergo.Merge(&cluster.Proxy, &c.Proxy.Value); err != nil {
+		return errors.Wrap(err, "failed to merge proxy settings")
+	}
 
 	if len(cp.NetworkID) > 0 {
 		cluster.ClusterNetwork.NetworkID = cp.NetworkID


### PR DESCRIPTION
**What this PR does / why we need it**:
in #698 we introduced a bug that unconditionally overwrite proxy settings sourced from the terraform, EVEN IF THEY ARE EMPTY.
That means, if there are proxy settings configured in config, they will be effectively nullified, which is a bug.

Proxy settings defined in kubeone manifest have precedence over those defined in terraform output.

```release-note
Fix terraform proxy output handling
Proxy settings defined in kubeone manifest have precedence over those defined in terraform output.
```
