### PR TITLE
Fix dangling newline

### DIFF
--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -156,7 +156,7 @@ func investigateCluster(s *state.State) error {
 			if !leaderElected {
 				s.LiveCluster.ControlPlane[i].Config.IsLeader = true
 				leaderElected = true
-				s.Logger.Infof("Elected leader %q...\n", s.LiveCluster.ControlPlane[i].Config.Hostname)
+				s.Logger.Infof("Elected leader %q...", s.LiveCluster.ControlPlane[i].Config.Hostname)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
No need to add an explicit newline, it looks ugly in the nocolor output:

```
time="14:31:10 UTC" level=info msg="Running host probes..."
time="14:31:10 UTC" level=info msg="Electing cluster leader..."
time="14:31:10 UTC" level=info msg="Elected leader \"captain-control-plane-1\"...\n" <---
time="14:31:11 UTC" level=info msg="Building Kubernetes clientset..."
time="14:31:11 UTC" level=info msg="Running cluster probes..."
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
