### PR TITLE
Ensure correct order of operations for cluster upgrades

### DIFF
--- a/pkg/scripts/node.go
+++ b/pkg/scripts/node.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scripts
+
+const (
+	drainNodeScriptTemplate = `
+kubectl drain {{ .NODE_NAME }} --ignore-daemonsets
+`
+
+	cordonNodeScriptTemplate = `
+kubectl cordon {{ .NODE_NAME }}
+`
+)
+
+func DrainNode(nodeName string) (string, error) {
+	return Render(drainNodeScriptTemplate, Data{
+		"NODE_NAME": nodeName,
+	})
+}
+
+func CordonNode(nodeName string) (string, error) {
+	return Render(cordonNodeScriptTemplate, Data{
+		"NODE_NAME": nodeName,
+	})
+}

--- a/pkg/scripts/node.go
+++ b/pkg/scripts/node.go
@@ -21,7 +21,7 @@ const (
 kubectl drain {{ .NODE_NAME }} --ignore-daemonsets
 `
 
-	cordonNodeScriptTemplate = `
+	uncordonNodeScriptTemplate = `
 kubectl uncordon {{ .NODE_NAME }}
 `
 )
@@ -33,7 +33,7 @@ func DrainNode(nodeName string) (string, error) {
 }
 
 func UncordonNode(nodeName string) (string, error) {
-	return Render(cordonNodeScriptTemplate, Data{
+	return Render(uncordonNodeScriptTemplate, Data{
 		"NODE_NAME": nodeName,
 	})
 }

--- a/pkg/scripts/node.go
+++ b/pkg/scripts/node.go
@@ -22,7 +22,7 @@ kubectl drain {{ .NODE_NAME }} --ignore-daemonsets
 `
 
 	cordonNodeScriptTemplate = `
-kubectl cordon {{ .NODE_NAME }}
+kubectl uncordon {{ .NODE_NAME }}
 `
 )
 
@@ -32,7 +32,7 @@ func DrainNode(nodeName string) (string, error) {
 	})
 }
 
-func CordonNode(nodeName string) (string, error) {
+func UncordonNode(nodeName string) (string, error) {
 	return Render(cordonNodeScriptTemplate, Data{
 		"NODE_NAME": nodeName,
 	})

--- a/pkg/scripts/node.go
+++ b/pkg/scripts/node.go
@@ -18,7 +18,7 @@ package scripts
 
 const (
 	drainNodeScriptTemplate = `
-kubectl drain {{ .NODE_NAME }} --ignore-daemonsets
+kubectl drain {{ .NODE_NAME }} --ignore-daemonsets --delete-local-data
 `
 
 	uncordonNodeScriptTemplate = `

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -249,14 +249,6 @@ cd /opt/bin
 sudo systemctl stop kubelet
 sudo mv /var/tmp/kube-binaries/kubeadm .
 sudo chmod +x kubeadm
-
-sudo mkdir -p /etc/systemd/system/kubelet.service.d
-curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" |
-	sed "s:/usr/bin:/opt/bin:g" |
-	sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-
-sudo systemctl daemon-reload
-sudo systemctl start kubelet
 `
 
 	upgradeKubeletAndKubectlDebianScriptTemplate = `
@@ -301,6 +293,12 @@ sudo chmod +x {kubelet,kubectl}
 curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" |
 	sed "s:/usr/bin:/opt/bin:g" |
 	sudo tee /etc/systemd/system/kubelet.service
+
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" |
+	sed "s:/usr/bin:/opt/bin:g" |
+	sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+
 	 
 sudo systemctl daemon-reload
 sudo systemctl start kubelet

--- a/pkg/upgrader/upgrade/drain_nodes.go
+++ b/pkg/upgrader/upgrade/drain_nodes.go
@@ -33,8 +33,8 @@ func drainNode(s *state.State, node kubeoneapi.HostConfig) error {
 	return err
 }
 
-func cordonNode(s *state.State, node kubeoneapi.HostConfig) error {
-	cmd, err := scripts.CordonNode(node.Hostname)
+func uncordonNode(s *state.State, node kubeoneapi.HostConfig) error {
+	cmd, err := scripts.UncordonNode(node.Hostname)
 	if err != nil {
 		return err
 	}

--- a/pkg/upgrader/upgrade/drain_nodes.go
+++ b/pkg/upgrader/upgrade/drain_nodes.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
+	"github.com/kubermatic/kubeone/pkg/scripts"
+	"github.com/kubermatic/kubeone/pkg/state"
+)
+
+func drainNode(s *state.State, node kubeoneapi.HostConfig) error {
+	cmd, err := scripts.DrainNode(node.Hostname)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = s.Runner.RunRaw(cmd)
+
+	return err
+}
+
+func cordonNode(s *state.State, node kubeoneapi.HostConfig) error {
+	cmd, err := scripts.CordonNode(node.Hostname)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = s.Runner.RunRaw(cmd)
+
+	return err
+}

--- a/pkg/upgrader/upgrade/kubernetes_node_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_node_binaries.go
@@ -80,7 +80,7 @@ func upgradeKubernetesNodeBinariesCentOS(s *state.State) error {
 }
 
 func upgradeKubernetesNodeBinariesCoreOS(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeletAndKubectlCentOS(s.Cluster.Versions.Kubernetes)
+	cmd, err := scripts.UpgradeKubeletAndKubectlCoreOS(s.Cluster.Versions.Kubernetes)
 	if err != nil {
 		return err
 	}

--- a/pkg/upgrader/upgrade/kubernetes_node_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_node_binaries.go
@@ -17,6 +17,8 @@ limitations under the License.
 package upgrade
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
@@ -36,6 +38,9 @@ func upgradeKubernetesNodeBinariesExecutor(s *state.State, node *kubeoneapi.Host
 	if err := upgradeKubernetesNodeBinariesScript(s, *node); err != nil {
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on leader control plane")
 	}
+
+	logger.Infof("Waiting %v seconds to ensure kubelet is up…", timeoutKubeletUpgrade.String())
+	time.Sleep(timeoutKubeletUpgrade)
 
 	return nil
 }

--- a/pkg/upgrader/upgrade/kubernetes_node_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_node_binaries.go
@@ -21,19 +21,35 @@ import (
 
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/scripts"
+	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/state"
 )
 
-func upgradeKubernetesBinaries(s *state.State, node kubeoneapi.HostConfig) error {
+func upgradeKubernetesNodeBinaries(s *state.State) error {
+	return s.RunTaskOnAllNodes(upgradeKubernetesNodeBinariesExecutor, false)
+}
+
+func upgradeKubernetesNodeBinariesExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
+	logger := s.Logger.WithField("node", node.PublicAddress)
+
+	logger.Infoln("Upgrading Kubernetes node binaries on control planes…")
+	if err := upgradeKubernetesNodeBinariesScript(s, *node); err != nil {
+		return errors.Wrap(err, "failed to upgrade kubernetes binaries on leader control plane")
+	}
+
+	return nil
+}
+
+func upgradeKubernetesNodeBinariesScript(s *state.State, node kubeoneapi.HostConfig) error {
 	var err error
 
 	switch node.OperatingSystem {
 	case "ubuntu", "debian":
-		err = upgradeKubernetesBinariesDebian(s)
+		err = upgradeKubernetesNodeBinariesDebian(s)
 	case "coreos":
-		err = upgradeKubernetesBinariesCoreOS(s)
+		err = upgradeKubernetesNodeBinariesCoreOS(s)
 	case "centos":
-		err = upgradeKubernetesBinariesCentOS(s)
+		err = upgradeKubernetesNodeBinariesCentOS(s)
 	default:
 		err = errors.Errorf("'%s' is not a supported operating system", node.OperatingSystem)
 	}
@@ -41,8 +57,8 @@ func upgradeKubernetesBinaries(s *state.State, node kubeoneapi.HostConfig) error
 	return err
 }
 
-func upgradeKubernetesBinariesDebian(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeadmAndCNIDebian(s.Cluster.Versions.Kubernetes, s.Cluster.Versions.KubernetesCNIVersion())
+func upgradeKubernetesNodeBinariesDebian(s *state.State) error {
+	cmd, err := scripts.UpgradeKubeletAndKubectlDebian(s.Cluster.Versions.Kubernetes)
 	if err != nil {
 		return err
 	}
@@ -52,8 +68,8 @@ func upgradeKubernetesBinariesDebian(s *state.State) error {
 	return errors.WithStack(err)
 }
 
-func upgradeKubernetesBinariesCentOS(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeadmAndCNICentOS(s.Cluster.Versions.Kubernetes, s.Cluster.Versions.KubernetesCNIVersion())
+func upgradeKubernetesNodeBinariesCentOS(s *state.State) error {
+	cmd, err := scripts.UpgradeKubeletAndKubectlCentOS(s.Cluster.Versions.Kubernetes)
 	if err != nil {
 		return err
 	}
@@ -63,8 +79,8 @@ func upgradeKubernetesBinariesCentOS(s *state.State) error {
 	return errors.WithStack(err)
 }
 
-func upgradeKubernetesBinariesCoreOS(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeadmAndCNICoreOS(s.Cluster.Versions.Kubernetes, s.Cluster.Versions.KubernetesCNIVersion())
+func upgradeKubernetesNodeBinariesCoreOS(s *state.State) error {
+	cmd, err := scripts.UpgradeKubeletAndKubectlCentOS(s.Cluster.Versions.Kubernetes)
 	if err != nil {
 		return err
 	}

--- a/pkg/upgrader/upgrade/kubernetes_node_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_node_binaries.go
@@ -39,7 +39,7 @@ func upgradeKubernetesNodeBinariesExecutor(s *state.State, node *kubeoneapi.Host
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on leader control plane")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure kubelet is up…", timeoutKubeletUpgrade)
+	logger.Infof("Waiting %v to ensure kubelet is up…", timeoutKubeletUpgrade)
 	time.Sleep(timeoutKubeletUpgrade)
 
 	return nil

--- a/pkg/upgrader/upgrade/kubernetes_node_binaries.go
+++ b/pkg/upgrader/upgrade/kubernetes_node_binaries.go
@@ -39,7 +39,7 @@ func upgradeKubernetesNodeBinariesExecutor(s *state.State, node *kubeoneapi.Host
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on leader control plane")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure kubelet is up…", timeoutKubeletUpgrade.String())
+	logger.Infof("Waiting %v seconds to ensure kubelet is up…", timeoutKubeletUpgrade)
 	time.Sleep(timeoutKubeletUpgrade)
 
 	return nil

--- a/pkg/upgrader/upgrade/upgrade.go
+++ b/pkg/upgrader/upgrade/upgrade.go
@@ -40,7 +40,7 @@ const (
 	timeoutKubeletUpgrade = 1 * time.Minute
 	// timeoutNodeUpgrade is time for how long kubeone will wait after finishing the upgrade
 	// process on the node
-	timeoutNodeUpgrade = 15 * time.Second
+	timeoutNodeUpgrade = 30 * time.Second
 )
 
 // Upgrade performs all the steps required to upgrade Kubernetes on

--- a/pkg/upgrader/upgrade/upgrade.go
+++ b/pkg/upgrader/upgrade/upgrade.go
@@ -54,6 +54,7 @@ func Upgrade(s *state.State) error {
 		{Fn: runPreflightChecks, ErrMsg: "preflight checks failed"},
 		{Fn: upgradeLeader, ErrMsg: "unable to upgrade leader control plane", Retries: 3},
 		{Fn: upgradeFollower, ErrMsg: "unable to upgrade follower control plane", Retries: 3},
+		{Fn: upgradeKubernetesNodeBinaries, ErrMsg: "unable to upgrade kubernetes node binaries", Retries: 3},
 		{Fn: nodelocaldns.Deploy, ErrMsg: "unable to deploy nodelocaldns", Retries: 3},
 		{Fn: features.Activate, ErrMsg: "unable to activate features"},
 		{Fn: certificate.DownloadCA, ErrMsg: "unable to download ca from leader", Retries: 3},

--- a/pkg/upgrader/upgrade/upgrade_follower.go
+++ b/pkg/upgrader/upgrade/upgrade_follower.go
@@ -51,23 +51,20 @@ func upgradeFollowerExecutor(s *state.State, node *kubeoneapi.HostConfig, conn s
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on follower control plane")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure kubelet is up…", timeoutKubeletUpgrade.String())
-	time.Sleep(timeoutKubeletUpgrade)
-
 	logger.Infoln("Running 'kubeadm upgrade' on the follower control plane node…")
 	err = upgradeFollowerControlPlane(s)
 	if err != nil {
 		return errors.Wrap(err, "failed to upgrade follower control plane")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade.String())
-	time.Sleep(timeoutNodeUpgrade)
-
 	logger.Infoln("Uncordoning follower control plane…")
 	err = uncordonNode(s, *node)
 	if err != nil {
 		return errors.Wrap(err, "failed to uncordon follower control plane node")
 	}
+
+	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade.String())
+	time.Sleep(timeoutNodeUpgrade)
 
 	logger.Infoln("Unlabeling follower control plane…")
 	err = unlabelNode(s.DynamicClient, node)

--- a/pkg/upgrader/upgrade/upgrade_follower.go
+++ b/pkg/upgrader/upgrade/upgrade_follower.go
@@ -40,7 +40,8 @@ func upgradeFollowerExecutor(s *state.State, node *kubeoneapi.HostConfig, conn s
 	}
 
 	logger.Infoln("Draining follower control plane…")
-	if err := drainNode(s, *node); err != nil {
+	err = drainNode(s, *node)
+	if err != nil {
 		return errors.Wrap(err, "failed to drain leader control plane node")
 	}
 
@@ -62,9 +63,10 @@ func upgradeFollowerExecutor(s *state.State, node *kubeoneapi.HostConfig, conn s
 	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade.String())
 	time.Sleep(timeoutNodeUpgrade)
 
-	logger.Infoln("Cordoning follower control plane…")
-	if err := cordonNode(s, *node); err != nil {
-		return errors.Wrap(err, "failed to cordon follower control plane node")
+	logger.Infoln("Uncordoning follower control plane…")
+	err = uncordonNode(s, *node)
+	if err != nil {
+		return errors.Wrap(err, "failed to uncordon follower control plane node")
 	}
 
 	logger.Infoln("Unlabeling follower control plane…")

--- a/pkg/upgrader/upgrade/upgrade_follower.go
+++ b/pkg/upgrader/upgrade/upgrade_follower.go
@@ -63,7 +63,7 @@ func upgradeFollowerExecutor(s *state.State, node *kubeoneapi.HostConfig, conn s
 		return errors.Wrap(err, "failed to uncordon follower control plane node")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade)
+	logger.Infof("Waiting %v to ensure all components are up…", timeoutNodeUpgrade)
 	time.Sleep(timeoutNodeUpgrade)
 
 	logger.Infoln("Unlabeling follower control plane…")

--- a/pkg/upgrader/upgrade/upgrade_follower.go
+++ b/pkg/upgrader/upgrade/upgrade_follower.go
@@ -63,7 +63,7 @@ func upgradeFollowerExecutor(s *state.State, node *kubeoneapi.HostConfig, conn s
 		return errors.Wrap(err, "failed to uncordon follower control plane node")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade.String())
+	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade)
 	time.Sleep(timeoutNodeUpgrade)
 
 	logger.Infoln("Unlabeling follower control plane…")

--- a/pkg/upgrader/upgrade/upgrade_leader.go
+++ b/pkg/upgrader/upgrade/upgrade_leader.go
@@ -38,6 +38,11 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 		return errors.Wrap(err, "failed to label leader control plane node")
 	}
 
+	logger.Infoln("Draining leader control plane…")
+	if err := drainNode(s, *node); err != nil {
+		return errors.Wrap(err, "failed to drain leader control plane node")
+	}
+
 	logger.Infoln("Upgrading Kubernetes binaries on leader control plane…")
 	if err := upgradeKubernetesBinaries(s, *node); err != nil {
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on leader control plane")
@@ -63,6 +68,11 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 
 	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade.String())
 	time.Sleep(timeoutNodeUpgrade)
+
+	logger.Infoln("Cordoning leader control plane…")
+	if err := cordonNode(s, *node); err != nil {
+		return errors.Wrap(err, "failed to cordon leader control plane node")
+	}
 
 	logger.Infoln("Unlabeling leader control plane…")
 	if err := unlabelNode(s.DynamicClient, node); err != nil {

--- a/pkg/upgrader/upgrade/upgrade_leader.go
+++ b/pkg/upgrader/upgrade/upgrade_leader.go
@@ -68,7 +68,7 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 		return errors.Wrap(err, "failed to uncordon leader control plane node")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade.String())
+	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade)
 	time.Sleep(timeoutNodeUpgrade)
 
 	logger.Infoln("Unlabeling leader control plane…")

--- a/pkg/upgrader/upgrade/upgrade_leader.go
+++ b/pkg/upgrader/upgrade/upgrade_leader.go
@@ -68,7 +68,7 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 		return errors.Wrap(err, "failed to uncordon leader control plane node")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade)
+	logger.Infof("Waiting %v to ensure all components are up…", timeoutNodeUpgrade)
 	time.Sleep(timeoutNodeUpgrade)
 
 	logger.Infoln("Unlabeling leader control plane…")

--- a/pkg/upgrader/upgrade/upgrade_leader.go
+++ b/pkg/upgrader/upgrade/upgrade_leader.go
@@ -69,9 +69,9 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade.String())
 	time.Sleep(timeoutNodeUpgrade)
 
-	logger.Infoln("Cordoning leader control plane…")
-	if err := cordonNode(s, *node); err != nil {
-		return errors.Wrap(err, "failed to cordon leader control plane node")
+	logger.Infoln("Uncordoning leader control plane…")
+	if err := uncordonNode(s, *node); err != nil {
+		return errors.Wrap(err, "failed to uncordon leader control plane node")
 	}
 
 	logger.Infoln("Unlabeling leader control plane…")

--- a/pkg/upgrader/upgrade/upgrade_leader.go
+++ b/pkg/upgrader/upgrade/upgrade_leader.go
@@ -48,9 +48,6 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on leader control plane")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure kubelet is up…", timeoutKubeletUpgrade.String())
-	time.Sleep(timeoutKubeletUpgrade)
-
 	logger.Infoln("Generating kubeadm config …")
 	if err := generateKubeadmConfig(s, *node); err != nil {
 		return errors.Wrap(err, "failed to generate kubeadm config")
@@ -66,13 +63,13 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 		return errors.Wrap(err, "failed to run 'kubeadm upgrade' on leader control plane")
 	}
 
-	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade.String())
-	time.Sleep(timeoutNodeUpgrade)
-
 	logger.Infoln("Uncordoning leader control plane…")
 	if err := uncordonNode(s, *node); err != nil {
 		return errors.Wrap(err, "failed to uncordon leader control plane node")
 	}
+
+	logger.Infof("Waiting %v seconds to ensure all components are up…", timeoutNodeUpgrade.String())
+	time.Sleep(timeoutNodeUpgrade)
 
 	logger.Infoln("Unlabeling leader control plane…")
 	if err := unlabelNode(s.DynamicClient, node); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures we use the correct order of operation when upgrading a cluster. The correct order is stated in [the upstream kubeadm documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).

This is going to fix 1.16 to 1.17 upgrades, but 1.13 to 1.14 upgrades will not work anymore.

**Does this PR introduce a user-facing change?**:
```release-note
It is possible to upgrade 1.16 to 1.17
It is NOT possible to upgrade 1.13 to 1.14 anymore
```