### PR TITLE
Add support for insecure Docker registries

### DIFF
--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -113,3 +113,13 @@ func (r *RegistryConfiguration) ImageRegistry(defaultRegistry string) string {
 	}
 	return defaultRegistry
 }
+
+// InsecureRegistryAddress returns the registry that should be configured
+// as insecure if InsecureRegistry is enabled
+func (r *RegistryConfiguration) InsecureRegistryAddress() string {
+	insecureRegistry := ""
+	if r != nil && r.InsecureRegistry {
+		insecureRegistry = r.OverwriteRegistry
+	}
+	return insecureRegistry
+}

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -377,6 +377,10 @@ type RegistryConfiguration struct {
 	// calico/cni would translate to 127.0.0.1:5000/example/calico/cni.
 	// Default: ""
 	OverwriteRegistry string `json:"overwriteRegistry,omitempty"`
+	// InsecureRegistry configures Docker to threat the registry specified
+	// in OverwriteRegistry as an insecure registry. This is also propagated
+	// to the worker nodes managed by machine-controller and/or KubeOne.
+	InsecureRegistry bool `json:"insecureRegistry,omitempty"`
 }
 
 // PodNodeSelector feature flag

--- a/pkg/apis/kubeone/v1beta1/types.go
+++ b/pkg/apis/kubeone/v1beta1/types.go
@@ -377,6 +377,10 @@ type RegistryConfiguration struct {
 	// calico/cni would translate to 127.0.0.1:5000/example/calico/cni.
 	// Default: ""
 	OverwriteRegistry string `json:"overwriteRegistry,omitempty"`
+	// InsecureRegistry configures Docker to threat the registry specified
+	// in OverwriteRegistry as an insecure registry. This is also propagated
+	// to the worker nodes managed by machine-controller and/or KubeOne.
+	InsecureRegistry bool `json:"insecureRegistry,omitempty"`
 }
 
 // PodNodeSelector feature flag

--- a/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
@@ -1388,6 +1388,7 @@ func Convert_kubeone_ProxyConfig_To_v1beta1_ProxyConfig(in *kubeone.ProxyConfig,
 
 func autoConvert_v1beta1_RegistryConfiguration_To_kubeone_RegistryConfiguration(in *RegistryConfiguration, out *kubeone.RegistryConfiguration, s conversion.Scope) error {
 	out.OverwriteRegistry = in.OverwriteRegistry
+	out.InsecureRegistry = in.InsecureRegistry
 	return nil
 }
 
@@ -1398,6 +1399,7 @@ func Convert_v1beta1_RegistryConfiguration_To_kubeone_RegistryConfiguration(in *
 
 func autoConvert_kubeone_RegistryConfiguration_To_v1beta1_RegistryConfiguration(in *kubeone.RegistryConfiguration, out *RegistryConfiguration, s conversion.Scope) error {
 	out.OverwriteRegistry = in.OverwriteRegistry
+	out.InsecureRegistry = in.InsecureRegistry
 	return nil
 }
 

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -52,6 +52,7 @@ func ValidateKubeOneCluster(c kubeone.KubeOneCluster) field.ErrorList {
 
 	allErrs = append(allErrs, ValidateFeatures(c.Features, field.NewPath("features"))...)
 	allErrs = append(allErrs, ValidateAddons(c.Addons, field.NewPath("addons"))...)
+	allErrs = append(allErrs, ValidateRegistryConfiguration(c.RegistryConfiguration, field.NewPath("registryConfiguration"))...)
 
 	return allErrs
 }
@@ -388,6 +389,20 @@ func ValidateHostConfig(hosts []kubeone.HostConfig, fldPath *field.Path) field.E
 		if len(h.SSHUsername) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath, "no SSH username given"))
 		}
