### PR TITLE
Bind docker-ce-cli to the same version as docker-ce

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -88,6 +88,7 @@ cni_ver=$(apt-cache madison kubernetes-cni | grep "{{ .CNI_VERSION }}" | head -1
 sudo apt-mark unhold docker-ce kubelet kubeadm kubectl kubernetes-cni
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	docker-ce=${docker_ver} \
+	docker-ce-cli=${docker_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
 	kubelet=${kube_ver} \
@@ -152,6 +153,7 @@ sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/dock
 
 sudo yum install -y --disableexcludes=kubernetes \
 	docker-ce-{{ .DOCKER_VERSION }} \
+	docker-ce-cli-{{ .DOCKER_VERSION }} \
 	kubelet-{{ .KUBERNETES_VERSION }}-0 \
 	kubeadm-{{ .KUBERNETES_VERSION }}-0 \
 	kubectl-{{ .KUBERNETES_VERSION }}-0 \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -54,6 +54,7 @@ sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/dock
 
 sudo yum install -y --disableexcludes=kubernetes \
 	docker-ce-18.09.9-3.el7 \
+	docker-ce-cli-18.09.9-3.el7 \
 	kubelet-v1.17.4-0 \
 	kubeadm-v1.17.4-0 \
 	kubectl-v1.17.4-0 \

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -73,6 +73,7 @@ cni_ver=$(apt-cache madison kubernetes-cni | grep "0.7.5" | head -1 | awk '{prin
 sudo apt-mark unhold docker-ce kubelet kubeadm kubectl kubernetes-cni
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
 	docker-ce=${docker_ver} \
+	docker-ce-cli=${docker_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
 	kubelet=${kube_ver} \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR binds the `docker-ce-cli` package to the same version as the `docker-ce` package. This fixes the incompatibilities between CLI and daemon, causing provisioning to fail.

Before this fix, we were getting the following error when trying to provision the cluster:

```
Server:
ERROR: Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39
```

This error was present at the `Running kubeadm` phase. It was happening because the latest Docker CLI requires the daemon supporting API version 1.40 or newer.

**Does this PR introduce a user-facing change?**:
```release-note
Bind docker-ce-cli to the same version as docker-ce. This fixes the cluster provisioning failures.
```

/assign @kron4eg 
