### PR TITLE
Force restart kubelet on CentOS

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -166,6 +166,10 @@ sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kuberne
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
+
+{{- if or .FORCE .KUBELET }}
+sudo systemctl restart kubelet
+{{- end }}
 `
 
 	kubeadmCoreOSTemplate = `

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -85,3 +85,4 @@ sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kuberne
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -84,3 +84,4 @@ sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kuberne
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -84,3 +84,4 @@ sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kuberne
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -84,3 +84,4 @@ sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kuberne
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -84,3 +84,4 @@ sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kuberne
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet


### PR DESCRIPTION
**What this PR does / why we need it**:
On CentOS8 yum install doesn't couse automatic kubelet restarts, so we
do it manually.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Force restart kubelet on CentOS on upgrade
```
