### PR TITLE
Set omitempty on providerSpec fields in v1alpha1/v1beta1 APIs

### DIFF
--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -180,9 +180,9 @@ type WorkerConfig struct {
 // ProviderSpec describes a worker node
 type ProviderSpec struct {
 	CloudProviderSpec   json.RawMessage   `json:"cloudProviderSpec"`
-	Labels              map[string]string `json:"labels"`
+	Labels              map[string]string `json:"labels,omitempty"`
 	Taints              []corev1.Taint    `json:"taints,omitempty"`
-	SSHPublicKeys       []string          `json:"sshPublicKeys"`
+	SSHPublicKeys       []string          `json:"sshPublicKeys,omitempty"`
 	OperatingSystem     string            `json:"operatingSystem"`
 	OperatingSystemSpec json.RawMessage   `json:"operatingSystemSpec"`
 

--- a/pkg/apis/kubeone/v1beta1/types.go
+++ b/pkg/apis/kubeone/v1beta1/types.go
@@ -210,9 +210,9 @@ type DynamicWorkerConfig struct {
 // ProviderSpec describes a worker node
 type ProviderSpec struct {
 	CloudProviderSpec   json.RawMessage   `json:"cloudProviderSpec"`
-	Labels              map[string]string `json:"labels"`
+	Labels              map[string]string `json:"labels,omitempty"`
 	Taints              []corev1.Taint    `json:"taints,omitempty"`
-	SSHPublicKeys       []string          `json:"sshPublicKeys"`
+	SSHPublicKeys       []string          `json:"sshPublicKeys,omitempty"`
 	OperatingSystem     string            `json:"operatingSystem"`
 	OperatingSystemSpec json.RawMessage   `json:"operatingSystemSpec"`
 


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #531 #966 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 