### PR TITLE
Update docs for the v0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,75 @@
 # Changelog
 
-# [v0.11.0-beta.3](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0-beta.0) - 2019-12-20
+# [v0.11.0](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0) - 2020-03-05
+
+**Changelog since v0.10.0. For changelog since v0.11.0-beta.3, please check the [release notes](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0)**
+
+## Attention Needed
+
+* Kubernetes 1.14 clusters are not supported as of this release because 1.14 isn't supported by the upstream anymore
+  * It remains possible and is advisable to upgrade 1.14 clusters to 1.15
+  * Currently, it also remains possible to provision 1.14 clusters, but that can be dropped at any time and it'll not be fixed if it stops working
+* As of this release, it is not possible to upgrade 1.13 clusters to 1.14
+  * Please use an older version of KubeOne in the case you need to upgrade 1.13 clusters
+* The AWS Terraform configuration has been refactored a in backward-incompatible way ([#729](https://github.com/kubermatic/kubeone/issues/729))
+  * Terraform now handles setting up subnets
+  * All resources are tagged ensuring all cluster features offered by AWS CCM are supported
+  * The security of the setup has been increased
+  * Access to nodes and the Kubernetes API is now going over a bastion host
+  * The `aws-private` configuration has been removed
+  * Check out the [new Terraform configuration](https://github.com/kubermatic/kubeone/tree/v0.11.0-beta.0/examples/terraform/aws) for more details
+
+## Added
+
+* Add support for Kubernetes 1.17
+  * Fix cluster upgrade failures when upgrading from 1.16 to 1.17 ([#764](https://github.com/kubermatic/kubeone/pull/764))
+* Add support for ARM64 clusters ([#783](https://github.com/kubermatic/kubeone/pull/783))
+* Add ability to deploy Kubernetes manifests on the provisioning time (KubeOne Addons) ([#782](https://github.com/kubermatic/kubeone/pull/782))
+* Add the `kubeone status` command which checks the health of the cluster, API server and `etcd` ([#734](https://github.com/kubermatic/kubeone/issues/734))
+* Add support for NodeLocalDNSCache ([#704](https://github.com/kubermatic/kubeone/issues/704))
+* Add ability to divert access to the Kubernetes API over SSH tunnel ([#714](https://github.com/kubermatic/kubeone/issues/714))
+* Add support for sourcing proxy settings from Terraform output ([#698](https://github.com/kubermatic/kubeone/issues/698))
+* Persist configured proxy in the system package managers ([#749](https://github.com/kubermatic/kubeone/pull/749))
+
+## Changed
+
+### General
+
+* [Breaking] The AWS Terraform configuration has been refactored ([#729](https://github.com/kubermatic/kubeone/issues/729))
+* The KubeOneCluster manifests is now parsed strictly ([#802](https://github.com/kubermatic/kubeone/pull/802))
+* The leader instance can be defined declarative using API ([#790](https://github.com/kubermatic/kubeone/pull/790))
+* Make vSphere Cloud Controller Manager read credentials from a Secret instead from `cloud-config` ([#724](https://github.com/kubermatic/kubeone/issues/724))
+
+### Bug fixes
+
+* Fix CentOS cluster provisioning ([#770](https://github.com/kubermatic/kubeone/pull/770))
+* Fix AWS shared credentials file handling ([#806](https://github.com/kubermatic/kubeone/pull/806))
+* Fix credentials handling if `.cloudProvider.Name` is `none` ([#696](https://github.com/kubermatic/kubeone/issues/696))
+* Fix upgrades not determining hostname correctly causing upgrades to fail ([#708](https://github.com/kubermatic/kubeone/issues/708))
+* Fix `kubeone reset` failing to reset the cluster ([#727](https://github.com/kubermatic/kubeone/issues/727))
+* Fix `configure-cloud-routes` bug for AWS causing `kube-controller-manager` to log warnings ([#725](https://github.com/kubermatic/kubeone/issues/725))
+* Disable validation of replicas count in the workers definition ([#775](https://github.com/kubermatic/kubeone/pull/775))
+* Proxy settings defined in the config have precedence over those defined in Terraform ([#760](https://github.com/kubermatic/kubeone/pull/760))
+
+### Updates
+
+* Update machine-controller to v1.9.0 ([#774](https://github.com/kubermatic/kubeone/pull/774))
+* Update Canal CNI to v3.10 ([#718](https://github.com/kubermatic/kubeone/issues/718))
+* Update metrics-server to v0.3.6 ([#720](https://github.com/kubermatic/kubeone/issues/720))
+* Update DigitalOcean Cloud Controller Manager to v0.1.21 ([#722](https://github.com/kubermatic/kubeone/issues/722))
+* Update Hetzner Cloud Controller Manager to v1.5.0 ([#726](https://github.com/kubermatic/kubeone/issues/726))
+
+### Removed
+
+* Remove ability to upgrade 1.13 clusters to 1.14 ([#764](https://github.com/kubermatic/kubeone/pull/764))
+* Removed FlexVolume support from the Canal CNI ([#756](https://github.com/kubermatic/kubeone/pull/756))
+
+### Docs
+
+* GCE clusters must be configured as Regional to work properly ([#732](https://github.com/kubermatic/kubeone/issues/732))
+
+
+# [v0.11.0-beta.3](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0-beta.3) - 2019-12-20
 
 ## Attention Needed
 
@@ -19,7 +88,7 @@
 
 * Remove ability to upgrade 1.13 clusters to 1.14 ([#764](https://github.com/kubermatic/kubeone/pull/764))
 
-# [v0.11.0-beta.2](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0-beta.0) - 2019-12-12
+# [v0.11.0-beta.2](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0-beta.2) - 2019-12-12
 
 ## Changed
 
@@ -27,7 +96,7 @@
 
 * Proxy settings defined in the config have precedence over those defined in Terraform ([#760](https://github.com/kubermatic/kubeone/pull/760))
 
-# [v0.11.0-beta.1](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0-beta.0) - 2019-12-10
+# [v0.11.0-beta.1](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0-beta.1) - 2019-12-10
 
 ## Added
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,39 @@
 # Documentation Index
 
-* Quickstart
+## Getting started
+
+* [Frequently Asked Questions](frequently_asked_questions.md)
+* Quickstart guides
   * [AWS](quickstart-aws.md)
+  * [Azure](quickstart-azure.md)
   * [DigitalOcean](quickstart-digitalocean.md)
   * [Google Compute Engine (GCE)](quickstart-gce.md)
   * [Hetzner](quickstart-hetzner.md)
-  * [Packet](quickstart-packet.md)
   * [OpenStack](quickstart-openstack.md)
-* [Frequently Asked Questions](frequently_asked_questions.md)
-* [Backwards Compatibility Policy](backwards_compatibility_policy.md)
-* [Migrating to the KubeOneCluster API](api_migration.md)
-* [Upgrading Kubernetes Cluster Using KubeOne](upgrading_cluster.md)
-* [Project Structure](project_structure.md)
+  * [Packet](quickstart-packet.md)
+  * [VMware vSphere](quickstart-vsphere.md)
+
+## Using KubeOne
+
+* [SSH requirements](manual-cluster-repair.md)
+* [Upgrading Kubernetes Clusters Using KubeOne](upgrading_cluster.md)
+* [Using Addons](adding_provider_support.md)
+* [Proxy support](proxy.md)
+* [Manual Cluster Repair](manual-cluster-repair.md)
 * [Environment variables used by KubeOne](environment_variables.md)
-* [Adding support for provider](adding_provider_support.md)
-* [Proposals](./proposals)
-  * [Cluster Upgrades](./proposals/20190211-upgrades.md)
-  * [KubeOneCluster API](./proposals/20190409-kubeonecluster-api.md)
+* [Terraform LoadBalancers in Examples](example-loadbalancer.md)
+* [Migrating to the KubeOneCluster API](api_migration.md)
+
+## Development
+
+* [Adding support for a provider](adding_provider_support.md)
+* [Project Structure](project_structure.md)
+* [Backwards Compatibility Policy](backwards_compatibility_policy.md)
+* [Release Process](release_process.md)
+
+## [Proposals](./proposals)
+
+* [Cluster Upgrades (implemented)](./proposals/20190211-upgrades.md)
+* [KubeOneCluster API (implemented)](./proposals/20190409-kubeonecluster-api.md)
+* [KubeOne Addons (implemented)](./proposals/20200205-addons.md)
+* [KubeOne Reconciliation process (draft)](./proposals/20200224-apply.md)

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -6,40 +6,41 @@ This document lists all environment variables used by KubeOne and related compon
 
 In the following table you can find all configuration variables with support for sourcing using the `env:` prefix:
 
-| Variable | Type | Default Value | Description |
-|----------|------|---------------|-------------|
-| `hosts.ssh_agent_socket` | string | "" | Socket to be used for SSH |
+| Variable                 | Type   | Default Value | Description               |
+| ------------------------ | ------ | ------------- | ------------------------- |
+| `hosts.ssh_agent_socket` | string | ""            | Socket to be used for SSH |
 
 ## `machine-controller` Environment Variables
 
 [`machine-controller`](https://github.com/kubermatic/machine-controller) is used to create worker nodes. It needs credentials with the appropriate permissions, so it can create machines and needed infrastructure. Those credentials are deployed on the cluster.
 
-| Environment Variable | Description |
-|---|---|
-| `AWS_ACCESS_KEY_ID` | The AWS Access Key used for creating workers on AWS |
-| `AWS_SECRET_ACCESS_KEY` | The AWS Secret Access Key used for creating workers on AWS |
-| | |
-| `DIGITALOCEAN_TOKEN` | The DigitalOcean API Access Token used for creating workers on DO |
-| | |
-| `HCLOUD_TOKEN` | The Hetzner API Access Token used for creating workers on Hetzner |
-| | |
-| `OS_AUTH_URL` | The URL of OpenStack Identity Service |
-| `OS_USERNAME` | The username of the OpenStack user |
-| `OS_PASSWORD` | The password of the OpenStack user |
-| `OS_DOMAIN_NAME` | The name of the OpenStack domain |
-| `OS_TENANT_ID` | The ID of the OpenStack tenant |
-| `OS_TENANT_NAME` | The name of the OpenStack tenant |
-| | |
-| `PACKET_AUTH_TOKEN` | Packet auth token |
-| `PACKET_PROJECT_ID` | Packet project ID |
-| | |
-| `VSPHERE_ADDRESS` | The address of the vSphere instance |
-| `VSPHERE_USERNAME` | The username of the vSphere user |
-| `VSPHERE_PASSWORD` | The password of the vSphere user |
-| | |
-| `GOOGLE_CREDENTIALS` | GCE Service Account |
-| | |
-| `ARM_CLIENT_ID` | Azure ClientID |
-| `ARM_CLIENT_SECRET` | Azure Client secret |
-| `ARM_TENANT_ID` | Azure TenantID |
-| `ARM_SUBSCRIPTION_ID` | Azure SubscriptionID |
+| Environment Variable    | Description                                                       |
+| ----------------------- | ----------------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`     | The AWS Access Key used for creating workers on AWS               |
+| `AWS_SECRET_ACCESS_KEY` | The AWS Secret Access Key used for creating workers on AWS        |
+| `AWS_PROFILE`           | The AWS profile to be used for creating workers on AWS            |
+|                         |                                                                   |
+| `DIGITALOCEAN_TOKEN`    | The DigitalOcean API Access Token used for creating workers on DO |
+|                         |                                                                   |
+| `HCLOUD_TOKEN`          | The Hetzner API Access Token used for creating workers on Hetzner |
+|                         |                                                                   |
+| `OS_AUTH_URL`           | The URL of OpenStack Identity Service                             |
+| `OS_USERNAME`           | The username of the OpenStack user                                |
+| `OS_PASSWORD`           | The password of the OpenStack user                                |
+| `OS_DOMAIN_NAME`        | The name of the OpenStack domain                                  |
+| `OS_TENANT_ID`          | The ID of the OpenStack tenant                                    |
+| `OS_TENANT_NAME`        | The name of the OpenStack tenant                                  |
+|                         |                                                                   |
+| `PACKET_AUTH_TOKEN`     | Packet auth token                                                 |
+| `PACKET_PROJECT_ID`     | Packet project ID                                                 |
+|                         |                                                                   |
+| `VSPHERE_ADDRESS`       | The address of the vSphere instance                               |
+| `VSPHERE_USERNAME`      | The username of the vSphere user                                  |
+| `VSPHERE_PASSWORD`      | The password of the vSphere user                                  |
+|                         |                                                                   |
+| `GOOGLE_CREDENTIALS`    | GCE Service Account                                               |
+|                         |                                                                   |
+| `ARM_CLIENT_ID`         | Azure ClientID                                                    |
+| `ARM_CLIENT_SECRET`     | Azure Client secret                                               |
+| `ARM_TENANT_ID`         | Azure TenantID                                                    |
+| `ARM_SUBSCRIPTION_ID`   | Azure SubscriptionID                                              |

--- a/docs/quickstart-aws.md
+++ b/docs/quickstart-aws.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.10.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-azure.md
+++ b/docs/quickstart-azure.md
@@ -12,7 +12,7 @@ three control plane nodes and one worker node.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.10.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-digitalocean.md
+++ b/docs/quickstart-digitalocean.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.10.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -12,7 +12,7 @@ three control plane nodes and one worker node.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.10.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-hetzner.md
+++ b/docs/quickstart-hetzner.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.10.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-openstack.md
+++ b/docs/quickstart-openstack.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.10.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-packet.md
+++ b/docs/quickstart-packet.md
@@ -12,7 +12,7 @@ three control plane nodes and one worker node (which can be easily scaled).
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.10.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-vsphere.md
+++ b/docs/quickstart-vsphere.md
@@ -12,7 +12,7 @@ three control plane nodes and one worker node.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.10.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the changelog and docs for the upcoming v0.11.0 release, planned for today.

```
## Added

* Add support for ARM64 clusters ([#783](https://github.com/kubermatic/kubeone/pull/783))
* Add ability to deploy Kubernetes manifests on the provisioning time (KubeOne Addons) ([#782](https://github.com/kubermatic/kubeone/pull/782))

## Changed

### General

* The KubeOneCluster manifests is now parsed strictly ([#802](https://github.com/kubermatic/kubeone/pull/802))
* The leader instance can be defined declarative using API ([#790](https://github.com/kubermatic/kubeone/pull/790))

### Bug Fixes

* Fix CentOS cluster provisioning ([#770](https://github.com/kubermatic/kubeone/pull/770))
* Disable validation of replicas count in the workers definition ([#775](https://github.com/kubermatic/kubeone/pull/775))
* Fix `apt` config file generation when proxy is enabled ([#791](https://github.com/kubermatic/kubeone/pull/791))
* Fix AWS shared credentials file handling ([#806](https://github.com/kubermatic/kubeone/pull/806))

### Updates

* Update machine-controller to v1.9.0 ([#774](https://github.com/kubermatic/kubeone/pull/774))
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 