### PR TITLE
Fixed link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ See [the list of releases][3] to find out about feature changes.
 [9]: https://github.com/kubermatic/kubeone/releases
 [10]: ./docs
 [12]: https://github.com/kubermatic/kubeone/tree/master/examples/ansible
-[11]: ./docs/quickstart-aws.md
+[11]: https://docs.kubermatic.com/kubeone/master/getting_started/aws/
 [13]: https://github.com/kubermatic/kubeone#features
 [14]: https://groups.google.com/forum/#!forum/loodse-dev
 [15]: http://slack.k8s.io/


### PR DESCRIPTION
**What this PR does / why we need it**:
Broken link for the "AWS Getting Started" link in the README file.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
