### PR TITLE
Enable Strict mode to decode KubeOne API

### DIFF
--- a/pkg/apis/kubeone/scheme/scheme.go
+++ b/pkg/apis/kubeone/scheme/scheme.go
@@ -31,7 +31,7 @@ import (
 var Scheme = runtime.NewScheme()
 
 // Codecs is a CodecFactory object used to provide encoding and decoding for the scheme
-var Codecs = serializer.NewCodecFactory(Scheme)
+var Codecs = serializer.NewCodecFactory(Scheme, serializer.EnableStrict)
 
 func init() {
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})


### PR DESCRIPTION
**What this PR does / why we need it**:
To warn people at very early stages that they have some mistakes in their YAMLs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #759

**Does this PR introduce a user-facing change?**:
```release-note
Strict KubeOne config decoding
```
