### PR TITLE
Update kubeone-e2e image to Go 1.15

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
     path_alias: k8c.io/kubeone
     spec:
       containers:
-      - image: golang:1.14.4
+      - image: golang:1.15.0
         command:
         - make
         args:
@@ -59,7 +59,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     spec:
       containers:
-      - image: golang:1.14.4
+      - image: golang:1.15.0
         command:
         - make
         args:
@@ -78,7 +78,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     spec:
       containers:
-      - image: golang:1.14.4
+      - image: golang:1.15.0
         command:
         - make
         args:

--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,7 +14,7 @@
 
 # building image
 
-FROM golang:1.14.4 as builder
+FROM golang:1.15.0 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip \
@@ -37,7 +37,7 @@ RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
-FROM golang:1.14.4
+FROM golang:1.15.0
 
 ARG version
 

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,9 +17,9 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.16"]="v1.16.11"
-full_versions["1.17"]="v1.17.7"
-full_versions["1.18"]="v1.18.4"
+full_versions["1.16"]="v1.16.14"
+full_versions["1.17"]="v1.17.11"
+full_versions["1.18"]="v1.18.8"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.8
+TAG=v0.1.9
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -16,6 +16,7 @@
 
 set -eu -o pipefail
 
+export GOFLAGS=-mod=vendor
 
 # The code generation script takes the following arguments:
 # * generators (we use only deepcopy, conversion and defaulter)

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -16,6 +16,8 @@
 
 set -eu -o pipefail
 
+export GOFLAGS=-mod=vendor
+
 cd $(dirname "${BASH_SOURCE}")/..
 
 DIFFROOT="pkg"


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the kubeone-e2e image to Go 1.15. Once the image is pushed, I'll update the remaining jobs to use it. This PR also updates the Kubernetes test binaries to the latest versions.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 