### PR TITLE
Fix CoreOS install and upgrade scripts

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -201,23 +201,11 @@ for binary in kubeadm kubelet kubectl; do
 done
 
 cat <<EOF | sudo tee /etc/systemd/system/kubelet.service
-[Service]
-Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
-Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
-# This is a file that "kubeadm init" and "kubeadm join" generate at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
-EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
-# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
-# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
-EnvironmentFile=-/etc/default/kubelet
-ExecStart=
-ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
-EOF
-
-sudo mkdir -p /etc/systemd/system/kubelet.service.d
-cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 [Unit]
 Description=kubelet: The Kubernetes Node Agent
-Documentation=http://kubernetes.io/docs/
+Documentation=https://kubernetes.io/docs/home/
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/opt/bin/kubelet
@@ -227,6 +215,20 @@ RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
+EOF
+
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/usr/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
 EOF
 
 sudo systemctl daemon-reload
@@ -364,13 +366,37 @@ cd /opt/bin
 sudo systemctl stop kubelet
 sudo mv /var/tmp/kube-binaries/{kubelet,kubectl} .
 sudo chmod +x {kubelet,kubectl}
-curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" |
-	sed "s:/usr/bin:/opt/bin:g" |
-	sudo tee /etc/systemd/system/kubelet.service
+
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/home/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/opt/bin/kubelet
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
-curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" |
-	sed "s:/usr/bin:/opt/bin:g" |
-	sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/usr/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
+EOF
 	 
 sudo systemctl daemon-reload
 sudo systemctl start kubelet

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -228,7 +228,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
 ExecStart=
-ExecStart=/usr/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
+ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
 EOF
 
 sudo systemctl daemon-reload
@@ -395,7 +395,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
 ExecStart=
-ExecStart=/usr/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
+ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
 EOF
 	 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
@@ -52,23 +52,11 @@ for binary in kubeadm kubelet kubectl; do
 done
 
 cat <<EOF | sudo tee /etc/systemd/system/kubelet.service
-[Service]
-Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
-Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
-# This is a file that "kubeadm init" and "kubeadm join" generate at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
-EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
-# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
-# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
-EnvironmentFile=-/etc/default/kubelet
-ExecStart=
-ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
-EOF
-
-sudo mkdir -p /etc/systemd/system/kubelet.service.d
-cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 [Unit]
 Description=kubelet: The Kubernetes Node Agent
-Documentation=http://kubernetes.io/docs/
+Documentation=https://kubernetes.io/docs/home/
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/opt/bin/kubelet
@@ -78,6 +66,20 @@ RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
+EOF
+
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCoreOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCoreOS.golden
@@ -29,13 +29,37 @@ cd /opt/bin
 sudo systemctl stop kubelet
 sudo mv /var/tmp/kube-binaries/{kubelet,kubectl} .
 sudo chmod +x {kubelet,kubectl}
-curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" |
-	sed "s:/usr/bin:/opt/bin:g" |
-	sudo tee /etc/systemd/system/kubelet.service
+
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/home/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/opt/bin/kubelet
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
-curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" |
-	sed "s:/usr/bin:/opt/bin:g" |
-	sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
+EOF
 	 
 sudo systemctl daemon-reload
 sudo systemctl start kubelet


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is supposed to fix the CoreOS install and upgrade scripts. Without this fix, the kubelet fails to start due the incorrect formatted service file. This happens because we've swapped the file names when switching from downloading the files to using static files.

**Does this PR introduce a user-facing change?**:
```release-note
Fix CoreOS install and upgrade scripts
```

/assign @kron4eg 