### PR TITLE
Request and allow more memory for the lint job

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -103,10 +103,10 @@ presubmits:
         - lint
         resources:
           requests:
-            memory: 512Mi
+            memory: 1Gi
             cpu: 4
           limits:
-            memory: 1Gi
+            memory: 2Gi
 
   #########################################################
   # E2E/Conformance tests (AWS, 1.16-1.18)


### PR DESCRIPTION
**What this PR does / why we need it**:

The lint job is often getting killed by Prow. Let's try to increases the memory limits a bit and see is it going to improve anything.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 