### PR TITLE
Use upstream metrics-server image

### DIFF
--- a/pkg/templates/metricsserver/deployment.go
+++ b/pkg/templates/metricsserver/deployment.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	metricsServerImage = `quay.io/kubermatic/metrics-server-mirror:v0.3.6@sha256:129897020bc4b0dcf9783b5e0f15c1fa6ad95cde33f8c0b233325304c5fab4ec`
+	metricsServerImage = `k8s.gcr.io/metrics-server:v0.3.6`
 )
 
 // Deploy generate and POST all objects to apiserver


### PR DESCRIPTION
**Special notes for your reviewer**:
Drop mirroring of metrics-server to quay.io/kubermatic

```release-note
Use metrics-server multi-arch images from k8s.gcr.io registry
```
