### PR TITLE
Remove hold from the docker-ce-cli package on upgrade

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -71,7 +71,7 @@ kube_ver=$(apt-cache madison kubelet | grep "{{ .KUBERNETES_VERSION }}" | head -
 cni_ver=$(apt-cache madison kubernetes-cni | grep "{{ .KUBERNETES_CNI_VERSION }}" | head -1 | awk '{print $3}')
 
 {{- if or .FORCE .UPGRADE }}
-sudo apt-mark unhold docker-ce kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark unhold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 {{- end }}
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -68,7 +68,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 
 kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
 cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.6" | head -1 | awk '{print $3}')
-sudo apt-mark unhold docker-ce kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark unhold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -68,7 +68,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 
 kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
 cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.6" | head -1 | awk '{print $3}')
-sudo apt-mark unhold docker-ce kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark unhold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we don't remove the hold from the `docker-ce-cli` package when upgrading the cluster. This is not a problem if the Docker version is unchanged, however, if it needs to be upgraded, it would fail because of the hold.

This issue happens when upgrading a cluster created using KubeOne v0.11 because the v1.0 alpha/beta releases use the newer Docker version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #940 

**Does this PR introduce a user-facing change?**:
```release-note
Remove hold from the docker-ce-cli package on upgrade. Ensure clusters created with KubeOne v0.11 can be upgraded using KubeOne v1.0.0 beta releases.
```

/assign @kron4eg 