### PR TITLE
Update kubernetes-cni to v0.8.7

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultKubernetesCNIVersion = "0.8.6"
+	defaultKubernetesCNIVersion = "0.8.7"
 )
 
 const (

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -78,7 +78,7 @@ sudo yum install -y \
 	kubelet-v1.17.4 \
 	kubeadm-v1.17.4 \
 	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.6 \
+	kubernetes-cni-0.8.7 \
 	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -77,7 +77,7 @@ sudo yum install -y \
 	kubelet-v1.17.4 \
 	kubeadm-v1.17.4 \
 	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.6 \
+	kubernetes-cni-0.8.7 \
 	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -77,7 +77,7 @@ sudo yum install -y \
 	kubelet-v1.17.4 \
 	kubeadm-v1.17.4 \
 	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.6 \
+	kubernetes-cni-0.8.7 \
 	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -77,7 +77,7 @@ sudo yum install -y \
 	kubelet-v1.16.1 \
 	kubeadm-v1.16.1 \
 	kubectl-v1.16.1 \
-	kubernetes-cni-0.8.6 \
+	kubernetes-cni-0.8.7 \
 	docker-ce-18.09.9-3.el7 docker-ce-cli-18.09.9-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-force.golden
@@ -56,7 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo systemctl restart docker
 
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${HOST_ARCH}-v0.8.6.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="vv1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
@@ -56,7 +56,7 @@ sudo systemctl force-reload systemd-journald
 sudo systemctl restart docker
 
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${HOST_ARCH}-v0.8.6.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="vv1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -67,7 +67,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.6" | head -1 | awk '{print $3}')
+cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.7" | head -1 | awk '{print $3}')
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -76,7 +76,7 @@ sudo yum versionlock delete docker-ce docker-ce-cli kubelet kubeadm kubectl kube
 
 sudo yum install -y \
 	kubeadm-v1.17.4 \
-	kubernetes-cni-0.8.6 \
+	kubernetes-cni-0.8.7 \
 	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICoreOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICoreOS.golden
@@ -20,7 +20,7 @@ esac
 source /etc/kubeone/proxy-env
 
 sudo mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-${HOST_ARCH}-v0.8.6.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="vv1.17.4"

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -67,7 +67,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.6" | head -1 | awk '{print $3}')
+cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.7" | head -1 | awk '{print $3}')
 sudo apt-mark unhold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -77,7 +77,7 @@ sudo yum versionlock delete docker-ce docker-ce-cli kubelet kubeadm kubectl kube
 sudo yum install -y \
 	kubelet-v1.17.4 \
 	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.6 \
+	kubernetes-cni-0.8.7 \
 	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
 sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -67,7 +67,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.6" | head -1 | awk '{print $3}')
+cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.7" | head -1 | awk '{print $3}')
 sudo apt-mark unhold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a proposal to update the `kubernetes-cni` to v0.8.7. The upstream Kubernetes is currently updating CNI from v0.8.6 to v0.8.7 for all supported releases.

The minimum version is still v0.8.6, but I think this is a nice-to-have change that shouldn't have side-effects.

**Does this PR introduce a user-facing change?**:
```release-note
Update kubernetes-cni to v0.8.7
```

/assign @kron4eg 