### PR TITLE
Fix links in the addons docs

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -94,8 +94,8 @@ in the addons directory and correct addons configuration before running `kubeone
 The addons are applied in the alphabetical order. This means that you can control in which order addons
 will be applied by setting the appropriate file name.
 
-[design-proposal]: (proposals/20200205-addons.md)
-[go-templates]: (https://golang.org/pkg/text/template/)
-[sprig]: (https://github.com/Masterminds/sprig)
-[sprig-docs]: (http://masterminds.github.io/sprig/)
-[sprig-b64enc]: (http://masterminds.github.io/sprig/encoding.html)
+[design-proposal]: ./proposals/20200205-addons.md
+[go-templates]: https://golang.org/pkg/text/template/
+[sprig]: https://github.com/Masterminds/sprig
+[sprig-docs]: http://masterminds.github.io/sprig/
+[sprig-b64enc]: http://masterminds.github.io/sprig/encoding.html


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that links in the addons docs are rendered properly.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 