### PR TITLE
Make use of sudo to install tar

### DIFF
--- a/examples/terraform/hetzner/gobetween.sh
+++ b/examples/terraform/hetzner/gobetween.sh
@@ -28,7 +28,7 @@ PKG_MANAGER="noop"
 [ "$(command -v yum)" ] && PKG_MANAGER=yum
 [ "$(command -v apt-get)" ] && PKG_MANAGER=apt-get
 
-$PKG_MANAGER install tar -y
+sudo ${PKG_MANAGER} install tar -y
 
 mkdir -p /tmp/gobetween
 cd /tmp/gobetween

--- a/examples/terraform/openstack/gobetween.sh
+++ b/examples/terraform/openstack/gobetween.sh
@@ -28,7 +28,7 @@ PKG_MANAGER="noop"
 [ "$(command -v yum)" ] && PKG_MANAGER=yum
 [ "$(command -v apt-get)" ] && PKG_MANAGER=apt-get
 
-$PKG_MANAGER install tar -y
+sudo ${PKG_MANAGER} install tar -y
 
 mkdir -p /tmp/gobetween
 cd /tmp/gobetween

--- a/examples/terraform/packet/gobetween.sh
+++ b/examples/terraform/packet/gobetween.sh
@@ -28,7 +28,7 @@ PKG_MANAGER="noop"
 [ "$(command -v yum)" ] && PKG_MANAGER=yum
 [ "$(command -v apt-get)" ] && PKG_MANAGER=apt-get
 
-$PKG_MANAGER install tar -y
+sudo ${PKG_MANAGER} install tar -y
 
 mkdir -p /tmp/gobetween
 cd /tmp/gobetween

--- a/examples/terraform/vsphere/gobetween.sh
+++ b/examples/terraform/vsphere/gobetween.sh
@@ -28,7 +28,7 @@ PKG_MANAGER="noop"
 [ "$(command -v yum)" ] && PKG_MANAGER=yum
 [ "$(command -v apt-get)" ] && PKG_MANAGER=apt-get
 
-$PKG_MANAGER install tar -y
+sudo ${PKG_MANAGER} install tar -y
 
 mkdir -p /tmp/gobetween
 cd /tmp/gobetween


### PR DESCRIPTION
Signed-off-by: Johannes M. Scheuermann <joh.scheuer@gmail.com>
This PR: https://github.com/kubermatic/kubeone/pull/893 introduced a change to make the gobetween script also be usable on CentOS, sadly this breaks the ubuntu setup (since ubuntu uses the `ubuntu` user and not root):

```bash
openstack_compute_instance_v2.lb (remote-exec):   Checking Host Key: false
openstack_compute_instance_v2.lb: Still creating... [50s elapsed]
openstack_compute_instance_v2.lb (remote-exec): Connected!
openstack_compute_instance_v2.lb (remote-exec): E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
openstack_compute_instance_v2.lb (remote-exec): E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
```
 
**What this PR does / why we need it**:
Without this PR the provisioning of new clusters will fail with the error message from above.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix recursion bug in gobetween.sh script
```
