### PR TITLE
Dynamically determine AMI for E2E tests. Support for CentOS7 in E2E tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,3 +55,7 @@ issues:
 
   - path: pkg/apis/kubeone
     text: "type name will be used as kubeone.KubeOneCluster by other packages"
+
+  - path: test/e2e
+    text: "cyclomatic complexity 33 of func `TestClusterConformance` is high"
+

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -180,7 +180,13 @@ func TestClusterConformance(t *testing.T) {
 			}
 
 			if osWorkers != OperatingSystemDefault {
-				args = append(args, "-var", fmt.Sprintf("worker_os=%s", osWorkers))
+				switch {
+				case osWorkers == OperatingSystemCentOS7:
+					args = append(args, "-var", fmt.Sprintf("worker_os=%s", "centos"))
+					args = append(args, "-var", fmt.Sprintf("ami=%s", AWSCentOS7AMI))
+				default:
+					args = append(args, "-var", fmt.Sprintf("worker_os=%s", osWorkers))
+				}
 			}
 
 			if tc.provider == provisioner.GCE {
@@ -231,7 +237,13 @@ func TestClusterConformance(t *testing.T) {
 				}
 
 				if osWorkers != OperatingSystemDefault {
-					args = append(args, "-var", fmt.Sprintf("worker_os=%s", osWorkers))
+					switch {
+					case osWorkers == OperatingSystemCentOS7:
+						args = append(args, "-var", fmt.Sprintf("worker_os=%s", "centos"))
+						args = append(args, "-var", fmt.Sprintf("ami=%s", AWSCentOS7AMI))
+					default:
+						args = append(args, "-var", fmt.Sprintf("worker_os=%s", osWorkers))
+					}
 				}
 
 				_, err = pr.Provision(args...)


### PR DESCRIPTION
**What this PR does / why we need it**:

* Dynamically determine AMI for E2E tests
* Support for CentOS7 in E2E tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevant to #1095

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 