### PR TITLE
Update machine-controller to v1.19.0

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -46,7 +46,7 @@ const (
 	MachineControllerNamespace     = metav1.NamespaceSystem
 	MachineControllerAppLabelKey   = "app"
 	MachineControllerAppLabelValue = "machine-controller"
-	MachineControllerTag           = "v1.18.0"
+	MachineControllerTag           = "v1.19.0"
 )
 
 func CRDs() []runtime.Object {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps machine-controller to v1.19.0. The most important change is that this release uses the Hyperkube image for running Kubelet on Flatcar. The reason for doing that is that the Poseidon Kubelet repository doesn't push 1.18 images any longer.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.19.0
```
