### PR TITLE
Overwrite machine-controller Hyperkube and Kubelet image repositories

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -759,6 +759,14 @@ func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster, credentials
 		args = append(args, "-node-insecure-registries", insecureRegistry)
 	}
 
+	if cluster.RegistryConfiguration != nil && cluster.RegistryConfiguration.OverwriteRegistry != "" {
+		hyperkubeImage := cluster.RegistryConfiguration.ImageRegistry("k8s.gcr.io") + "/hyperkube-amd64"
+		poseidonKubeletImage := cluster.RegistryConfiguration.ImageRegistry("quay.io") + "/poseidon/kubelet"
+
+		args = append(args, "-node-hyperkube-image", hyperkubeImage)
+		args = append(args, "-node-kubelet-repository", poseidonKubeletImage)
+	}
+
 	envVar, err := credentials.EnvVarBindings(cluster.CloudProvider, credentialsFilePath)
 	envVar = append(envVar,
 		corev1.EnvVar{


### PR DESCRIPTION
**What this PR does / why we need it**:

Overwrite machine-controller Hyperkube and Kubelet image repositories.

**Does this PR introduce a user-facing change?**:
```release-note
Overwrite machine-controller Hyperkube and Kubelet image repositories
```

/assign @kron4eg 