+	}
+
+	return allErrs
+}
+
+func ValidateRegistryConfiguration(r *kubeone.RegistryConfiguration, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if r == nil {
+		return allErrs
+	}
+
+	if r.InsecureRegistry && r.OverwriteRegistry == "" {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("insecureRegistry"), r.InsecureRegistry, "insecureRegistry requires overwriteRegistry to be configured"))
 	}
 
 	return allErrs

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -1426,19 +1426,19 @@ func TestValidateRegistryConfiguration(t *testing.T) {
 			name: "valid registry config (overwrite registry and insecure)",
 			registryConfiguration: &kubeone.RegistryConfiguration{
 				OverwriteRegistry: "127.0.0.1:5000",
-				InsecureRegistry: true,
+				InsecureRegistry:  true,
 			},
 			expectedError: false,
 		},
 		{
-			name: "valid registry config (empty)",
+			name:                  "valid registry config (empty)",
 			registryConfiguration: &kubeone.RegistryConfiguration{},
-			expectedError: false,
+			expectedError:         false,
 		},
 		{
-			name: "valid registry config (nil)",
+			name:                  "valid registry config (nil)",
 			registryConfiguration: nil,
-			expectedError: false,
+			expectedError:         false,
 		},
 		{
 			name: "invalid registry config (insecure registry without overwrite registry)",

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -1409,6 +1409,57 @@ func TestValidateHostConfig(t *testing.T) {
 	}
 }
 
+func TestValidateRegistryConfiguration(t *testing.T) {
+	tests := []struct {
+		name                  string
+		registryConfiguration *kubeone.RegistryConfiguration
+		expectedError         bool
+	}{
+		{
+			name: "valid registry config (overwrite registry)",
+			registryConfiguration: &kubeone.RegistryConfiguration{
+				OverwriteRegistry: "127.0.0.1:5000",
+			},
+			expectedError: false,
+		},
+		{
+			name: "valid registry config (overwrite registry and insecure)",
+			registryConfiguration: &kubeone.RegistryConfiguration{
+				OverwriteRegistry: "127.0.0.1:5000",
+				InsecureRegistry: true,
+			},
+			expectedError: false,
+		},
+		{
+			name: "valid registry config (empty)",
+			registryConfiguration: &kubeone.RegistryConfiguration{},
+			expectedError: false,
+		},
+		{
+			name: "valid registry config (nil)",
+			registryConfiguration: nil,
+			expectedError: false,
+		},
+		{
+			name: "invalid registry config (insecure registry without overwrite registry)",
+			registryConfiguration: &kubeone.RegistryConfiguration{
+				InsecureRegistry: true,
+			},
+			expectedError: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			errs := ValidateRegistryConfiguration(tc.registryConfiguration, nil)
+			if (len(errs) == 0) == tc.expectedError {
+				t.Log(errs[0])
+				t.Errorf("test case failed: expected %v, but got %v", tc.expectedError, (len(errs) != 0))
+			}
+		})
+	}
+}
+
 func intPtr(i int) *int {
 	return &i
 }

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -667,6 +667,10 @@ registryConfiguration:
   # if overwriteRegistry is set to 127.0.0.1:5000/example, image called
   # calico/cni would translate to 127.0.0.1:5000/example/calico/cni.
   overwriteRegistry: ""
+  # InsecureRegistry configures Docker to threat the registry specified
+  # in OverwriteRegistry as an insecure registry. This is also propagated
+  # to the worker nodes managed by machine-controller and/or KubeOne.
+  insecureRegistry: false
 
 # Addons are Kubernetes manifests to be deployed after provisioning the cluster
 addons:

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -43,7 +43,7 @@ esac
 {{ define "docker-daemon-config" }}
 sudo mkdir -p /etc/docker
 cat <<EOF | sudo tee /etc/docker/daemon.json
-{{ dockerCfg }}
+{{ dockerCfg .DOCKER_INSECURE_REGISTRY }}
 EOF
 {{ end }}
 
@@ -73,13 +73,14 @@ sudo systemctl force-reload systemd-journald
 )
 
 type dockerConfig struct {
-	ExecOpts      []string          `json:"exec-opts,omitempty"`
-	StorageDriver string            `json:"storage-driver,omitempty"`
-	LogDriver     string            `json:"log-driver,omitempty"`
-	LogOpts       map[string]string `json:"log-opts,omitempty"`
+	ExecOpts           []string          `json:"exec-opts,omitempty"`
+	StorageDriver      string            `json:"storage-driver,omitempty"`
+	LogDriver          string            `json:"log-driver,omitempty"`
+	LogOpts            map[string]string `json:"log-opts,omitempty"`
+	InsecureRegistries []string          `json:"insecure-registries,omitempty"`
 }
 
