### PR TITLE
Add the CSIMigration and CSIMigrationComplete fields to the API

### DIFF
--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -152,6 +152,28 @@ type APIEndpoint struct {
 type CloudProviderSpec struct {
 	// External
 	External bool `json:"external,omitempty"`
+	// CSIMigration enables the CSIMigration and CSIMigration{Provider} feature gates
+	// for providers that support the CSI migration.
+	// The CSI migration stability depends on the provider.
+	// More details about stability can be found in the Feature Gates document:
+	// https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+	//
+	// Note: Azure has two type of CSI drivers (AzureFile and AzureDisk) and two different
+	// feature gates (CSIMigrationAzureDisk and CSIMigrationAzureFile). Enabling CSI migration
+	// enables both feature gates. If one CSI driver is not deployed, the volume operations
+	// for volumes with missing CSI driver will fallback to the in-tree volume plugin.
+	CSIMigration bool `json:"csiMigration,omitempty"`
+	// CSIMigrationComplete enables the CSIMigration{Provider}Complete feature gate
+	// for providers that support the CSI migration.
+	// This feature gate disables fallback to the in-tree volume plugins, therefore,
+	// it should be enabled only if the CSI driver is deploy on all nodes, and after
+	// ensuring that the CSI driver works properly.
+	//
+	// Note: If you're running on Azure, make sure that you have both AzureFile
+	// and AzureDisk CSI drivers deployed, as enabling this feature disables the fallback
+	// to the in-tree volume plugins. See description for the CSIMigration field for
+	// more details.
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
 	// CloudConfig
 	CloudConfig string `json:"cloudConfig,omitempty"`
 	// AWS

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
@@ -346,6 +346,8 @@ func autoConvert_v1alpha1_CloudProviderSpec_To_kubeone_CloudProviderSpec(in *Clo
 
 func autoConvert_kubeone_CloudProviderSpec_To_v1alpha1_CloudProviderSpec(in *kubeone.CloudProviderSpec, out *CloudProviderSpec, s conversion.Scope) error {
 	out.External = in.External
+	// WARNING: in.CSIMigration requires manual conversion: does not exist in peer-type
+	// WARNING: in.CSIMigrationComplete requires manual conversion: does not exist in peer-type
 	out.CloudConfig = in.CloudConfig
 	// WARNING: in.AWS requires manual conversion: does not exist in peer-type
 	// WARNING: in.Azure requires manual conversion: does not exist in peer-type

--- a/pkg/apis/kubeone/v1beta1/types.go
+++ b/pkg/apis/kubeone/v1beta1/types.go
@@ -152,6 +152,28 @@ type APIEndpoint struct {
 type CloudProviderSpec struct {
 	// External
 	External bool `json:"external,omitempty"`
+	// CSIMigration enables the CSIMigration and CSIMigration{Provider} feature gates
+	// for providers that support the CSI migration.
+	// The CSI migration stability depends on the provider.
+	// More details about stability can be found in the Feature Gates document:
+	// https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+	//
+	// Note: Azure has two type of CSI drivers (AzureFile and AzureDisk) and two different
+	// feature gates (CSIMigrationAzureDisk and CSIMigrationAzureFile). Enabling CSI migration
+	// enables both feature gates. If one CSI driver is not deployed, the volume operations
+	// for volumes with missing CSI driver will fallback to the in-tree volume plugin.
+	CSIMigration bool `json:"csiMigration,omitempty"`
+	// CSIMigrationComplete enables the CSIMigration{Provider}Complete feature gate
+	// for providers that support the CSI migration.
+	// This feature gate disables fallback to the in-tree volume plugins, therefore,
+	// it should be enabled only if the CSI driver is deploy on all nodes, and after
+	// ensuring that the CSI driver works properly.
+	//
+	// Note: If you're running on Azure, make sure that you have both AzureFile
+	// and AzureDisk CSI drivers deployed, as enabling this feature disables the fallback
+	// to the in-tree volume plugins. See description for the CSIMigration field for
+	// more details.
+	CSIMigrationComplete bool `json:"csiMigrationComplete,omitempty"`
 	// CloudConfig
 	CloudConfig string `json:"cloudConfig,omitempty"`
 	// AWS

--- a/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
@@ -596,6 +596,8 @@ func Convert_kubeone_CanalSpec_To_v1beta1_CanalSpec(in *kubeone.CanalSpec, out *
 
 func autoConvert_v1beta1_CloudProviderSpec_To_kubeone_CloudProviderSpec(in *CloudProviderSpec, out *kubeone.CloudProviderSpec, s conversion.Scope) error {
 	out.External = in.External
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	out.CloudConfig = in.CloudConfig
 	out.AWS = (*kubeone.AWSSpec)(unsafe.Pointer(in.AWS))
 	out.Azure = (*kubeone.AzureSpec)(unsafe.Pointer(in.Azure))
@@ -616,6 +618,8 @@ func Convert_v1beta1_CloudProviderSpec_To_kubeone_CloudProviderSpec(in *CloudPro
 
 func autoConvert_kubeone_CloudProviderSpec_To_v1beta1_CloudProviderSpec(in *kubeone.CloudProviderSpec, out *CloudProviderSpec, s conversion.Scope) error {
 	out.External = in.External
+	out.CSIMigration = in.CSIMigration
+	out.CSIMigrationComplete = in.CSIMigrationComplete
 	out.CloudConfig = in.CloudConfig
 	out.AWS = (*AWSSpec)(unsafe.Pointer(in.AWS))
 	out.Azure = (*AzureSpec)(unsafe.Pointer(in.Azure))

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -157,6 +157,10 @@ func ValidateCloudProviderSpec(p kubeone.CloudProviderSpec, fldPath *field.Path)
 		allErrs = append(allErrs, field.Invalid(fldPath, "", "provider must be specified"))
 	}
 
+	if p.CSIMigrationComplete && !p.CSIMigration {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("csiMigrationComplete"), "csiMigrationComplete requires csiMigration to be enabled"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -512,6 +512,32 @@ func TestValidateCloudProviderSpec(t *testing.T) {
 			providerConfig: kubeone.CloudProviderSpec{},
 			expectedError:  true,
 		},
+		{
+			name: "CSIMigration enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				CSIMigration: true,
+				AWS:          &kubeone.AWSSpec{},
+			},
+			expectedError: false,
+		},
+		{
+			name: "CSIMigration and CSIMigrationComplete enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				CSIMigration:         true,
+				CSIMigrationComplete: true,
+				AWS:                  &kubeone.AWSSpec{},
+			},
+			expectedError: false,
+		},
+		{
+			name: "CSIMigrationComplete enabled without CSIMigration",
+			providerConfig: kubeone.CloudProviderSpec{
+				CSIMigration:         false,
+				CSIMigrationComplete: true,
+				AWS:                  &kubeone.AWSSpec{},
+			},
+			expectedError: true,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -539,6 +539,28 @@ cloudProvider:
   {{ .CloudProviderName }}: {}
   # Set the kubelet flag '--cloud-provider=external' and deploy the external CCM for supported providers
   external: {{ .CloudProviderExternal }}
+  # csiMigration enables the CSIMigration and CSIMigration{Provider} feature gates
+  # for providers that support the CSI migration.
+  # The CSI migration stability depends on the provider.
+  # More details about stability can be found in the Feature Gates document:
+  # https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+  #
+  # Note: Azure has two type of CSI drivers (AzureFile and AzureDisk) and two different
+  # feature gates (CSIMigrationAzureDisk and CSIMigrationAzureFile). Enabling CSI migration
+  # enables both feature gates. If one CSI driver is not deployed, the volume operations
+  # for volumes with missing CSI driver will fallback to the in-tree volume plugin.
+  csiMigration: false
+  # csiMigrationComplete enables the CSIMigration{Provider}Complete feature gate
+  # for providers that support the CSI migration.
+  # This feature gate disables fallback to the in-tree volume plugins, therefore,
+  # it should be enabled only if the CSI driver is deploy on all nodes, and after
+  # ensuring that the CSI driver works properly.
+  #
+  # Note: If you're running on Azure, make sure that you have both AzureFile
+  # and AzureDisk CSI drivers deployed, as enabling this feature disables the fallback
+  # to the in-tree volume plugins. See description for the CSIMigration field for
+  # more details.
+  csiMigrationComplete: false 
   # Path to file that will be uploaded and used as custom '--cloud-config' file.
   cloudConfig: "{{ .CloudProviderCloudCfg }}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the following fields to the v1beta1 API:

- `CSIMigration` (`csiMigration`) - enables `CSIMigration` and `CSIMigration{Provider}` feature flags on the API server, kube-controller-manager, and kubelets for providers that support the CSI migration
  - On Azure clusters, both `CSIMigrationAzureDisk` and `CSIMigrationAzureFile` feature gates are enabled
- `CSIMigrationComplete` (`csiMigrationComplete`) - enables the `CSIMigration{Provider}Complete` feature gate for providers that support the CSI migration. Enabling this feature disables fallback to the in-tree volume plugins.
  - On Azure clusters, both `CSIMigrationAzureDiskComplete` and `CSIMigrationAzureFileComplete` feature gates are enabled
  - You need to ensure that you have deployed the CSI driver on all nodes in a cluster before enabling this feature

This PR only adds the API fields. The code to enable the appropriate feature gates will be added in a follow-up PR.

This PR also adds a validation rule to ensure that `CSIMigration` is enabled if `CSIMigrationComplete` is enabled. The full config manifest has been updated to include those two fields and the appropriate descriptions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevant to #616
Supersedes #1107 

**Does this PR introduce a user-facing change?**:
```release-note
Add the CSIMigration and CSIMigrationComplete fields to the API
```

/assign @kron4eg 
/kind feature api-change