### PR TITLE
Fix folder usage in vSphere example

### DIFF
--- a/docs/quickstart-vsphere.md
+++ b/docs/quickstart-vsphere.md
@@ -92,6 +92,7 @@ For the list of available settings along with their names please see the
 * `datastore_name` (optional, default = "datastore1") - vSphere datastore name
 * `network_name` (optional, default = "public") - vSphere network name
 * `template_name` (optional, default = "ubuntu-18.04") - vSphere template name to clone VMs from
+* `folder_name` (optional, default = "kubeone") - vSphere VM folder name
 
 The `terraform.tfvars` file can look like:
 
@@ -161,8 +162,9 @@ cloudProvider:
     [Workspace]
     server = "1.1.1.1"
     datacenter = "dc-1"
-    default-datastore="exsi-nas"
-    resourcepool-path="kubeone"
+    default-datastore = "exsi-nas"
+    resourcepool-path = "kubeone"
+    folder = "kubeone"
 
     [Disk]
     scsicontrollertype = pvscsi

--- a/examples/terraform/vsphere/main.tf
+++ b/examples/terraform/vsphere/main.tf
@@ -63,6 +63,7 @@ resource "vsphere_virtual_machine" "control_plane" {
   count            = 3
   name             = "${var.cluster_name}-cp-${count.index + 1}"
   resource_pool_id = local.resource_pool_id
+  folder           = var.folder_name
   datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 2
   memory           = var.control_plane_memory
@@ -108,6 +109,7 @@ resource "vsphere_virtual_machine" "lb" {
   count            = 1
   name             = "${var.cluster_name}-lb-${count.index + 1}"
   resource_pool_id = local.resource_pool_id
+  folder           = var.folder_name
   datastore_id     = data.vsphere_datastore.datastore.id
   num_cpus         = 1
   memory           = 1024

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -71,8 +71,7 @@ output "kubeone_workers" {
           templateVMName = var.template_name
           vmNetName      = var.network_name
           resourcePool   = var.resource_pool_name
-          # Folder (optional)
-          # folder = ""
+          folder         = var.folder_name
         }
       }
     }

--- a/examples/terraform/vsphere/variables.tf
+++ b/examples/terraform/vsphere/variables.tf
@@ -75,6 +75,11 @@ variable "resource_pool_name" {
   description = "cluster resource pool name"
 }
 
+variable "folder_name" {
+  default     = "kubeone"
+  description = "folder name"
+}
+
 variable "network_name" {
   default     = "public"
   description = "network name"


### PR DESCRIPTION
Creating a cluster on vSphere fails if the cloud-config does not contain
a VM folder. Also MachineDeployments cannot be created with and empty
folder or without folder.

This change adds a folder variable to the Terraform example and updates
the vSphere quickstart documentation.

Signed-off-by: Christoph Kleineweber <christoph.kleineweber@loodse.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE
```
