### PR TITLE
Change default make target to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,17 @@ GITTAG=$(shell git describe --tags --always)
 GOLDFLAGS?=-extldflags=-zrelro -extldflags=-znow -s -w -X github.com/kubermatic/kubeone/pkg/cmd.version=$(GITTAG) -X github.com/kubermatic/kubeone/pkg/cmd.commit=$(GITCOMMIT) -X github.com/kubermatic/kubeone/pkg/cmd.date=$(BUILD_DATE)
 
 .PHONY: all
-all: install
-
-.PHONY: install
-install: buildenv
-	go install -ldflags='$(GOLDFLAGS)' -v .
+all: build
 
 .PHONY: build
 build: dist/kubeone
+
+dist/kubeone: buildenv
+	go build -ldflags='$(GOLDFLAGS)' -v -o $@ .
+
+.PHONY: install
+install: build
+	go install -ldflags='$(GOLDFLAGS)' -v .
 
 .PHONY: vendor
 vendor: buildenv download-dependencies
@@ -40,9 +43,6 @@ vendor: buildenv download-dependencies
 .PHONY: download-dependencies
 download-dependencies: buildenv
 	go mod download
-
-dist/kubeone: buildenv
-	go build -ldflags='$(GOLDFLAGS)' -v -o $@ .
 
 .PHONY: generate-internal-groups
 generate-internal-groups: GOFLAGS = -mod=readonly


### PR DESCRIPTION
**What this PR does / why we need it**:
Usually the default target of `make` is something that builds the project it manages. Currently kubeone has `install` as default target which installs kubeone to the gopath, but does not touch the `dist/` folder. This leads to confusion (on my side). I would like to change the default target to `build` and make `install` depending on it, even though both targets build the binary for themselves.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
