### PR TITLE
Add support for Kubernetes 1.16.11, 1.17.7, 1.18.4 releases

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package scripts
 
-import "github.com/Masterminds/semver"
+import (
+	"github.com/Masterminds/semver"
+)
 
 const (
 	libraryTemplate = `
@@ -113,15 +115,19 @@ func cniVersionFunc(kubernetesVersion string) (string, error) {
 		return "", err
 	}
 
-	c, _ := semver.NewConstraint(">= 1.13.0, <= 1.13.4")
+	lessThen1134, _ := semver.NewConstraint(">= 1.13.0, <= 1.13.4")
+	lessThen116, _ := semver.NewConstraint("< 1.16.0")
 
-	// Validation ensures that the oldest cluster version is 1.13.0.
 	// Versions 1.13.0-1.13.4 uses 0.6.0, so it's safe to return 0.6.0
 	// if >= 1.13.0, <= 1.13.4 constraint check successes.
-	if c.Check(s) {
+	// Versions lower than 1.16.0 use 0.7.5, and greater than 1.16.0 use 0.8.6.
+	switch {
+	case lessThen1134.Check(s):
 		return "0.6.0", nil
+	case lessThen116.Check(s):
+		return "0.7.5", nil
 	}
 
 	// return default
-	return "0.7.5", nil
+	return "0.8.6", nil
 }

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -64,7 +64,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	rsync
 
 kube_ver=$(apt-cache madison kubelet | grep "{{ .KUBERNETES_VERSION }}" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "{{ cniVersion .KUBERNETES_VERSION }}" | head -1 | awk '{print $3}')
 
 {{- if or .FORCE .UPGRADE }}
 sudo apt-mark unhold docker-ce kubelet kubeadm kubectl kubernetes-cni
@@ -86,10 +85,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 {{- if .KUBECTL }}
 	kubectl=${kube_ver} \
 {{- end }}
-	kubernetes-cni=${cni_ver} \
 	{{ aptDocker .KUBERNETES_VERSION }}
 
-sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
@@ -153,9 +151,8 @@ sudo yum install -y \
 {{- if .KUBECTL }}
 	kubectl-{{ .KUBERNETES_VERSION }}-0 \
 {{- end }}
-	kubernetes-cni-{{ cniVersion .KUBERNETES_VERSION }}-0 \
 	{{ yumDocker .KUBERNETES_VERSION }}
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
@@ -229,8 +226,8 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 sudo apt-get remove --purge -y \
 	kubeadm \
 	kubectl \
-	kubelet \
-	kubernetes-cni
+	kubelet
+sudo apt-get remove --purge -y kubernetes-cni || true
 `
 
 	removeBinariesCentOSScriptTemplate = `
@@ -238,8 +235,8 @@ sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
 sudo yum remove -y \
 	kubelet \
 	kubeadm \
-	kubectl \
-	kubernetes-cni
+	kubectl
+sudo yum remove -y kubernetes-cni || true
 `
 
 	removeBinariesCoreOSScriptTemplate = `

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -78,9 +78,8 @@ sudo yum install -y \
 	kubelet-v1.17.4-0 \
 	kubeadm-v1.17.4-0 \
 	kubectl-v1.17.4-0 \
-	kubernetes-cni-0.7.5-0 \
 	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -77,9 +77,8 @@ sudo yum install -y \
 	kubelet-v1.17.4-0 \
 	kubeadm-v1.17.4-0 \
 	kubectl-v1.17.4-0 \
-	kubernetes-cni-0.7.5-0 \
 	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -77,9 +77,8 @@ sudo yum install -y \
 	kubelet-v1.17.4-0 \
 	kubeadm-v1.17.4-0 \
 	kubectl-v1.17.4-0 \
-	kubernetes-cni-0.7.5-0 \
 	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -77,9 +77,8 @@ sudo yum install -y \
 	kubelet-v1.16.1-0 \
 	kubeadm-v1.16.1-0 \
 	kubectl-v1.16.1-0 \
-	kubernetes-cni-0.7.5-0 \
 	docker-ce-18.03.1.ce-1.el7.centos
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-force.golden
@@ -56,7 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo systemctl restart docker
 
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-${HOST_ARCH}-v0.7.5.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-${HOST_ARCH}-v0.8.6.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="vv1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
@@ -56,7 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo systemctl restart docker
 
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-${HOST_ARCH}-v0.7.5.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-${HOST_ARCH}-v0.8.6.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="vv1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -67,7 +67,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	rsync
 
 kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.7.5" | head -1 | awk '{print $3}')
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
@@ -76,10 +75,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver} \
 	docker-ce=5:19.03.9~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.9~3-0~ubuntu-$(lsb_release -cs)
 
-sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestRemoveBinariesCentOS.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesCentOS.golden
@@ -5,5 +5,5 @@ sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
 sudo yum remove -y \
 	kubelet \
 	kubeadm \
-	kubectl \
-	kubernetes-cni
+	kubectl
+sudo yum remove -y kubernetes-cni || true

--- a/pkg/scripts/testdata/TestRemoveBinariesDebian.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesDebian.golden
@@ -5,5 +5,5 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 sudo apt-get remove --purge -y \
 	kubeadm \
 	kubectl \
-	kubelet \
-	kubernetes-cni
+	kubelet
+sudo apt-get remove --purge -y kubernetes-cni || true

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -76,9 +76,8 @@ sudo yum versionlock delete docker-ce docker-ce-cli kubelet kubeadm kubectl kube
 
 sudo yum install -y \
 	kubeadm-v1.17.4-0 \
-	kubernetes-cni-0.7.5-0 \
 	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICoreOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICoreOS.golden
@@ -20,7 +20,7 @@ esac
 source /etc/kubeone/proxy-env
 
 sudo mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-${HOST_ARCH}-v0.7.5.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-${HOST_ARCH}-v0.8.6.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="vv1.17.4"

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -67,7 +67,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	rsync
 
 kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.7.5" | head -1 | awk '{print $3}')
 sudo apt-mark unhold docker-ce kubelet kubeadm kubectl kubernetes-cni
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
@@ -75,10 +74,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--no-install-recommends \
 	-y \
 	kubeadm=${kube_ver} \
-	kubernetes-cni=${cni_ver} \
 	docker-ce=5:19.03.9~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.9~3-0~ubuntu-$(lsb_release -cs)
 
-sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -77,9 +77,8 @@ sudo yum versionlock delete docker-ce docker-ce-cli kubelet kubeadm kubectl kube
 sudo yum install -y \
 	kubelet-v1.17.4-0 \
 	kubectl-v1.17.4-0 \
-	kubernetes-cni-0.7.5-0 \
 	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -67,7 +67,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	rsync
 
 kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.7.5" | head -1 | awk '{print $3}')
 sudo apt-mark unhold docker-ce kubelet kubeadm kubectl kubernetes-cni
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
@@ -76,10 +75,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	-y \
 	kubelet=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver} \
 	docker-ce=5:19.03.9~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.9~3-0~ubuntu-$(lsb_release -cs)
 
-sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker


### PR DESCRIPTION
**What this PR does / why we need it**:

The latest releases are using CNI v0.8.6 which include a fix
for the CVE-2020-10749.

It's strongly advised to upgrade all your clusters
as soon as possible.

Ubuntu and CentOS:

The `kubernetes-cni` package has been marked as obsolete
and is not installed for clusters using the patched releases.
When upgrading to the patched release, the `kubernetes-cni` package
is removed automatically.

CoreOS and Flatcar:

All newly provisioned 1.16+ clusters use CNI v0.8.6.
The new version of CNI will be installed when upgrading
the cluster.

CentOS 7 known issue:

It's currently impossible to install versions older than
1.16.11, due to a problem with upstream packages.

**Does this PR introduce a user-facing change?**:
```release-note
Add support for Kubernetes 1.16.11, 1.17.7, 1.18.4 releases. The latest patch releases include a fix for CVE-2020-10749, so it's strongly advised to upgrade as soon as possible.
```

/assign @kron4eg 