### PR TITLE
Update Packet CCM to v1.0.0

### DIFF
--- a/pkg/templates/externalccm/packet.go
+++ b/pkg/templates/externalccm/packet.go
@@ -41,6 +41,7 @@ const (
 	packetDeploymentName = "packet-cloud-controller-manager"
 
 	packetCloudSASecretName = "packet-cloud-config"
+	//nolint:gosec
 	packetCloudSASecretData = `
 {
 	"apiKey": "{{ .PACKET_API_KEY }}",


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update Packet CCM to v1.0.0
* Automatically create a secret with credentials and configuration needed for the CCM
* Kubernetes 1.15.0+ is now required for Packet

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #750

**Does this PR introduce a user-facing change?**:
```release-note
Update Packet CCM to v1.0.0
Automatically create a secret with credentials and configuration needed for the CCM
Kubernetes 1.15.0+ is now required for Packet
```
