### PR TITLE
Default the Canal MTU to 1450 when the v1alpha1 API is used and add the Canal MTU field to the example config

### DIFF
--- a/pkg/apis/kubeone/v1alpha1/conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/conversion.go
@@ -33,7 +33,9 @@ func Convert_v1alpha1_CNI_To_kubeone_CNI(in *CNI, out *kubeoneapi.CNI, s convers
 
 	switch in.Provider {
 	case CNIProviderCanal:
-		out.Canal = &kubeoneapi.CanalSpec{}
+		out.Canal = &kubeoneapi.CanalSpec{
+			MTU: 1450,
+		}
 	case CNIProviderWeaveNet:
 		out.WeaveNet = &kubeoneapi.WeaveNetSpec{
 			Encrypted: in.Encrypted,

--- a/pkg/apis/kubeone/v1alpha1/conversion_test.go
+++ b/pkg/apis/kubeone/v1alpha1/conversion_test.go
@@ -37,7 +37,9 @@ func TestCNIRoundTripConversion(t *testing.T) {
 				Provider: CNIProviderCanal,
 			},
 			expectedInternalCNI: &kubeoneapi.CNI{
-				Canal: &kubeoneapi.CanalSpec{},
+				Canal: &kubeoneapi.CanalSpec{
+					MTU: 1450,
+				},
 			},
 		},
 		{
@@ -111,7 +113,9 @@ func TestCNIWithEncryptionRoundTripConversion(t *testing.T) {
 				Encrypted: true,
 			},
 			expectedInternalCNI: &kubeoneapi.CNI{
-				Canal: &kubeoneapi.CanalSpec{},
+				Canal: &kubeoneapi.CanalSpec{
+					MTU: 1450,
+				},
 			},
 			expectedVersionedCNI: &CNI{
 				Provider: CNIProviderCanal,
@@ -415,7 +419,9 @@ func TestClusterNetworkRoundTripConversion(t *testing.T) {
 				ServiceSubnet:     "192.168.1.0/24",
 				ServiceDomainName: "cluster.local",
 				CNI: &kubeoneapi.CNI{
-					Canal: &kubeoneapi.CanalSpec{},
+					Canal: &kubeoneapi.CanalSpec{
+						MTU: 1450,
+					},
 				},
 			},
 		},

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -501,7 +501,15 @@ clusterNetwork:
     # * canal
     # * weave-net
     # * external - The CNI plugin can be installed as an addon or manually
-    canal: {}
+	canal:
+	  # MTU represents the maximum transmission unit.
+	  # Default MTU value depends on the specified provider:
+	  # * AWS - 8951 (9001 AWS Jumbo Frame - 50 VXLAN bytes)
+	  # * GCE - 1410 (GCE specific 1460 bytes - 50 VXLAN bytes)
+	  # * Hetzner - 1400 (Hetzner specific 1450 bytes - 50 VXLAN bytes)
+	  # * OpenStack - 1400 (Hetzner specific 1450 bytes - 50 VXLAN bytes)
+	  # * Default - 1450
+	  mtu: 1450
     # weaveNet:
     #   # When true is set, secret will be automatically generated and
     #   # referenced in appropriate manifests. Currently only weave-net


### PR DESCRIPTION
**What this PR does / why we need it**:

* Default the Canal MTU to 1450 when the v1alpha1 API is used. This fixes the issue preventing validation to pass when the v1alpha1 manifest is used
* Add the Canal MTU field to the example config

**Does this PR introduce a user-facing change?**:
```release-note
Default the Canal MTU to 1450 when the v1alpha1 API is used. This fixes the issue preventing validation to pass when the v1alpha1 manifest is used
```

/assign @kron4eg 