### PR TITLE
Implement config machinedeployments command

### DIFF
--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -210,9 +210,9 @@ type DynamicWorkerConfig struct {
 // ProviderSpec describes a worker node
 type ProviderSpec struct {
 	CloudProviderSpec   json.RawMessage   `json:"cloudProviderSpec"`
-	Labels              map[string]string `json:"labels"`
+	Labels              map[string]string `json:"labels,omitempty"`
 	Taints              []corev1.Taint    `json:"taints,omitempty"`
-	SSHPublicKeys       []string          `json:"sshPublicKeys"`
+	SSHPublicKeys       []string          `json:"sshPublicKeys,omitempty"`
 	OperatingSystem     string            `json:"operatingSystem"`
 	OperatingSystemSpec json.RawMessage   `json:"operatingSystemSpec"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Implement the `kubeone config machinedeployments` command used to generate manifest containing all defined MachineDeployments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #531 

**Does this PR introduce a user-facing change?**:
```release-note
Implement the `kubeone config machinedeployments` command used to generate manifest containing all defined MachineDeployments
```

/assign @kron4eg 