### PR TITLE
Update machine-controller to v1.15.3

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -46,7 +46,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.15.2"
+	MachineControllerTag           = "v1.15.3"
 )
 
 // Deploy deploys MachineController deployment with RBAC on the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

Update machine-controller to v1.15.3. This release includes a fix for the machine-controller's NodeCSRApprover controller refusing to approve certificates for the GCP nodes.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.15.3. This release includes a fix for the machine-controller's NodeCSRApprover controller refusing to approve certificates for the GCP nodes.
```

/assign @kron4eg 