### PR TITLE
MachineController v1.9.0

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -46,7 +46,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.8.0"
+	MachineControllerTag           = "v1.9.0"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster

--- a/pkg/templates/metricsserver/deployment.go
+++ b/pkg/templates/metricsserver/deployment.go
@@ -169,6 +169,11 @@ func metricsServerDeployment() *appsv1.Deployment {
 					Labels: k8sAppLabels,
 				},
 				Spec: corev1.PodSpec{
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
 					ServiceAccountName: "metrics-server",
 					Volumes: []corev1.Volume{
 						{


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade machine-controller to the latest v1.9.0

**Does this PR introduce a user-facing change?**:
```release-note
Upgrade machine-controller to the latest v1.9.0
```