-func dockerCfg() (string, error) {
+func dockerCfg(insecureRegistry string) (string, error) {
 	cfg := dockerConfig{
 		ExecOpts:      []string{"native.cgroupdriver=systemd"},
 		StorageDriver: "overlay2",
@@ -87,6 +88,9 @@ func dockerCfg() (string, error) {
 		LogOpts: map[string]string{
 			"max-size": "100m",
 		},
+	}
+	if insecureRegistry != "" {
+		cfg.InsecureRegistries = []string{insecureRegistry}
 	}
 
 	b, err := json.MarshalIndent(cfg, "", "	")

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -342,11 +342,6 @@ sudo systemctl start kubelet
 )
 
 func KubeadmDebian(cluster *kubeone.KubeOneCluster, force bool) (string, error) {
-	dockerInsecureRegistry := ""
-	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
-		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
-	}
-
 	return Render(kubeadmDebianTemplate, Data{
 		"KUBELET":                  true,
 		"KUBEADM":                  true,
@@ -354,7 +349,7 @@ func KubeadmDebian(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
 		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
-		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"DOCKER_INSECURE_REGISTRY": cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"HTTP_PROXY":               cluster.Proxy.HTTP,
 		"HTTPS_PROXY":              cluster.Proxy.HTTPS,
 		"FORCE":                    force,
@@ -366,10 +361,6 @@ func KubeadmCentOS(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
 	}
-	dockerInsecureRegistry := ""
-	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
-		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
-	}
 
 	return Render(kubeadmCentOSTemplate, Data{
 		"KUBELET":                  true,
@@ -378,22 +369,17 @@ func KubeadmCentOS(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
 		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
-		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"DOCKER_INSECURE_REGISTRY": cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"PROXY":                    proxy,
 		"FORCE":                    force,
 	})
 }
 
 func KubeadmCoreOS(cluster *kubeone.KubeOneCluster) (string, error) {
-	dockerInsecureRegistry := ""
-	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
-		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
-	}
-
 	return Render(kubeadmCoreOSTemplate, Data{
 		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
-		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"DOCKER_INSECURE_REGISTRY": cluster.RegistryConfiguration.InsecureRegistryAddress(),
 	})
 }
 
@@ -410,18 +396,13 @@ func RemoveBinariesCoreOS() (string, error) {
 }
 
 func UpgradeKubeadmAndCNIDebian(cluster *kubeone.KubeOneCluster) (string, error) {
-	dockerInsecureRegistry := ""
-	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
-		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
-	}
-
 	return Render(kubeadmDebianTemplate, Data{
 		"UPGRADE":                  true,
 		"KUBEADM":                  true,
 		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
 		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
-		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"DOCKER_INSECURE_REGISTRY": cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"HTTP_PROXY":               cluster.Proxy.HTTP,
 		"HTTPS_PROXY":              cluster.Proxy.HTTPS,
 	})
@@ -432,10 +413,6 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeone.KubeOneCluster) (string, error)
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
 	}
-	dockerInsecureRegistry := ""
-	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
-		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
-	}
 
 	return Render(kubeadmCentOSTemplate, Data{
 		"UPGRADE":                  true,
@@ -443,7 +420,7 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeone.KubeOneCluster) (string, error)
 		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
 		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
-		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"DOCKER_INSECURE_REGISTRY": cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"PROXY":                    proxy,
 	})
 }
@@ -456,11 +433,6 @@ func UpgradeKubeadmAndCNICoreOS(k8sVersion string) (string, error) {
 }
 
 func UpgradeKubeletAndKubectlDebian(cluster *kubeone.KubeOneCluster) (string, error) {
-	dockerInsecureRegistry := ""
-	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
-		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
-	}
-
 	return Render(kubeadmDebianTemplate, Data{
 		"UPGRADE":                  true,
 		"KUBELET":                  true,
@@ -468,7 +440,7 @@ func UpgradeKubeletAndKubectlDebian(cluster *kubeone.KubeOneCluster) (string, er
 		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
 		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
-		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"DOCKER_INSECURE_REGISTRY": cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"HTTP_PROXY":               cluster.Proxy.HTTP,
 		"HTTPS_PROXY":              cluster.Proxy.HTTPS,
 	})
@@ -479,10 +451,6 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, er
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
 	}
-	dockerInsecureRegistry := ""
-	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
-		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
-	}
 
 	return Render(kubeadmCentOSTemplate, Data{
 		"UPGRADE":                  true,
@@ -491,7 +459,7 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, er
 		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
 		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
-		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"DOCKER_INSECURE_REGISTRY": cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"PROXY":                    proxy,
 	})
 }

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -32,7 +32,7 @@ sudo systemctl disable --now ufw || true
 
 source /etc/kubeone/proxy-env
 
