### PR TITLE
Use CentOS8 AMIs

### DIFF
--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -61,7 +61,7 @@ output "kubeone_workers" {
           # see example under `cloudProviderSpec` section at:
           # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
           region           = var.aws_region
-          ami              = var.ami
+          ami              = local.ami
           availabilityZone = local.zoneA
           instanceProfile  = aws_iam_instance_profile.profile.name
           securityGroupIDs = [aws_security_group.common.id]
@@ -95,7 +95,7 @@ output "kubeone_workers" {
           # see example under `cloudProviderSpec` section at:
           # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
           region           = var.aws_region
-          ami              = var.ami
+          ami              = local.ami
           availabilityZone = local.zoneB
           instanceProfile  = aws_iam_instance_profile.profile.name
           securityGroupIDs = [aws_security_group.common.id]
@@ -129,7 +129,7 @@ output "kubeone_workers" {
           # see example under `cloudProviderSpec` section at:
           # https://github.com/kubermatic/machine-controller/blob/master/examples/aws-machinedeployment.yaml
           region           = var.aws_region
-          ami              = var.ami
+          ami              = local.ami
           availabilityZone = local.zoneC
           instanceProfile  = aws_iam_instance_profile.profile.name
           securityGroupIDs = [aws_security_group.common.id]

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -121,8 +121,8 @@ variable "ami_filters" {
     }
 
     centos = {
-      owners     = ["679593333241"] # CentOS
-      image_name = ["CentOS Linux 7 x86_64 HVM EBS*"]
+      owners     = ["125523088429"] # CentOS
+      image_name = ["CentOS 8.2.* x86_64"]
     }
 
     flatcar = {


### PR DESCRIPTION
**What this PR does / why we need it**:
A way to utilize CentOS8 on AWS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CentOS8 on AWS
```

/hold
until https://github.com/kubermatic/machine-controller/pull/793 is released and upgraded here