### PR TITLE
Insert small delay before starting node-local-dns

### DIFF
--- a/pkg/clientutil/wait_pods.go
+++ b/pkg/clientutil/wait_pods.go
@@ -33,7 +33,7 @@ func PodsReadyCondition(ctx context.Context, c dynclient.Client, listOpts dyncli
 		podsList := corev1.PodList{}
 
 		if err := c.List(ctx, &podsList, &listOpts); err != nil {
-			return false, errors.Wrapf(err, "failed to list %s pods", listOpts.FieldSelector.String())
+			return false, errors.Wrapf(err, "failed to list pods")
 		}
 
 		return allPodsAreRunningAndReady(&podsList), nil

--- a/pkg/templates/nodelocaldns/nodelocaldns.go
+++ b/pkg/templates/nodelocaldns/nodelocaldns.go
@@ -39,7 +39,7 @@ const VirtualIP = "169.254.20.10"
 
 const (
 	image                    = "k8s.gcr.io/k8s-dns-node-cache"
-	tag                      = "1.15.12"
+	tag                      = "1.15.13"
 	componentLabel           = "nodelocaldns"
 	dnscacheCorefileTemplate = `
 __PILLAR__DNS__DOMAIN__:53 {
@@ -188,6 +188,14 @@ func dnscacheDaemonSet() *appsv1.DaemonSet {
 	hostPathFileOrCreate := corev1.HostPathFileOrCreate
 	terminationGracePeriodSeconds := int64(0)
 
+	// "sleep 10" is needed to avoid race-condition for iptables creation between node-local-cache and kube-proxy, to
+	// make sure that kube-proxy will insert its iptables rules first.
+	// see more at: https://github.com/kubermatic/kubeone/pull/1058
+	execScript := fmt.Sprintf(`
+sleep 10;
+exec /node-cache -localip %s -conf /etc/Corefile -upstreamsvc kube-dns-upstream`,
+		VirtualIP)
+
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "node-local-dns",
@@ -225,13 +233,10 @@ func dnscacheDaemonSet() *appsv1.DaemonSet {
 						{
 							Name:  "node-cache",
 							Image: fmt.Sprintf("%s:%s", image, tag),
-							Args: []string{
-								"-localip",
-								VirtualIP,
-								"-conf",
-								"/etc/Corefile",
-								"-upstreamsvc",
-								"kube-dns-upstream",
+							Command: []string{
+								"/bin/sh",
+								"-c",
+								execScript,
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{


### PR DESCRIPTION
**What this PR does / why we need it**:
On some slow at the boot systems it may happen (race condition) that nodelocal dns will start before kube-proxy and that will mess up whole iptables setup. To make room for kube-proxy to be first to run we delay node-local-dns at the start s little bit.

This is TEMPORARY workaround, until the time when node-local-dns would start supporting iptables-nft

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1037 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix race condition between kube-proxy and node-local-dns
```