-{{ template "docker-daemon-config" }}
+{{ template "docker-daemon-config" . }}
 {{ template "sysctl-k8s" }}
 {{ template "journald-config" }}
 
@@ -116,7 +116,7 @@ sudo systemctl disable --now firewalld || true
 
 source /etc/kubeone/proxy-env
 
-{{ template "docker-daemon-config" }}
+{{ template "docker-daemon-config" . }}
 {{ template "sysctl-k8s" }}
 {{ template "journald-config" }}
 
@@ -184,7 +184,7 @@ sudo systemctl restart kubelet
 source /etc/kubeone/proxy-env
 
 {{ template "detect-host-cpu-architecture" }}
-{{ template "docker-daemon-config" }}
+{{ template "docker-daemon-config" . }}
 {{ template "sysctl-k8s" }}
 {{ template "journald-config" }}
 
@@ -342,16 +342,22 @@ sudo systemctl start kubelet
 )
 
 func KubeadmDebian(cluster *kubeone.KubeOneCluster, force bool) (string, error) {
+	dockerInsecureRegistry := ""
+	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
+		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
+	}
+
 	return Render(kubeadmDebianTemplate, Data{
-		"KUBELET":                true,
-		"KUBEADM":                true,
-		"KUBECTL":                true,
-		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
-		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
-		"HTTP_PROXY":             cluster.Proxy.HTTP,
-		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
-		"FORCE":                  force,
+		"KUBELET":                  true,
+		"KUBEADM":                  true,
+		"KUBECTL":                  true,
+		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
+		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
+		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
+		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"HTTP_PROXY":               cluster.Proxy.HTTP,
+		"HTTPS_PROXY":              cluster.Proxy.HTTPS,
+		"FORCE":                    force,
 	})
 }
 
@@ -360,23 +366,34 @@ func KubeadmCentOS(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
 	}
+	dockerInsecureRegistry := ""
+	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
+		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
+	}
 
 	return Render(kubeadmCentOSTemplate, Data{
-		"KUBELET":                true,
-		"KUBEADM":                true,
-		"KUBECTL":                true,
-		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
-		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
-		"PROXY":                  proxy,
-		"FORCE":                  force,
+		"KUBELET":                  true,
+		"KUBEADM":                  true,
+		"KUBECTL":                  true,
+		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
+		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
+		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
+		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"PROXY":                    proxy,
+		"FORCE":                    force,
 	})
 }
 
 func KubeadmCoreOS(cluster *kubeone.KubeOneCluster) (string, error) {
+	dockerInsecureRegistry := ""
+	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
+		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
+	}
+
 	return Render(kubeadmCoreOSTemplate, Data{
-		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
-		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
+		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
+		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
 	})
 }
 
@@ -393,14 +410,20 @@ func RemoveBinariesCoreOS() (string, error) {
 }
 
 func UpgradeKubeadmAndCNIDebian(cluster *kubeone.KubeOneCluster) (string, error) {
+	dockerInsecureRegistry := ""
+	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
+		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
+	}
+
 	return Render(kubeadmDebianTemplate, Data{
-		"UPGRADE":                true,
-		"KUBEADM":                true,
-		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
-		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
-		"HTTP_PROXY":             cluster.Proxy.HTTP,
-		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
+		"UPGRADE":                  true,
+		"KUBEADM":                  true,
+		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
+		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
+		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
+		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"HTTP_PROXY":               cluster.Proxy.HTTP,
+		"HTTPS_PROXY":              cluster.Proxy.HTTPS,
 	})
 }
 
@@ -409,14 +432,19 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeone.KubeOneCluster) (string, error)
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
 	}
+	dockerInsecureRegistry := ""
+	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
+		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
+	}
 
 	return Render(kubeadmCentOSTemplate, Data{
-		"UPGRADE":                true,
-		"KUBEADM":                true,
-		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
-		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
-		"PROXY":                  proxy,
+		"UPGRADE":                  true,
+		"KUBEADM":                  true,
+		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
+		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
+		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
+		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"PROXY":                    proxy,
 	})
 }
 
