### PR TITLE
Use CentOS7 Docker repo for both CentOS 7 and 8

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -142,6 +142,10 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
+# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
+# Therefore, we use CentOS7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 {{ end }}
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -66,6 +66,10 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
+# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
+# Therefore, we use CentOS7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -66,6 +66,10 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
+# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
+# Therefore, we use CentOS7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -66,6 +66,10 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
+# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
+# Therefore, we use CentOS7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -66,6 +66,10 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
+# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
+# Therefore, we use CentOS7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -66,6 +66,10 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
+# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
+# Therefore, we use CentOS7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -66,6 +66,10 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
+# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
+# Therefore, we use CentOS7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 sudo yum install -y \


### PR DESCRIPTION
**What this PR does / why we need it**:

CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently contains only Docker 19.03.13, which is not validated for all Kubernetes version. Therefore, we use the CentOS7 repo which has all Docker versions.

**Does this PR introduce a user-facing change?**:
```release-note
Use CentOS7 Docker repo for both CentOS 7 and 8
```

/assign @kron4eg 