### PR TITLE
Add the CSIMigration API

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,3 +59,6 @@ issues:
   - path: test/e2e
     text: "cyclomatic complexity 33 of func `TestClusterConformance` is high"
 
+  - path: pkg/apis/kubeone/validation
+    text: "cyclomatic complexity 34 of func `ValidateCloudProviderSpec` is high"
+

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -104,3 +104,59 @@ func (p CloudProviderSpec) CloudProviderInTree() bool {
 
 	return false
 }
+
+func (p CloudProviderSpec) CSIMigrationFeatureGates() map[string]bool {
+	featureGates := map[string]bool{}
+
+	switch {
+	case p.AWS != nil:
+		if p.AWS.CSIMigration {
+			featureGates["CSIMigration"] = true
+			featureGates["CSIMigrationAWS"] = true
+		}
+		if p.AWS.CSIMigrationComplete {
+			featureGates["CSIMigrationAWSComplete"] = true
+		}
+	case p.Azure != nil:
+		if p.Azure.CSIMigrationDisk {
+			featureGates["CSIMigration"] = true
+			featureGates["CSIMigrationAzureDisk"] = true
+		}
+		if p.Azure.CSIMigrationDiskComplete {
+			featureGates["CSIMigrationAzureDiskComplete"] = true
+		}
+		if p.Azure.CSIMigrationFile {
+			featureGates["CSIMigration"] = true
+			featureGates["CSIMigrationAzureFile"] = true
+		}
+		if p.Azure.CSIMigrationFileComplete {
+			featureGates["CSIMigrationAzureFileComplete"] = true
+		}
+	case p.GCE != nil:
+		if p.GCE.CSIMigration {
+			featureGates["CSIMigration"] = true
+			featureGates["CSIMigrationGCE"] = true
+		}
+		if p.GCE.CSIMigrationComplete {
+			featureGates["CSIMigrationGCEComplete"] = true
+		}
+	case p.Openstack != nil:
+		if p.Openstack.CSIMigration {
+			featureGates["CSIMigration"] = true
+			featureGates["CSIMigrationOpenStack"] = true
+		}
+		if p.Openstack.CSIMigrationComplete {
+			featureGates["CSIMigrationOpenStackComplete"] = true
+		}
+	case p.Vsphere != nil:
+		if p.Vsphere.CSIMigration {
+			featureGates["CSIMigration"] = true
+			featureGates["CSIMigrationvSphere"] = true
+		}
+		if p.Vsphere.CSIMigrationComplete {
+			featureGates["CSIMigrationvSphereComplete"] = true
+		}
+	}
+
+	return featureGates
+}

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -175,16 +175,27 @@ type CloudProviderSpec struct {
 }
 
 // AWSSpec defines the AWS cloud provider
-type AWSSpec struct{}
+type AWSSpec struct {
+	CSIMigration         bool `json:"csiMigration,omitempty"`
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
+}
 
 // AzureSpec defines the Azure cloud provider
-type AzureSpec struct{}
+type AzureSpec struct {
+	CSIMigrationFile         bool `json:"csiMigrationFile,omitempty"`
+	CSIMigrationDisk         bool `json:"csiMigrationDisk,omitempty"`
+	CSIMigrationFileComplete bool `json:"csiMigrationFileComplete,omitempty"`
+	CSIMigrationDiskComplete bool `json:"csiMigrationDiskComplete,omitempty"`
+}
 
 // DigitalOceanSpec defines the DigitalOcean cloud provider
 type DigitalOceanSpec struct{}
 
 // GCESpec defines the GCE cloud provider
