### PR TITLE
Upgrade docker versions, minimal is 18.09.9

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -86,11 +86,11 @@ func aptDockerFunc(v string) (string, error) {
 	lessThen117, _ := semver.NewConstraint("< 1.17")
 
 	if lessThen117.Check(sver) {
-		return "docker-ce=18.03.1~ce~3-0~ubuntu", nil
+		return "docker-ce=5:18.09.9~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:18.09.9~3-0~ubuntu-$(lsb_release -cs)", nil
 	}
 
 	// return default
-	return "docker-ce=5:19.03.9~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.9~3-0~ubuntu-$(lsb_release -cs)", nil
+	return "docker-ce=5:19.03.12~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.12~3-0~ubuntu-$(lsb_release -cs)", nil
 }
 
 func yumDockerFunc(v string) (string, error) {
@@ -102,9 +102,9 @@ func yumDockerFunc(v string) (string, error) {
 	lessThen117, _ := semver.NewConstraint("< 1.17")
 
 	if lessThen117.Check(sver) {
-		return "docker-ce-18.03.1.ce-1.el7.centos", nil
+		return "docker-ce-18.09.9-3.el7 docker-ce-cli-18.09.9-3.el7", nil
 	}
 
 	// return default
-	return "docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7", nil
+	return "docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7", nil
 }

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -79,7 +79,7 @@ sudo yum install -y \
 	kubeadm-v1.17.4 \
 	kubectl-v1.17.4 \
 	kubernetes-cni-0.8.6 \
-	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
+	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -78,7 +78,7 @@ sudo yum install -y \
 	kubeadm-v1.17.4 \
 	kubectl-v1.17.4 \
 	kubernetes-cni-0.8.6 \
-	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
+	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -78,7 +78,7 @@ sudo yum install -y \
 	kubeadm-v1.17.4 \
 	kubectl-v1.17.4 \
 	kubernetes-cni-0.8.6 \
-	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
+	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -78,7 +78,7 @@ sudo yum install -y \
 	kubeadm-v1.16.1 \
 	kubectl-v1.16.1 \
 	kubernetes-cni-0.8.6 \
-	docker-ce-18.03.1.ce-1.el7.centos
+	docker-ce-18.09.9-3.el7 docker-ce-cli-18.09.9-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -79,7 +79,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
 	kubernetes-cni=${cni_ver} \
-	docker-ce=5:19.03.9~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.9~3-0~ubuntu-$(lsb_release -cs)
+	docker-ce=5:19.03.12~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.12~3-0~ubuntu-$(lsb_release -cs)
 
 sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -77,7 +77,7 @@ sudo yum versionlock delete docker-ce docker-ce-cli kubelet kubeadm kubectl kube
 sudo yum install -y \
 	kubeadm-v1.17.4 \
 	kubernetes-cni-0.8.6 \
-	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
+	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -78,7 +78,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	-y \
 	kubeadm=${kube_ver} \
 	kubernetes-cni=${cni_ver} \
-	docker-ce=5:19.03.9~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.9~3-0~ubuntu-$(lsb_release -cs)
+	docker-ce=5:19.03.12~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.12~3-0~ubuntu-$(lsb_release -cs)
 
 sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -78,7 +78,7 @@ sudo yum install -y \
 	kubelet-v1.17.4 \
 	kubectl-v1.17.4 \
 	kubernetes-cni-0.8.6 \
-	docker-ce-19.03.9-3.el7 docker-ce-cli-19.03.9-3.el7
+	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -79,7 +79,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubectl=${kube_ver} \
 	kubernetes-cni=${cni_ver} \
-	docker-ce=5:19.03.9~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.9~3-0~ubuntu-$(lsb_release -cs)
+	docker-ce=5:19.03.12~3-0~ubuntu-$(lsb_release -cs) docker-ce-cli=5:19.03.12~3-0~ubuntu-$(lsb_release -cs)
 
 sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix downgraded docker 18.03.1.
New minimal docker version is 18.9.9 for clusters `< 1.17`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1000

**Special notes for your reviewer**:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#unchanged has

>The list of validated docker versions remains unchanged.
>The current list is 1.13.1, 17.03, 17.06, 17.09, 18.06, 18.09.

Plus, machine-controller uses 18.09.9 for everything.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Minimal docker version is 18.09.9
```
