### PR TITLE
Update CloudProviderSpec to match machine-controller fields for vSphere, Azure and RHSM

### DIFF
--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -78,8 +78,6 @@ output "kubeone_workers" {
           tags = {
             "${var.cluster_name}-workers" = ""
           }
-          # Red Hat subscription manager offline token (only to be used for RHEL)
-          # rhsmOfflineToken = ""
         }
       }
     }
@@ -114,8 +112,6 @@ output "kubeone_workers" {
           tags = {
             "${var.cluster_name}-workers" = ""
           }
-          # Red Hat subscription manager offline token (only to be used for RHEL)
-          # rhsmOfflineToken = ""
         }
       }
     }
@@ -150,8 +146,6 @@ output "kubeone_workers" {
           tags = {
             "${var.cluster_name}-workers" = ""
           }
-          # Red Hat subscription manager offline token (only to be used for RHEL)
-          # rhsmOfflineToken = ""
         }
       }
     }

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -73,11 +73,15 @@ output "kubeone_workers" {
           # osDiskSize = 100
           # Size of the data disk (optional)
           # dataDiskSize = 100
+          # Zones (optional)
+          # Represents Availability Zones is a high-availability offering
+          # that protects your applications and data from datacenter failures.
+          # zones = {
+          #   "1"
+          # }
           tags = {
             "${var.cluster_name}-workers" = "pool1"
           }
-          # Red Hat subscription manager offline token (only to be used for RHEL)
-          # rhsmOfflineToken = ""
         }
       }
     }

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -75,8 +75,6 @@ output "kubeone_workers" {
           regional = false
           # Use custom image (optional)
           # customImage = ""
-          # Red Hat subscription manager offline token (only to be used for RHEL)
-          # rhsmOfflineToken = ""
         }
       }
     }

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -74,8 +74,6 @@ output "kubeone_workers" {
           tags = {
             "${var.cluster_name}-workers" = "pool1"
           }
-          # Red Hat subscription manager offline token (only to be used for RHEL)
-          # rhsmOfflineToken = ""
         }
       }
     }

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -70,8 +70,13 @@ output "kubeone_workers" {
           memoryMB       = var.worker_memory
           templateVMName = var.template_name
           vmNetName      = var.network_name
-          # Red Hat subscription manager offline token (only to be used for RHEL)
-          # rhsmOfflineToken = ""
+          # Folder (optional)
+          # folder = ""
+          # Resource pool (optional)
+          # Force VMs to be provisoned to the specified resourcePool
+          # Default is to use the resourcePool of the template VM
+          # example: kubeone or /DC/host/Cluster01/Resources/kubeone
+          resourcePool = var.resource_pool
         }
       }
     }

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -72,11 +72,6 @@ output "kubeone_workers" {
           vmNetName      = var.network_name
           # Folder (optional)
           # folder = ""
-          # Resource pool (optional)
-          # Force VMs to be provisoned to the specified resourcePool
-          # Default is to use the resourcePool of the template VM
-          # example: kubeone or /DC/host/Cluster01/Resources/kubeone
-          resourcePool = var.resource_pool
         }
       }
     }

--- a/examples/terraform/vsphere/variables.tf
+++ b/examples/terraform/vsphere/variables.tf
@@ -70,6 +70,11 @@ variable "datastore_cluster_name" {
   description = "datastore cluster name"
 }
 
