### PR TITLE
Allow node resources in examples/terraform/vsphere to be changed by variables

### DIFF
--- a/examples/terraform/vsphere/main.tf
+++ b/examples/terraform/vsphere/main.tf
@@ -51,7 +51,7 @@ resource "vsphere_virtual_machine" "control_plane" {
   resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
   datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 2
-  memory           = 2048
+  memory           = var.control_plane_memory
   guest_id         = data.vsphere_virtual_machine.template.guest_id
   scsi_type        = data.vsphere_virtual_machine.template.scsi_type
 

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -64,8 +64,8 @@ output "kubeone_workers" {
           datastore     = var.datastore_name
           # Optional: Resize the root disk to this size. Must be bigger than the existing size
           # Default is to leave the disk at the same size as the template
-          diskSizeGB     = 10
-          memoryMB       = 2048
+          diskSizeGB     = var.worker_disk
+          memoryMB       = var.worker_memory
           templateVMName = var.template_name
           vmNetName      = var.network_name
         }

--- a/examples/terraform/vsphere/variables.tf
+++ b/examples/terraform/vsphere/variables.tf
@@ -85,3 +85,18 @@ variable "disk_size" {
   description = "disk size"
 }
 
+variable "control_plane_memory" {
+  default = 2048
+  description = "memory size of each control plane node in MB"
+}
+
+variable "worker_memory" {
+  default = 2048
+  description = "memory size of each worker node in MB"
+}
+
+variable "worker_disk" {
+  default = 10
+  description = "disk size of each worker node in GB"
+}
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes is easier to install KubeOne within vsphere without running OOM

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Increased vsphere template resource definitions
```
