### PR TITLE
Fix IsLeader parsing from terraform

### DIFF
--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -31,7 +31,6 @@ output "kubeone_hosts" {
       cloud_provider       = "aws"
       private_address      = aws_instance.control_plane.*.private_ip
       hostnames            = aws_instance.control_plane.*.private_dns
-      leader_ip            = aws_instance.control_plane.0.private_ip
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -191,6 +191,12 @@ func (c *Config) Apply(cluster *kubeonev1alpha1.KubeOneCluster) error {
 }
 
 func newHostConfig(id int, publicIP, privateIP, hostname string, cp controlPlane) kubeonev1alpha1.HostConfig {
+	var isLeader bool
+
+	if cp.LeaderIP != "" {
+		isLeader = cp.LeaderIP == publicIP || cp.LeaderIP == privateIP
+	}
+
 	return kubeonev1alpha1.HostConfig{
 		ID:                id,
 		PublicAddress:     publicIP,
@@ -203,7 +209,7 @@ func newHostConfig(id int, publicIP, privateIP, hostname string, cp controlPlane
 		Bastion:           cp.Bastion,
 		BastionPort:       cp.BastionPort,
 		BastionUser:       cp.BastionUser,
-		IsLeader:          cp.LeaderIP == publicIP || cp.LeaderIP == privateIP,
+		IsLeader:          isLeader,
 	}
 }
 


### PR DESCRIPTION
Previously, if no leader_ip was given in terraform outputs, every host
will be considered as a leader, which fails the API validation.

**What this PR does / why we need it**:
Fixes a bug introduced with explicit leader_ip parsing from terraform.

```release-note
FIX: fixes leader_ip parsing from terraform
```