+variable "resource_pool" {
+  default     = ""
+  description = "cluster resource pool"
+}
+
 variable "network_name" {
   default     = "public"
   description = "network name"
@@ -91,17 +96,17 @@ variable "disk_size" {
 }
 
 variable "control_plane_memory" {
-  default = 2048
+  default     = 2048
   description = "memory size of each control plane node in MB"
 }
 
 variable "worker_memory" {
-  default = 2048
+  default     = 2048
   description = "memory size of each worker node in MB"
 }
 
 variable "worker_disk" {
-  default = 10
+  default     = 10
   description = "disk size of each worker node in GB"
 }
 

--- a/pkg/templates/machinecontroller/cloudprovider_specs.go
+++ b/pkg/templates/machinecontroller/cloudprovider_specs.go
@@ -33,7 +33,6 @@ type AWSSpec struct {
 	SubnetID           string            `json:"subnetId"`
 	Tags               map[string]string `json:"tags"`
 	VPCID              string            `json:"vpcId"`
-	RHSMOfflineToken   string            `json:"rhsmOfflineToken,omitempty"`
 }
 
 // DigitalOceanSpec holds cloudprovider spec for DigitalOcean
@@ -60,7 +59,6 @@ type OpenStackSpec struct {
 	NodeVolumeAttachLimit *uint             `json:"nodeVolumeAttachLimit,omitempty"`
 	TrustDevicePath       bool              `json:"trustDevicePath"`
 	Tags                  map[string]string `json:"tags"`
-	RHSMOfflineToken      string            `json:"rhsmOfflineToken,omitempty"`
 }
 
 // GCESpec holds cloudprovider spec for GCE
@@ -78,7 +76,6 @@ type GCESpec struct {
 	MultiZone             *bool             `json:"multizone"`
 	Regional              *bool             `json:"regional"`
 	CustomImage           string            `json:"customImage,omitempty"`
-	RHSMOfflineToken      string            `json:"rhsmOfflineToken,omitempty"`
 }
 
 // HetznerSpec holds cloudprovider spec for Hetzner
@@ -112,7 +109,6 @@ type VSphereSpec struct {
 	MemoryMB         int    `json:"memoryMB"`
 	TemplateVMName   string `json:"templateVMName"`
 	VMNetName        string `json:"vmNetName,omitempty"`
-	RHSMOfflineToken string `json:"rhsmOfflineToken,omitempty"`
 }
 
 // AzureSpec holds cloudprovider spec for Azure
@@ -130,5 +126,4 @@ type AzureSpec struct {
 	ImageID           string            `json:"imageID"`
 	OSDiskSize        int               `json:"osDiskSize"`
 	DataDiskSize      int               `json:"dataDiskSize"`
-	RHSMOfflineToken  string            `json:"rhsmOfflineToken,omitempty"`
 }

--- a/pkg/templates/machinecontroller/cloudprovider_specs.go
+++ b/pkg/templates/machinecontroller/cloudprovider_specs.go
@@ -119,6 +119,7 @@ type AzureSpec struct {
 	ResourceGroup     string            `json:"resourceGroup"`
 	RouteTableName    string            `json:"routeTableName"`
 	SecurityGroupName string            `json:"securityGroupName"`
+	Zones             []string          `json:"zones"`
 	SubnetName        string            `json:"subnetName"`
 	Tags              map[string]string `json:"tags"`
 	VMSize            string            `json:"vmSize"`

--- a/pkg/templates/machinecontroller/cloudprovider_specs.go
+++ b/pkg/templates/machinecontroller/cloudprovider_specs.go
@@ -106,6 +106,7 @@ type VSphereSpec struct {
 	DatastoreCluster string `json:"datastoreCluster"`
 	DiskSizeGB       *int   `json:"diskSizeGB,omitempty"`
 	Folder           string `json:"folder"`
+	ResourcePool     string `json:"resourcePool"`
 	MemoryMB         int    `json:"memoryMB"`
 	TemplateVMName   string `json:"templateVMName"`
 	VMNetName        string `json:"vmNetName,omitempty"`

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -238,7 +238,6 @@ func (c *Config) updateAWSWorkerset(existingWorkerSet *kubeonev1alpha1.WorkerCon
 		{key: "subnetId", value: awsCloudConfig.SubnetID},
 		{key: "tags", value: awsCloudConfig.Tags},
 		{key: "vpcId", value: awsCloudConfig.VPCID},
-		{key: "rhsmOfflineToken", value: awsCloudConfig.RHSMOfflineToken},
 	}
 
 	for _, flag := range flags {
@@ -271,7 +270,6 @@ func (c *Config) updateAzureWorkerset(existingWorkerSet *kubeonev1alpha1.WorkerC
 		{key: "imageID", value: azureCloudConfig.ImageID},
 		{key: "osDiskSize", value: azureCloudConfig.OSDiskSize},
 		{key: "dataDiskSize", value: azureCloudConfig.DataDiskSize},
-		{key: "rhsmOfflineToken", value: azureCloudConfig.RHSMOfflineToken},
 	}
 
 	for _, flag := range flags {
@@ -304,7 +302,6 @@ func (c *Config) updateGCEWorkerset(existingWorkerSet *kubeonev1alpha1.WorkerCon
 		{key: "multizone", value: gceCloudConfig.MultiZone},
 		{key: "regional", value: gceCloudConfig.Regional},
 		{key: "customImage", value: gceCloudConfig.CustomImage},
-		{key: "rhsmOfflineToken", value: gceCloudConfig.RHSMOfflineToken},
 	}
 
 	for _, flag := range flags {
@@ -385,7 +382,6 @@ func (c *Config) updateOpenStackWorkerset(existingWorkerSet *kubeonev1alpha1.Wor
 		{key: "nodeVolumeAttachLimit", value: openstackConfig.NodeVolumeAttachLimit},
 		{key: "tags", value: openstackConfig.Tags},
 		{key: "trustDevicePath", value: openstackConfig.TrustDevicePath},
-		{key: "rhsmOfflineToken", value: openstackConfig.RHSMOfflineToken},
 	}
 
 	for _, flag := range flags {
@@ -440,7 +436,6 @@ func (c *Config) updateVSphereWorkerset(existingWorkerSet *kubeonev1alpha1.Worke
 		{key: "memoryMB", value: vsphereConfig.MemoryMB},
 		{key: "templateVMName", value: vsphereConfig.TemplateVMName},
 		{key: "vmNetName", value: vsphereConfig.VMNetName},
-		{key: "rhsmOfflineToken", value: vsphereConfig.RHSMOfflineToken},
 	}
 
 	for _, flag := range flags {

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -434,6 +434,7 @@ func (c *Config) updateVSphereWorkerset(existingWorkerSet *kubeonev1alpha1.Worke
 		{key: "datastoreCluster", value: vsphereConfig.DatastoreCluster},
 		{key: "diskSizeGB", value: vsphereConfig.DiskSizeGB},
 		{key: "folder", value: vsphereConfig.Folder},
+		{key: "resourcePool", value: vsphereConfig.ResourcePool},
 		{key: "memoryMB", value: vsphereConfig.MemoryMB},
 		{key: "templateVMName", value: vsphereConfig.TemplateVMName},
 		{key: "vmNetName", value: vsphereConfig.VMNetName},

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -263,6 +263,7 @@ func (c *Config) updateAzureWorkerset(existingWorkerSet *kubeonev1alpha1.WorkerC
 		{key: "resourceGroup", value: azureCloudConfig.ResourceGroup},
 		{key: "routeTableName", value: azureCloudConfig.RouteTableName},
 		{key: "securityGroupName", value: azureCloudConfig.SecurityGroupName},
+		{key: "zones", value: azureCloudConfig.Zones},
 		{key: "subnetName", value: azureCloudConfig.SubnetName},
 		{key: "tags", value: azureCloudConfig.Tags},
 		{key: "vmSize", value: azureCloudConfig.VMSize},


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add support for vSphere resource pools
* Add support for Azure AZs
* Remove RHSMOfflineToken from the CloudProviderSpec. RHSM settings are now located in the OperatingSystemSpec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #594

**Does this PR introduce a user-facing change?**:
```release-note
Add support for vSphere resource pools
Add support for Azure AZs
Remove RHSMOfflineToken from the CloudProviderSpec. RHSM settings are now located in the OperatingSystemSpec.
```

/assign @kron4eg 