### PR TITLE
Use leader for polling etcd status

### DIFF
--- a/pkg/clusterstatus/etcdstatus/etcdstatus.go
+++ b/pkg/clusterstatus/etcdstatus/etcdstatus.go
@@ -44,15 +44,11 @@ type Report struct {
 }
 
 func MemberList(s *state.State) (*clientv3.MemberListResponse, error) {
-	etcdEndpoints := []string{}
-	for _, node := range s.Cluster.ControlPlane.Hosts {
-		etcdEndpoints = append(etcdEndpoints, fmt.Sprintf(clientEndpointFmt, node.PrivateAddress))
-	}
-
 	leader, err := s.Cluster.Leader()
 	if err != nil {
 		return nil, err
 	}
+	etcdEndpoints := []string{fmt.Sprintf(clientEndpointFmt, leader.PrivateAddress)}
 
 	etcdcfg, err := etcdutil.NewClientConfig(s, leader)
 	if err != nil {

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -165,7 +165,6 @@ func investigateCluster(s *state.State) error {
 		return errors.New("leader not elected, quorum mostly like lost")
 	}
 
-	// TODO: this doesn't work properly if the first node is broken
 	etcdMembers, err := etcdstatus.MemberList(s)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #531 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 