### PR TITLE
WIP: How to manually replace failed control-plane node documentation

### DIFF
--- a/docs/manual-cluster-repair.md
+++ b/docs/manual-cluster-repair.md
@@ -1,0 +1,125 @@
+# Manual cluster repair
+When one of the control-plane nodes fails, it's necessary to restore it back as
+fast as possible to avoid loosing ETCD quorum and blocking all kubeapi-server
+operations.
+
+This is a guide on how to restore you cluster back to the normal state.
+
+## One dead control-plane instance
+If you are running KubeOne cluster with machine-controller enabled, it will
+automatically recreate your failed worker nodes. But it can happen that
+cloud-instance with control-plane node fails.
+
+In this document we will cover the case when 1 (out of 3 in total) control-plane
+node is lost.
+
+### Remove dead ETCD member
+Even when one ETCD member is physically (and abruptly) removed, ETCD-ring still
+hopes it might return back online. Unfortunately this is not our case and we
+need to let ETCD-ring know that dead ETCD member is dead forever.
+
+Exec into the shell of the alive ETCD container:
+```bash
+kubectl -n kube-system exec -it ETCD-<ALIVE-HOSTNAME> sh
+```
+
+Setup client TLS authentication:
+```bash
+export ETCDCTL_API=3
+export ETCDCTL_CACERT=/etc/kubernetes/pki/ETCD/ca.crt
+export ETCDCTL_CERT=/etc/kubernetes/pki/ETCD/healthcheck-client.crt
+export ETCDCTL_KEY=/etc/kubernetes/pki/ETCD/healthcheck-client.key
+```
+
+Retrieve currently known members list (example output):
+```bash
+etcdctl member list
+2ce40012b4b4e4e6, started, ip-172-31-153-216.eu-west-3.compute.internal, https://172.31.153.216:2380, https://172.31.153.216:2379, false
+2e39cf93b81fb7ed, started, ip-172-31-153-246.eu-west-3.compute.internal, https://172.31.153.246:2380, https://172.31.153.246:2379, false
+6713c8f2e74fb553, started, ip-172-31-153-235.eu-west-3.compute.internal, https://172.31.153.235:2380, https://172.31.153.235:2379, false
+```
+
+We are going to need an ID of the dead ETCD member. To locate it, please check
+(by IP for example, or hostnames) your online instances list and find one from
+the list above, that is not online anymore.
+
+Locate and delete dead ETCD member:
+```bash
+etcdctl member remove 6713c8f2e74fb553
+Member 6713c8f2e74fb553 removed from cluster 4ec111e0dee094c3
+```
+
+Exit the ETCD pod shell.
+
+### Recreate failed instance
+Assuming you've used Terraform to provision your cloud infrastructure, use
+`terraform apply` to restore cloud infrastructure to the declared state, i.e. 3
+control-plane instances for HA clusters.
+
+From your local machine:
+```bash
+terraform apply
+```
+
+Save the terraform JSON output to the file:
+```bash
+terraform output -json > tfout.json
+```
+
+### What is Leader instance
+In KubeOne the Leader instance is the first instance from the `Hosts` (or
+`kubeone_hosts` in Terraform output) list. This instance will be used to "init"
+the cluster.
+
+If Leader instance has failed, we can reorder `Hosts` list (or `kubeone_hosts`
+in Terraform output), and place a healthy instance as first one. 
+
+Let's review Terraform case.
+
+Locate the `Leader` node.
+```bash
+jq '.kubeone_hosts.value.control_plane.hostnames' < tfout.json
+[
+  "ip-172-31-153-222.eu-west-3.compute.internal",
+  "ip-172-31-153-228.eu-west-3.compute.internal",
+  "ip-172-31-153-246.eu-west-3.compute.internal"
+]
+
+jq '.kubeone_hosts.value.control_plane.private_address' < tfout.json
+[
+  "172.31.153.222",
+  "172.31.153.228",
+  "172.31.153.246"
+]
+```
+
+In case when first instance from those lists has failed, edit JSON file directy,
+and reorder it.
+
+Example how to reorder:
+```bash
+jq '.kubeone_hosts.value.control_plane.hostnames' < tfout.json
+[
+  "ip-172-31-153-228.eu-west-3.compute.internal",
+  "ip-172-31-153-222.eu-west-3.compute.internal",
+  "ip-172-31-153-246.eu-west-3.compute.internal"
+]
+
+jq '.kubeone_hosts.value.control_plane.private_address' < tfout.json
+[
+  "172.31.153.228",
+  "172.31.153.222",
+  "172.31.153.246"
+]
+```
+
+### Join new control-plane node back to the cluster
+`kubeone install` will install kubernetes dependencies to the freshly created
+instance and join it back to the cluster as one of the control plane nodes.
+
+```bash
+kubeone install -v config.yaml -t tfout.json
+```
+
+## Mulpiple dead control-plane instances
+In this case, you'd need to recreate cluster from the backup of ETCD.

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "aws"
       private_address      = aws_instance.control_plane.*.private_ip
       hostnames            = aws_instance.control_plane.*.private_dns
