### PR TITLE
Update machine-controller to v1.18.0

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -46,7 +46,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.17.2"
+	MachineControllerTag           = "v1.18.0"
 )
 
 func CRDs() []runtime.Object {


### PR DESCRIPTION
**What this PR does / why we need it**:

Update machine-controller to v1.18.0. This release includes a fix for the Docker installation issue on CentOS/RHEL.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1111

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.18.0
```

/assign @kron4eg 