### PR TITLE
Fix inconsistencies in the quickstart docs

### DIFF
--- a/docs/quickstart-aws.md
+++ b/docs/quickstart-aws.md
@@ -2,7 +2,7 @@
 
 In this quick start we're going to show how to get started with KubeOne on AWS. We'll cover how to create the needed infrastructure using our example Terraform scripts and then install Kubernetes. Finally, we're going to show how to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and two worker nodes.
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and three worker nodes.
 
 ### Prerequisites
 
@@ -94,7 +94,7 @@ Before you start you'll need a configuration file that defines how Kubernetes
 will be installed, e.g. what version will be used and what features will be
 enabled. For the configuration file reference run `kubeone config print --full`.
 
-To get started you can use the following configuration. It'll install Kubernetes 1.16.1 and create one worker node. KubeOne automatically populates all needed information about worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/ec8bf305446ac22529e9683fd4ce3c9abf753d1e/examples/terraform/aws/output.tf#L38-L87). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [AWS example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml) for available options.
+To get started you can use the following configuration. It'll install Kubernetes 1.16.1 and create three worker nodes. KubeOne automatically populates all needed information about worker nodes from the [Terraform output](https://github.com/kubermatic/kubeone/blob/258ec7a06b39fe27d741edc24ed77796829249cd/examples/terraform/aws/output.tf#L46-L146). Alternatively, you can set those information manually. As KubeOne is using [Kubermatic `machine-controller`](https://github.com/kubermatic/machine-controller) for creating worker nodes, see [AWS example manifest](https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml) for available options.
 
 For example, to create a cluster with Kubernetes `1.16.1`, save the following to
 `config.yaml`:

--- a/docs/quickstart-azure.md
+++ b/docs/quickstart-azure.md
@@ -6,7 +6,7 @@ Terraform scripts and then install Kubernetes. Finally, we're going to show how
 to destroy the cluster along with the infrastructure.
 
 As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with
-three control plane nodes and two worker nodes.
+three control plane nodes and one worker node.
 
 ### Prerequisites
 
@@ -288,7 +288,7 @@ terraform destroy
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
 Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three
-control plane nodes and two worker nodes. If you want to learn more about
+control plane nodes and one worker node. If you want to learn more about
 KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to
 check our [documentation][9].
 

--- a/docs/quickstart-digitalocean.md
+++ b/docs/quickstart-digitalocean.md
@@ -2,7 +2,7 @@
 
 In this quick start we're going to show how to get started with KubeOne on DigitalOcean. We'll cover how to create the needed infrastructure using our example Terraform scripts and then install Kubernetes. Finally, we're going to show how to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and two worker nodes.
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and one worker node.
 
 ### Prerequisites
 
@@ -223,6 +223,6 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and one worker node. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
 
 [scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -6,7 +6,7 @@ configuration and then install Kubernetes. Finally, we're going to show how to
 destroy the cluster along with the infrastructure.
 
 As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with
-three control plane nodes and two worker nodes.
+three control plane nodes and one worker node.
 
 ### Prerequisites
 
@@ -288,7 +288,7 @@ terraform destroy
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
 Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three
-control plane nodes and three worker nodes. If you want to learn more about
+control plane nodes and one worker node. If you want to learn more about
 KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to
 check our
 [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).

--- a/docs/quickstart-hetzner.md
+++ b/docs/quickstart-hetzner.md
@@ -2,7 +2,7 @@
 
 In this quick start we're going to show how to get started with KubeOne on Hetzner. We'll cover how to create the needed infrastructure using our example Terraform scripts and then install Kubernetes. Finally, we're going to show how to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and three worker nodes.
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and one worker node.
 
 ### Prerequisites
 
@@ -216,6 +216,6 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and three worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and one worker node. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
 
 [scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-openstack.md
+++ b/docs/quickstart-openstack.md
@@ -2,7 +2,7 @@
 
 In this quick start we're going to show how to get started with KubeOne on OpenStack. We'll cover how to create the needed infrastructure using our example Terraform scripts and then install Kubernetes. Finally, we're going to show how to destroy the cluster along with the infrastructure.
 
-As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and two worker nodes.
+As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with three control plane nodes and one worker node.
 
 ### Prerequisites
 
@@ -246,6 +246,6 @@ terraform destroy
 
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
-Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and two worker nodes. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
+Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three control plane nodes and one worker node. If you want to learn more about KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to check our [documentation](https://github.com/kubermatic/kubeone/tree/master/docs).
 
 [scale_issue]: https://github.com/kubermatic/kubeone/issues/593#issuecomment-513282468

--- a/docs/quickstart-vsphere.md
+++ b/docs/quickstart-vsphere.md
@@ -6,7 +6,7 @@ Terraform scripts and then install Kubernetes. Finally, we're going to show how
 to destroy the cluster along with the infrastructure.
 
 As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with
-three control plane nodes and two worker nodes.
+three control plane nodes and one worker node.
 
 ### Prerequisites
 
@@ -295,7 +295,7 @@ terraform destroy
 You'll be asked to enter `yes` to confirm your intention to destroy the cluster.
 
 Congratulations! You're now running Kubernetes 1.16.1 HA cluster with three
-control plane nodes and two worker nodes. If you want to learn more about
+control plane nodes and one worker node. If you want to learn more about
 KubeOne and its features, such as [upgrades](upgrading_cluster.md), make sure to
 check our [documentation][9].
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes some inconsistencies we have in the quickstart docs, regarding the number of worker nodes initially created.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 