### PR TITLE
Fix broken link in the documentation index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@
 
 ## Using KubeOne
 
-* [SSH requirements](manual-cluster-repair.md)
+* [SSH requirements](ssh.md)
 * [Upgrading Kubernetes Clusters Using KubeOne](upgrading_cluster.md)
 * [Using Addons](adding_provider_support.md)
 * [Proxy support](proxy.md)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix broken link in the documentation index.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 