### PR TITLE
Remove tabs from the full config

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -501,15 +501,15 @@ clusterNetwork:
     # * canal
     # * weave-net
     # * external - The CNI plugin can be installed as an addon or manually
-	canal:
-	  # MTU represents the maximum transmission unit.
-	  # Default MTU value depends on the specified provider:
-	  # * AWS - 8951 (9001 AWS Jumbo Frame - 50 VXLAN bytes)
-	  # * GCE - 1410 (GCE specific 1460 bytes - 50 VXLAN bytes)
-	  # * Hetzner - 1400 (Hetzner specific 1450 bytes - 50 VXLAN bytes)
-	  # * OpenStack - 1400 (Hetzner specific 1450 bytes - 50 VXLAN bytes)
-	  # * Default - 1450
-	  mtu: 1450
+    canal:
+      # MTU represents the maximum transmission unit.
+      # Default MTU value depends on the specified provider:
+      # * AWS - 8951 (9001 AWS Jumbo Frame - 50 VXLAN bytes)
+      # * GCE - 1410 (GCE specific 1460 bytes - 50 VXLAN bytes)
+      # * Hetzner - 1400 (Hetzner specific 1450 bytes - 50 VXLAN bytes)
+      # * OpenStack - 1400 (Hetzner specific 1450 bytes - 50 VXLAN bytes)
+      # * Default - 1450
+      mtu: 1450
     # weaveNet:
     #   # When true is set, secret will be automatically generated and
     #   # referenced in appropriate manifests. Currently only weave-net


### PR DESCRIPTION
**What this PR does / why we need it**:

There are tabs in the full config which are causing the following error:

```
Error: failed to decode new config: error converting YAML to JSON: yaml: line 25: found character that cannot start any token
failed to decode new config: error converting YAML to JSON: yaml: line 25: found character that cannot start any token
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 