-type GCESpec struct{}
+type GCESpec struct {
+	CSIMigration         bool `json:"csiMigration,omitempty"`
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
+}
 
 // HetznerSpec defines the Hetzner cloud provider
 type HetznerSpec struct {
@@ -193,13 +204,19 @@ type HetznerSpec struct {
 }
 
 // OpenstackSpec defines the Openstack provider
-type OpenstackSpec struct{}
+type OpenstackSpec struct {
+	CSIMigration         bool `json:"csiMigration,omitempty"`
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
+}
 
 // PacketSpec defines the Packet cloud provider
 type PacketSpec struct{}
 
 // VsphereSpec defines the vSphere provider
-type VsphereSpec struct{}
+type VsphereSpec struct {
+	CSIMigration         bool `json:"csiMigration,omitempty"`
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
+}
 
 // NoneSpec defines a none provider
 type NoneSpec struct{}

--- a/pkg/apis/kubeone/v1beta1/types.go
+++ b/pkg/apis/kubeone/v1beta1/types.go
@@ -175,16 +175,27 @@ type CloudProviderSpec struct {
 }
 
 // AWSSpec defines the AWS cloud provider
-type AWSSpec struct{}
+type AWSSpec struct {
+	CSIMigration         bool `json:"csiMigration,omitempty"`
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
+}
 
 // AzureSpec defines the Azure cloud provider
-type AzureSpec struct{}
+type AzureSpec struct {
+	CSIMigrationFile         bool `json:"csiMigrationFile,omitempty"`
+	CSIMigrationDisk         bool `json:"csiMigrationDisk,omitempty"`
+	CSIMigrationFileComplete bool `json:"csiMigrationFileComplete,omitempty"`
+	CSIMigrationDiskComplete bool `json:"csiMigrationDiskComplete,omitempty"`
+}
 
 // DigitalOceanSpec defines the DigitalOcean cloud provider
 type DigitalOceanSpec struct{}
 
 // GCESpec defines the GCE cloud provider
-type GCESpec struct{}
+type GCESpec struct {
+	CSIMigration         bool `json:"csiMigration,omitempty"`
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
+}
 
 // HetznerSpec defines the Hetzner cloud provider
 type HetznerSpec struct {
@@ -193,13 +204,19 @@ type HetznerSpec struct {
 }
 
 // OpenstackSpec defines the Openstack provider
-type OpenstackSpec struct{}
+type OpenstackSpec struct {
+	CSIMigration         bool `json:"csiMigration,omitempty"`
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
+}
 
 // PacketSpec defines the Packet cloud provider
 type PacketSpec struct{}
 
 // VsphereSpec defines the vSphere provider
-type VsphereSpec struct{}
+type VsphereSpec struct {
+	CSIMigration         bool `json:"csiMigration,omitempty"`
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
+}
 
 // NoneSpec defines a none provider
 type NoneSpec struct{}

--- a/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
@@ -493,6 +493,8 @@ func Convert_kubeone_APIEndpoint_To_v1beta1_APIEndpoint(in *kubeone.APIEndpoint,
 }
 
 func autoConvert_v1beta1_AWSSpec_To_kubeone_AWSSpec(in *AWSSpec, out *kubeone.AWSSpec, s conversion.Scope) error {
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	return nil
 }
 
@@ -502,6 +504,8 @@ func Convert_v1beta1_AWSSpec_To_kubeone_AWSSpec(in *AWSSpec, out *kubeone.AWSSpe
 }
 
 func autoConvert_kubeone_AWSSpec_To_v1beta1_AWSSpec(in *kubeone.AWSSpec, out *AWSSpec, s conversion.Scope) error {
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	return nil
 }
 
@@ -533,6 +537,10 @@ func Convert_kubeone_Addons_To_v1beta1_Addons(in *kubeone.Addons, out *Addons, s
 }
 
 func autoConvert_v1beta1_AzureSpec_To_kubeone_AzureSpec(in *AzureSpec, out *kubeone.AzureSpec, s conversion.Scope) error {
+	out.CSIMigrationFile = in.CSIMigrationFile
+	out.CSIMigrationDisk = in.CSIMigrationDisk
+	out.CSIMigrationFileComplete = in.CSIMigrationFileComplete
+	out.CSIMigrationDiskComplete = in.CSIMigrationDiskComplete
 	return nil
 }
 
@@ -542,6 +550,10 @@ func Convert_v1beta1_AzureSpec_To_kubeone_AzureSpec(in *AzureSpec, out *kubeone.
 }
 
 func autoConvert_kubeone_AzureSpec_To_v1beta1_AzureSpec(in *kubeone.AzureSpec, out *AzureSpec, s conversion.Scope) error {
+	out.CSIMigrationFile = in.CSIMigrationFile
+	out.CSIMigrationDisk = in.CSIMigrationDisk
+	out.CSIMigrationFileComplete = in.CSIMigrationFileComplete
+	out.CSIMigrationDiskComplete = in.CSIMigrationDiskComplete
 	return nil
 }
 
@@ -877,6 +889,8 @@ func Convert_kubeone_Features_To_v1beta1_Features(in *kubeone.Features, out *Fea
 }
 
 func autoConvert_v1beta1_GCESpec_To_kubeone_GCESpec(in *GCESpec, out *kubeone.GCESpec, s conversion.Scope) error {
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	return nil
 }
 
@@ -886,6 +900,8 @@ func Convert_v1beta1_GCESpec_To_kubeone_GCESpec(in *GCESpec, out *kubeone.GCESpe
 }
 
 func autoConvert_kubeone_GCESpec_To_v1beta1_GCESpec(in *kubeone.GCESpec, out *GCESpec, s conversion.Scope) error {
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	return nil
 }
 
@@ -1163,6 +1179,8 @@ func Convert_kubeone_OpenIDConnectConfig_To_v1beta1_OpenIDConnectConfig(in *kube
 }
 
 func autoConvert_v1beta1_OpenstackSpec_To_kubeone_OpenstackSpec(in *OpenstackSpec, out *kubeone.OpenstackSpec, s conversion.Scope) error {
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	return nil
 }
 
@@ -1172,6 +1190,8 @@ func Convert_v1beta1_OpenstackSpec_To_kubeone_OpenstackSpec(in *OpenstackSpec, o
 }
 
 func autoConvert_kubeone_OpenstackSpec_To_v1beta1_OpenstackSpec(in *kubeone.OpenstackSpec, out *OpenstackSpec, s conversion.Scope) error {
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	return nil
 }
 
@@ -1485,6 +1505,8 @@ func Convert_kubeone_VersionConfig_To_v1beta1_VersionConfig(in *kubeone.VersionC
 }
 
 func autoConvert_v1beta1_VsphereSpec_To_kubeone_VsphereSpec(in *VsphereSpec, out *kubeone.VsphereSpec, s conversion.Scope) error {
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	return nil
 }
 
@@ -1494,6 +1516,8 @@ func Convert_v1beta1_VsphereSpec_To_kubeone_VsphereSpec(in *VsphereSpec, out *ku
 }
 
 func autoConvert_kubeone_VsphereSpec_To_v1beta1_VsphereSpec(in *kubeone.VsphereSpec, out *VsphereSpec, s conversion.Scope) error {
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	return nil
 }
 

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -94,6 +94,9 @@ func ValidateCloudProviderSpec(p kubeone.CloudProviderSpec, fldPath *field.Path)
 	providerFound := false
 	if p.AWS != nil {
 		providerFound = true
+		if p.AWS.CSIMigrationComplete && !p.AWS.CSIMigration {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("aws").Child("csiMigrationComplete"), "csiMigrationComplete requires csiMigration to be enabled"))
+		}
 	}
 	if p.Azure != nil {
 		if providerFound {
@@ -101,6 +104,12 @@ func ValidateCloudProviderSpec(p kubeone.CloudProviderSpec, fldPath *field.Path)
 		}
 		if len(p.CloudConfig) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("cloudConfig"), ".cloudProvider.cloudConfig is required for azure provider"))