+      leader_ip            = aws_instance.control_plane.0.private_ip
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "azure"
       private_address      = azurerm_network_interface.control_plane.*.private_ip_address
       public_address       = azurerm_public_ip.control_plane.*.ip_address
+      leader_ip            = azurerm_network_interface.control_plane.0.private_ip_address
       hostnames            = formatlist("${var.cluster_name}-cp-%d", [0, 1, 2])
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port

--- a/examples/terraform/digitalocean/output.tf
+++ b/examples/terraform/digitalocean/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "digitalocean"
       private_address      = digitalocean_droplet.control_plane.*.ipv4_address_private
       public_address       = digitalocean_droplet.control_plane.*.ipv4_address
+      leader_ip            = digitalocean_droplet.control_plane.0.ipv4_address_private
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "gce"
       private_address      = google_compute_instance.control_plane.*.network_interface.0.network_ip
       public_address       = google_compute_instance.control_plane.*.network_interface.0.access_config.0.nat_ip
+      leader_ip            = google_compute_instance.control_plane.0.network_interface.0.network_ip
       hostnames            = google_compute_instance.control_plane.*.name
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port

--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "hetzner"
       private_address      = hcloud_server_network.control_plane.*.ip
       public_address       = hcloud_server.control_plane.*.ipv4_address
+      leader_ip            = hcloud_server_network.control_plane.0.ip
       network_id           = hcloud_network.net.id
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "openstack"
       private_address      = openstack_compute_instance_v2.control_plane.*.access_ip_v4
       public_address       = openstack_networking_floatingip_v2.control_plane.*.address
+      leader_ip            = openstack_compute_instance_v2.control_plane.0.access_ip_v4
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/examples/terraform/packet/output.tf
+++ b/examples/terraform/packet/output.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "packet"
       private_address      = packet_device.control_plane.*.access_private_ipv4
       public_address       = packet_device.control_plane.*.access_public_ipv4
