### PR TITLE
Stop copying admin.conf to $HOME

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -29,9 +29,8 @@ import (
 )
 
 const (
-	addonLabel = "kubeone.io/addon"
-
-	kubectlApplyScript = `kubectl apply -f {{.FILE_NAME}} --prune -l "%s"`
+	addonLabel         = "kubeone.io/addon"
+	kubectlApplyScript = `sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f {{.FILE_NAME}} --prune -l "%s"`
 )
 
 // TemplateData is data available in the addons render template

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -30,7 +30,10 @@ import (
 
 const (
 	addonLabel         = "kubeone.io/addon"
-	kubectlApplyScript = `sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f {{.FILE_NAME}} --prune -l "%s"`
+	kubectlApplyScript = `
+sudo KUBECONFIG=/etc/kubernetes/admin.conf \
+    kubectl apply -f {{.FILE_NAME}} --prune -l "%s"
+`
 )
 
 // TemplateData is data available in the addons render template

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -17,10 +17,7 @@ limitations under the License.
 package runner
 
 import (
-	"fmt"
 	"os"
-	"strings"
-	"time"
 
 	"github.com/koron-go/prefixw"
 	"github.com/pkg/errors"
@@ -77,37 +74,4 @@ func (r *Runner) Run(cmd string, variables TemplateVariables) (string, string, e
 	}
 
 	return r.RunRaw(cmd)
-}
-
-// WaitForPod waits for the availability of the given Kubernetes element.
-func (r *Runner) WaitForPod(namespace string, name string, timeout time.Duration) error {
-	cmd := fmt.Sprintf(`sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf -n "%s" get pod "%s" -o jsonpath='{.status.phase}' --ignore-not-found`, namespace, name)
-	if !r.WaitForCondition(cmd, timeout, IsRunning) {
-		return errors.Errorf("timed out while waiting for %s/%s to come up for %v", namespace, name, timeout)
-	}
-
-	return nil
-}
-
-type validatorFunc func(stdout string) bool
-
-// IsRunning checks if the given output represents the "Running" status of a Kubernetes pod.
-func IsRunning(stdout string) bool {
-	return strings.ToLower(stdout) == "running"
-}
-
-// WaitForCondition waits for something to be true.
-func (r *Runner) WaitForCondition(cmd string, timeout time.Duration, validator validatorFunc) bool {
-	cutoff := time.Now().Add(timeout)
-
-	for time.Now().Before(cutoff) {
-		stdout, _, _ := r.Run(cmd, nil)
-		if validator(stdout) {
-			return true
-		}
-
-		time.Sleep(1 * time.Second)
-	}
-
-	return false
 }

--- a/pkg/scripts/configs.go
+++ b/pkg/scripts/configs.go
@@ -17,12 +17,6 @@ limitations under the License.
 package scripts
 
 const (
-	kubernetesAdminConfigScript = `
-mkdir -p $HOME/.kube/
-sudo cp /etc/kubernetes/admin.conf $HOME/.kube/config
-sudo chown $(id -u):$(id -g) $HOME/.kube/config
-`
-
 	cloudConfigScriptTemplate = `
 sudo mkdir -p /etc/systemd/system/kubelet.service.d/ /etc/kubernetes
 sudo mv {{ .WORK_DIR }}/cfg/cloud-config /etc/kubernetes/cloud-config
@@ -48,10 +42,6 @@ if [[ -f "{{ .WORK_DIR }}/cfg/podnodeselector.yaml" ]]; then
 fi
 `
 )
-
-func KubernetesAdminConfig() (string, error) {
-	return Render(kubernetesAdminConfigScript, nil)
-}
 
 func SaveCloudConfig(workdir string) (string, error) {
 	return Render(cloudConfigScriptTemplate, Data{

--- a/pkg/scripts/configs_test.go
+++ b/pkg/scripts/configs_test.go
@@ -22,17 +22,6 @@ import (
 	"github.com/kubermatic/kubeone/pkg/testhelper"
 )
 
-func TestKubernetesAdminConfig(t *testing.T) {
-	t.Parallel()
-
-	got, err := KubernetesAdminConfig()
-	if err != nil {
-		t.Fatalf("KubernetesAdminConfig() error = %v", err)
-	}
-
-	testhelper.DiffOutput(t, testhelper.FSGoldenName(t), got, *updateFlag)
-}
-
 func TestSaveCloudConfig(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/scripts/node.go
+++ b/pkg/scripts/node.go
@@ -18,13 +18,13 @@ package scripts
 
 const (
 	drainNodeScriptTemplate = `
-export KUBECONFIG=/etc/kubernetes/admin.conf
-sudo kubectl drain {{ .NODE_NAME }} --ignore-daemonsets --delete-local-data
+sudo KUBECONFIG=/etc/kubernetes/admin.conf \
+    kubectl drain {{ .NODE_NAME }} --ignore-daemonsets --delete-local-data
 `
 
 	uncordonNodeScriptTemplate = `
-export KUBECONFIG=/etc/kubernetes/admin.conf
-sudo kubectl uncordon {{ .NODE_NAME }}
+sudo KUBECONFIG=/etc/kubernetes/admin.conf \
+    kubectl uncordon {{ .NODE_NAME }}
 `
 )
 

--- a/pkg/scripts/testdata/TestDrainNode.golden
+++ b/pkg/scripts/testdata/TestDrainNode.golden
@@ -1,5 +1,5 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-export KUBECONFIG=/etc/kubernetes/admin.conf
-sudo kubectl drain testNode1 --ignore-daemonsets --delete-local-data
+sudo KUBECONFIG=/etc/kubernetes/admin.conf \
+    kubectl drain testNode1 --ignore-daemonsets --delete-local-data

--- a/pkg/scripts/testdata/TestKubernetesAdminConfig.golden
+++ b/pkg/scripts/testdata/TestKubernetesAdminConfig.golden
@@ -1,6 +1,0 @@
-set -xeu pipefail
-export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
-
-mkdir -p $HOME/.kube/
-sudo cp /etc/kubernetes/admin.conf $HOME/.kube/config
-sudo chown $(id -u):$(id -g) $HOME/.kube/config

--- a/pkg/scripts/testdata/TestUncordonNode.golden
+++ b/pkg/scripts/testdata/TestUncordonNode.golden
@@ -1,5 +1,5 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-export KUBECONFIG=/etc/kubernetes/admin.conf
-sudo kubectl uncordon testNode2
+sudo KUBECONFIG=/etc/kubernetes/admin.conf \
+    kubectl uncordon testNode2

--- a/pkg/tasks/kubeconfig.go
+++ b/pkg/tasks/kubeconfig.go
@@ -22,25 +22,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	kubeoneapi "github.com/kubermatic/kubeone/pkg/apis/kubeone"
 	"github.com/kubermatic/kubeone/pkg/kubeconfig"
-	"github.com/kubermatic/kubeone/pkg/scripts"
-	"github.com/kubermatic/kubeone/pkg/ssh"
 	"github.com/kubermatic/kubeone/pkg/state"
 )
-
-func copyKubeconfig(s *state.State) error {
-	return s.RunTaskOnNodes(s.Cluster.ControlPlane.Hosts, func(s *state.State, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {
-		s.Logger.Infoln("Copying Kubeconfig to home directory…")
-		cmd, err := scripts.KubernetesAdminConfig()
-		if err != nil {
-			return err
-		}
-
-		_, _, err = s.Runner.RunRaw(cmd)
-		return err
-	}, state.RunParallel)
-}
 
 func saveKubeconfig(s *state.State) error {
 	s.Logger.Info("Downloading kubeconfig…")

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -83,7 +83,6 @@ func WithFullInstall(t Tasks) Tasks {
 			{Fn: kubeconfig.BuildKubernetesClientset, ErrMsg: "failed to build kubernetes clientset"},
 			{Fn: repairClusterIfNeeded, ErrMsg: "failed to repair cluster"},
 			{Fn: joinControlplaneNode, ErrMsg: "failed to join other masters a cluster"},
-			{Fn: copyKubeconfig, ErrMsg: "failed to copy kubeconfig to home directory"},
 			{Fn: saveKubeconfig, ErrMsg: "failed to save kubeconfig to the local machine"},
 		}...).
 		append(kubernetesResources()...).


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes bug on instances where $HOME is located on tmpfs and is not persisted across restarts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #935

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stop copying admin.conf to $HOME
```
