### PR TITLE
Skip subPath NodeConformance test on Flatcar

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,5 +57,5 @@ issues:
     text: "type name will be used as kubeone.KubeOneCluster by other packages"
 
   - path: test/e2e
-    text: "cyclomatic complexity 33 of func `TestClusterConformance` is high"
+    text: "cyclomatic complexity 35 of func `TestClusterConformance` is high"
 

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -282,7 +282,11 @@ func TestClusterConformance(t *testing.T) {
 
 			// Run NodeConformance tests
 			t.Log("Running conformance tests (this can take up to 30 minutes)...")
-			if err = clusterVerifier.Verify(tc.scenario); err != nil {
+			skipTests := Skip
+			if osControlPlane == OperatingSystemFlatcar || osWorkers == OperatingSystemFlatcar {
+				skipTests = SkipFlatcar
+			}
+			if err = clusterVerifier.Verify(tc.scenario, skipTests); err != nil {
 				t.Fatalf("e2e tests failed: %v", err)
 			}
 		})

--- a/test/e2e/kubetest.go
+++ b/test/e2e/kubetest.go
@@ -31,6 +31,7 @@ const (
 	NodeConformance = `\[NodeConformance\]`
 	Conformance     = `\[Conformance\]`
 	Skip            = `Alpha|\[(Disruptive|Feature:[^\]]+|Flaky|Serial|Slow)\]`
+	SkipFlatcar     = `Alpha|\[(Disruptive|Feature:[^\]]+|Flaky|Serial|Slow)\]|should support subPath`
 )
 
 // Kubetest configures the Kubetest conformance tester
@@ -51,7 +52,7 @@ func NewKubetest(k8sVersion, kubetestDir string, envVars map[string]string) *Kub
 }
 
 // Verify verifies the cluster
-func (p *Kubetest) Verify(scenario string) error {
+func (p *Kubetest) Verify(scenario, skip string) error {
 	kubetestPath, err := findKubetest(p.kubetestDir, p.kubernetesVersion)
 	if err != nil {
 		return fmt.Errorf("coudn't find kubetest scenarios: %w", err)
@@ -65,7 +66,7 @@ func (p *Kubetest) Verify(scenario string) error {
 	err = testutil.NewExec("./hack/ginkgo-e2e.sh",
 		testutil.WithArgs(
 			fmt.Sprintf("--ginkgo.focus=%s", scenario),
-			fmt.Sprintf("--ginkgo.skip=%s", Skip),
+			fmt.Sprintf("--ginkgo.skip=%s", skip),
 			"--ginkgo.noColor=true",
 			"--ginkgo.flakeAttempts=2",
 		),


### PR DESCRIPTION
**What this PR does / why we need it**:

Skip subPath NodeConformance test on Flatcar.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
