### PR TITLE
CLI BREAKING Replace positional argument for config.yaml with global flag

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -73,7 +73,7 @@ func installCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	opts := &installOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "install <manifest>",
+		Use:   "install",
 		Short: "Install Kubernetes",
 		Long: `
 Install Kubernetes on pre-existing machines
@@ -82,8 +82,7 @@ This command takes KubeOne manifest which contains information about hosts and
 how the cluster should be provisioned. It's possible to source information about
 hosts from Terraform output, using the '--tfjson' flag.
 `,
-		Args:    cobra.ExactArgs(1),
-		Example: `kubeone install mycluster.yaml -t terraformoutput.json`,
+		Example: `kubeone install -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)
 			if err != nil {
@@ -91,8 +90,6 @@ hosts from Terraform output, using the '--tfjson' flag.
 			}
 
 			opts.globalOptions = *gopts
-			opts.ManifestFile = args[0]
-
 			return runInstall(opts)
 		},
 	}

--- a/pkg/cmd/kubeconfig.go
+++ b/pkg/cmd/kubeconfig.go
@@ -29,7 +29,7 @@ import (
 // KubeconfigCommand returns the structure for declaring the "install" subcommand.
 func kubeconfigCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "kubeconfig <manifest>",
+		Use:   "kubeconfig",
 		Short: "Download the kubeconfig file from master",
 		Long: `
 Download the kubeconfig file from master.
@@ -38,14 +38,12 @@ This command takes KubeOne manifest which contains information about hosts.
 It's possible to source information about hosts from Terraform output, using the
 '--tfjson' flag.
 `,
-		Args:    cobra.ExactArgs(1),
-		Example: `kubeone kubeconfig mycluster.yaml -t terraformoutput.json`,
+		Example: `kubeone kubeconfig -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)
 			if err != nil {
 				return errors.Wrap(err, "unable to get global flags")
 			}
-			gopts.ManifestFile = args[0]
 
 			return runKubeconfig(gopts)
 		},

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -47,7 +47,7 @@ func resetCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	opts := &resetOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "reset <manifest>",
+		Use:   "reset",
 		Short: "Revert changes",
 		Long: `
 Undo all changes done by KubeOne to the configured machines.
@@ -56,8 +56,7 @@ This command takes KubeOne manifest which contains information about hosts.
 It's possible to source information about hosts from Terraform output, using the
 '--tfjson' flag.
 `,
-		Args:    cobra.ExactArgs(1),
-		Example: `kubeone reset mycluster.yaml -t terraformoutput.json`,
+		Example: `kubeone reset -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)
 			if err != nil {
@@ -65,8 +64,6 @@ It's possible to source information about hosts from Terraform output, using the
 			}
 
 			opts.globalOptions = *gopts
-			opts.ManifestFile = args[0]
-
 			return runReset(opts)
 		},
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -77,6 +77,12 @@ func newRoot() *cobra.Command {
 
 	fs := rootCmd.PersistentFlags()
 
+	fs.StringVarP(&opts.ManifestFile,
+		longFlagName(opts, "ManifestFile"),
+		shortFlagName(opts, "ManifestFile"),
+		"./kubeone.yaml",
+		"Path to the KubeOne config")
+
 	fs.StringVarP(&opts.TerraformState,
 		longFlagName(opts, "TerraformState"),
 		shortFlagName(opts, "TerraformState"),

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -30,7 +30,7 @@ import (
 )
 
 type globalOptions struct {
-	ManifestFile    string
+	ManifestFile    string `longflag:"manifest" shortflag:"m"`
 	TerraformState  string `longflag:"tfjson" shortflag:"t"`
 	CredentialsFile string `longflag:"credentials" shortflag:"c"`
 	Verbose         bool   `longflag:"verbose" shortflag:"v"`
@@ -75,6 +75,12 @@ func shortFlagName(obj interface{}, fieldName string) string {
 
 func persistentGlobalOptions(fs *pflag.FlagSet) (*globalOptions, error) {
 	gf := &globalOptions{}
+
+	manifestFile, err := fs.GetString(longFlagName(gf, "ManifestFile"))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	gf.ManifestFile = manifestFile
 
 	verbose, err := fs.GetBool(longFlagName(gf, "Verbose"))
 	if err != nil {

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -25,33 +25,23 @@ import (
 	"github.com/kubermatic/kubeone/pkg/kubeconfig"
 )
 
-type statusOptions struct {
-	globalOptions
-	Manifest string
-}
-
 // statusCmd returns the structure for declaring the "status" subcommand.
 func statusCmd(rootFlags *pflag.FlagSet) *cobra.Command {
-	opts := &statusOptions{}
 	cmd := &cobra.Command{
-		Use:   "status <manifest>",
+		Use:   "status",
 		Short: "Status of the cluster",
 		Long: `Status of the cluster.
 
 This command takes KubeOne manifest which contains information about hosts.
 It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.`,
-		Args:    cobra.ExactArgs(1),
-		Example: `kubeone status mycluster.yaml -t terraformoutput.json`,
-		RunE: func(_ *cobra.Command, args []string) error {
+		Example: `kubeone status -m mycluster.yaml -t terraformoutput.json`,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)
 			if err != nil {
 				return errors.Wrap(err, "unable to get global flags")
 			}
 
-			opts.globalOptions = *gopts
-			opts.Manifest = args[0]
-
-			return runStatus(opts)
+			return runStatus(gopts)
 		},
 	}
 
@@ -59,7 +49,7 @@ It's possible to source information about hosts from Terraform output, using the
 }
 
 // runStatus gets cluster status
-func runStatus(opts *statusOptions) error {
+func runStatus(opts *globalOptions) error {
 	s, err := opts.BuildState()
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize State")

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -52,17 +52,14 @@ func upgradeCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 
 This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
 It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.`,
