### PR TITLE
Introduce flatcar linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ upgrade to the v0.6.0 or newer as soon as possible.
 * Supports Kubernetes 1.13+ High-Available (HA) clusters
 * Uses `kubeadm` to provision clusters
 * Comes with a straightforward and easy to use CLI
-* Choice of Linux distributions between Ubuntu, CentOS and CoreOS
+* Choice of Linux distributions between Ubuntu, CentOS and CoreOS/Flatcar
 * Integrates with [Cluster-API][7] and [Kubermatic machine-controller][8] to
   manage worker nodes
 * Integrates with Terraform for sourcing data about infrastructure and control

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -25,6 +25,7 @@ variable "worker_os" {
   # * ubuntu
   # * centos
   # * coreos
+  # * flatcar
   default = "ubuntu"
 }
 

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -272,6 +272,7 @@ sudo yum install -y --disableexcludes=kubernetes \
 	kubeadm-{{ .KUBERNETES_VERSION }}-0 \
 	kubernetes-cni-{{ .CNI_VERSION }}-0
 `
+
 	upgradeKubeadmAndCNICoreOSScriptTemplate = `
 source /etc/kubeone/proxy-env
 

--- a/pkg/tasks/kubernetes_binaries.go
+++ b/pkg/tasks/kubernetes_binaries.go
@@ -24,45 +24,24 @@ import (
 	"github.com/kubermatic/kubeone/pkg/state"
 )
 
