### PR TITLE
Add NodeRegistration to kubeadm v1beta2 JoinConfiguration for static workers

### DIFF
--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -277,5 +277,7 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 		nodeRegistration.KubeletExtraArgs["cloud-provider"] = "external"
 	}
 
+	joinConfig.NodeRegistration = nodeRegistration
+
 	return []runtime.Object{joinConfig}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `NodeRegistration` object to the kubeadm v1beta2 `JoinConfiguration` object for static workers. Fixes the issue with nodes not joining a cluster on AWS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #531 

**Does this PR introduce a user-facing change?**:
```release-note
Add NodeRegistration to kubeadm v1beta2 JoinConfiguration for static workers. Fixes the issue with nodes not joining a cluster on AWS.
```

/assign @kron4eg 
