### PR TITLE
Update e2e image

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -121,7 +121,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -146,7 +146,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -171,7 +171,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -196,7 +196,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -206,7 +206,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.0"
+              value: "1.19.2"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -225,7 +225,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -250,7 +250,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -275,7 +275,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -300,7 +300,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -310,7 +310,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.0"
+              value: "1.19.2"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -329,7 +329,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -354,7 +354,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -379,7 +379,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -404,7 +404,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -414,7 +414,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.0"
+              value: "1.19.2"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -433,7 +433,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -460,7 +460,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -487,7 +487,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -514,7 +514,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -524,7 +524,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.0"
+              value: "1.19.2"
             - name: TEST_SET
               value: "conformance"
             - name: TF_VAR_project
@@ -545,7 +545,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -570,7 +570,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -595,7 +595,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -620,7 +620,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -630,7 +630,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.0"
+              value: "1.19.2"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -649,7 +649,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -674,7 +674,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -699,7 +699,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -724,7 +724,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -734,7 +734,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.0"
+              value: "1.19.2"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -753,7 +753,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -777,7 +777,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -801,7 +801,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -813,7 +813,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.18.8"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.0"
+          value: "1.19.2"
         - name: TEST_SET
           value: "upgrades"
 
@@ -829,7 +829,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -853,7 +853,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -877,7 +877,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -889,7 +889,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.18.8"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.0"
+          value: "1.19.2"
         - name: TEST_SET
           value: "upgrades"
 
@@ -905,7 +905,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -929,7 +929,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -953,7 +953,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -965,7 +965,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.18.8"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.0"
+          value: "1.19.2"
         - name: TEST_SET
           value: "upgrades"
 
@@ -981,7 +981,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -1007,7 +1007,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -1033,7 +1033,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -1045,7 +1045,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.18.8"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.0"
+          value: "1.19.2"
         - name: TEST_SET
           value: "upgrades"
         - name: TF_VAR_project
@@ -1063,7 +1063,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -1087,7 +1087,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -1111,7 +1111,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.10
+      - image: kubermatic/kubeone-e2e:v0.1.11
         imagePullPolicy: Always
         command:
         - make
@@ -1123,7 +1123,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.18.8"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.0"
+          value: "1.19.2"
         - name: TEST_SET
           value: "upgrades"
 
@@ -1139,7 +1139,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -1163,7 +1163,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -1187,7 +1187,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.10
+        - image: kubermatic/kubeone-e2e:v0.1.11
           imagePullPolicy: Always
           command:
             - make
@@ -1199,7 +1199,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.18.8"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.0"
+              value: "1.19.2"
             - name: TEST_SET
               value: "upgrades"
 

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -121,7 +121,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -131,7 +131,7 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -146,7 +146,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -156,7 +156,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.11"
+              value: "1.17.12"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -171,7 +171,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -181,7 +181,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.8"
+              value: "1.18.9"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -196,7 +196,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -225,7 +225,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -235,7 +235,7 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -250,7 +250,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -260,7 +260,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.11"
+              value: "1.17.12"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -275,7 +275,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -285,7 +285,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.8"
+              value: "1.18.9"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -300,7 +300,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -329,7 +329,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -339,7 +339,7 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -354,7 +354,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -364,7 +364,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.11"
+              value: "1.17.12"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -379,7 +379,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -389,7 +389,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.8"
+              value: "1.18.9"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -404,7 +404,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -433,7 +433,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -443,7 +443,7 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_SET
           value: "conformance"
         - name: TF_VAR_project
@@ -460,7 +460,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -470,7 +470,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.11"
+              value: "1.17.12"
             - name: TEST_SET
               value: "conformance"
             - name: TF_VAR_project
@@ -487,7 +487,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -497,7 +497,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.8"
+              value: "1.18.9"
             - name: TEST_SET
               value: "conformance"
             - name: TF_VAR_project
@@ -514,7 +514,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -545,7 +545,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -555,7 +555,7 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -570,7 +570,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -580,7 +580,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.11"
+              value: "1.17.12"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -595,7 +595,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -605,7 +605,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.8"
+              value: "1.18.9"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -620,7 +620,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -649,7 +649,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -659,7 +659,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.16.14"
+              value: "1.16.15"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -674,7 +674,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -684,7 +684,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.11"
+              value: "1.17.12"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -699,7 +699,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -709,7 +709,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.8"
+              value: "1.18.9"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -724,7 +724,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -753,7 +753,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -763,9 +763,9 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_SET
           value: "upgrades"
 
