### PR TITLE
Update jobs for E2E tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -121,7 +121,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -146,7 +146,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -171,7 +171,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -200,7 +200,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -225,7 +225,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -250,7 +250,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -279,7 +279,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -304,7 +304,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -329,7 +329,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -358,7 +358,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -385,7 +385,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -412,7 +412,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -443,7 +443,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -468,7 +468,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -493,7 +493,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -522,7 +522,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -547,7 +547,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -572,7 +572,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -601,7 +601,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -625,7 +625,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -653,7 +653,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -677,7 +677,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -705,7 +705,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -729,7 +729,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -757,7 +757,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -783,7 +783,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -813,7 +813,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -837,7 +837,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.9
+      - image: kubermatic/kubeone-e2e:v0.1.10
         imagePullPolicy: Always
         command:
         - make
@@ -865,7 +865,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make
@@ -889,7 +889,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.9
+        - image: kubermatic/kubeone-e2e:v0.1.10
           imagePullPolicy: Always
           command:
             - make

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -131,7 +131,7 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -156,7 +156,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.7"
+              value: "1.17.11"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -181,7 +181,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.4"
+              value: "1.18.8"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -210,7 +210,7 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -235,7 +235,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.7"
+              value: "1.17.11"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -260,7 +260,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.4"
+              value: "1.18.8"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -289,7 +289,7 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -314,7 +314,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.7"
+              value: "1.17.11"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -339,7 +339,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.4"
+              value: "1.18.8"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -368,7 +368,7 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_SET
           value: "conformance"
         - name: TF_VAR_project
@@ -395,7 +395,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.7"
+              value: "1.17.11"
             - name: TEST_SET
               value: "conformance"
             - name: TF_VAR_project
@@ -422,7 +422,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.4"
+              value: "1.18.8"
             - name: TEST_SET
               value: "conformance"
             - name: TF_VAR_project
@@ -453,7 +453,7 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -478,7 +478,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.7"
+              value: "1.17.11"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -503,7 +503,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.4"
+              value: "1.18.8"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -532,7 +532,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.16.11"
+              value: "1.16.14"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -557,7 +557,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.7"
+              value: "1.17.11"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -582,7 +582,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.4"
+              value: "1.18.8"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -611,9 +611,9 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_SET
           value: "upgrades"
 
@@ -635,9 +635,9 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.4"
+          value: "1.18.8"
         - name: TEST_SET
           value: "upgrades"
 
@@ -663,9 +663,9 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_SET
           value: "upgrades"
 
@@ -687,9 +687,9 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.4"
+          value: "1.18.8"
         - name: TEST_SET
           value: "upgrades"
 
@@ -715,9 +715,9 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_SET
           value: "upgrades"
 
@@ -739,9 +739,9 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.4"
+          value: "1.18.8"
         - name: TEST_SET
           value: "upgrades"
 
@@ -767,9 +767,9 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_SET
           value: "upgrades"
         - name: TF_VAR_project
@@ -793,9 +793,9 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.4"
+          value: "1.18.8"
         - name: TEST_SET
           value: "upgrades"
         - name: TF_VAR_project
@@ -823,9 +823,9 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.11"
+          value: "1.16.14"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_SET
           value: "upgrades"
 
@@ -847,9 +847,9 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.7"
+          value: "1.17.11"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.4"
+          value: "1.18.8"
         - name: TEST_SET
           value: "upgrades"
 
@@ -875,9 +875,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.16.11"
+              value: "1.16.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.7"
+              value: "1.17.11"
             - name: TEST_SET
               value: "upgrades"
 
@@ -899,9 +899,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.17.7"
+              value: "1.17.11"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.4"
+              value: "1.18.8"
             - name: TEST_SET
               value: "upgrades"
 

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -110,7 +110,7 @@ presubmits:
             memory: 2Gi
 
   #########################################################
-  # E2E/Conformance tests (AWS, 1.16-1.18)
+  # E2E/Conformance tests (AWS, 1.16-1.19)
   #########################################################
 
   - name: pull-kubeone-e2e-aws-conformance-1.16
@@ -188,8 +188,33 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-aws-conformance-1.19
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-aws: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.10
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "aws"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.19.0"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
-  # E2E/Conformance tests (DigitalOcean, 1.16-1.18)
+  # E2E/Conformance tests (DigitalOcean, 1.16-1.19)
   #########################################################
 
   - name: pull-kubeone-e2e-digitalocean-conformance-1.16
