### PR TITLE
heredoc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module k8c.io/kubeone
 go 1.14
 
 require (
+	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.4.2
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,9 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
+github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -88,13 +89,13 @@ func applyCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Reconcile the cluster",
-		Long: `
-Reconcile (Install/Upgrade/Repair/Restore) Kubernetes cluster on pre-existing machines. MachineDeployments get 
-initialized but won't get modified by default, see '--upgrade-machine-deployments'.
+		Long: heredoc.Doc(`
+			Reconcile (Install/Upgrade/Repair/Restore) Kubernetes cluster on pre-existing machines. MachineDeployments get
+			initialized but won't get modified by default, see '--upgrade-machine-deployments'.
 
-This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
-It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.
-`,
+			This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
+			It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.
+		`),
 		Example: `kubeone apply -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -99,11 +100,11 @@ func printCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "print",
 		Short: "Print an example configuration manifest",
-		Long: `
-Print an example configuration manifest. Using the appropriate flags you can
-customize the configuration manifest. For the full reference of the
-configuration manifest, run the print command with --full flag.
-`,
+		Long: heredoc.Doc(`
+			Print an example configuration manifest. Using the appropriate flags you can
+			customize the configuration manifest. For the full reference of the
+			configuration manifest, run the print command with --full flag.
+		`),
 		Args:    cobra.ExactArgs(0),
 		Example: fmt.Sprintf("kubeone config print --provider digitalocean --kubernetes-version %s --cluster-name example", defaultKubernetesVersion),
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -560,7 +561,7 @@ cloudProvider:
   # and AzureDisk CSI drivers deployed, as enabling this feature disables the fallback
   # to the in-tree volume plugins. See description for the CSIMigration field for
   # more details.
-  csiMigrationComplete: false 
+  csiMigrationComplete: false
   # Path to file that will be uploaded and used as custom '--cloud-config' file.
   cloudConfig: "{{ .CloudProviderCloudCfg }}"
 

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -77,12 +78,12 @@ func installCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install Kubernetes",
-		Long: `
-Install Kubernetes on pre-existing machines
+		Long: heredoc.Doc(`
+			Install Kubernetes on pre-existing machines
 
-This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
-It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.
-`,
+			This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
+			It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.
+		`),
 		Example: `kubeone install -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)

--- a/pkg/cmd/kubeconfig.go
+++ b/pkg/cmd/kubeconfig.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -31,12 +32,12 @@ func kubeconfigCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kubeconfig",
 		Short: "Download the kubeconfig file from master",
-		Long: `
-Download the kubeconfig file from master.
+		Long: heredoc.Doc(`
+			Download the kubeconfig file from master.
 
-This command takes KubeOne manifest which contains information about hosts. It's possible to source information about
-hosts from Terraform output, using the '--tfjson' flag.
-`,
+			This command takes KubeOne manifest which contains information about hosts. It's possible to source information about
+			hosts from Terraform output, using the '--tfjson' flag.
+		`),
 		Example: `kubeone kubeconfig -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)

--- a/pkg/cmd/packaging.go
+++ b/pkg/cmd/packaging.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -27,11 +28,11 @@ func completionCmd(rootCmd *cobra.Command) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "completion <bash|zsh>",
 		Short: "Generates completion scripts for bash and zsh",
-		Long: `
-To load completion run into your current shell run
+		Long: heredoc.Doc(`
+			To load completion run into your current shell run
 
-. <(kubeone completion <shell>)
-`,
+			. <(kubeone completion <shell>)
+		`),
 		Example:   "kubeone completion bash",
 		ValidArgs: []string{"bash", "zsh"},
 		Args:      cobra.ExactValidArgs(1),
@@ -53,9 +54,9 @@ func documentCmd(rootCmd *cobra.Command) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "document <man|md|rest|yaml>",
 		Short: "Generates documentation",
-		Long: `
-Documentation can be generated as man pages, markdown, restructured text docs or yaml
-`,
+		Long: heredoc.Doc(`
+			Documentation can be generated as man pages, markdown, restructured text docs or yaml
+		`),
 		Example:   "kubeone document man",
 		ValidArgs: []string{"man", "md", "rest", "yaml"},
 		Args:      cobra.ExactValidArgs(1),

--- a/pkg/cmd/proxy.go
+++ b/pkg/cmd/proxy.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -39,13 +40,13 @@ func proxyCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "proxy",
 		Short: "Proxy to the kube-apiserver using SSH tunnel",
-		Long: `
-HTTPS Proxy (CONNECT method) SSH tunnel.
+		Long: heredoc.Doc(`
+			HTTPS Proxy (CONNECT method) SSH tunnel.
 
-This command helps to reach kubeapi endpoint with local kubectl in case when private/firewalled endpoint is used (e.g.
-internal loadbalancer). It creates SSH tunnel to one of the control-plane nodes and then proxies incomming requests
-through it.
-`,
+			This command helps to reach kubeapi endpoint with local kubectl in case when private/firewalled endpoint is used (e.g.
+			internal loadbalancer). It creates SSH tunnel to one of the control-plane nodes and then proxies incomming requests
+			through it.
+		`),
 		Example: `kubeone proxy -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(*cobra.Command, []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -49,12 +50,12 @@ func resetCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset",
 		Short: "Revert changes",
-		Long: `
-Undo all changes done by KubeOne to the configured machines.
+		Long: heredoc.Doc(`
+			Undo all changes done by KubeOne to the configured machines.
 
-This command takes KubeOne manifest which contains information about hosts. It's possible to source information about
-hosts from Terraform output, using the '--tfjson' flag.
-`,
+			This command takes KubeOne manifest which contains information about hosts. It's possible to source information about
+			hosts from Terraform output, using the '--tfjson' flag.
+		`),
 		Example: `kubeone reset -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -29,11 +30,12 @@ func statusCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Status of the cluster",
-		Long: `Status of the cluster.
+		Long: heredoc.Doc(`
+			Status of the cluster.
 
-This command takes KubeOne manifest which contains information about hosts. It's possible to source information about
-hosts from Terraform output, using the '--tfjson' flag.
-`,
+			This command takes KubeOne manifest which contains information about hosts. It's possible to source information about
+			hosts from Terraform output, using the '--tfjson' flag.
+		`),
 		Example: `kubeone status -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -48,11 +49,12 @@ func upgradeCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade <manifest>",
 		Short: "Upgrade Kubernetes",
-		Long: `Upgrade Kubernetes
+		Long: heredoc.Doc(`
+			Upgrade Kubernetes
 
-This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
-It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.
-`,
+			This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
+			It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.
+		`),
 		Example: `kubeone upgrade -m mycluster.yaml -t terraformoutput.json`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/Masterminds/semver"
 	"github.com/spf13/cobra"
 
@@ -47,9 +48,9 @@ func versionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Display KubeOne version",
-		Long: `
-Prints the exact version number, as embedded by the build system.
-`,
+		Long: heredoc.Doc(`
+			Prints the exact version number, as embedded by the build system.
+		`),
 		Args: cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ownver := k8sversion.Info{


### PR DESCRIPTION
**What this PR does / why we need it**:
Use heredoc, to have straight indentation on multiline strings, like doc strings for CLI commands.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```