@@ -777,7 +777,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -787,9 +787,9 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_SET
           value: "upgrades"
 
@@ -801,7 +801,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -811,7 +811,7 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_CLUSTER_TARGET_VERSION
           value: "1.19.2"
         - name: TEST_SET
@@ -829,7 +829,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -839,9 +839,9 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_SET
           value: "upgrades"
 
@@ -853,7 +853,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -863,9 +863,9 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_SET
           value: "upgrades"
 
@@ -877,7 +877,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -887,7 +887,7 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_CLUSTER_TARGET_VERSION
           value: "1.19.2"
         - name: TEST_SET
@@ -905,7 +905,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -915,9 +915,9 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_SET
           value: "upgrades"
 
@@ -929,7 +929,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -939,9 +939,9 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_SET
           value: "upgrades"
 
@@ -953,7 +953,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -963,7 +963,7 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_CLUSTER_TARGET_VERSION
           value: "1.19.2"
         - name: TEST_SET
@@ -981,7 +981,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -991,9 +991,9 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_SET
           value: "upgrades"
         - name: TF_VAR_project
@@ -1007,7 +1007,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -1017,9 +1017,9 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_SET
           value: "upgrades"
         - name: TF_VAR_project
@@ -1033,7 +1033,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -1043,7 +1043,7 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_CLUSTER_TARGET_VERSION
           value: "1.19.2"
         - name: TEST_SET
@@ -1063,7 +1063,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -1073,9 +1073,9 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.14"
+          value: "1.16.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_SET
           value: "upgrades"
 
@@ -1087,7 +1087,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -1097,9 +1097,9 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.11"
+          value: "1.17.12"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_SET
           value: "upgrades"
 
@@ -1111,7 +1111,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.11
+      - image: kubermatic/kubeone-e2e:v0.1.12
         imagePullPolicy: Always
         command:
         - make
@@ -1121,7 +1121,7 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.8"
+          value: "1.18.9"
         - name: TEST_CLUSTER_TARGET_VERSION
           value: "1.19.2"
         - name: TEST_SET
@@ -1139,7 +1139,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -1149,9 +1149,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.16.14"
+              value: "1.16.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.11"
+              value: "1.17.12"
             - name: TEST_SET
               value: "upgrades"
 
@@ -1163,7 +1163,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -1173,9 +1173,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.17.11"
+              value: "1.17.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.8"
+              value: "1.18.9"
             - name: TEST_SET
               value: "upgrades"
 
@@ -1187,7 +1187,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.11
+        - image: kubermatic/kubeone-e2e:v0.1.12
           imagePullPolicy: Always
           command:
             - make
@@ -1197,7 +1197,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.8"
+              value: "1.18.9"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.19.2"
             - name: TEST_SET

--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,13 +14,13 @@
 
 # building image
 
-FROM golang:1.15.0 as builder
+FROM golang:1.15.2 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip \
     upx-ucl
 
-ENV TERRAFORM_VERSION "0.12.16"
+ENV TERRAFORM_VERSION "0.12.29"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform
 RUN chmod +x /usr/local/bin/terraform
 
@@ -37,7 +37,7 @@ RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
-FROM golang:1.15.0
+FROM golang:1.15.2
 
 ARG version
 

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -20,7 +20,7 @@ declare -A full_versions
 full_versions["1.16"]="v1.16.14"
 full_versions["1.17"]="v1.17.11"
 full_versions["1.18"]="v1.18.8"
-full_versions["1.19"]="v1.19.0"
+full_versions["1.19"]="v1.19.2"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,9 +17,9 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.16"]="v1.16.14"
-full_versions["1.17"]="v1.17.11"
-full_versions["1.18"]="v1.18.8"
+full_versions["1.16"]="v1.16.15"
+full_versions["1.17"]="v1.17.12"
+full_versions["1.18"]="v1.18.9"
 full_versions["1.19"]="v1.19.2"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.10
+TAG=v0.1.11
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.11
+TAG=v0.1.12
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:
* update golang to 1.15.2
* update terraform to 0.12.29
* update kubernetes to 1.19.2
* release new e2e image 0.1.12

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
terraform upgrade is required to pass `pull-kubeone-e2e-hetzner-*` tests

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
