### PR TITLE
Support Kubernetes 1.18

### DIFF
--- a/pkg/kubeflags/data.go
+++ b/pkg/kubeflags/data.go
@@ -17,20 +17,7 @@ limitations under the License.
 package kubeflags
 
 var (
-	defaultAdmissionControllersv1130v1132 = []string{
-		"NamespaceLifecycle",
-		"LimitRanger",
-		"ServiceAccount",
-		"Priority",
-		"DefaultTolerationSeconds",
-		"DefaultStorageClass",
-		"PersistentVolumeClaimResize",
-		"MutatingAdmissionWebhook",
-		"ValidatingAdmissionWebhook",
-		"ResourceQuota",
-	}
-
-	defaultAdmissionControllersv1133v114x = []string{
+	defaultAdmissionControllersv114x = []string{
 		"NamespaceLifecycle",
 		"LimitRanger",
 		"ServiceAccount",
@@ -59,7 +46,7 @@ var (
 		"ResourceQuota",
 	}
 
-	defaultAdmissionControllersv116x = []string{
+	defaultAdmissionControllersv116xv117x = []string{
 		"NamespaceLifecycle",
 		"LimitRanger",
 		"ServiceAccount",
@@ -72,6 +59,26 @@ var (
 		"MutatingAdmissionWebhook",
 		"ValidatingAdmissionWebhook",
 		"RuntimeClass",
+		"ResourceQuota",
+	}
+
+	defaultAdmissionControllersv118x = []string{
+		"NamespaceLifecycle",
+		"LimitRanger",
+		"ServiceAccount",
+		"TaintNodesByCondition",
+		"Priority",
+		"DefaultTolerationSeconds",
+		"DefaultStorageClass",
+		"StorageObjectInUseProtection",
+		"PersistentVolumeClaimResize",
+		"RuntimeClass",
+		"CertificateApproval",
+		"CertificateSigning",
+		"CertificateSubjectRestriction",
+		"DefaultIngressClass",
+		"MutatingAdmissionWebhook",
+		"ValidatingAdmissionWebhook",
 		"ResourceQuota",
 	}
 )

--- a/pkg/kubeflags/flags.go
+++ b/pkg/kubeflags/flags.go
@@ -23,28 +23,28 @@ import (
 )
 
 var (
-	constrainv1130v1132 = mustConstraint(">= 1.13.0, < 1.13.3")
-	constrainv1133v114x = mustConstraint(">= 1.13.3, < 1.15.0")
+	constrainv114x      = mustConstraint(">= 1.14.0, < 1.15.0")
 	constrainv115x      = mustConstraint("1.15.x")
-	constrainv116x      = mustConstraint("1.16.x")
+	constrainv116xv117x = mustConstraint(">= 1.16.0, < 1.18.0")
+	constrainv118x      = mustConstraint("1.18.x")
 )
 
 // DefaultAdmissionControllers return list of default admission controllers for
 // given kubernetes version
 func DefaultAdmissionControllers(kubeVersion *semver.Version) string {
 	switch {
-	case constrainv1130v1132.Check(kubeVersion):
-		return strings.Join(defaultAdmissionControllersv1130v1132, ",")
-	case constrainv1133v114x.Check(kubeVersion):
-		return strings.Join(defaultAdmissionControllersv1133v114x, ",")
+	case constrainv114x.Check(kubeVersion):
+		return strings.Join(defaultAdmissionControllersv114x, ",")
 	case constrainv115x.Check(kubeVersion):
 		return strings.Join(defaultAdmissionControllersv115x, ",")
-	case constrainv116x.Check(kubeVersion):
-		return strings.Join(defaultAdmissionControllersv116x, ",")
+	case constrainv116xv117x.Check(kubeVersion):
+		return strings.Join(defaultAdmissionControllersv116xv117x, ",")
+	case constrainv118x.Check(kubeVersion):
+		return strings.Join(defaultAdmissionControllersv118x, ",")
 	}
 
 	// return same as for last known release
-	return strings.Join(defaultAdmissionControllersv116x, ",")
+	return strings.Join(defaultAdmissionControllersv118x, ",")
 }
 
 func mustConstraint(c string) *semver.Constraints {

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -215,9 +215,10 @@ func machineControllerClusterRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"update"},
 			},
 			{
-				APIGroups: []string{"certificates.k8s.io"},
-				Resources: []string{"certificatesigningrequests/status"},
-				Verbs:     []string{"edit", "update"},
+				APIGroups:     []string{"certificates.k8s.io"},
+				Resources:     []string{"signers"},
+				ResourceNames: []string{"kubernetes.io/kubelet-serving"},
+				Verbs:         []string{"approve"},
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for Kubernetes 1.18. The following changes had to be done to make this possible:
* Update default admission controllers to match those enabled by default on 1.18
* Update `machine-controller` RBAC roles, so the NodeCSRApprover controller can approve the kubelet serving certificates

The CNI plugin is version 0.7.5 because the `kubelet` and `kubeadm` are still depending on the `kubernetes-cni` package. The latest `kubernetes-cni` package is 0.7.5 because of some compatibility problems. This is supposed to be fixed for 1.19, but until now, it is okay to use CNI v0.7.5.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #838 (to be closed after cherry-pick on release/v0.11)

**Does this PR introduce a user-facing change?**:
```release-note
Support Kubernetes 1.18
```

/assign @kron4eg 