### PR TITLE
Add changelog for the v0.11.1 release and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+# [v0.11.1](https://github.com/kubermatic/kubeone/releases/tag/v0.11.1) - 2020-04-07
+
+## Added
+
+* Add support for Kubernetes 1.18 ([#841](https://github.com/kubermatic/kubeone/pull/841))
+
+## Changed
+
+### Bug Fixes
+
+* Ensure machine-controller CRDs are Established before deploying MachineDeployments ([#824](https://github.com/kubermatic/kubeone/pull/824))
+* Fix `leader_ip` parsing from Terraform ([#819](https://github.com/kubermatic/kubeone/pull/819))
+
+### Updated
+
+* Update machine-controller to v1.11.1 ([#808](https://github.com/kubermatic/kubeone/pull/808))
+  * NodeCSRApprover controller is enabled by default to automatically approve CSRs for kubelet serving certificates
+  * machine-controller types are updated to include recently added fields
+  * Terraform example scripts are updated with the new fields
+
 # [v0.11.0](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0) - 2020-03-05
 
 **Changelog since v0.10.0. For changelog since v0.11.0-beta.3, please check the [release notes](https://github.com/kubermatic/kubeone/releases/tag/v0.11.0)**

--- a/docs/quickstart-aws.md
+++ b/docs/quickstart-aws.md
@@ -9,7 +9,7 @@ As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with thre
 To follow this quick start, you'll need:
 
 * `kubeone` v0.11.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
-* `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
+* `terraform` v0.12.10 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials
 

--- a/docs/quickstart-aws.md
+++ b/docs/quickstart-aws.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-azure.md
+++ b/docs/quickstart-azure.md
@@ -12,7 +12,7 @@ three control plane nodes and one worker node.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-digitalocean.md
+++ b/docs/quickstart-digitalocean.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-gce.md
+++ b/docs/quickstart-gce.md
@@ -12,7 +12,7 @@ three control plane nodes and one worker node.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-hetzner.md
+++ b/docs/quickstart-hetzner.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-openstack.md
+++ b/docs/quickstart-openstack.md
@@ -8,7 +8,7 @@ As a result, you'll get Kubernetes 1.16.1 High-Available (HA) clusters with thre
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-packet.md
+++ b/docs/quickstart-packet.md
@@ -12,7 +12,7 @@ three control plane nodes and one worker node (which can be easily scaled).
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials

--- a/docs/quickstart-vsphere.md
+++ b/docs/quickstart-vsphere.md
@@ -12,7 +12,7 @@ three control plane nodes and one worker node.
 
 To follow this quick start, you'll need:
 
-* `kubeone` v0.11.0 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
+* `kubeone` v0.11.1 or newer installed, which can be done by following the `Installing KubeOne` section of [the README](https://github.com/kubermatic/kubeone/blob/master/README.md),
 * `terraform` v0.12.0 or later installed. Older releases are not compatible. The binaries for `terraform` can be found on the [Terraform website](https://www.terraform.io/downloads.html)
 
 ## Setting Up Credentials


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add changelog for the v0.11.1 release
* Update recommended KubeOne version to v0.11.1
* Update recommended Terraform version for AWS to v0.12.10

Tentatively, the plan is to release today (April 7th).

**Special notes for your reviewer**:

Docs PR: https://github.com/loodse/docs/pull/295

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 
/hold