-const (
-	osNameDebian = "debian"
-	osNameUbuntu = "ubuntu"
-	osNameCoreos = "coreos"
-	osNameCentos = "centos"
-)
-
 func upgradeKubeletAndKubectlBinaries(s *state.State, node kubeoneapi.HostConfig) error {
-	var err error
-
-	switch node.OperatingSystem {
-	case osNameDebian, osNameUbuntu:
-		err = upgradeKubeletAndKubectlBinariesDebian(s)
-	case osNameCoreos:
-		err = upgradeKubeletAndKubectlBinariesCoreOS(s)
-	case osNameCentos:
-		err = upgradeKubeletAndKubectlBinariesCentOS(s)
-	default:
-		err = errors.Errorf("%q is not a supported operating system", node.OperatingSystem)
-	}
-
-	return err
+	return runOnOS(s, osNameEnum(node.OperatingSystem), map[osNameEnum]runOnOSFn{
+		osNameDebian:  upgradeKubeletAndKubectlBinariesDebian,
+		osNameUbuntu:  upgradeKubeletAndKubectlBinariesDebian,
+		osNameCoreos:  upgradeKubeletAndKubectlBinariesCoreOS,
+		osNameFlatcar: upgradeKubeletAndKubectlBinariesCoreOS,
+		osNameCentos:  upgradeKubeletAndKubectlBinariesCentOS,
+	})
 }
 
 func upgradeKubeadmAndCNIBinaries(s *state.State, node kubeoneapi.HostConfig) error {
-	var err error
-
-	switch node.OperatingSystem {
-	case osNameDebian, osNameUbuntu:
-		err = upgradeKubeadmAndCNIBinariesDebian(s)
-	case osNameCoreos:
-		err = upgradeKubeadmAndCNIBinariesCoreOS(s)
-	case osNameCentos:
-		err = upgradeKubeadmAndCNIBinariesCentOS(s)
-	default:
-		err = errors.Errorf("%q is not a supported operating system", node.OperatingSystem)
-	}
-
-	return err
+	return runOnOS(s, osNameEnum(node.OperatingSystem), map[osNameEnum]runOnOSFn{
+		osNameDebian:  upgradeKubeadmAndCNIBinariesDebian,
+		osNameUbuntu:  upgradeKubeadmAndCNIBinariesDebian,
+		osNameCoreos:  upgradeKubeadmAndCNIBinariesCoreOS,
+		osNameFlatcar: upgradeKubeadmAndCNIBinariesCoreOS,
+		osNameCentos:  upgradeKubeadmAndCNIBinariesCentOS,
+	})
 }
 
 func upgradeKubeletAndKubectlBinariesDebian(s *state.State) error {

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -77,20 +77,13 @@ func createEnvironmentFile(s *state.State) error {
 }
 
 func installKubeadm(s *state.State, node kubeoneapi.HostConfig) error {
-	var err error
-
-	switch node.OperatingSystem {
-	case osNameDebian, osNameUbuntu:
-		err = installKubeadmDebian(s)
-	case osNameCoreos:
-		err = installKubeadmCoreOS(s)
-	case osNameCentos:
-		err = installKubeadmCentOS(s)
-	default:
-		err = errors.Errorf("%q is not a supported operating system", node.OperatingSystem)
-	}
-
-	return err
+	return runOnOS(s, osNameEnum(node.OperatingSystem), map[osNameEnum]runOnOSFn{
+		osNameDebian:  installKubeadmDebian,
+		osNameUbuntu:  installKubeadmDebian,
+		osNameCoreos:  installKubeadmCoreOS,
+		osNameFlatcar: installKubeadmCoreOS,
+		osNameCentos:  installKubeadmCentOS,
+	})
 }
 
 func installKubeadmDebian(s *state.State) error {

--- a/pkg/tasks/reset.go
+++ b/pkg/tasks/reset.go
@@ -126,19 +126,13 @@ func removeBinaries(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connec
 		return errors.Wrap(err, "failed to determine operating system")
 	}
 
-	// Remove Kubernetes binaries
-	switch node.OperatingSystem {
-	case osNameDebian, osNameUbuntu:
-		err = removeBinariesDebian(s)
-	case osNameCentos:
-		err = removeBinariesCentOS(s)
-	case osNameCoreos:
-		err = removeBinariesCoreOS(s)
-	default:
-		err = errors.Errorf("%q is not a supported operating system", node.OperatingSystem)
-	}
-
-	return err
+	return runOnOS(s, osNameEnum(node.OperatingSystem), map[osNameEnum]runOnOSFn{
+		osNameDebian:  removeBinariesDebian,
+		osNameUbuntu:  removeBinariesDebian,
+		osNameCoreos:  removeBinariesCoreOS,
+		osNameFlatcar: removeBinariesCoreOS,
+		osNameCentos:  removeBinariesCentOS,
+	})
 }
 
 func removeBinariesDebian(s *state.State) error {

--- a/pkg/tasks/util.go
+++ b/pkg/tasks/util.go
@@ -115,3 +115,24 @@ func unlabelNode(client dynclient.Client, host *kubeoneapi.HostConfig) error {
 
 	return errors.Wrapf(retErr, "failed to remove label %s from node %s", labelUpgradeLock, host.Hostname)
 }
+
+type osNameEnum string
+
+type runOnOSFn func(*state.State) error
+
+const (
+	osNameDebian  osNameEnum = "debian"
+	osNameUbuntu  osNameEnum = "ubuntu"
+	osNameCoreos  osNameEnum = "coreos"
+	osNameFlatcar osNameEnum = "flatcar"
+	osNameCentos  osNameEnum = "centos"
+)
+
+func runOnOS(s *state.State, osname osNameEnum, fnMap map[osNameEnum]runOnOSFn) error {
+	fn, ok := fnMap[osname]
+	if !ok {
+		return errors.Errorf("%q is not a supported operating system", osname)
+	}
+
+	return errors.WithStack(fn(s))
+}

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -46,7 +46,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.11.2"
+	MachineControllerTag           = "v1.13.0"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster

--- a/test/e2e/os.go
+++ b/test/e2e/os.go
@@ -29,12 +29,14 @@ const (
 	OperatingSystemUbuntu  OperatingSystem = "ubuntu"
 	OperatingSystemCentOS  OperatingSystem = "centos"
 	OperatingSystemCoreOS  OperatingSystem = "coreos"
+	OperatingSystemFlatcar OperatingSystem = "flatcar"
 	OperatingSystemDefault OperatingSystem = ""
 )
 
 func ValidateOperatingSystem(osName string) error {
 	switch OperatingSystem(osName) {
-	case OperatingSystemUbuntu, OperatingSystemCentOS, OperatingSystemCoreOS, OperatingSystemDefault:
+	case OperatingSystemUbuntu, OperatingSystemCoreOS, OperatingSystemFlatcar,
+		OperatingSystemCentOS, OperatingSystemDefault:
 		return nil
 	}
 	return errors.New("failed to validate operating system")
@@ -64,6 +66,9 @@ func discoverAWSImage(osName OperatingSystem) (string, string, error) {
 		return "ami-0e1ab783dc9489f34", "centos", nil
 	case OperatingSystemCoreOS:
 		return "ami-04de4c2943ebaa320", "core", nil
+	case OperatingSystemFlatcar:
+		return "ami-083e4a190c9b050b1", "core", nil
 	}
+
 	return "", "", errors.New("operating system not matched")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Partial support for Flatcar linux, partial because at the moment machine-controller supports it only at AWS.

Ref  #870

```release-note
* upgrade machine-controller to v1.13.0
* add flatcar linux support (on AWS)
```
