### PR TITLE
Add addons to the release archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,3 +25,4 @@ archives:
       - LICENSE
       - examples/**/*
       - hack/image-loader.sh
+      - addons/**/*


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes addons are version-dependents (like now, when we introduced new template function Registry).

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
addons are now distributed with the release archive
```
