### PR TITLE
Add support for running apply with static workers

### DIFF
--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -212,7 +212,7 @@ func runApplyInstall(s *state.State, opts *applyOpts) error { // Print the expec
 			fmt.Printf("+ provision control plane host %q (%s)\n", node.Config.Hostname, node.Config.PrivateAddress)
 		}
 	}
-	for _, node := range s.LiveCluster.Workers {
+	for _, node := range s.LiveCluster.StaticWorkers {
 		if !node.IsInCluster {
 			fmt.Printf("+ provision worker host %q (%s)\n", node.Config.Hostname, node.Config.PrivateAddress)
 		}

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -209,7 +209,12 @@ func runApplyInstall(s *state.State, opts *applyOpts) error { // Print the expec
 
 	for _, node := range s.LiveCluster.ControlPlane {
 		if !node.IsInCluster {
-			fmt.Printf("+ provision host %q (%s)\n", node.Config.Hostname, node.Config.PrivateAddress)
+			fmt.Printf("+ provision control plane host %q (%s)\n", node.Config.Hostname, node.Config.PrivateAddress)
+		}
+	}
+	for _, node := range s.LiveCluster.Workers {
+		if !node.IsInCluster {
+			fmt.Printf("+ provision worker host %q (%s)\n", node.Config.Hostname, node.Config.PrivateAddress)
 		}
 	}
 
@@ -249,14 +254,21 @@ func runApplyUpgradeIfNeeded(s *state.State, opts *applyOpts) error {
 		// TODO: Maybe it's not needed to upgrade each node, check version
 		for _, node := range s.Cluster.ControlPlane.Hosts {
 			if opts.ForceUpgrade {
-				fmt.Printf("~ force upgrade node %q (%s) to Kubernetes %s\n", node.Hostname, node.PrivateAddress, s.Cluster.Versions.Kubernetes)
+				fmt.Printf("~ force upgrade control plane node %q (%s) to Kubernetes %s\n", node.Hostname, node.PrivateAddress, s.Cluster.Versions.Kubernetes)
 			} else {
-				fmt.Printf("~ upgrade node %q (%s) to Kubernetes %s\n", node.Hostname, node.PrivateAddress, s.Cluster.Versions.Kubernetes)
+				fmt.Printf("~ upgrade control plane node %q (%s) to Kubernetes %s\n", node.Hostname, node.PrivateAddress, s.Cluster.Versions.Kubernetes)
+			}
+		}
+		for _, node := range s.Cluster.StaticWorkers.Hosts {
+			if opts.ForceUpgrade {
+				fmt.Printf("~ force upgrade worker node %q (%s) to Kubernetes %s\n", node.Hostname, node.PrivateAddress, s.Cluster.Versions.Kubernetes)
+			} else {
+				fmt.Printf("~ upgrade worker node %q (%s) to Kubernetes %s\n", node.Hostname, node.PrivateAddress, s.Cluster.Versions.Kubernetes)
 			}
 		}
 
 		if s.UpgradeMachineDeployments {
-			fmt.Printf("~ replace all worker machines with %s\n", s.Cluster.Versions.Kubernetes)
+			fmt.Printf("~ upgrade all machinedeployment objects to %s\n", s.Cluster.Versions.Kubernetes)
 		}
 
 		fmt.Println()

--- a/pkg/state/cluster.go
+++ b/pkg/state/cluster.go
@@ -29,7 +29,7 @@ import (
 
 type Cluster struct {
 	ControlPlane    []Host
-	Workers         []Host
+	StaticWorkers   []Host
 	ExpectedVersion *semver.Version
 	Lock            sync.Mutex
 }
@@ -92,8 +92,8 @@ func (c *Cluster) Healthy() bool {
 		}
 	}
 
-	for i := range c.Workers {
-		if !c.Workers[i].WorkerHealthy() {
+	for i := range c.StaticWorkers {
+		if !c.StaticWorkers[i].WorkerHealthy() {
 			return false
 		}
 	}
@@ -161,8 +161,8 @@ func (c *Cluster) UpgradeNeeded() (bool, error) {
 		}
 	}
 
-	for i := range c.Workers {
-		verDiff := c.ExpectedVersion.Compare(c.Workers[i].Kubelet.Version)
+	for i := range c.StaticWorkers {
+		verDiff := c.ExpectedVersion.Compare(c.StaticWorkers[i].Kubelet.Version)
 		if verDiff > 0 {
 			return true, nil
 		} else if verDiff < 0 {

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -67,7 +67,7 @@ func runProbes(s *state.State) error {
 		})
 	}
 	for i := range s.Cluster.StaticWorkers.Hosts {
-		s.LiveCluster.Workers = append(s.LiveCluster.Workers, state.Host{
+		s.LiveCluster.StaticWorkers = append(s.LiveCluster.StaticWorkers, state.Host{
 			Config: &s.Cluster.StaticWorkers.Hosts[i],
 		})
 	}
@@ -99,8 +99,8 @@ func investigateHost(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Conne
 		}
 	}
 	if h == nil {
-		for i := range s.LiveCluster.Workers {
-			host := s.LiveCluster.Workers[i]
+		for i := range s.LiveCluster.StaticWorkers {
+			host := s.LiveCluster.StaticWorkers[i]
 			if host.Config.Hostname == node.Hostname {
 				h = &host
 				idx = i


### PR DESCRIPTION
**What this PR does / why we need it**:

* Run host probes on the static worker nodes
* Print information about the static worker nodes when running apply
* Rename `.Cluster.Workers` to `.Cluster.StaticWorkers`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #531 

**Special notes for your reviewer**:

TODO in a follow-up:
* Run cluster probes on the static worker nodes

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 