### PR TITLE
Explicitly restart Kubelet on upgrade for Ubuntu

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -100,6 +100,10 @@ sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cn
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
+
+{{- if or .FORCE .KUBELET }}
+sudo systemctl restart kubelet
+{{- end }}
 `
 
 	kubeadmCentOSTemplate = `

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -84,3 +84,4 @@ sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cn
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -84,3 +84,4 @@ sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cn
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet


### PR DESCRIPTION
**What this PR does / why we need it**:

Explicitly restart Kubelet on upgrade for Ubuntu. We already do this for CentOS/RHEL and CoreOS/Flatcar.

**Does this PR introduce a user-facing change?**:
```release-note
Explicitly restart Kubelet on upgrade for Ubuntu
```

/assign @kron4eg 