### PR TITLE
addons: apply only yaml/yml/json manifests

### DIFF
--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -78,6 +78,14 @@ func loadAddonsManifests(addonsPath string, logger logrus.FieldLogger, verbose b
 			logger.Infof("Found directory '%s' in the addons path. Ignoring.\n", file.Name())
 			continue
 		}
+		ext := strings.ToLower(filepath.Ext(filePath))
+		// Only YAML/YML and JSON manifests are supported
+		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+			if verbose {
+				logger.Infof("Skipping file '%s' because it's not .yaml/.yml/.json file\n", file.Name())
+			}
+			continue
+		}
 		if verbose {
 			logger.Infof("Parsing addons manifest '%s'\n", file.Name())
 		}

--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -79,10 +79,12 @@ func loadAddonsManifests(addonsPath string, logger logrus.FieldLogger, verbose b
 			continue
 		}
 		ext := strings.ToLower(filepath.Ext(filePath))
-		// Only YAML/YML and JSON manifests are supported
-		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+		// Only YAML, YML and JSON manifests are supported
+		switch ext {
+		case ".yaml", ".yml", ".json":
+		default:
 			if verbose {
-				logger.Infof("Skipping file '%s' because it's not .yaml/.yml/.json file\n", file.Name())
+				logger.Infof("Skipping file %q because it's not .yaml/.yml/.json file\n", file.Name())
 			}
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Apply only addons that have `.yaml`, `.yml` and `.json` extensions.

This prevents errors such as:
```
INFO[12:46:28 CEST] Applying addons…                             
INFO[12:46:28 CEST] Parsing addons manifest 'README.md'          
WARN[12:46:28 CEST] Task failed…                                 
WARN[12:46:28 CEST] error was: failed to decode manifest README.md: error converting YAML to JSON: yaml: line 4: mapping values are not allowed in this context 
```

**Does this PR introduce a user-facing change?**:
```release-note
Apply only addons with .yaml, .yml and .json extensions
```

/assign @kron4eg 