+		}
+		if p.Azure.CSIMigrationFileComplete && !p.Azure.CSIMigrationFile {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("azure").Child("csiMigrationFileComplete"), "csiMigrationFileComplete requires csiMigrationFile to be enabled"))
+		}
+		if p.Azure.CSIMigrationDiskComplete && !p.Azure.CSIMigrationDisk {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("azure").Child("csiMigrationDiskComplete"), "csiMigrationDiskComplete requires csiMigrationDisk to be enabled"))
 		}
 		providerFound = true
 	}
@@ -113,6 +122,9 @@ func ValidateCloudProviderSpec(p kubeone.CloudProviderSpec, fldPath *field.Path)
 	if p.GCE != nil {
 		if providerFound {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("gce"), "only one provider can be used at the same time"))
+		}
+		if p.GCE.CSIMigrationComplete && !p.GCE.CSIMigration {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("gce").Child("csiMigrationComplete"), "csiMigrationComplete requires csiMigration to be enabled"))
 		}
 		providerFound = true
 	}
@@ -129,6 +141,9 @@ func ValidateCloudProviderSpec(p kubeone.CloudProviderSpec, fldPath *field.Path)
 		if len(p.CloudConfig) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("cloudConfig"), ".cloudProvider.cloudConfig is required for openstack provider"))
 		}
