### PR TITLE
Fix CNI URL for CoreOS/Flatcar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ to an issue with packages.
 * Currently it's impossible to install Kubernetes on CentOS 7. The 1.16.11 release is not working due to an [upstream
 issue](https://github.com/kubernetes/kubernetes/issues/92250) with the kube-proxy component, while newer releases are
 having DNS problems which we are investigating.
+* Currently it's impossible to install Kubernetes on CoreOS/Flatcar due to an incorrect URL
+to the CNI plugin. The fix has been already merged and will be included in the upcoming release.
 
 ## Added
 

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -108,26 +108,3 @@ func yumDockerFunc(v string) (string, error) {
 	// return default
 	return "docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7", nil
 }
-
-func cniVersionFunc(kubernetesVersion string) (string, error) {
-	s, err := semver.NewVersion(kubernetesVersion)
-	if err != nil {
-		return "", err
-	}
-
-	lessThen1134, _ := semver.NewConstraint(">= 1.13.0, <= 1.13.4")
-	lessThen116, _ := semver.NewConstraint("< 1.16.0")
-
-	// Versions 1.13.0-1.13.4 uses 0.6.0, so it's safe to return 0.6.0
-	// if >= 1.13.0, <= 1.13.4 constraint check successes.
-	// Versions lower than 1.16.0 use 0.7.5, and greater than 1.16.0 use 0.8.6.
-	switch {
-	case lessThen1134.Check(s):
-		return "0.6.0", nil
-	case lessThen116.Check(s):
-		return "0.7.5", nil
-	}
-
-	// return default
-	return "0.8.6", nil
-}

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -170,7 +170,7 @@ source /etc/kubeone/proxy-env
 sudo systemctl restart docker
 
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v{{ cniVersion .KUBERNETES_VERSION }}/cni-plugins-${HOST_ARCH}-v{{ cniVersion .KUBERNETES_VERSION }}.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${HOST_ARCH}-v0.8.6.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v{{ .KUBERNETES_VERSION }}"
@@ -252,7 +252,7 @@ sudo rm /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.
 source /etc/kubeone/proxy-env
 
 sudo mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/v{{ cniVersion .KUBERNETES_VERSION }}/cni-plugins-${HOST_ARCH}-v{{ cniVersion .KUBERNETES_VERSION }}.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${HOST_ARCH}-v0.8.6.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v{{ .KUBERNETES_VERSION }}"

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -28,9 +28,8 @@ type Data map[string]interface{}
 // Render text template with given `variables` Render-context
 func Render(cmd string, variables map[string]interface{}) (string, error) {
 	tpl := template.New("base").Funcs(template.FuncMap{
-		"yumDocker":  yumDockerFunc,
-		"aptDocker":  aptDockerFunc,
-		"cniVersion": cniVersionFunc,
+		"yumDocker": yumDockerFunc,
+		"aptDocker": aptDockerFunc,
 	})
 
 	_, err := tpl.New("library").Parse(libraryTemplate)

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-force.golden
@@ -56,7 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo systemctl restart docker
 
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-${HOST_ARCH}-v0.8.6.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${HOST_ARCH}-v0.8.6.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="vv1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
@@ -56,7 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo systemctl restart docker
 
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-${HOST_ARCH}-v0.8.6.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${HOST_ARCH}-v0.8.6.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="vv1.17.4"

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICoreOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICoreOS.golden
@@ -20,7 +20,7 @@ esac
 source /etc/kubeone/proxy-env
 
 sudo mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-${HOST_ARCH}-v0.8.6.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${HOST_ARCH}-v0.8.6.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="vv1.17.4"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the CNI URL for CoreOS and Flatcar. Currently, it's impossible to provision/upgrade clusters on those platforms, as CNI URLs got changed after v0.7.5.

The approach used in this PR is that we now use CNI v0.8.6 for all Kubernetes versions on CoreOS/Flatcar. The same approach is used by machine-controller, although, it can be slightly risky because older versions (e.g. 1.15 and older releases of 1.16/1.17) are not verified by upstream with the latest CNI. Since we use this approach in MC anyways, I think it should be okay to proceed with this change.

**Does this PR introduce a user-facing change?**:
```release-note
Fix CoreOS/Flatcar cluster provisioning/upgrading: use the correct URL for the CNI plugins 
```

/assign @kron4eg 