### PR TITLE
Include image-loader in the release assets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,3 +24,4 @@ archives:
       - CHANGELOG.md
       - LICENSE
       - examples/**/*
+      - hack/image-loader.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to fixate the script to the kubeone version we are including it into the release archive.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
