### PR TITLE
Add KubeletConfiguration to kubeadm configs

### DIFF
--- a/pkg/templates/kubeadm/kubeadmv1beta1.go
+++ b/pkg/templates/kubeadm/kubeadmv1beta1.go
@@ -35,7 +35,7 @@ func (*kubeadmv1beta1) Config(s *state.State, instance kubeoneapi.HostConfig) (s
 		return "", err
 	}
 
-	return templates.KubernetesToYAML(config)
+	return templates.KubernetesToYAML(config, kubeletConf)
 }
 
 func (*kubeadmv1beta1) ConfigWorker(s *state.State, instance kubeoneapi.HostConfig) (string, error) {
@@ -44,8 +44,9 @@ func (*kubeadmv1beta1) ConfigWorker(s *state.State, instance kubeoneapi.HostConf
 		return "", err
 	}
 
-	return templates.KubernetesToYAML(config)
+	return templates.KubernetesToYAML(config, kubeletConf)
 }
+
 func (k *kubeadmv1beta1) UpgradeLeaderCommand() string {
 	return fmt.Sprintf("kubeadm upgrade apply -y %s", k.version)
 }

--- a/pkg/templates/kubeadm/kubeadmv1beta2.go
+++ b/pkg/templates/kubeadm/kubeadmv1beta2.go
@@ -35,7 +35,7 @@ func (*kubeadmv1beta2) Config(s *state.State, instance kubeoneapi.HostConfig) (s
 		return "", err
 	}
 
-	return templates.KubernetesToYAML(config)
+	return templates.KubernetesToYAML(config, kubeletConf)
 }
 
 func (*kubeadmv1beta2) ConfigWorker(s *state.State, instance kubeoneapi.HostConfig) (string, error) {
@@ -44,7 +44,7 @@ func (*kubeadmv1beta2) ConfigWorker(s *state.State, instance kubeoneapi.HostConf
 		return "", err
 	}
 
-	return templates.KubernetesToYAML(config)
+	return templates.KubernetesToYAML(config, kubeletConf)
 }
 
 func (k *kubeadmv1beta2) UpgradeLeaderCommand() string {

--- a/pkg/templates/kubeadm/kubelet.go
+++ b/pkg/templates/kubeadm/kubelet.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+const (
+	kubeletConf = `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: systemd
+`
+)

--- a/pkg/templates/yaml.go
+++ b/pkg/templates/yaml.go
@@ -32,7 +32,7 @@ import (
 // This function takes a slice of items to support creating a
 // multi-document YAML string (separated with "---" between each
 // item).
-func KubernetesToYAML(data []runtime.Object) (string, error) {
+func KubernetesToYAML(data []runtime.Object, auxiliaries ...string) (string, error) {
 	var buffer bytes.Buffer
 
 	for _, item := range data {
@@ -51,6 +51,12 @@ func KubernetesToYAML(data []runtime.Object) (string, error) {
 		}
 
 		if _, err := buffer.WriteString("\n---\n"); err != nil {
+			return "", errors.Wrap(err, "failed to write into buffer")
+		}
+	}
+
+	for _, item := range auxiliaries {
+		if _, err := buffer.WriteString(item + "\n---\n"); err != nil {
 			return "", errors.Wrap(err, "failed to write into buffer")
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubelet under containerd should be explicitly configured with cgroups driver

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
re #1085 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
