### PR TITLE
Fix remove binaries script for Amazon Linux and Flatcar

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -387,19 +387,27 @@ sudo yum remove -y kubernetes-cni || true
 `
 
 	removeBinariesAmazonLinuxScriptTemplate = `
+# Stop kubelet
+sudo systemctl stop kubelet || true
 # Remove CNI and binaries
 sudo rm -rf /opt/cni /opt/bin/kubeadm /opt/bin/kubectl /opt/bin/kubelet
 # Remove symlinks
 sudo rm -rf /usr/bin/kubeadm /usr/bin/kubectl /usr/bin/kubelet
 # Remove systemd unit files
-sudo rm /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sudo rm -f /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+# Reload systemd
+sudo systemctl daemon-reload
 `
 
 	removeBinariesCoreOSScriptTemplate = `
+# Stop kubelet
+sudo systemctl stop kubelet || true
 # Remove CNI and binaries
 sudo rm -rf /opt/cni /opt/bin/kubeadm /opt/bin/kubectl /opt/bin/kubelet
 # Remove systemd unit files
-sudo rm /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sudo rm -f /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+# Reload systemd
+sudo systemctl daemon-reload
 `
 
 	upgradeKubeadmAndCNICoreOSScriptTemplate = `

--- a/pkg/scripts/testdata/TestRemoveBinariesAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesAmazonLinux.golden
@@ -1,9 +1,13 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+# Stop kubelet
+sudo systemctl stop kubelet || true
 # Remove CNI and binaries
 sudo rm -rf /opt/cni /opt/bin/kubeadm /opt/bin/kubectl /opt/bin/kubelet
 # Remove symlinks
 sudo rm -rf /usr/bin/kubeadm /usr/bin/kubectl /usr/bin/kubelet
 # Remove systemd unit files
-sudo rm /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sudo rm -f /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+# Reload systemd
+sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestRemoveBinariesCoreOS.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesCoreOS.golden
@@ -1,7 +1,11 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+# Stop kubelet
+sudo systemctl stop kubelet || true
 # Remove CNI and binaries
 sudo rm -rf /opt/cni /opt/bin/kubeadm /opt/bin/kubectl /opt/bin/kubelet
 # Remove systemd unit files
-sudo rm /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sudo rm -f /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+# Reload systemd
+sudo systemctl daemon-reload


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix remove binaries script for Amazon Linux and Flatcar

* Stop Kubelet before removing it
* Force remove unit files
* Reload systemd after removing units

Without this, running apply after removing binaries wouldn't work
because systemd service would still exist, so apply assumes that kubelet
is installed. However, the binary is not available, which causes apply
to fail to determine the kubelet version.

**Does this PR introduce a user-facing change?**:
```release-note
Fix remove binaries script for Amazon Linux and Flatcar
```

/assign @kron4eg 