### PR TITLE
Update machine-controller to v1.15.1 and add the imagePlan field for Azure

### DIFF
--- a/pkg/templates/machinecontroller/cloudprovider_specs.go
+++ b/pkg/templates/machinecontroller/cloudprovider_specs.go
@@ -121,6 +121,7 @@ type AzureSpec struct {
 	RouteTableName    string            `json:"routeTableName"`
 	SecurityGroupName string            `json:"securityGroupName"`
 	Zones             []string          `json:"zones"`
+	ImagePlan         *AzureImagePlan   `json:"imagePlan"`
 	SubnetName        string            `json:"subnetName"`
 	Tags              map[string]string `json:"tags"`
 	VMSize            string            `json:"vmSize"`
@@ -128,4 +129,10 @@ type AzureSpec struct {
 	ImageID           string            `json:"imageID"`
 	OSDiskSize        int               `json:"osDiskSize"`
 	DataDiskSize      int               `json:"dataDiskSize"`
+}
+
+type AzureImagePlan struct {
+	Name      string `json:"name,omitempty"`
+	Publisher string `json:"publisher,omitempty"`
+	Product   string `json:"product,omitempty"`
 }

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -46,7 +46,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.14.3"
+	MachineControllerTag           = "v1.15.1"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster

--- a/pkg/terraform/v1beta1/config.go
+++ b/pkg/terraform/v1beta1/config.go
@@ -274,6 +274,7 @@ func (c *Config) updateAzureWorkerset(existingWorkerSet *kubeonev1beta1.DynamicW
 		{key: "routeTableName", value: azureCloudConfig.RouteTableName},
 		{key: "securityGroupName", value: azureCloudConfig.SecurityGroupName},
 		{key: "zones", value: azureCloudConfig.Zones},
+		{key: "imagePlan", value: azureCloudConfig.ImagePlan},
 		{key: "subnetName", value: azureCloudConfig.SubnetName},
 		{key: "tags", value: azureCloudConfig.Tags},
 		{key: "vmSize", value: azureCloudConfig.VMSize},
@@ -492,6 +493,11 @@ func setWorkersetFlag(w *kubeonev1beta1.DynamicWorkerConfig, name string, value 
 		}
 	case bool:
 	case *bool:
+		if s == nil {
+			return nil
+		}
+	case machinecontroller.AzureImagePlan:
+	case *machinecontroller.AzureImagePlan:
 		if s == nil {
 			return nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Update machine-controller to v1.15.1 and add the ImagePlan field for Azure.

**Special notes for your reviewer**:

The type of the `ImagePlan` field is different than for other fields. This time, the field type is a struct, and so far we only used primitive types. I don't have access to Azure, so I can't this is this going to work. I assume it should work this way, but I'm not sure.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.15.1
Add the ImagePlan field for Azure Terraform integration
```
