### PR TITLE
Add new Untaint API Field to avoid default master taint

### DIFF
--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -71,6 +71,7 @@ type HostConfig struct {
 	BastionUser       string `json:"bastionUser"`
 	Hostname          string `json:"hostname"`
 	IsLeader          bool   `json:"isLeader"`
+	Untaint           bool   `json:"untaint"`
 
 	// Information populated at the runtime
 	OperatingSystem string `json:"-"`

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -71,6 +71,7 @@ type HostConfig struct {
 	BastionUser       string `json:"bastionUser"`
 	Hostname          string `json:"hostname"`
 	IsLeader          bool   `json:"isLeader"`
+	Untaint           bool   `json:"untaint"`
 
 	// Information populated at the runtime
 	OperatingSystem string `json:"-"`

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
@@ -471,6 +471,7 @@ func autoConvert_v1alpha1_HostConfig_To_kubeone_HostConfig(in *HostConfig, out *
 	out.BastionUser = in.BastionUser
 	out.Hostname = in.Hostname
 	out.IsLeader = in.IsLeader
+	out.Untaint = in.Untaint
 	out.OperatingSystem = in.OperatingSystem
 	return nil
 }
@@ -493,6 +494,7 @@ func autoConvert_kubeone_HostConfig_To_v1alpha1_HostConfig(in *kubeone.HostConfi
 	out.BastionUser = in.BastionUser
 	out.Hostname = in.Hostname
 	out.IsLeader = in.IsLeader
+	out.Untaint = in.Untaint
 	out.OperatingSystem = in.OperatingSystem
 	return nil
 }

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -546,6 +546,9 @@ addons:
 #   # prefixed with "env:" to refer to an environment variable.
 #   sshPrivateKeyFile: '/home/me/.ssh/id_rsa'
 #   sshAgentSocket: 'env:SSH_AUTH_SOCK'
+#   # setting this to true will skip node-role.kubernetes.io/master taint from
+#   # Node object on this host
+#   untaint: false
 
 # The API server can also be overwritten by Terraform. Provide the
 # external address of your load balancer or the public addresses of

--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -55,14 +55,19 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		nodeIP = host.PublicAddress
 	}
 
-	nodeRegistration := kubeadmv1beta1.NodeRegistrationOptions{
-		Name: host.Hostname,
-		Taints: []corev1.Taint{
-			{
-				Effect: corev1.TaintEffectNoSchedule,
-				Key:    "node-role.kubernetes.io/master",
-			},
+	taints := []corev1.Taint{
+		{
+			Effect: corev1.TaintEffectNoSchedule,
+			Key:    "node-role.kubernetes.io/master",
 		},
+	}
+	if host.Untaint {
+		taints = nil
+	}
+
+	nodeRegistration := kubeadmv1beta1.NodeRegistrationOptions{
+		Name:   host.Hostname,
+		Taints: taints,
 		KubeletExtraArgs: map[string]string{
 			"anonymous-auth":      "false",
 			"node-ip":             nodeIP,

--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -55,14 +55,19 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		nodeIP = host.PublicAddress
 	}
 
-	nodeRegistration := kubeadmv1beta2.NodeRegistrationOptions{
-		Name: host.Hostname,
-		Taints: []corev1.Taint{
-			{
-				Effect: corev1.TaintEffectNoSchedule,
-				Key:    "node-role.kubernetes.io/master",
-			},
+	taints := []corev1.Taint{
+		{
+			Effect: corev1.TaintEffectNoSchedule,
+			Key:    "node-role.kubernetes.io/master",
 		},
+	}
+	if host.Untaint {
+		taints = nil
+	}
+
+	nodeRegistration := kubeadmv1beta2.NodeRegistrationOptions{
+		Name:   host.Hostname,
+		Taints: taints,
 		KubeletExtraArgs: map[string]string{
 			"anonymous-auth":      "false",
 			"node-ip":             nodeIP,

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -33,6 +33,7 @@ type controlPlane struct {
 	PrivateAddress    []string `json:"private_address"`
 	LeaderIP          string   `json:"leader_ip"`
 	Hostnames         []string `json:"hostnames"`
+	Untaint           bool     `json:"untaint"`
 	SSHUser           string   `json:"ssh_user"`
 	SSHPort           int      `json:"ssh_port"`
 	SSHPrivateKeyFile string   `json:"ssh_private_key_file"`
@@ -210,6 +211,7 @@ func newHostConfig(id int, publicIP, privateIP, hostname string, cp controlPlane
 		BastionPort:       cp.BastionPort,
 		BastionUser:       cp.BastionUser,
 		IsLeader:          isLeader,
+		Untaint:           cp.Untaint,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In some usecases (i.e. at the edge) there is a need to init 1 or ever 3 nodes cluster, but only control-plane nodes without workers in a way that normal workloads would be allowed by default on the those nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #821 

**Does this PR introduce a user-facing change?**:

```release-note
New Untaint API field in config to remove default taints from control plane Nodes
```
