### PR TITLE
Overwrite pause image on worker nodes

### DIFF
--- a/hack/image-loader.sh
+++ b/hack/image-loader.sh
@@ -143,9 +143,9 @@ done
 # Pull images needed for machine-controller
 minorVersion=$(cut -d '.' -f 2 <<< "${KUBERNETES_VERSION}")
 if [ "${minorVersion}" -le "18" ]; then
-  retag "k8s.gcr.io/hyperkube-amd64:${KUBERNETES_VERSION}"
+  retag "k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"
 else
-  retag "quay.io/poseidon/kubelet:${KUBERNETES_VERSION}"
+  retag "quay.io/poseidon/kubelet:v${KUBERNETES_VERSION}"
 fi
 
 if [ "$PULL_OPTIONAL_IMAGES" == "false" ]; then

--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -63,6 +63,12 @@ rm -rf "{{ .WORK_DIR }}"
 
 	kubeadmUpgradeLeaderScriptTemplate = `
 sudo {{ .KUBEADM_UPGRADE }} --config={{ .WORK_DIR }}/cfg/master_0.yaml`
+
+	kubeadmPauseImageVersionScriptTemplate = `
+sudo kubeadm config images list --kubernetes-version={{ .KUBERNETES_VERSION }} |
+  grep "k8s.gcr.io/pause" |
+  cut -d ":" -f2
+`
 )
 
 func KubeadmJoin(workdir string, nodeID int, verboseFlag string) (string, error) {
@@ -110,5 +116,11 @@ func KubeadmUpgradeLeader(kubeadmCmd, workdir string) (string, error) {
 	return Render(kubeadmUpgradeLeaderScriptTemplate, map[string]interface{}{
 		"KUBEADM_UPGRADE": kubeadmCmd,
 		"WORK_DIR":        workdir,
+	})
+}
+
+func KubeadmPauseImageVersion(kubernetesVersion string) (string, error) {
+	return Render(kubeadmPauseImageVersionScriptTemplate, map[string]interface{}{
+		"KUBERNETES_VERSION": kubernetesVersion,
 	})
 }

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -67,6 +67,7 @@ type State struct {
 	PatchCNI                  bool
 	CredentialsFilePath       string
 	ManifestFilePath          string
+	PauseImage                string
 }
 
 func (s *State) KubeadmVerboseFlag() string {

--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -70,7 +70,7 @@ func Deploy(s *state.State) error {
 
 	image := s.Cluster.RegistryConfiguration.ImageRegistry(MachineControllerImageRegistry) + MachineControllerImage + MachineControllerTag
 
-	deployment, err := machineControllerDeployment(s.Cluster, s.CredentialsFilePath, image)
+	deployment, err := machineControllerDeployment(s.Cluster, s.CredentialsFilePath, image, s.PauseImage)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate machine-controller deployment")
 	}
@@ -731,7 +731,7 @@ func machineControllerMachineDeploymentCRD() *apiextensions.CustomResourceDefini
 	}
 }
 
-func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster, credentialsFilePath, image string) (*appsv1.Deployment, error) {
+func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster, credentialsFilePath, image, pauseImage string) (*appsv1.Deployment, error) {
 	var replicas int32 = 1
 
 	args := []string{
@@ -765,6 +765,8 @@ func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster, credentials
 
 		args = append(args, "-node-hyperkube-image", hyperkubeImage)
 		args = append(args, "-node-kubelet-repository", poseidonKubeletImage)
+
+		args = append(args, "-node-pause-image", pauseImage)
 	}
 
 	envVar, err := credentials.EnvVarBindings(cluster.CloudProvider, credentialsFilePath)


### PR DESCRIPTION
**What this PR does / why we need it**:

Overwrite the pause image (`k8s.gcr.io/pause`) on worker nodes if overwriteRegistry is configured. The pause image version is determined using `kubeadm`.

The pause image on the control plane nodes is already overwritten by `kubeadm`.

**Does this PR introduce a user-facing change?**:
```release-note
Overwrite pause image on worker nodes if overwriteRegistry is used
```

/assign @kron4eg 