+      leader_ip            = packet_device.control_plane.0.access_private_ipv4
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -31,6 +31,7 @@ output "kubeone_hosts" {
       cloud_provider       = "vsphere"
       private_address      = []
       public_address       = vsphere_virtual_machine.control_plane.*.default_ip_address
+      leader_ip            = vsphere_virtual_machine.control_plane.0.default_ip_address
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -42,7 +42,13 @@ func (c KubeOneCluster) RandomHost() HostConfig {
 // Followers returns all but the first configured host. Only call
 // this after validating the cluster config to ensure hosts exist.
 func (c KubeOneCluster) Followers() []HostConfig {
-	return c.Hosts[1:]
+	followers := []HostConfig{}
+	for _, h := range c.Hosts {
+		if !h.IsLeader {
+			followers = append(followers, h)
+		}
+	}
+	return followers
 }
 
 // SetHostname sets the hostname for the given host

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -70,10 +70,10 @@ type HostConfig struct {
 	BastionPort       int    `json:"bastionPort"`
 	BastionUser       string `json:"bastionUser"`
 	Hostname          string `json:"hostname"`
+	IsLeader          bool   `json:"isLeader"`
 
 	// Information populated at the runtime
 	OperatingSystem string `json:"-"`
-	IsLeader        bool   `json:"-"`
 }
 
 // APIEndpoint is the endpoint used to communicate with the Kubernetes API

--- a/pkg/apis/kubeone/v1alpha1/defaults.go
+++ b/pkg/apis/kubeone/v1alpha1/defaults.go
@@ -50,13 +50,23 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 		return
 	}
 
-	// Set first host to be the leader
-	obj.Hosts[0].IsLeader = true
+	setDefaultLeader := true
 
 	// Define a unique ID for each host
 	for idx := range obj.Hosts {
+		if setDefaultLeader && obj.Hosts[idx].IsLeader {
+			// override setting default leader, as explicit leader already
+			// defined
+			setDefaultLeader = false
+		}
 		obj.Hosts[idx].ID = idx
 		defaultHostConfig(&obj.Hosts[idx])
+	}
+
+	if setDefaultLeader {
+		// In absence of explicitly defined leader set the first host to be the
+		// default leader
+		obj.Hosts[0].IsLeader = true
 	}
 }
 

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -70,10 +70,10 @@ type HostConfig struct {
 	BastionPort       int    `json:"bastionPort"`
 	BastionUser       string `json:"bastionUser"`
 	Hostname          string `json:"hostname"`
+	IsLeader          bool   `json:"isLeader"`
 
 	// Information populated at the runtime
 	OperatingSystem string `json:"-"`
-	IsLeader        bool   `json:"-"`
 }
 
 // APIEndpoint is the endpoint used to communicate with the Kubernetes API

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -90,7 +90,14 @@ func ValidateCloudProviderSpec(p kubeone.CloudProviderSpec, fldPath *field.Path)
 func ValidateHostConfig(hosts []kubeone.HostConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	leaderFound := false
 	for _, h := range hosts {
+		if leaderFound && h.IsLeader {
+			allErrs = append(allErrs, field.Invalid(fldPath, h.IsLeader, "only 1 leader is allowed"))
+		}
+		if h.IsLeader {
+			leaderFound = true
+		}
 		if len(h.PublicAddress) == 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath, h.PublicAddress, "no public IP/address given"))
 		}

--- a/pkg/installer/installation/kubeadm_leader.go
+++ b/pkg/installer/installation/kubeadm_leader.go
@@ -17,6 +17,8 @@ limitations under the License.
 package installation
 
 import (
+	"time"
+
 	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/scripts"
 	"github.com/kubermatic/kubeone/pkg/ssh"
@@ -50,7 +52,7 @@ func initKubernetesLeader(s *state.State) error {
 	return s.RunTaskOnLeader(func(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 		s.Logger.Infoln("Running kubeadm…")
 
-		cmd, err := scripts.KubeadmInit(s.WorkDir, node.ID, s.KubeadmVerboseFlag(), s.JoinCommand, "1h")
+		cmd, err := scripts.KubeadmInit(s.WorkDir, node.ID, s.KubeadmVerboseFlag(), s.JoinToken, time.Hour.String())
 		if err != nil {
 			return err
 		}

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -31,6 +31,7 @@ type controlPlane struct {
 	CloudProvider     *string  `json:"cloud_provider"`
 	PublicAddress     []string `json:"public_address"`
 	PrivateAddress    []string `json:"private_address"`
+	LeaderIP          string   `json:"leader_ip"`
 	Hostnames         []string `json:"hostnames"`
 	SSHUser           string   `json:"ssh_user"`
 	SSHPort           int      `json:"ssh_port"`
@@ -202,6 +203,7 @@ func newHostConfig(id int, publicIP, privateIP, hostname string, cp controlPlane
 		Bastion:           cp.Bastion,
 		BastionPort:       cp.BastionPort,
 		BastionUser:       cp.BastionUser,
+		IsLeader:          cp.LeaderIP == publicIP || cp.LeaderIP == privateIP,
 	}
 }
 


### PR DESCRIPTION
Also fixes a bug for token creation at install time

**What this PR does / why we need it**:
Documentation to fix broken cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #747

```release-note
NONE
```
