### PR TITLE
Update release date for v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# [v0.11.1](https://github.com/kubermatic/kubeone/releases/tag/v0.11.1) - 2020-04-07
+# [v0.11.1](https://github.com/kubermatic/kubeone/releases/tag/v0.11.1) - 2020-04-08
 
 ## Added
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Originally, we have planned to release v0.11.1 yesterday, but we have decided to move it for today. This PR updates the release date in the changelog.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/assign @kron4eg 