### PR TITLE
Bump Go and k8s versions in the kubeone-e2e image

### DIFF
--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,7 +14,7 @@
 
 # building image
 
-FROM golang:1.13.4 as builder
+FROM golang:1.14.4 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip \
@@ -37,7 +37,7 @@ RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
-FROM golang:1.13.4
+FROM golang:1.14.4
 
 ARG version
 

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,9 +17,9 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.16"]="v1.16.8"
-full_versions["1.17"]="v1.17.4"
-full_versions["1.18"]="v1.18.0"
+full_versions["1.16"]="v1.16.11"
+full_versions["1.17"]="v1.17.7"
+full_versions["1.18"]="v1.18.4"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.7
+TAG=v0.1.8
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the kubeone-e2e image to:
- Bump Go to 1.14.4. We have been using Go 1.14 to cut releases since 1.14 went out, so we should use 1.14 in CI as well
- Bump Kubernetes versions to the latest patch releases
- Bump the image version to v0.1.8

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 