### PR TITLE
Unconditionally renew certificates when upgrading the cluster

### DIFF
--- a/pkg/scripts/kubeadm_test.go
+++ b/pkg/scripts/kubeadm_test.go
@@ -261,7 +261,7 @@ func TestKubeadmUpgradeLeader(t *testing.T) {
 			name: "v1beta2",
 			args: args{
 				workdir:    "test-wd",
-				kubeadmCmd: "kubeadm upgrade node",
+				kubeadmCmd: "kubeadm upgrade node --certificate-renewal=true",
 			},
 		},
 	}

--- a/pkg/scripts/testdata/TestKubeadmUpgradeLeader-v1beta2.golden
+++ b/pkg/scripts/testdata/TestKubeadmUpgradeLeader-v1beta2.golden
@@ -1,4 +1,4 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-sudo kubeadm upgrade node --config=test-wd/cfg/master_0.yaml
+sudo kubeadm upgrade node --certificate-renewal=true --config=test-wd/cfg/master_0.yaml

--- a/pkg/templates/kubeadm/kubeadm.go
+++ b/pkg/templates/kubeadm/kubeadm.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	kubeadmUpgradeNodeCommand = "kubeadm upgrade node"
+	kubeadmUpgradeNodeCommand = "kubeadm upgrade node --certificate-renewal=true"
 )
 
 var (

--- a/pkg/templates/kubeadm/kubeadmv1beta2.go
+++ b/pkg/templates/kubeadm/kubeadmv1beta2.go
@@ -48,7 +48,7 @@ func (*kubeadmv1beta2) ConfigWorker(s *state.State, instance kubeoneapi.HostConf
 }
 
 func (k *kubeadmv1beta2) UpgradeLeaderCommand() string {
-	return fmt.Sprintf("kubeadm upgrade apply -y %s", k.version)
+	return fmt.Sprintf("kubeadm upgrade apply -y --certificate-renewal=true %s", k.version)
 }
 
 func (*kubeadmv1beta2) UpgradeFollowerCommand() string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Unconditionally renew certificates when upgrading the cluster.

Due to an upstream bug, kubeadm wasn't automatically renewing the certificates as the `--certificate-renewal` flag was set to false by default. In v1.17 that bug has been fixed, but as we still support older versions, we unconditionally set this flag to true to ensure that certificates will be renewed.

https://github.com/kubernetes/kubeadm/issues/1818

**Does this PR introduce a user-facing change?**:
```release-note
Unconditionally renew certificates when upgrading the cluster. Due to an upstream bug, kubeadm wasn't automatically renewing for clusters running Kubernetes versions older than v1.17
```

/assign @kron4eg 