@@ -428,15 +456,21 @@ func UpgradeKubeadmAndCNICoreOS(k8sVersion string) (string, error) {
 }
 
 func UpgradeKubeletAndKubectlDebian(cluster *kubeone.KubeOneCluster) (string, error) {
+	dockerInsecureRegistry := ""
+	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
+		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
+	}
+
 	return Render(kubeadmDebianTemplate, Data{
-		"UPGRADE":                true,
-		"KUBELET":                true,
-		"KUBECTL":                true,
-		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
-		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
-		"HTTP_PROXY":             cluster.Proxy.HTTP,
-		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
+		"UPGRADE":                  true,
+		"KUBELET":                  true,
+		"KUBECTL":                  true,
+		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
+		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
+		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
+		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"HTTP_PROXY":               cluster.Proxy.HTTP,
+		"HTTPS_PROXY":              cluster.Proxy.HTTPS,
 	})
 }
 
@@ -445,15 +479,20 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, er
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
 	}
+	dockerInsecureRegistry := ""
+	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.InsecureRegistry {
+		dockerInsecureRegistry = cluster.RegistryConfiguration.OverwriteRegistry
+	}
 
 	return Render(kubeadmCentOSTemplate, Data{
-		"UPGRADE":                true,
-		"KUBELET":                true,
-		"KUBECTL":                true,
-		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
-		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
-		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
-		"PROXY":                  proxy,
+		"UPGRADE":                  true,
+		"KUBELET":                  true,
+		"KUBECTL":                  true,
+		"KUBERNETES_VERSION":       cluster.Versions.Kubernetes,
+		"KUBERNETES_CNI_VERSION":   defaultKubernetesCNIVersion,
+		"CONFIGURE_REPOSITORIES":   cluster.SystemPackages.ConfigureRepositories,
+		"DOCKER_INSECURE_REGISTRY": dockerInsecureRegistry,
+		"PROXY":                    proxy,
 	})
 }
 

--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -38,6 +38,23 @@ func withProxy(proxy string) genClusterOpts {
 	}
 }
 
