### PR TITLE
Bump E2E binaries to their latest versions

### DIFF
--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,8 +17,8 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.15"]="v1.15.6"
-full_versions["1.16"]="v1.16.3"
+full_versions["1.15"]="v1.15.7"
+full_versions["1.16"]="v1.16.4"
 full_versions["1.17"]="v1.17.0"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.5
+TAG=v0.1.6
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump E2E binaries to their latest versions.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 