### PR TITLE
fix dns-resolution for minio

### DIFF
--- a/addons/backups-restic/backups-restic.yaml
+++ b/addons/backups-restic/backups-restic.yaml
@@ -33,6 +33,7 @@ spec:
       template:
         spec:
           hostNetwork: true
+          dnsPolicy: ClusterFirstWithHostNet
           nodeSelector:
             node-role.kubernetes.io/master: ""
           tolerations:


### PR DESCRIPTION
Fix restrict backup addon according to: https://github.com/kubermatic/kubeone/issues/1178#issuecomment-736072497
and
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix Backup Addon in combination of in-cluster minio service

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1178 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
