### PR TITLE
CentOS: update repo and lock configs before upgrade

### DIFF
--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -193,7 +193,7 @@ func TestUpgradeKubeadmAndCNIDebian(t *testing.T) {
 func TestUpgradeKubeadmAndCNICentOS(t *testing.T) {
 	t.Parallel()
 
-	got, err := UpgradeKubeadmAndCNICentOS("v1.17.4", "v0.7.5")
+	got, err := UpgradeKubeadmAndCNICentOS("v1.17.4", "v0.7.5", true)
 	if err != nil {
 		t.Errorf("UpgradeKubeadmAndCNICentOS() error = %v", err)
 		return

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -3,8 +3,25 @@ export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 source /etc/kubeone/proxy-env
 
-sudo yum versionlock delete kubeadm kubernetes-cni || true
+# Kubeadm and CNI is are the first packages that we upgrade
+# Before upgrading them, override the repo configs with the latest ones
+# and then install and configure the yum-plugin-versionlock package
+
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+
+sudo yum install -y yum-plugin-versionlock
+sudo yum versionlock docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+
+sudo yum versionlock delete kubeadm kubernetes-cni
 sudo yum install -y \
 	kubeadm-v1.17.4-0 \
 	kubernetes-cni-v0.7.5-0
-sudo yum versionlock kubeadm kubernetes-cni || true
+sudo yum versionlock kubeadm kubernetes-cni

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -2,8 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 source /etc/kubeone/proxy-env
-sudo yum versionlock delete kubelet kubectl || true
-sudo yum install -y --disableexcludes=kubernetes \
+sudo yum versionlock delete kubelet kubectl
+sudo yum install -y \
 	kubelet-v1.17.4-0 \
 	kubectl-v1.17.4-0
-sudo yum versionlock kubelet kubectl || true
+sudo yum versionlock kubelet kubectl

--- a/pkg/tasks/kubernetes_binaries.go
+++ b/pkg/tasks/kubernetes_binaries.go
@@ -89,7 +89,7 @@ func upgradeKubeadmAndCNIBinariesDebian(s *state.State) error {
 }
 
 func upgradeKubeadmAndCNIBinariesCentOS(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeadmAndCNICentOS(s.Cluster.Versions.Kubernetes, s.Cluster.Versions.KubernetesCNIVersion())
+	cmd, err := scripts.UpgradeKubeadmAndCNICentOS(s.Cluster.Versions.Kubernetes, s.Cluster.Versions.KubernetesCNIVersion(), s.Cluster.SystemPackages.ConfigureRepositories)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Revert removed --disableexcludes=kubernetes for yum install.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 