### PR TITLE
Fixes flexvolumes support on all OS including Flatcar / CoreOS

### DIFF
--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -74,6 +74,7 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			"read-only-port":      "0",
 			"rotate-certificates": "true",
 			"cluster-dns":         nodelocaldns.VirtualIP,
+			"volume-plugin-dir":   "/var/lib/kubelet/volumeplugins",
 		},
 	}
 
@@ -152,7 +153,9 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			CertSANs: []string{strings.ToLower(cluster.APIEndpoint.Host)},
 		},
 		ControllerManager: kubeadmv1beta1.ControlPlaneComponent{
-			ExtraArgs:    map[string]string{},
+			ExtraArgs: map[string]string{
+				"flex-volume-plugin-dir": "/var/lib/kubelet/volumeplugins",
+			},
 			ExtraVolumes: []kubeadmv1beta1.HostPathMount{},
 		},
 		ClusterName: cluster.Name,
@@ -242,6 +245,7 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 			"read-only-port":      "0",
 			"rotate-certificates": "true",
 			"cluster-dns":         nodelocaldns.VirtualIP,
+			"volume-plugin-dir":   "/var/lib/kubelet/volumeplugins",
 		},
 	}
 

--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -74,6 +74,7 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			"read-only-port":      "0",
 			"rotate-certificates": "true",
 			"cluster-dns":         nodelocaldns.VirtualIP,
+			"volume-plugin-dir":   "/var/lib/kubelet/volumeplugins",
 		},
 	}
 
@@ -152,7 +153,9 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			CertSANs: []string{strings.ToLower(cluster.APIEndpoint.Host)},
 		},
 		ControllerManager: kubeadmv1beta2.ControlPlaneComponent{
-			ExtraArgs:    map[string]string{},
+			ExtraArgs: map[string]string{
+				"flex-volume-plugin-dir": "/var/lib/kubelet/volumeplugins",
+			},
 			ExtraVolumes: []kubeadmv1beta2.HostPathMount{},
 		},
 		ClusterName: cluster.Name,
@@ -242,6 +245,7 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 			"read-only-port":      "0",
 			"rotate-certificates": "true",
 			"cluster-dns":         nodelocaldns.VirtualIP,
+			"volume-plugin-dir":   "/var/lib/kubelet/volumeplugins",
 		},
 	}
 

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -46,7 +46,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.13.0"
+	MachineControllerTag           = "v1.13.1"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster


### PR DESCRIPTION
xref #870

**Does this PR introduce a user-facing change?**:

```release-note
* Upgrade machine-controller to v1.13.1
* Support flexvolumes on all supported OSes
```