@@ -267,8 +292,33 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-digitalocean-conformance-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-digitalocean: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.10
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.19.0"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
-  # E2E/Conformance tests (Hetzner, 1.16-1.18)
+  # E2E/Conformance tests (Hetzner, 1.16-1.19)
   #########################################################
 
   - name: pull-kubeone-e2e-hetzner-conformance-1.16
@@ -346,8 +396,33 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-hetzner-conformance-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-hetzner: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.10
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "hetzner"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.19.0"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
-  # E2E/Conformance tests (GCE, 1.16-1.18)
+  # E2E/Conformance tests (GCE, 1.16-1.19)
   #########################################################
 
   - name: pull-kubeone-e2e-gce-conformance-1.16
@@ -431,8 +506,35 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-gce-conformance-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-gce: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.10
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "gce"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.19.0"
+            - name: TEST_SET
+              value: "conformance"
+            - name: TF_VAR_project
+              value: "kubeone-terraform-test"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
-  # E2E/Conformance tests (Packet, 1.16-1.18)
+  # E2E/Conformance tests (Packet, 1.16-1.19)
   #########################################################
 
   - name: pull-kubeone-e2e-packet-conformance-1.16
@@ -510,8 +612,33 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-packet-conformance-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-packet: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.10
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "packet"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.19.0"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
-  # E2E/Conformance tests (OpenStack, 1.16-1.18)
+  # E2E/Conformance tests (OpenStack, 1.16-1.19)
   #########################################################
 
   - name: pull-kubeone-e2e-openstack-conformance-1.16
@@ -589,6 +716,31 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-openstack-conformance-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.10
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.19.0"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
   # E2E/Upgrade tests (AWS)
   #########################################################
@@ -638,6 +790,30 @@ presubmits:
           value: "1.17.11"
         - name: TEST_CLUSTER_TARGET_VERSION
           value: "1.18.8"
+        - name: TEST_SET
+          value: "upgrades"
+
+  - name: pull-kubeone-e2e-aws-upgrade-1.18-1.19
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-aws: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.10
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "aws"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.18.8"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.19.0"
         - name: TEST_SET
           value: "upgrades"
 
@@ -693,6 +869,30 @@ presubmits:
         - name: TEST_SET
           value: "upgrades"
 
+  - name: pull-kubeone-e2e-digitalocean-upgrade-1.18-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-digitalocean: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.10
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "digitalocean"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.18.8"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.19.0"
+        - name: TEST_SET
+          value: "upgrades"
+
   #########################################################
   # E2E/Upgrade tests (Hetzner)
   #########################################################
@@ -742,6 +942,30 @@ presubmits:
           value: "1.17.11"
         - name: TEST_CLUSTER_TARGET_VERSION
           value: "1.18.8"
+        - name: TEST_SET
+          value: "upgrades"
+
+  - name: pull-kubeone-e2e-hetzner-upgrade-1.18-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-hetzner: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.10
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "hetzner"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.18.8"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.19.0"
         - name: TEST_SET
           value: "upgrades"
 
@@ -801,6 +1025,32 @@ presubmits:
         - name: TF_VAR_project
           value: "kubeone-terraform-test"
 
+  - name: pull-kubeone-e2e-gce-upgrade-1.18-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-gce: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.10
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "gce"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.18.8"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.19.0"
+        - name: TEST_SET
+          value: "upgrades"
+        - name: TF_VAR_project
+          value: "kubeone-terraform-test"
+
   #########################################################
   # E2E/Upgrade tests (Packet)
   #########################################################
@@ -853,6 +1103,30 @@ presubmits:
         - name: TEST_SET
           value: "upgrades"
 
+  - name: pull-kubeone-e2e-packet-upgrade-1.18-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-packet: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.10
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "packet"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.18.8"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.19.0"
+        - name: TEST_SET
+          value: "upgrades"
+
   #########################################################
   # E2E/Upgrade tests (OpenStack)
   #########################################################
@@ -902,6 +1176,30 @@ presubmits:
               value: "1.17.11"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.18.8"
+            - name: TEST_SET
+              value: "upgrades"
+
+  - name: pull-kubeone-e2e-openstack-upgrade-1.18-1.19
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.10
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.18.8"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.19.0"
             - name: TEST_SET
               value: "upgrades"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Bump kubeone-e2e image to v0.1.10
* Bump Kubernetes patch releases for existing jobs
* Add Kubernetes 1.19 conformance and upgrade jobs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #984 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
