### PR TITLE
Merge CloudProvider structs instead of overriding them when cloud provider is defined via Terraform

### DIFF
--- a/pkg/terraform/v1beta1/config.go
+++ b/pkg/terraform/v1beta1/config.go
@@ -92,8 +92,12 @@ func (c *Config) Apply(cluster *kubeonev1beta1.KubeOneCluster) error {
 	cp := c.KubeOneHosts.Value.ControlPlane
 
 	if cp.CloudProvider != nil {
-		if err := kubeonev1beta1.SetCloudProvider(&cluster.CloudProvider, *cp.CloudProvider); err != nil {
+		cloudProvider := &kubeonev1beta1.CloudProviderSpec{}
+		if err := kubeonev1beta1.SetCloudProvider(cloudProvider, *cp.CloudProvider); err != nil {
 			return errors.Wrap(err, "failed to set cloud provider")
+		}
+		if err := mergo.Merge(&cluster.CloudProvider, cloudProvider); err != nil {
+			return errors.Wrap(err, "failed to merge cloud provider structs")
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Merge CloudProvider structs instead of overriding them when the cloud provider is defined via Terraform.

**Does this PR introduce a user-facing change?**:
```release-note
Merge CloudProvider structs instead of overriding them when the cloud provider is defined via Terraform
```

/assign @kron4eg 