### PR TITLE
Save etcd snapshot as etcd-snapshot.db

### DIFF
--- a/addons/backups-restic/backups-restic.yaml
+++ b/addons/backups-restic/backups-restic.yaml
@@ -65,7 +65,7 @@ spec:
               cp -a /etc/kubernetes/pki/front-proxy-ca.key /backup/pki/kubernetes
               cp -a /etc/kubernetes/pki/sa.key /backup/pki/kubernetes
               cp -a /etc/kubernetes/pki/sa.pub /backup/pki/kubernetes
-              etcdctl snapshot save /backup/${ETCD_HOSTNAME}-snapshot.db
+              etcdctl snapshot save /backup/etcd-snapshot.db
             env:
             - name: ETCDCTL_API
               value: "3"


### PR DESCRIPTION
**What this PR does / why we need it**:

Save the etcd snapshot as `etcd-snapshot.db` for backups done using the addon.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 
