### PR TITLE
ARM64 support

### DIFF
--- a/pkg/templates/canal/canal.go
+++ b/pkg/templates/canal/canal.go
@@ -33,7 +33,7 @@ import (
 const (
 	installCNIImage = "calico/cni:v3.10.0"
 	calicoImage     = "calico/node:v3.10.0"
-	flannelImage    = "quay.io/coreos/flannel:v0.11.0"
+	flannelImage    = "quay.io/kubermatic/coreos_flannel:v0.11.0@sha256:3de983d62621898fe58ffd9537a4845c7112961a775efb205cab56e089e163b6"
 
 	// cniNetworkConfig configures installation on the each node. The special values in this config will be
 	// automatically populated

--- a/pkg/templates/metricsserver/deployment.go
+++ b/pkg/templates/metricsserver/deployment.go
@@ -33,6 +33,10 @@ import (
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
+const (
+	metricsServerImage = `quay.io/kubermatic/metrics-server-mirror:v0.3.6@sha256:129897020bc4b0dcf9783b5e0f15c1fa6ad95cde33f8c0b233325304c5fab4ec`
+)
+
 // Deploy generate and POST all objects to apiserver
 func Deploy(s *state.State) error {
 	if s.DynamicClient == nil {
@@ -186,7 +190,7 @@ func metricsServerDeployment() *appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name:            "metrics-server",
-							Image:           "k8s.gcr.io/metrics-server-amd64:v0.3.6",
+							Image:           metricsServerImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"--kubelet-insecure-tls",


### PR DESCRIPTION
**What this PR does / why we need it**:
This is limited ARM64 support. Limited because there is no machine-controller for arm64.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #773

**Special notes for your reviewer**:
* flannel image was replaced by our mirror at quay.io/kubermatic/coreos_flannel for multi-arch support
* metrics-server image was replaces by our mirror at quay.io/kubermatic/metrics-server-mirror for multi-arch support

Mirrors are needed because upstream repositories doesn't have support for multi-arch manifests.

In follow-up PR I'll be adding new API field(s) to regulate master taints.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ARM support
```
