### PR TITLE
Mention official Arch linux release in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,14 @@ progress follow the [issue #471][17]
 
 #### Arch Linux
 
-We have a package in the AUR [here](https://aur.archlinux.org/packages/kubeone).
-Use your favorite method to build it on your system, for example by using
-`aurutils`:
+`kubeone` can be found in the official Arch Linux repositories:
+
+[https://www.archlinux.org/packages/community/x86_64/kubeone/](https://www.archlinux.org/packages/community/x86_64/kubeone/)
+
+Install it via:
+
 ```bash
-aur sync kubeone && pacman -S kubeone
+pacman -S kubeone
 ```
 
 ### Shell completion and generating documentation


### PR DESCRIPTION
**What this PR does / why we need it**:

Hi,
I've cleaned up the kubeone AUR package and moved kubeone to the official Arch Linux repositories. The AUR package will be removed. If necessary you can push a kubeone-git package to the AUR, but I think we stable release in the official repositories will work well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

This PR just adds documentation in the README

**Special notes for your reviewer**:

The package can be found here: https://www.archlinux.org/packages/community/x86_64/kubeone/

and can be installed via `pacman -S kubeone`.
The PKGBUILD is here: https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/kubeone

I took the AUR PKGBUILD as template and cleaned it up + added zsh completions to it.

If you have any questions, feel free to ask :)

**Does this PR introduce a user-facing change?**:

No