### PR TITLE
CoreOS: Add empty ExecStart to the kubelet service file

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -227,6 +227,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
+ExecStart=
 ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
 
@@ -393,6 +394,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
+ExecStart=
 ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
 	 

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
@@ -78,6 +78,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
+ExecStart=
 ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCoreOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCoreOS.golden
@@ -57,6 +57,7 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/default/kubelet
+ExecStart=
 ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
 	 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the empty `ExecStart=` directive to the Kubelet service file on CoreOS. Without that directive, the Kubelet service fails to start with the following error:
```
May 21 14:47:17 marko-1-control-plane-1 systemd[1]: Stopped kubelet: The Kubernetes Node Agent.
May 21 14:47:34 marko-1-control-plane-1 systemd[1]: kubelet.service: Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services. Refusing.
May 21 14:47:34 marko-1-control-plane-1 systemd[1]: kubelet.service: Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services. Refusing.
```

**Does this PR introduce a user-facing change?**:
```release-note
CoreOS: Add empty ExecStart to the kubelet service file
```

/assign @kron4eg 