### PR TITLE
Skip creating weave-passwd secret if it already exists

### DIFF
--- a/pkg/templates/weave/weave-net.go
+++ b/pkg/templates/weave/weave-net.go
@@ -82,13 +82,12 @@ func Deploy(s *state.State) error {
 		err = s.DynamicClient.Get(ctx, key, secCopy)
 		switch {
 		case k8serrors.IsNotFound(err):
+			err = s.DynamicClient.Create(ctx, sec)
+			if err != nil {
+				return errors.Wrap(err, "failed to create weave-net Secret")
+			}
 		case err != nil:
 			return errors.Wrap(err, "failed to get weave-net Secret")
-		}
-
-		err = s.DynamicClient.Create(ctx, sec)
-		if err != nil {
-			return errors.Wrap(err, "failed to create weave-net Secret")
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Running `kubeone install` on already provisioned cluster (e.g. to repair it) with WeaveNet CNI causes the following error:

```
INFO[14:54:35 CEST] Applying weave-net CNI plugin…               
WARN[14:54:36 CEST] Task failed, error was: failed to create weave-net Secret: secrets "weave-passwd" already exists
```

The reason for this error is that we try to unconditionally create the secret, even if it exists. This PR changes the behavior, so the secret is created only if it doesn't exist.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #531 

**Does this PR introduce a user-facing change?**:
```release-note
Ensure weave-passwd secret is created on install only if it doesn't exist
```

/assign @kron4eg 