### PR TITLE
Disable validation of the Replicas in the Worker definition

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -151,8 +151,8 @@ func ValidateWorkerConfig(workerset []kubeone.WorkerConfig, fldPath *field.Path)
 		if w.Name == "" {
 			allErrs = append(allErrs, field.Invalid(fldPath, w.Name, "no name given"))
 		}
-		if w.Replicas == nil || *w.Replicas < 1 {
-			allErrs = append(allErrs, field.Invalid(fldPath, w.Replicas, "replicas must be specified and >= 1"))
+		if w.Replicas == nil || *w.Replicas < 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath, w.Replicas, "replicas must be specified and >= 0"))
 		}
 	}
 

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -344,6 +344,10 @@ func TestValidateWorkerConfig(t *testing.T) {
 					Name:     "test-2",
 					Replicas: intPtr(5),
 				},
+				{
+					Name:     "test-3",
+					Replicas: intPtr(0),
+				},
 			},
 			expectedError: false,
 		},
@@ -351,20 +355,6 @@ func TestValidateWorkerConfig(t *testing.T) {
 			name:          "valid worker config (no worker defined)",
 			workerConfig:  []kubeone.WorkerConfig{},
 			expectedError: false,
-		},
-		{
-			name: "invalid worker config (zero replicas)",
-			workerConfig: []kubeone.WorkerConfig{
-				{
-					Name:     "test-1",
-					Replicas: intPtr(0),
-				},
-				{
-					Name:     "test-2",
-					Replicas: intPtr(5),
-				},
-			},
-			expectedError: true,
 		},
 		{
 			name: "invalid worker config (replicas not provided)",


### PR DESCRIPTION
**What this PR does / why we need it**:
This will allow to have 0 Replicas configured for initial cluster setup, for later export and versioning in infra repositories.

```release-note
Allow 0 replicas definition in the worker
```
