### PR TITLE
Bump kubeone-e2e to v0.1.9

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -121,7 +121,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -146,7 +146,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -171,7 +171,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -200,7 +200,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -225,7 +225,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -250,7 +250,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -279,7 +279,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -304,7 +304,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -329,7 +329,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -358,7 +358,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -385,7 +385,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -412,7 +412,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -443,7 +443,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -468,7 +468,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -493,7 +493,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -522,7 +522,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -547,7 +547,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -572,7 +572,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -601,7 +601,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -625,7 +625,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -653,7 +653,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -677,7 +677,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -705,7 +705,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -729,7 +729,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -757,7 +757,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -783,7 +783,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -813,7 +813,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -837,7 +837,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.8
+      - image: kubermatic/kubeone-e2e:v0.1.9
         imagePullPolicy: Always
         command:
         - make
@@ -865,7 +865,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make
@@ -889,7 +889,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.8
+        - image: kubermatic/kubeone-e2e:v0.1.9
           imagePullPolicy: Always
           command:
             - make


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump kubeone-e2e to v0.1.9.

**Does this PR introduce a user-facing change?**:
```release-note
Build KubeOne using Go 1.15
```

/assign @kron4eg 