### PR TITLE
Remove hidden from the kubeone apply command

### DIFF
--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -86,9 +86,8 @@ func applyCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	opts := &applyOpts{}
 
 	cmd := &cobra.Command{
-		Hidden: true, // for now
-		Use:    "apply",
-		Short:  "apply reconcile the cluster",
+		Use:   "apply",
+		Short: "Reconcile the cluster",
 		Long: `
 Reconcile (Install/Upgrade/Repair/Restore) Kubernetes cluster on pre-existing machines
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove hidden from the `kubeone apply` command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #531 

**Does this PR introduce a user-facing change?**:
```release-note
Implement the kubeone apply command responsible for reconciling clusters
```

/assign @kron4eg 
