### PR TITLE
[release/v1.0] Update docs URLs to point to the correct documents

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -7,6 +7,6 @@ how to use the KubeOne Addons, consider the [KubeOne documentation][addons-docs]
 
 * [Cluster backups (with Restic)][backups-addon]
 
-[addons-docs]: (https://docs.kubermatic.com/kubeone/master/using_kubeone/addons/)
+[addons-docs]: (https://docs.kubermatic.com/kubeone/master/advanced/addons/)
 [backups-addon]: (./backups-restic)
 [restic]: (https://restic.net/)

--- a/addons/README.md
+++ b/addons/README.md
@@ -7,6 +7,6 @@ how to use the KubeOne Addons, consider the [KubeOne documentation][addons-docs]
 
 * [Cluster backups (with Restic)][backups-addon]
 
-[addons-docs]: (https://docs.kubermatic.com/kubeone/master/advanced/addons/)
+[addons-docs]: (https://docs.kubermatic.com/kubeone/v1.0/advanced/addons/)
 [backups-addon]: (./backups-restic)
 [restic]: (https://restic.net/)

--- a/docs/proposals/20200224-apply.md
+++ b/docs/proposals/20200224-apply.md
@@ -259,6 +259,6 @@ the specific operation.
 * Write and/or update documentation
 
 [etcd-quorum]: https://github.com/etcd-io/etcd/blob/master/Documentation/faq.md#why-an-odd-number-of-cluster-members
-[manual-cluster-repair]: https://docs.kubermatic.com/kubeone/master/using_kubeone/manual_cluster_repair/
+[manual-cluster-repair]: https://docs.kubermatic.com/kubeone/master/maintenance/manual_cluster_repair/
 [automated-cluster-repairs]: https://github.com/kubermatic/kubeone/pull/888
-[disaster-recovery]: https://docs.kubermatic.com/kubeone/master/using_kubeone/manual_cluster_recovery/
+[disaster-recovery]: https://docs.kubermatic.com/kubeone/master/maintenance/manual_cluster_recovery/

--- a/docs/proposals/20200224-apply.md
+++ b/docs/proposals/20200224-apply.md
@@ -259,6 +259,6 @@ the specific operation.
 * Write and/or update documentation
 
 [etcd-quorum]: https://github.com/etcd-io/etcd/blob/master/Documentation/faq.md#why-an-odd-number-of-cluster-members
-[manual-cluster-repair]: https://docs.kubermatic.com/kubeone/master/maintenance/manual_cluster_repair/
+[manual-cluster-repair]: https://docs.kubermatic.com/kubeone/v1.0/maintenance/manual_cluster_repair/
 [automated-cluster-repairs]: https://github.com/kubermatic/kubeone/pull/888
-[disaster-recovery]: https://docs.kubermatic.com/kubeone/master/maintenance/manual_cluster_recovery/
+[disaster-recovery]: https://docs.kubermatic.com/kubeone/v1.0/maintenance/manual_cluster_recovery/

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -147,5 +147,5 @@ shows the correct version.
 [goreleaser]: https://goreleaser.com
 [goreleaser-install]: https://goreleaser.com/install/
 [github-token]: https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
-[docs-compatibility]: https://docs.kubermatic.com/kubeone/master/compatibility_info/
+[docs-compatibility]: https://docs.kubermatic.com/kubeone/v1.0/compatibility_info/
 [changelog]: https://github.com/kubermatic/kubeone/blob/master/CHANGELOG.md

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -25,15 +25,9 @@ to reference to the upcoming version and generate a changelog.
 
 ### Updating documentation
 
-You need to update the following documents to point to the new release:
-
-* The Kubernetes versions compatibility matrix should be updated if there
-  are changes in supported Kubernetes versions, Terraform versions and/or
-  providers. The compatibility matrix is located in two places, in the
-  repo [`README.md` file][matrix-readme] and at the 
-  [docs website][matrix-docs]
-* Update [the quickstart guides][quickstart] to require/recommend
-  the latest version if needed
+The [Compatibility document][docs-compatibility] should be updated if there
+are changes in supported Kubernetes versions, Terraform versions, operating
+systems, and/or providers.
 
 ### Generating the changelog
 
@@ -153,7 +147,5 @@ shows the correct version.
 [goreleaser]: https://goreleaser.com
 [goreleaser-install]: https://goreleaser.com/install/
 [github-token]: https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
-[matrix-readme]: https://github.com/kubermatic/kubeone#kubernetes-versions-compatibility
-[matrix-docs]: https://docs.kubermatic.com/kubeone/master/#kubernetes-versions-compatibility
-[quickstart]: https://docs.kubermatic.com/kubeone/master/getting_started/
+[docs-compatibility]: https://docs.kubermatic.com/kubeone/master/compatibility_info/
 [changelog]: https://github.com/kubermatic/kubeone/blob/master/CHANGELOG.md

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -1,10 +1,11 @@
-# AWS Quickstart Terraform scripts
+# AWS Quickstart Terraform configs
 
-The AWS Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
-Check out the following [AWS getting started walkthrough][aws-quickstart] to learn more about how to use the
-scripts and how to provision a Kubernetes cluster using KubeOne.
+The AWS Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[aws-quickstart]: https://docs.kubermatic.com/kubeone/master/getting_started/aws/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
 
 ## Requirements
 

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.0/infrastructure/terraform_configs/
 
 ## Requirements
 

--- a/examples/terraform/azure/README.md
+++ b/examples/terraform/azure/README.md
@@ -1,11 +1,11 @@
-# Azure Quickstart Terraform scripts
+# Azure Quickstart Terraform configs
 
-The Azure Quickstart Terraform scripts can be used to create the needed
-infrastructure for a Kubernetes HA cluster. Check out the following 
-[Azure getting started walkthrough][1] to learn more about how to use the
-scripts and how to provision a Kubernetes cluster using KubeOne.
+The Azure Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[1]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-azure.md
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
 
 ## Inputs
 

--- a/examples/terraform/azure/README.md
+++ b/examples/terraform/azure/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.0/infrastructure/terraform_configs/
 
 ## Inputs
 

--- a/examples/terraform/digitalocean/README.md
+++ b/examples/terraform/digitalocean/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.0/infrastructure/terraform_configs/
 
 ## Inputs
 

--- a/examples/terraform/digitalocean/README.md
+++ b/examples/terraform/digitalocean/README.md
@@ -1,10 +1,11 @@
-# DigitalOcean Quickstart Terraform scripts
+# DigitalOcean Quickstart Terraform configs
 
-The DigitalOcean Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
-Check out the following [DigitalOcean getting started walkthrough][do-quickstart] to learn more about how to use the
-scripts and how to provision a Kubernetes cluster using KubeOne.
+The DigitalOcean Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the following
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[do-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-digitalocean.md
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
 
 ## Inputs
 

--- a/examples/terraform/gce/README.md
+++ b/examples/terraform/gce/README.md
@@ -5,7 +5,7 @@ infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.0/infrastructure/terraform_configs/
 
 ## GCE Provider configuration
 

--- a/examples/terraform/gce/README.md
+++ b/examples/terraform/gce/README.md
@@ -1,10 +1,11 @@
-# GCE Quickstart Terraform scripts
+# GCE Quickstart Terraform configs
 
-The GCE Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
-Check out the following [GCE getting started walkthrough][gce-quickstart] to learn more about how to use the
-scripts and how to provision a Kubernetes cluster using KubeOne.
+The GCE Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the following
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-[gce-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-gce.md
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
 
 ## GCE Provider configuration
 

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -1,13 +1,16 @@
-# Hetzner Quickstart Terraform scripts
+# Hetzner Quickstart Terraform configs
 
-The Hetzner Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
-Check out the following [Hetzner getting started walkthrough][hetzner-quickstart] to learn more about how to use the
-scripts and how to provision a Kubernetes cluster using KubeOne.
+The Hetzner Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the following
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-## Kubernetes APIserver LoadBalancing
-See https://docs.kubermatic.com/kubeone/master/using_kubeone/example_loadbalancer/
+## Kubernetes API Server Load Balancing
 
-[hetzner-quickstart]: https://docs.kubermatic.com/kubeone/master/getting_started/hetzner/
+See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
+
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
 
 ## Inputs
 

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -9,8 +9,8 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.0/infrastructure/terraform_configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.0/advanced/example_loadbalancer/
 
 ## Inputs
 

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -9,8 +9,8 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.0/infrastructure/terraform_configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.0/advanced/example_loadbalancer/
 
 ## Inputs
 

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -1,12 +1,16 @@
-# OpenStack Quickstart Terraform scripts
+# OpenStack Quickstart Terraform configs
 
-The OpenStack Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
-Check out the following [OpenStack getting started walkthrough](https://docs.kubermatic.com/kubeone/master/getting_started/openstack) to learn more about how to use the
-scripts and how to provision a Kubernetes cluster using KubeOne.
+The OpenStack Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the following
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-## Kubernetes APIserver LoadBalancing
+## Kubernetes API Server Load Balancing
 
-See [example-loadbalancer](https://docs.kubermatic.com/kubeone/master/using_kubeone/example_loadbalancer)
+See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
+
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
 
 ## Inputs
 

--- a/examples/terraform/packet/README.md
+++ b/examples/terraform/packet/README.md
@@ -1,13 +1,16 @@
-# Packet Quickstart Terraform scripts
+# Packet Quickstart Terraform configs
 
-The Packet Quickstart Terraform scripts can be used to create the needed infrastructure for a Kubernetes HA cluster.
-Check out the following [Packet getting started walkthrough][packet-quickstart] to learn more about how to use the
-scripts and how to provision a Kubernetes cluster using KubeOne.
+The Packet Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the following
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
 
-## Kubernetes APIserver LoadBalancing
-See https://github.com/kubermatic/kubeone/blob/master/docs/example-loadbalancer.md
+## Kubernetes API Server Load Balancing
 
-[packet-quickstart]: https://github.com/kubermatic/kubeone/blob/master/docs/quickstart-packet.md
+See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
+
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
 
 ## Inputs
 

--- a/examples/terraform/packet/README.md
+++ b/examples/terraform/packet/README.md
@@ -9,8 +9,8 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.0/infrastructure/terraform_configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.0/advanced/example_loadbalancer/
 
 ## Inputs
 

--- a/examples/terraform/vsphere/README.md
+++ b/examples/terraform/vsphere/README.md
@@ -20,8 +20,8 @@ See https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md
 
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.0/infrastructure/terraform_configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/v1.0/advanced/example_loadbalancer/
 
 ## Inputs
 

--- a/examples/terraform/vsphere/README.md
+++ b/examples/terraform/vsphere/README.md
@@ -1,3 +1,10 @@
+# vSphere Quickstart Terraform configs
+
+The vSphere Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the following
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
+
 ## Required environment variables
 
 * `VSPHERE_USER`
@@ -6,10 +13,15 @@
 * `VSPHERE_ALLOW_UNVERIFIED_SSL`
 
 ## How to prepare a template
+
 See https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md
 
-## Kubernetes APIserver LoadBalancing
-See https://github.com/kubermatic/kubeone/blob/master/docs/example-loadbalancer.md
+## Kubernetes API Server Load Balancing
+
+See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
+
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/terraform_configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
 
 ## Inputs
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick #1051 to the `release/v1.0` branch with v1.0 URLs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 