### PR TITLE
Update machine-controller to v1.17.1

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -46,7 +46,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.16.1"
+	MachineControllerTag           = "v1.17.1"
 )
 
 func CRDs() []runtime.Object {


### PR DESCRIPTION
**What this PR does / why we need it**:

Update machine-controller to v1.17.0.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.17.0
```

/assign @kron4eg 