### PR TITLE
Fix Flatcar/CoreOS kubelet unit

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -227,8 +227,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
-ExecStart=
-ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
+ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
 
 sudo systemctl daemon-reload
@@ -394,8 +393,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
-ExecStart=
-ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
+ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
 	 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
@@ -78,8 +78,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
-ExecStart=
-ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
+ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCoreOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCoreOS.golden
@@ -57,8 +57,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
-ExecStart=
-ExecStart=/opt/bin/kubelet $$KUBELET_KUBECONFIG_ARGS $$KUBELET_CONFIG_ARGS $$KUBELET_KUBEADM_ARGS $$KUBELET_EXTRA_ARGS
+ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
 	 
 sudo systemctl daemon-reload


### PR DESCRIPTION
**What this PR does / why we need it**:
Flatcar/CoreOS kubelet unit file still was incorrect, now fixed.

```release-note
Fix Flatcar/CoreOS kubelet unit
```
