### PR TITLE
hetzner ubuntu-20.04

### DIFF
--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -47,7 +47,7 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas = 1
+      replicas = var.workers_replicas
       providerSpec = {
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -63,16 +63,20 @@ variable "worker_type" {
   default = "cx21"
 }
 
+variable "workers_replicas" {
+  default = 1
+}
+
 variable "lb_type" {
   default = "lb11"
 }
 
 variable "datacenter" {
-  default = "fsn1"
+  default = "nbg1"
 }
 
 variable "image" {
-  default = "ubuntu-18.04"
+  default = "ubuntu-20.04"
 }
 
 variable "ip_range" {

--- a/examples/terraform/hetzner/versions.tf
+++ b/examples/terraform/hetzner/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    hcloud = {
+      source = "hetznercloud/hcloud"
+    }
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* Use ubuntu-20.04 by default on hentzer
* make this config compatible with terraform 0.12 and 0.13

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use ubuntu-20.04 by default on hentzer
```
