### PR TITLE
Add Kubernetes v1.19.0 binaries to the E2E tests image

### DIFF
--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -20,6 +20,7 @@ declare -A full_versions
 full_versions["1.16"]="v1.16.14"
 full_versions["1.17"]="v1.17.11"
 full_versions["1.18"]="v1.18.8"
+full_versions["1.19"]="v1.19.0"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.9
+TAG=v0.1.10
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Kubernetes v1.19.0 binaries to the E2E tests image. The v1.16 binaries are intentionally left in the place, as v1.16 is still supported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #984 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
