### PR TITLE
Don't stop Kubelet when upgrading Kubeadm on Flatcar

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -281,7 +281,6 @@ sudo curl -L --remote-name-all \
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
-sudo systemctl stop kubelet
 sudo mv /var/tmp/kube-binaries/kubeadm .
 sudo chmod +x kubeadm
 `

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICoreOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICoreOS.golden
@@ -32,6 +32,5 @@ sudo curl -L --remote-name-all \
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
-sudo systemctl stop kubelet
 sudo mv /var/tmp/kube-binaries/kubeadm .
 sudo chmod +x kubeadm


### PR DESCRIPTION
**What this PR does / why we need it**:

For some reason, we stop Kubelet when upgrading Kubeadm and CNI binaries, but we don't start it until the upgrade is fully done. Usually, and as per [the upgrade instructions](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/), restarting Kubelet should be done as the last step.

I don't know the reason why we introduced this, but it might be some leftover when copying code from another function.

**Special notes for your reviewer**:

/hold
for manual testing

**Does this PR introduce a user-facing change?**:
```release-note
Don't stop Kubelet when upgrading Kubeadm on Flatcar
```

/assign @kron4eg 