### PR TITLE
(WIP) fixes for coreos control plane

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -151,6 +151,20 @@ sudo systemctl enable --now kubelet
 	kubeadmCoreOSTemplate = `
 . /etc/kubeone/proxy-env
 
+HOST_ARCH=""
+case $(uname -m) in
+x86_64)
+    HOST_ARCH="amd64"
+    ;;
+aarch64)
+    HOST_ARCH="arm64"
+    ;;
+*)
+    echo "unsupported CPU architecture, exiting"
+    exit 1
+    ;;
+esac
+
 # Short-Circuit the installation if it was already executed
 if type docker &>/dev/null && type kubelet &>/dev/null; then exit 0; fi
 

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -55,12 +55,12 @@ EOF
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
-{{- if .HTTPS_PROXY }}
+{{ if .HTTPS_PROXY -}}
 Acquire::https::Proxy "{{ .HTTPS_PROXY }}";
 {{ end -}}
 {{- if .HTTP_PROXY -}}
 Acquire::http::Proxy "{{ .HTTP_PROXY }}";
-{{ end -}}
+{{ end }}
 EOF
 
 sudo apt-get update

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -55,12 +55,12 @@ EOF
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
-{{ if .HTTPS_PROXY -}}
+{{- if .HTTPS_PROXY }}
 Acquire::https::Proxy "{{ .HTTPS_PROXY }}";
-{{ end -}}
-{{- if .HTTP_PROXY -}}
+{{- end }}
+{{- if .HTTP_PROXY }}
 Acquire::http::Proxy "{{ .HTTP_PROXY }}";
-{{ end }}
+{{- end }}
 EOF
 
 sudo apt-get update

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -55,13 +55,12 @@ EOF
 
 sudo mkdir -p /etc/apt/apt.conf.d
 cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
-{{- if .HTTPS_PROXY -}}
-Acquire::https::Proxy = "{{ .HTTPS_PROXY }}";
-{{ end }}
-
+{{- if .HTTPS_PROXY }}
+Acquire::https::Proxy "{{ .HTTPS_PROXY }}";
+{{ end -}}
 {{- if .HTTP_PROXY -}}
-Acquire::http::Proxy = "{{ .HTTP_PROXY }}";
-{{ end }}
+Acquire::http::Proxy "{{ .HTTP_PROXY }}";
+{{ end -}}
 EOF
 
 sudo apt-get update

--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -69,6 +69,8 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			"read-only-port":      "0",
 			"rotate-certificates": "true",
 			"cluster-dns":         nodelocaldns.VirtualIP,
+			// default path is not writable on coreos
+			"volume-plugin-dir": "/etc/kubernetes/kubelet-plugins",
 		},
 	}
 
@@ -147,7 +149,9 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			CertSANs: []string{strings.ToLower(cluster.APIEndpoint.Host)},
 		},
 		ControllerManager: kubeadmv1beta1.ControlPlaneComponent{
-			ExtraArgs:    map[string]string{},
+			ExtraArgs: map[string]string{
+				"flex-volume-plugin-dir": "/etc/kubernetes/kubelet-plugins/volume/exec",
+			},
 			ExtraVolumes: []kubeadmv1beta1.HostPathMount{},
 		},
 		ClusterName: cluster.Name,

--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -69,6 +69,8 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			"read-only-port":      "0",
 			"rotate-certificates": "true",
 			"cluster-dns":         nodelocaldns.VirtualIP,
+			// default path is not writable on coreos
+			"volume-plugin-dir": "/etc/kubernetes/kubelet-plugins",
 		},
 	}
 
@@ -147,7 +149,9 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			CertSANs: []string{strings.ToLower(cluster.APIEndpoint.Host)},
 		},
 		ControllerManager: kubeadmv1beta2.ControlPlaneComponent{
-			ExtraArgs:    map[string]string{},
+			ExtraArgs: map[string]string{
+				"flex-volume-plugin-dir": "/etc/kubernetes/kubelet-plugins/volume/exec",
+			},
 			ExtraVolumes: []kubeadmv1beta2.HostPathMount{},
 		},
 		ClusterName: cluster.Name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: currently centos control plane setup fails on two different things:
1. `pkg/scripts/os.go/kubeadmCentOSTemplate` is referencing `HOST_ARCH` but it is never set - fixed through copy paste from `kubeadmDebianTemplate` (btw same thing is missing from `upgradeKubeletAndKubectlCoreOSScriptTemplate`)
2. on coreos the path `/usr/libexec/kuberentes/plugins/volume` is readonly and this breaks flexvolumes for kube-controller-manager - solution: force different by setting (file: `pkg/templates/kubeadm/v1beta{1,2}`)
  * KubeletExtraArgs["volume-plugin-dir"] = "/etc/kubernetes/kubelet-plugins"
  * ControllerManager.ExtraArgs["flex-volume-plugin-dir"] = "/etc/kubernetes/kubelet-plugins/volume/exec"
  
But I don't know if this specific new path is a good choice and I don't know a clean way to bring knowledge about the nodes target OS to `pkg/templates/kubeadm/v1beta{1,2}`
 
Also:
```
CoreOS Container Linux will no longer receive updates after May 26, 2020.
Begin migrating your workloads to another operating system.
For more info, see https://coreos.com/os/eol/
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
