### PR TITLE
Fix apt proxy configuration on ubunt/debian

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -55,12 +55,12 @@ EOF
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
-{{- if .HTTPS_PROXY }}
+{{ if .HTTPS_PROXY -}}
 Acquire::https::Proxy "{{ .HTTPS_PROXY }}";
 {{ end -}}
 {{- if .HTTP_PROXY -}}
 Acquire::http::Proxy "{{ .HTTP_PROXY }}";
-{{ end -}}
+{{ end }}
 EOF
 
 sudo apt-get update

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -55,12 +55,12 @@ EOF
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
-{{ if .HTTPS_PROXY -}}
+{{- if .HTTPS_PROXY }}
 Acquire::https::Proxy "{{ .HTTPS_PROXY }}";
-{{ end -}}
-{{- if .HTTP_PROXY -}}
+{{- end }}
+{{- if .HTTP_PROXY }}
 Acquire::http::Proxy "{{ .HTTP_PROXY }}";
-{{ end }}
+{{- end }}
 EOF
 
 sudo apt-get update

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -55,13 +55,12 @@ EOF
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
-{{- if .HTTPS_PROXY -}}
-Acquire::https::Proxy = "{{ .HTTPS_PROXY }}";
-{{ end }}
-
+{{- if .HTTPS_PROXY }}
+Acquire::https::Proxy "{{ .HTTPS_PROXY }}";
+{{ end -}}
 {{- if .HTTP_PROXY -}}
-Acquire::http::Proxy = "{{ .HTTP_PROXY }}";
-{{ end }}
+Acquire::http::Proxy "{{ .HTTP_PROXY }}";
+{{ end -}}
 EOF
 
 sudo apt-get update


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: this pr fixes apt proxy configuration
before - the templated script would generate:

```
cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.confAcquire::https::Proxy = "{{ .HTTPS_PROXY }}";
```

which broke the setup when one enabled proxy support in k1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix broken apt config file generation when http/https proxies are enabled. 
```
