### PR TITLE
Create a dedicated vSphere CCM secret

### DIFF
--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -18,7 +18,6 @@ package credentials
 
 import (
 	"encoding/base64"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -136,17 +135,8 @@ func ProviderCredentials(p kubeone.CloudProviderSpec, credentialsFilePath string
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-
-		vcenterPrefix := vscreds[VSphereAddressMC]
-
 		// force scheme, as machine-controller requires it while terraform does not
 		vscreds[VSphereAddressMC] = "https://" + vscreds[VSphereAddressMC]
-
-		// Save credentials in Secret and configure vSphere cloud controller
-		// manager to read it, in replace of storing those in /etc/kubernates/cloud-config
-		// see more: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/k8s-secret.html
-		vscreds[fmt.Sprintf("%s.username", vcenterPrefix)] = vscreds[VSphereUsernameMC]
-		vscreds[fmt.Sprintf("%s.password", vcenterPrefix)] = vscreds[VSpherePassword]
 		return vscreds, nil
 	case p.None != nil:
 		return map[string]string{}, nil

--- a/pkg/templates/nodelocaldns/nodelocaldns.go
+++ b/pkg/templates/nodelocaldns/nodelocaldns.go
@@ -165,7 +165,7 @@ func dnscacheService() *corev1.Service {
 }
 
 func dnscacheConfigMap(pillarDNSDomain string) *corev1.ConfigMap {
-	corefile := strings.Replace(dnscacheCorefileTemplate, "__PILLAR__DNS__DOMAIN__", pillarDNSDomain, -1)
+	corefile := strings.ReplaceAll(dnscacheCorefileTemplate, "__PILLAR__DNS__DOMAIN__", pillarDNSDomain)
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we're creating a single secret to be used for both machine-controller and vSphere CCM. The vSphere CCM requires that the secret data is in the format of `<vcenter-address>.username` and `<vcenter-address>.password`, while the machine-controller requires the secret data in the format of `VSPHERE_*`.

The problem is that the vSphere CCM fails to parse the secret if there are any other fields than `<vcenter-address>.username` and `<vcenter-address>.password`. That causes authorization failures, so node metadata would not be populated from the API, as well as, it would not be possible to use volumes.

To fix this issue, this PR introduces another secret, that would be used only for the vSphere CCM. The secret is called `vsphere-ccm-credentials` and is located in the kube-system namespace.

Both in-tree CCM and the external CCM are affected.

Reference: https://github.com/kubernetes/kubernetes/blob/e0aeb1b17d6bfc180de62c1adce39b38238176fc/staging/src/k8s.io/legacy-cloud-providers/vsphere/credentialmanager.go#L137-L169

**Does this PR introduce a user-facing change?**:
```release-note
Create a dedicated vSphere CCM secret to be used by kube-controller-manager/external CCM
```

/assign @kron4eg 