### PR TITLE
Add no-init option to the install command

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -35,6 +35,7 @@ type installOptions struct {
 	globalOptions
 	Manifest   string
 	BackupFile string
+	NoInit     bool
 }
 
 // installCmd setups install command
@@ -72,6 +73,7 @@ It's possible to source information about hosts from Terraform output, using the
 	}
 
 	cmd.Flags().StringVarP(&iopts.BackupFile, "backup", "b", "", "path to where the PKI backup .tar.gz file should be placed (default: location of cluster config file)")
+	cmd.Flags().BoolVarP(&iopts.NoInit, "no-init", "", false, "don't initialize the cluster (only install binaries)")
 
 	return cmd
 }
@@ -125,6 +127,7 @@ func createInstallerOptions(clusterFile string, cluster *kubeoneapi.KubeOneClust
 		Manifest:        options.Manifest,
 		CredentialsFile: options.CredentialsFilePath,
 		BackupFile:      options.BackupFile,
+		NoInit:          options.NoInit,
 		Verbose:         options.Verbose,
 	}, nil
 }

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -33,6 +33,7 @@ type Options struct {
 	Manifest        string
 	CredentialsFile string
 	BackupFile      string
+	NoInit          bool
 	DestroyWorkers  bool
 	RemoveBinaries  bool
 }
@@ -91,6 +92,7 @@ func (i *Installer) createState(options *Options) (*state.State, error) {
 	s.ManifestFilePath = options.Manifest
 	s.CredentialsFilePath = options.CredentialsFile
 	s.BackupFile = options.BackupFile
+	s.NoInit = options.NoInit
 	s.DestroyWorkers = options.DestroyWorkers
 	s.RemoveBinaries = options.RemoveBinaries
 	return s, nil

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -51,6 +51,7 @@ type State struct {
 	DynamicClient             dynclient.Client
 	Verbose                   bool
 	BackupFile                string
+	NoInit                    bool
 	DestroyWorkers            bool
 	RemoveBinaries            bool
 	ForceUpgrade              bool


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `no-init` option to the install command. This option instructs the install command just to install the binaries and deploy configuration files. This is useful in disaster recovery scenarios.

The no-init is used such as:
```
kubeone install config.yaml -t . --no-init
```

**Does this PR introduce a user-facing change?**:
```release-note
Add ability to skip cluster provisioning when running the install command using the --no-init flag
```

/assign @kron4eg 