### PR TITLE
Use v1beta1 API in E2E tests

### DIFF
--- a/pkg/apis/kubeone/v1beta1/helpers.go
+++ b/pkg/apis/kubeone/v1beta1/helpers.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"github.com/pkg/errors"
+)
+
+// SetCloudProvider parses the string representation of the provider
+// name and sets the appropriate CloudProviderSpec field.
+func SetCloudProvider(cp *CloudProviderSpec, name string) error {
+	switch name {
+	case "aws":
+		cp.AWS = &AWSSpec{}
+	case "azure":
+		cp.Azure = &AzureSpec{}
+	case "digitalocean":
+		cp.DigitalOcean = &DigitalOceanSpec{}
+	case "gce":
+		cp.GCE = &GCESpec{}
+	case "hetzner":
+		cp.Hetzner = &HetznerSpec{}
+	case "openstack":
+		cp.Openstack = &OpenstackSpec{}
+	case "packet":
+		cp.Packet = &PacketSpec{}
+	case "vsphere":
+		cp.Vsphere = &VsphereSpec{}
+	case "none":
+		cp.None = &NoneSpec{}
+	default:
+		return errors.Errorf("provider %q is not supported", name)
+	}
+	return nil
+}

--- a/pkg/terraform/v1beta1/config.go
+++ b/pkg/terraform/v1beta1/config.go
@@ -92,7 +92,7 @@ func (c *Config) Apply(cluster *kubeonev1beta1.KubeOneCluster) error {
 	cp := c.KubeOneHosts.Value.ControlPlane
 
 	if cp.CloudProvider != nil {
-		if err := setCloudProvider(&cluster.CloudProvider, *cp.CloudProvider); err != nil {
+		if err := kubeonev1beta1.SetCloudProvider(&cluster.CloudProvider, *cp.CloudProvider); err != nil {
 			return errors.Wrap(err, "failed to set cloud provider")
 		}
 	}
@@ -454,33 +454,6 @@ func (c *Config) updateVSphereWorkerset(existingWorkerSet *kubeonev1beta1.Dynami
 		if err := setWorkersetFlag(existingWorkerSet, flag.key, flag.value); err != nil {
 			return errors.WithStack(err)
 		}
-	}
-
-	return nil
-}
-
-func setCloudProvider(cp *kubeonev1beta1.CloudProviderSpec, name string) error {
-	switch name {
-	case "aws":
-		cp.AWS = &kubeonev1beta1.AWSSpec{}
-	case "azure":
-		cp.Azure = &kubeonev1beta1.AzureSpec{}
-	case "digitalocean":
-		cp.DigitalOcean = &kubeonev1beta1.DigitalOceanSpec{}
-	case "gce":
-		cp.GCE = &kubeonev1beta1.GCESpec{}
-	case "hetzner":
-		cp.Hetzner = &kubeonev1beta1.HetznerSpec{}
-	case "openstack":
-		cp.Openstack = &kubeonev1beta1.OpenstackSpec{}
-	case "packet":
-		cp.Packet = &kubeonev1beta1.PacketSpec{}
-	case "vsphere":
-		cp.Vsphere = &kubeonev1beta1.VsphereSpec{}
-	case "none":
-		cp.None = &kubeonev1beta1.NoneSpec{}
-	default:
-		return errors.Errorf("provider %q is not supported", name)
 	}
 
 	return nil

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	k1api "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
 	"github.com/kubermatic/kubeone/test/e2e/provisioner"
 	"github.com/kubermatic/kubeone/test/e2e/testutil"
 
@@ -40,7 +39,7 @@ const (
 func TestClusterConformance(t *testing.T) {
 	testcases := []struct {
 		name                  string
-		provider              k1api.CloudProviderName
+		provider              string
 		providerExternal      bool
 		scenario              string
 		configFilePath        string
@@ -102,7 +101,7 @@ func TestClusterConformance(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Only run selected test suite.
 			// Test options are controlled using flags.
-			if testProvider != string(tc.provider) {
+			if testProvider != tc.provider {
 				t.SkipNow()
 			}
 
@@ -129,7 +128,7 @@ func TestClusterConformance(t *testing.T) {
 			// Create provisioner
 			testPath := fmt.Sprintf("../../_build/%s", testRunIdentifier)
 
-			pr, err := provisioner.CreateProvisioner(testPath, testRunIdentifier, string(tc.provider))
+			pr, err := provisioner.CreateProvisioner(testPath, testRunIdentifier, tc.provider)
 			if err != nil {
 				t.Fatalf("failed to create provisioner: %v", err)
 			}
@@ -172,7 +171,7 @@ func TestClusterConformance(t *testing.T) {
 			args := []string{}
 
 			if osControlPlane != OperatingSystemDefault {
-				tfFlags, errFlags := ControlPlaneImageFlags(string(tc.provider), osControlPlane)
+				tfFlags, errFlags := ControlPlaneImageFlags(tc.provider, osControlPlane)
 				if errFlags != nil {
 					t.Fatalf("failed to discover control plane os image: %v", errFlags)
 				}
@@ -224,7 +223,7 @@ func TestClusterConformance(t *testing.T) {
 				args = []string{}
 
 				if osControlPlane != OperatingSystemDefault {
-					tfFlags, errFlags := ControlPlaneImageFlags(string(tc.provider), osControlPlane)
+					tfFlags, errFlags := ControlPlaneImageFlags(tc.provider, osControlPlane)
 					if errFlags != nil {
 						t.Fatalf("failed to discover control plane os image: %v", errFlags)
 					}

--- a/test/e2e/kubeone.go
+++ b/test/e2e/kubeone.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
-	k1api "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
+	k1api "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1beta1"
 	"github.com/kubermatic/kubeone/test/e2e/testutil"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +51,7 @@ func NewKubeone(kubeoneDir, configurationFilePath string) *Kubeone {
 // CreateConfig creates a KubeOneCluster manifest
 func (k1 *Kubeone) CreateConfig(
 	kubernetesVersion string,
-	providerName k1api.CloudProviderName,
+	providerName string,
 	providerExternal bool,
 	clusterNetworkPod string,
 	clusterNetworkService string,
@@ -59,7 +59,7 @@ func (k1 *Kubeone) CreateConfig(
 ) error {
 	k1Cluster := k1api.KubeOneCluster{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kubeone.io/v1alpha1",
+			APIVersion: k1api.SchemeGroupVersion.String(),
 			Kind:       "KubeOneCluster",
 		},
 	}
@@ -67,8 +67,10 @@ func (k1 *Kubeone) CreateConfig(
 	k1api.SetObjectDefaults_KubeOneCluster(&k1Cluster)
 
 	k1Cluster.CloudProvider = k1api.CloudProviderSpec{
-		Name:     providerName,
 		External: providerExternal,
+	}
+	if err := k1api.SetCloudProvider(&k1Cluster.CloudProvider, providerName); err != nil {
+		return errors.Wrap(err, "failed to set cloud provider")
 	}
 
 	k1Cluster.Versions = k1api.VersionConfig{

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 
-	k1api "github.com/kubermatic/kubeone/pkg/apis/kubeone/v1alpha1"
 	"github.com/kubermatic/kubeone/test/e2e/provisioner"
 	"github.com/kubermatic/kubeone/test/e2e/testutil"
 
@@ -46,7 +45,7 @@ const (
 func TestClusterUpgrade(t *testing.T) {
 	testcases := []struct {
 		name                  string
-		provider              k1api.CloudProviderName
+		provider              string
 		providerExternal      bool
 		initialConfigPath     string
 		targetConfigPath      string
@@ -120,7 +119,7 @@ func TestClusterUpgrade(t *testing.T) {
 				t.Fatal("-target-version must be set")
 			}
 
-			if testProvider != string(tc.provider) {
+			if testProvider != tc.provider {
 				t.SkipNow()
 			}
 
@@ -129,7 +128,7 @@ func TestClusterUpgrade(t *testing.T) {
 			// Create provisioner
 			testPath := fmt.Sprintf("../../_build/%s", testRunIdentifier)
 
-			pr, err := provisioner.CreateProvisioner(testPath, testRunIdentifier, string(tc.provider))
+			pr, err := provisioner.CreateProvisioner(testPath, testRunIdentifier, tc.provider)
 			if err != nil {
 				t.Fatalf("failed to create provisioner: %v", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the v1beta1 API for E2E tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #828 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 