+func withRegistry(registry string) genClusterOpts {
+	return func(cls *kubeone.KubeOneCluster) {
+		cls.RegistryConfiguration = &kubeone.RegistryConfiguration{
+			OverwriteRegistry: registry,
+		}
+	}
+}
+
+func withInsecureRegistry(registry string) genClusterOpts {
+	return func(cls *kubeone.KubeOneCluster) {
+		cls.RegistryConfiguration = &kubeone.RegistryConfiguration{
+			OverwriteRegistry: registry,
+			InsecureRegistry:  true,
+		}
+	}
+}
+
 func genCluster(opts ...genClusterOpts) kubeone.KubeOneCluster {
 	c := &kubeone.KubeOneCluster{
 		Versions: kubeone.VersionConfig{
@@ -77,6 +94,20 @@ func TestKubeadmDebian(t *testing.T) {
 			args: args{
 				dockerVersion: "18.0.6",
 				cluster:       genCluster(),
+			},
+		},
+		{
+			name: "overwrite registry",
+			args: args{
+				dockerVersion: "18.0.6",
+				cluster:       genCluster(withRegistry("127.0.0.1:5000")),
+			},
+		},
+		{
+			name: "overwrite registry insecure",
+			args: args{
+				dockerVersion: "18.0.6",
+				cluster:       genCluster(withInsecureRegistry("127.0.0.1:5000")),
 			},
 		},
 	}
@@ -132,6 +163,18 @@ func TestKubeadmCentOS(t *testing.T) {
 				cluster: genCluster(withKubeVersion("v1.16.1")),
 			},
 		},
+		{
+			name: "overwrite registry",
+			args: args{
+				cluster: genCluster(withRegistry("127.0.0.1:5000")),
+			},
+		},
+		{
+			name: "overwrite registry insecure",
+			args: args{
+				cluster: genCluster(withInsecureRegistry("127.0.0.1:5000")),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -169,6 +212,18 @@ func TestKubeadmCoreOS(t *testing.T) {
 			name: "force",
 			args: args{
 				cluster: genCluster(),
+			},
+		},
+		{
+			name: "overwrite registry",
+			args: args{
+				cluster: genCluster(withRegistry("127.0.0.1:5000")),
+			},
+		},
+		{
+			name: "overwrite registry insecure",
+			args: args{
+				cluster: genCluster(withInsecureRegistry("127.0.0.1:5000")),
 			},
 		},
 	}

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -1,0 +1,93 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+sudo swapoff -a
+sudo sed -i '/.*swap.*/d' /etc/fstab
+sudo setenforce 0 || true
+sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/sysconfig/selinux
+sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
+sudo systemctl disable --now firewalld || true
+
+source /etc/kubeone/proxy-env
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+kernel.panic_on_oops = 1
+kernel.panic = 10
+net.ipv4.ip_forward = 1
+vm.overcommit_memory = 1
+fs.inotify.max_user_watches = 1048576
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+yum_proxy=""
+yum_proxy="proxy=http://https.proxy #kubeone"
+
+grep -v '#kubeone' /etc/yum.conf > /tmp/yum.conf || true
+echo -n "${yum_proxy}" >> /tmp/yum.conf
+sudo mv /tmp/yum.conf /etc/yum.conf
+
+
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
+# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
+# Therefore, we use CentOS7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+sudo yum install -y \
+	yum-plugin-versionlock \
+	device-mapper-persistent-data \
+	lvm2
+
+sudo yum install -y \
+	kubelet-v1.17.4 \
+	kubeadm-v1.17.4 \
+	kubectl-v1.17.4 \
+	kubernetes-cni-0.8.7 \
+	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
+sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -1,0 +1,96 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+sudo swapoff -a
+sudo sed -i '/.*swap.*/d' /etc/fstab
+sudo setenforce 0 || true
+sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/sysconfig/selinux
+sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
+sudo systemctl disable --now firewalld || true
+
+source /etc/kubeone/proxy-env
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	},
+	"insecure-registries": [
+		"127.0.0.1:5000"
+	]
+}
+EOF
+
+
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+kernel.panic_on_oops = 1
+kernel.panic = 10
+net.ipv4.ip_forward = 1
+vm.overcommit_memory = 1
+fs.inotify.max_user_watches = 1048576
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+yum_proxy=""
+yum_proxy="proxy=http://https.proxy #kubeone"
+
+grep -v '#kubeone' /etc/yum.conf > /tmp/yum.conf || true
+echo -n "${yum_proxy}" >> /tmp/yum.conf
+sudo mv /tmp/yum.conf /etc/yum.conf
+
+
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
+# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
+# Therefore, we use CentOS7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+sudo yum install -y \
+	yum-plugin-versionlock \
+	device-mapper-persistent-data \
+	lvm2
+
+sudo yum install -y \
+	kubelet-v1.17.4 \
+	kubeadm-v1.17.4 \
+	kubectl-v1.17.4 \
+	kubernetes-cni-0.8.7 \
+	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
+sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-overwrite_registry.golden
@@ -1,0 +1,109 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+source /etc/kubeone/proxy-env
+
+
+HOST_ARCH=""
+case $(uname -m) in
+x86_64)
+	HOST_ARCH="amd64"
+	;;
+aarch64)
+	HOST_ARCH="arm64"
+	;;
+*)
+	echo "unsupported CPU architecture, exiting"
+	exit 1
+	;;
+esac
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+kernel.panic_on_oops = 1
+kernel.panic = 10
+net.ipv4.ip_forward = 1
+vm.overcommit_memory = 1
+fs.inotify.max_user_watches = 1048576
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+sudo systemctl restart docker
+
+sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+	sudo tar -C /opt/cni/bin -xz
+
+RELEASE="vv1.17.4"
+
+sudo mkdir -p /opt/bin
+cd /opt/bin
+k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+for binary in kubeadm kubelet kubectl; do
+	curl -L --output /tmp/$binary \
+		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary
+	sudo install --owner=0 --group=0 --mode=0755 /tmp/$binary /opt/bin/$binary
+	rm /tmp/$binary
+done
+
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/home/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/opt/bin/kubelet
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-overwrite_registry_insecure.golden
@@ -1,0 +1,112 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+source /etc/kubeone/proxy-env
+
+
+HOST_ARCH=""
+case $(uname -m) in
+x86_64)
+	HOST_ARCH="amd64"
+	;;
+aarch64)
+	HOST_ARCH="arm64"
+	;;
+*)
+	echo "unsupported CPU architecture, exiting"
+	exit 1
+	;;
+esac
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	},
+	"insecure-registries": [
+		"127.0.0.1:5000"
+	]
+}
+EOF
+
+
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+kernel.panic_on_oops = 1
+kernel.panic = 10
+net.ipv4.ip_forward = 1
+vm.overcommit_memory = 1
+fs.inotify.max_user_watches = 1048576
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+sudo systemctl restart docker
+
+sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+	sudo tar -C /opt/cni/bin -xz
+
+RELEASE="vv1.17.4"
+
+sudo mkdir -p /opt/bin
+cd /opt/bin
+k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+for binary in kubeadm kubelet kubectl; do
+	curl -L --output /tmp/$binary \
+		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary
+	sudo install --owner=0 --group=0 --mode=0755 /tmp/$binary /opt/bin/$binary
+	rm /tmp/$binary
+done
+
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/home/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/opt/bin/kubelet
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -1,0 +1,89 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+sudo swapoff -a
+sudo sed -i '/.*swap.*/d' /etc/fstab
+sudo systemctl disable --now ufw || true
+
+source /etc/kubeone/proxy-env
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+kernel.panic_on_oops = 1
+kernel.panic = 10
+net.ipv4.ip_forward = 1
+vm.overcommit_memory = 1
+fs.inotify.max_user_watches = 1048576
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+sudo mkdir -p /etc/apt/apt.conf.d
+cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
+Acquire::https::Proxy "http://https.proxy";
+Acquire::http::Proxy "http://http.proxy";
+EOF
+
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	lsb-release \
+	rsync
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
+	sudo tee /etc/apt/sources.list.d/docker.list
+
+# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
+# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
+echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
+
+kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
+cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.7" | head -1 | awk '{print $3}')
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+	--option "Dpkg::Options::=--force-confold" \
+	--no-install-recommends \
+	-y \
+	kubelet=${kube_ver} \
+	kubeadm=${kube_ver} \
+	kubectl=${kube_ver} \
+	kubernetes-cni=${cni_ver} \
+	docker-ce=5:19.03.12~3-0~ubuntu-bionic docker-ce-cli=5:19.03.12~3-0~ubuntu-bionic
+
+sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -1,0 +1,92 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+sudo swapoff -a
+sudo sed -i '/.*swap.*/d' /etc/fstab
+sudo systemctl disable --now ufw || true
+
+source /etc/kubeone/proxy-env
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	},
+	"insecure-registries": [
+		"127.0.0.1:5000"
+	]
+}
+EOF
+
+
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+kernel.panic_on_oops = 1
+kernel.panic = 10
+net.ipv4.ip_forward = 1
+vm.overcommit_memory = 1
+fs.inotify.max_user_watches = 1048576
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+sudo mkdir -p /etc/apt/apt.conf.d
+cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
+Acquire::https::Proxy "http://https.proxy";
+Acquire::http::Proxy "http://http.proxy";
+EOF
+
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	lsb-release \
+	rsync
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
+	sudo tee /etc/apt/sources.list.d/docker.list
+
+# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
+# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
+echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
+
+kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
+cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.7" | head -1 | awk '{print $3}')
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+	--option "Dpkg::Options::=--force-confold" \
+	--no-install-recommends \
+	-y \
+	kubelet=${kube_ver} \
+	kubeadm=${kube_ver} \
+	kubectl=${kube_ver} \
+	kubernetes-cni=${cni_ver} \
+	docker-ce=5:19.03.12~3-0~ubuntu-bionic docker-ce-cli=5:19.03.12~3-0~ubuntu-bionic
+
+sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -754,6 +754,11 @@ func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster, credentials
 		args = append(args, "-external-cloud-provider")
 	}
 
+	insecureRegistry := cluster.RegistryConfiguration.InsecureRegistryAddress()
+	if insecureRegistry != "" {
+		args = append(args, "-node-insecure-registries", insecureRegistry)
+	}
+
 	envVar, err := credentials.EnvVarBindings(cluster.CloudProvider, credentialsFilePath)
 	envVar = append(envVar,
 		corev1.EnvVar{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for using the insecure Docker registry with the OverwriteRegistry functionality.

The RegistryConfiguration API has been extended with a new field `insecureRegistry`, that is used such as:

```yaml
registryConfiguration:
  overwriteRegistry: "127.0.0.1:5000"
  insecureRegistry: true
```

If `insecureRegistry` is set to `true`, the registry specified in the `overwriteRegistry` field will be configured as an insecure registry.

**Special notes for your reviewer**:

It's up to discussion do we want this field to be a boolean, or maybe a slice of strings, where users would be able to specify the custom insecure registries.

**Does this PR introduce a user-facing change?**:
```release-note
Add support for insecure Docker registries
```

/assign @kron4eg 