### PR TITLE
extract terraform example to current working directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,15 +31,16 @@ DEST=/usr/local/bin
 # Download the latest version for the OS and save it as zip
 
 if curl -LO "$URL"
-then 
+then
     echo "Copying kubeone binary into $DEST"
     # unpack:
-    
+
 
     if unzip "kubeone_${VERSION}_${OS}_amd64.zip" -d "kubeone_${VERSION}_${OS}_amd64"
     then
         sudo mv "kubeone_${VERSION}_${OS}_amd64/kubeone" "$DEST"
         rm "kubeone_${VERSION}_${OS}_amd64.zip"
+        cp -a "kubeone_${VERSION}_${OS}_amd64/examples/terraform/." "./"
         rm -rf "kubeone_${VERSION}_${OS}_amd64"
         echo "kubeone has been installed into $DEST/kubeone"
         exit 0


### PR DESCRIPTION
Signed-off-by: Jelto Wodstrcil <mail@jel.to>

**What this PR does / why we need it**:
The PR adds terraform example extraction to the `install.sh` script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This PR adds missing extraction of terraform examples in the `install.sh` script.
The official [Getting KubeOne]() documentation states:
```
The installation script downloads the release archive from GitHub, installs the KubeOne binary in your /usr/local/bin directory and unpacks the example Terraform configs in your current working directory.
```
However when running the script, the example files are missing, only the kubeone binary gets copied.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