-		Args:    cobra.ExactArgs(1),
-		Example: `kubeone upgrade mycluster.yaml -t terraformoutput.json`,
-		RunE: func(_ *cobra.Command, args []string) error {
+		Example: `kubeone upgrade -m mycluster.yaml -t terraformoutput.json`,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)
 			if err != nil {
 				return errors.Wrap(err, "unable to get global flags")
 			}
 
 			opts.globalOptions = *gopts
-			opts.ManifestFile = args[0]
-
 			return runUpgrade(opts)
 		},
 	}

--- a/test/e2e/kubeone.go
+++ b/test/e2e/kubeone.go
@@ -147,7 +147,9 @@ func (k1 *Kubeone) Upgrade(upgradeFlags []string) error {
 func (k1 *Kubeone) Kubeconfig() ([]byte, error) {
 	var kubeconfigBuf bytes.Buffer
 
-	exe := k1.build("kubeconfig", "--tfjson", "tf.json", k1.ConfigurationFilePath)
+	exe := k1.build("kubeconfig",
+		"--tfjson", "tf.json",
+		"--manifest", k1.ConfigurationFilePath)
 	testutil.StdoutTo(&kubeconfigBuf)(exe)
 
 	if err := exe.Run(); err != nil {
@@ -168,7 +170,11 @@ func (k1 *Kubeone) Kubeconfig() ([]byte, error) {
 
 // Reset runs 'kubeone reset' command to destroy worker nodes and unprovision the cluster
 func (k1 *Kubeone) Reset() error {
-	err := k1.run("-v", "reset", "--tfjson", "tf.json", "--destroy-workers", k1.ConfigurationFilePath)
+	err := k1.run("reset",
+		"-v",
+		"--tfjson", "tf.json",
+		"--destroy-workers",
+		"--manifest", k1.ConfigurationFilePath)
 	if err != nil {
 		return fmt.Errorf("destroing workers failed: %w", err)
 	}

--- a/test/e2e/kubeone.go
+++ b/test/e2e/kubeone.go
@@ -110,7 +110,9 @@ func (k1 *Kubeone) Install(tfJSON string, installFlags []string) error {
 		return err
 	}
 
-	flags := []string{"install", "--tfjson", "tf.json", k1.ConfigurationFilePath}
+	flags := []string{"install",
+		"--tfjson", "tf.json",
+		"--manifest", k1.ConfigurationFilePath}
 	if len(installFlags) != 0 {
 		flags = append(flags, installFlags...)
 	}
@@ -125,7 +127,10 @@ func (k1 *Kubeone) Install(tfJSON string, installFlags []string) error {
 
 // Upgrade runs 'kubeone upgrade' command to upgrade the cluster
 func (k1 *Kubeone) Upgrade(upgradeFlags []string) error {
-	flags := []string{"upgrade", "--tfjson", "tf.json", "--upgrade-machine-deployments", k1.ConfigurationFilePath}
+	flags := []string{"upgrade",
+		"--tfjson", "tf.json",
+		"--upgrade-machine-deployments",
+		"--manifest", k1.ConfigurationFilePath}
 	if len(upgradeFlags) != 0 {
 		flags = append(flags, upgradeFlags...)
 	}


### PR DESCRIPTION
Fixes #866
Fixes #867

docs: https://github.com/loodse/docs/pull/303

```release-note
* CLI BREAKING replace positional argument for config.yaml with global (`--manifest`) flag
* Default new --manifest flag to ./kubeone.yaml
```