+		if p.Openstack.CSIMigrationComplete && !p.Openstack.CSIMigration {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("openstack").Child("csiMigrationComplete"), "csiMigrationComplete requires csiMigration to be enabled"))
+		}
 		providerFound = true
 	}
 	if p.Packet != nil {
@@ -143,6 +158,9 @@ func ValidateCloudProviderSpec(p kubeone.CloudProviderSpec, fldPath *field.Path)
 		}
 		if len(p.CloudConfig) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("cloudConfig"), ".cloudProvider.cloudConfig is required for vSphere provider"))
+		}
+		if p.Vsphere.CSIMigrationComplete && !p.Vsphere.CSIMigration {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("vsphere").Child("csiMigrationComplete"), "csiMigrationComplete requires csiMigration to be enabled"))
 		}
 		providerFound = true
 	}

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -512,6 +512,225 @@ func TestValidateCloudProviderSpec(t *testing.T) {
 			providerConfig: kubeone.CloudProviderSpec{},
 			expectedError:  true,
 		},
+		{
+			name: "AWS with CSIMigration enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				AWS: &kubeone.AWSSpec{
+					CSIMigration: true,
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "AWS with CSIMigration and CSIMigrationComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				AWS: &kubeone.AWSSpec{
+					CSIMigration:         true,
+					CSIMigrationComplete: true,
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "Azure with CSIMigrationFile enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Azure: &kubeone.AzureSpec{
+					CSIMigrationFile: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: false,
+		},
+		{
+			name: "Azure with CSIMigrationFile and CSIMigrationFileComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Azure: &kubeone.AzureSpec{
+					CSIMigrationFile:         true,
+					CSIMigrationFileComplete: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: false,
+		},
+		{
+			name: "Azure with CSIMigrationFile and CSIMigrationDisk enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Azure: &kubeone.AzureSpec{
+					CSIMigrationFile: true,
+					CSIMigrationDisk: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: false,
+		},
+		{
+			name: "Azure with CSIMigrationFile, CSIMigrationFileComplete, and CSIMigrationDisk enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Azure: &kubeone.AzureSpec{
+					CSIMigrationFile:         true,
+					CSIMigrationFileComplete: true,
+					CSIMigrationDisk:         true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: false,
+		},
+		{
+			name: "Azure with all CSIMigration flags enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Azure: &kubeone.AzureSpec{
+					CSIMigrationFile:         true,
+					CSIMigrationFileComplete: true,
+					CSIMigrationDisk:         true,
+					CSIMigrationDiskComplete: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: false,
+		},
+		{
+			name: "GCE with CSIMigration enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				GCE: &kubeone.GCESpec{
+					CSIMigration: true,
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "GCE with CSIMigration and CSIMigrationComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				GCE: &kubeone.GCESpec{
+					CSIMigration:         true,
+					CSIMigrationComplete: true,
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "OpenStack with CSIMigration enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Openstack: &kubeone.OpenstackSpec{
+					CSIMigration: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: false,
+		},
+		{
+			name: "OpenStack with CSIMigration and CSIMigrationComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Openstack: &kubeone.OpenstackSpec{
+					CSIMigration:         true,
+					CSIMigrationComplete: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: false,
+		},
+		{
+			name: "vSphere with CSIMigration enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Vsphere: &kubeone.VsphereSpec{
+					CSIMigration: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: false,
+		},
+		{
+			name: "vSphere with CSIMigration and CSIMigrationComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Vsphere: &kubeone.VsphereSpec{
+					CSIMigration:         true,
+					CSIMigrationComplete: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: false,
+		},
+		{
+			name: "AWS with CSIMigration disabled, but with CSIMigrationComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				AWS: &kubeone.AWSSpec{
+					CSIMigration:         false,
+					CSIMigrationComplete: true,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "Azure with CSIMigrationFile disabled, but with CSIMigrationFileComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Azure: &kubeone.AzureSpec{
+					CSIMigrationFile:         false,
+					CSIMigrationFileComplete: true,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "Azure with CSIMigrationDisk disabled, but with CSIMigrationDiskComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Azure: &kubeone.AzureSpec{
+					CSIMigrationDisk:         false,
+					CSIMigrationDiskComplete: true,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "Azure with CSIMigrationFile enabled, but with CSIMigrationDiskComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Azure: &kubeone.AzureSpec{
+					CSIMigrationFile:         true,
+					CSIMigrationDiskComplete: true,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "Azure with CSIMigrationDisk enabled, but with CSIMigrationFileComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Azure: &kubeone.AzureSpec{
+					CSIMigrationDisk:         true,
+					CSIMigrationFileComplete: true,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "GCE with CSIMigration disabled, but with CSIMigrationComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				GCE: &kubeone.GCESpec{
+					CSIMigration:         false,
+					CSIMigrationComplete: true,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "OpenStack with CSIMigration disabled, but with CSIMigrationComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Openstack: &kubeone.OpenstackSpec{
+					CSIMigration:         false,
+					CSIMigrationComplete: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: true,
+		},
+		{
+			name: "vSphere with CSIMigration disabled, but with CSIMigrationComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Vsphere: &kubeone.VsphereSpec{
+					CSIMigration:         false,
+					CSIMigrationComplete: true,
+				},
+				CloudConfig: "cloud-config",
+			},
+			expectedError: true,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/pkg/terraform/v1beta1/config.go
+++ b/pkg/terraform/v1beta1/config.go
@@ -92,8 +92,12 @@ func (c *Config) Apply(cluster *kubeonev1beta1.KubeOneCluster) error {
 	cp := c.KubeOneHosts.Value.ControlPlane
 
 	if cp.CloudProvider != nil {
-		if err := kubeonev1beta1.SetCloudProvider(&cluster.CloudProvider, *cp.CloudProvider); err != nil {
+		cloudProvider := &kubeonev1beta1.CloudProviderSpec{}
+		if err := kubeonev1beta1.SetCloudProvider(cloudProvider, *cp.CloudProvider); err != nil {
 			return errors.Wrap(err, "failed to set cloud provider")
+		}
+		if err := mergo.Merge(&cluster.CloudProvider, cloudProvider); err != nil {
+			return errors.Wrap(err, "failed to merge cloud provider structs")
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Extend the v1beta1 CloudProvider-specific structs to include fields for controlling CSIMigration. For most providers, there are two fields:

- CSIMigration - used to enable CSIMigration and CSIMigration{Provider} feature gates on all relevant components
- CSIMigrationComplete - used to enable the appropriate CSIMigration{Provider}Complete feature gate. Requires CSIMigration to be enabled. This feature flag disables fallback to in-tree volume plugins and should be enabled only after deploying CSI driver to all nodes and ensuring it works correctly.

This PR includes only the API. The logic that enables the feature gates will be done in a follow-up.

/hold
Validation is missing

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Releavant to #616

**Does this PR introduce a user-facing change?**:
```release-note
Add API fields used to enable the CSIMigration
```

/assign @kron4eg 
/kind api-change