### PR TITLE
Fix openstack e2e tests image selection

### DIFF
--- a/examples/terraform/openstack/main.tf
+++ b/examples/terraform/openstack/main.tf
@@ -22,6 +22,12 @@ data "openstack_networking_network_v2" "external_network" {
   external = true
 }
 
+data "openstack_images_image_v2" "image" {
+  name        = var.image
+  most_recent = true
+  properties  = var.image_properties_query
+}
+
 resource "openstack_compute_keypair_v2" "deployer" {
   name       = "${var.cluster_name}-deployer-key"
   public_key = file(var.ssh_public_key_file)
@@ -90,7 +96,7 @@ resource "openstack_compute_instance_v2" "control_plane" {
   count = 3
   name  = "${var.cluster_name}-cp-${count.index}"
 
-  image_name      = var.image
+  image_name      = data.openstack_images_image_v2.image.name
   flavor_name     = var.control_plane_flavor
   key_pair        = openstack_compute_keypair_v2.deployer.name
   security_groups = [openstack_networking_secgroup_v2.securitygroup.name]
@@ -102,7 +108,7 @@ resource "openstack_compute_instance_v2" "control_plane" {
 
 resource "openstack_compute_instance_v2" "lb" {
   name       = "${var.cluster_name}-lb"
-  image_name = var.image
+  image_name = data.openstack_images_image_v2.image.name
 
   flavor_name     = var.lb_flavor
   key_pair        = openstack_compute_keypair_v2.deployer.name

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -60,7 +60,7 @@ output "kubeone_workers" {
           # provider specific fields:
           # see example under `cloudProviderSpec` section at:
           # https://github.com/kubermatic/machine-controller/blob/master/examples/openstack-machinedeployment.yaml
-          image          = var.image
+          image          = data.openstack_images_image_v2.image.name
           flavor         = var.worker_flavor
           securityGroups = [openstack_networking_secgroup_v2.securitygroup.name]
           network        = openstack_networking_network_v2.network.name

--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -76,13 +76,21 @@ variable "worker_flavor" {
 }
 
 variable "lb_flavor" {
-  default     = "m1.micro"
+  default     = "m1.tiny"
   description = "OpenStack instance flavor for the LoadBalancer node"
 }
 
 variable "image" {
-  default     = "Ubuntu 18.04"
+  default     = ""
   description = "image name to use"
+}
+
+variable "image_properties_query" {
+  default = {
+    os_distro  = "ubuntu"
+    os_version = "18.04"
+  }
+  description = "in absense of var.image, this will be used to query API for the image"
 }
 
 variable "subnet_cidr" {

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -103,8 +103,6 @@ function setup_ci_environment_vars() {
     export OS_PASSWORD=${OS_PASSWORD}
     export TF_VAR_external_network_name="ext-net"
     export TF_VAR_subnet_cidr="10.0.42.0/24"
-    export TF_VAR_image="Ubuntu Bionic 18.04 (2020-03-12)"
-    export TF_VAR_lb_flavor="m1.tiny"
     echo "${OS_K1_CREDENTIALS}" >/tmp/credentials.yaml
     CREDENTIALS_FILE_PATH=/tmp/credentials.yaml
     ;;

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -256,7 +256,7 @@ func TestClusterConformance(t *testing.T) {
 
 			// Ensure nodes are ready and version is matching desired
 			t.Log("Waiting for all nodes to become ready…")
-			if err = waitForNodesReady(client, tc.expectedNumberOfNodes); err != nil {
+			if err = waitForNodesReady(t, client, tc.expectedNumberOfNodes); err != nil {
 				t.Fatalf("failed to bring up all nodes up: %v", err)
 			}
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -82,12 +82,13 @@ func setupTearDown(p provisioner.Provisioner, k *Kubeone) func(t *testing.T) {
 	}
 }
 
-func waitForNodesReady(client dynclient.Client, expectedNumberOfNodes int) error {
+func waitForNodesReady(t *testing.T, client dynclient.Client, expectedNumberOfNodes int) error {
 	return wait.Poll(5*time.Second, 10*time.Minute, func() (bool, error) {
 		nodes := corev1.NodeList{}
 
 		if err := client.List(context.Background(), &nodes); err != nil {
-			return false, errors.Wrap(err, "unable to list nodes")
+			t.Logf("error: %v", err)
+			return false, nil
 		}
 
 		if len(nodes.Items) != expectedNumberOfNodes {

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -230,7 +230,7 @@ func TestClusterUpgrade(t *testing.T) {
 			// Ensure nodes are ready and version is matching desired
 			t.Log("Waiting for all nodes to become ready…")
 
-			err = waitForNodesReady(client, tc.expectedNumberOfNodes)
+			err = waitForNodesReady(t, client, tc.expectedNumberOfNodes)
 			if err != nil {
 				t.Fatalf("nodes are not ready: %v", err)
 			}
@@ -276,7 +276,7 @@ func TestClusterUpgrade(t *testing.T) {
 			// Ensure nodes are ready and version is matching desired
 			t.Log("Waiting for all nodes to become ready…")
 
-			err = waitForNodesReady(client, tc.expectedNumberOfNodes)
+			err = waitForNodesReady(t, client, tc.expectedNumberOfNodes)
 			if err != nil {
 				t.Fatalf("nodes are not ready: %v", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Named image selection in e2e tests for openstack gave us a lot of headache as images are quite often changed at our provider side. This will ensure that we always get an image to use by default without naming it explicitly.

```release-note
NONE
```
