### PR TITLE
Ignore etcd data if it is present on CP node

### DIFF
--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -21,7 +21,8 @@ const (
 if [[ -f /etc/kubernetes/admin.conf ]]; then exit 0; fi
 
 sudo kubeadm join {{ .VERBOSE }} \
-	--config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
+	--config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml \
+	--ignore-preflight-errors=DirAvailable--var-lib-etcd
 `
 
 	kubeadmWorkerJoinScriptTemplate = `
@@ -45,7 +46,9 @@ if [[ -f /etc/kubernetes/admin.conf ]]; then
 	sudo kubeadm {{ .VERBOSE }} token create {{ .TOKEN }} --ttl {{ .TOKEN_DURATION }}
 	exit 0;
 fi
-sudo kubeadm {{ .VERBOSE }} init --config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
+sudo kubeadm {{ .VERBOSE }} \
+	init --config=./{{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml \
+	--ignore-preflight-errors=DirAvailable--var-lib-etcd
 `
 
 	kubeadmResetScriptTemplate = `


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR instructs kubeadm to ignore the `/var/lib/etcd` (etcd data) directory if it's present on the control plane node. This is needed for the cluster disaster recovery scenarios.

**Does this PR introduce a user-facing change?**:
```release-note
Ignore etcd data if it is present on the control plane node
```

/assign @kron4eg 
