### PR TITLE
Fix a typo in the full config example

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -507,7 +507,7 @@ clusterNetwork:
       # * AWS - 8951 (9001 AWS Jumbo Frame - 50 VXLAN bytes)
       # * GCE - 1410 (GCE specific 1460 bytes - 50 VXLAN bytes)
       # * Hetzner - 1400 (Hetzner specific 1450 bytes - 50 VXLAN bytes)
-      # * OpenStack - 1400 (Hetzner specific 1450 bytes - 50 VXLAN bytes)
+      # * OpenStack - 1400 (OpenStack specific 1450 bytes - 50 VXLAN bytes)
       # * Default - 1450
       mtu: 1450
     # weaveNet:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a typo in the full config example.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 