### PR TITLE
Enable disk.enableUUID for vSphere control plane instances

### DIFF
--- a/examples/terraform/vsphere/main.tf
+++ b/examples/terraform/vsphere/main.tf
@@ -92,6 +92,10 @@ resource "vsphere_virtual_machine" "control_plane" {
     template_uuid = data.vsphere_virtual_machine.template.id
   }
 
+  extra_config = {
+    "disk.enableUUID" = "TRUE"
+  }
+
   vapp {
     properties = {
       hostname    = local.hostnames[count.index]


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the vSphere Terraform config to enable disk.enableUUID for the control plane instances. This is required for volumes to work properly, as stated in the [vSphere Storage docs](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/prerequisites.html#vms).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1125

**Does this PR introduce a user-facing change?**:
```release-note
Enable disk.enableUUID for vSphere control plane instances
```

/assign @kron4eg 