### PR TITLE
Containerd Support

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -30,9 +30,9 @@ locals {
   worker_os        = var.worker_os == "" ? var.os : var.worker_os
 
   subnets = {
-    "${local.zoneA}" = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[0].id : ""
-    "${local.zoneB}" = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[1].id : ""
-    "${local.zoneC}" = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[2].id : ""
+    (local.zoneA) = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[0].id : ""
+    (local.zoneB) = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[1].id : ""
+    (local.zoneC) = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[2].id : ""
   }
 }
 

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -22,6 +22,10 @@ output "kubeone_api" {
   }
 }
 
+output "ssh_commands" {
+  value = formatlist("ssh -J ${var.bastion_user}@${aws_instance.bastion.public_ip} ${var.ssh_username}@%s", aws_instance.control_plane.*.private_ip)
+}
+
 output "kubeone_hosts" {
   description = "Control plane endpoints to SSH to"
 

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -67,6 +67,17 @@ func (h *HostConfig) SetLeader(leader bool) {
 	h.IsLeader = leader
 }
 
+func (crc ContainerRuntimeConfig) String() string {
+	switch {
+	case crc.Containerd != nil:
+		return "containerd"
+	case crc.Docker != nil:
+		return "docker"
+	}
+
+	return "unknown"
+}
+
 // CloudProviderName returns name of the cloud provider
 func (p CloudProviderSpec) CloudProviderName() string {
 	switch {

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -170,14 +170,15 @@ func runApply(opts *applyOpts) error {
 		return err
 	}
 
+	containerRuntimeString := s.Cluster.ContainerRuntime.String()
 	if s.Verbose {
 		// Print information about hosts collected by probes
 		for _, host := range s.LiveCluster.ControlPlane {
-			printHostInformation(host)
+			printHostInformation(host, containerRuntimeString)
 		}
 
 		for _, host := range s.LiveCluster.StaticWorkers {
-			printHostInformation(host)
+			printHostInformation(host, containerRuntimeString)
 		}
 	}
 
@@ -395,17 +396,17 @@ func confirmApply(autoApprove bool) (bool, error) {
 	return strings.Trim(confirmation, "\n") == "yes", nil
 }
 
-func printHostInformation(host state.Host) {
+func printHostInformation(host state.Host, containerRuntime string) {
 	fmt.Printf("Host: %q\n", host.Config.Hostname)
 	fmt.Printf("\tHost initialized: %s\n", boolStr(host.Initialized()))
-	fmt.Printf("\tContainer runtime healthy: %s (%s)\n", boolStr(host.ContainerRuntime.Healthy()), printVersion(host.ContainerRuntime.Version))
+	fmt.Printf("\t%s healthy: %s (%s)\n", containerRuntime, boolStr(host.ContainerRuntime.Healthy()), printVersion(host.ContainerRuntime.Version))
 	fmt.Printf("\tKubelet healthy: %s (%s)\n", boolStr(host.Kubelet.Healthy()), printVersion(host.Kubelet.Version))
 
 	fmt.Println()
-	fmt.Printf("\tContainer runtime is installed: %s\n", boolStr(host.ContainerRuntime.Status&state.ComponentInstalled != 0))
-	fmt.Printf("\tContainer runtime is running: %s\n", boolStr(host.ContainerRuntime.Status&state.SystemDStatusRunning != 0))
-	fmt.Printf("\tContainer runtime is active: %s\n", boolStr(host.ContainerRuntime.Status&state.SystemDStatusActive != 0))
-	fmt.Printf("\tContainer runtime is restarting: %s\n", boolStr(host.ContainerRuntime.Status&state.SystemDStatusRestarting != 0))
+	fmt.Printf("\t%s is installed: %s\n", containerRuntime, boolStr(host.ContainerRuntime.Status&state.ComponentInstalled != 0))
+	fmt.Printf("\t%s is running: %s\n", containerRuntime, boolStr(host.ContainerRuntime.Status&state.SystemDStatusRunning != 0))
+	fmt.Printf("\t%s is active: %s\n", containerRuntime, boolStr(host.ContainerRuntime.Status&state.SystemDStatusActive != 0))
+	fmt.Printf("\t%s is restarting: %s\n", containerRuntime, boolStr(host.ContainerRuntime.Status&state.SystemDStatusRestarting != 0))
 
 	fmt.Println()
 	fmt.Printf("\tKubelet is installed: %s\n", boolStr(host.Kubelet.Status&state.ComponentInstalled != 0))

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -398,14 +398,14 @@ func confirmApply(autoApprove bool) (bool, error) {
 func printHostInformation(host state.Host) {
 	fmt.Printf("Host: %q\n", host.Config.Hostname)
 	fmt.Printf("\tHost initialized: %s\n", boolStr(host.Initialized()))
-	fmt.Printf("\tDocker healthy: %s (%s)\n", boolStr(host.ContainerRuntime.Healthy()), printVersion(host.ContainerRuntime.Version))
+	fmt.Printf("\tContainer runtime healthy: %s (%s)\n", boolStr(host.ContainerRuntime.Healthy()), printVersion(host.ContainerRuntime.Version))
 	fmt.Printf("\tKubelet healthy: %s (%s)\n", boolStr(host.Kubelet.Healthy()), printVersion(host.Kubelet.Version))
 
 	fmt.Println()
-	fmt.Printf("\tDocker is installed: %s\n", boolStr(host.ContainerRuntime.Status&state.ComponentInstalled != 0))
-	fmt.Printf("\tDocker is running: %s\n", boolStr(host.ContainerRuntime.Status&state.SystemDStatusRunning != 0))
-	fmt.Printf("\tDocker is active: %s\n", boolStr(host.ContainerRuntime.Status&state.SystemDStatusActive != 0))
-	fmt.Printf("\tDocker is restarting: %s\n", boolStr(host.ContainerRuntime.Status&state.SystemDStatusRestarting != 0))
+	fmt.Printf("\tContainer runtime is installed: %s\n", boolStr(host.ContainerRuntime.Status&state.ComponentInstalled != 0))
+	fmt.Printf("\tContainer runtime is running: %s\n", boolStr(host.ContainerRuntime.Status&state.SystemDStatusRunning != 0))
+	fmt.Printf("\tContainer runtime is active: %s\n", boolStr(host.ContainerRuntime.Status&state.SystemDStatusActive != 0))
+	fmt.Printf("\tContainer runtime is restarting: %s\n", boolStr(host.ContainerRuntime.Status&state.SystemDStatusRestarting != 0))
 
 	fmt.Println()
 	fmt.Printf("\tKubelet is installed: %s\n", boolStr(host.Kubelet.Status&state.ComponentInstalled != 0))

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -19,57 +19,71 @@ package scripts
 import (
 	"encoding/json"
 
-	"github.com/Masterminds/semver"
+	"github.com/MakeNowJust/heredoc/v2"
+)
+
+var (
+	libraryTemplate = heredoc.Doc(`
+		{{ define "detect-host-cpu-architecture" }}
+		HOST_ARCH=""
+		case $(uname -m) in
+		x86_64)
+			HOST_ARCH="amd64"
+			;;
+		aarch64)
+			HOST_ARCH="arm64"
+			;;
+		*)
+			echo "unsupported CPU architecture, exiting"
+			exit 1
+			;;
+		esac
+		{{ end }}
+
+		{{ define "docker-daemon-config" }}
+		sudo mkdir -p /etc/docker
+		cat <<EOF | sudo tee /etc/docker/daemon.json
+		{{ dockerCfg .DOCKER_INSECURE_REGISTRY }}
+		EOF
+		{{ end }}
+
+		{{ define "sysctl-k8s" }}
+		cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+		overlay
+		br_netfilter
+		EOF
+		sudo modprobe overlay
+		sudo modprobe br_netfilter
+		sudo mkdir -p /etc/sysctl.d
+		cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+		fs.inotify.max_user_watches         = 1048576
+		kernel.panic                        = 10
+		kernel.panic_on_oops                = 1
+		net.bridge.bridge-nf-call-ip6tables = 1
+		net.bridge.bridge-nf-call-iptables  = 1
+		net.ipv4.ip_forward                 = 1
+		net.netfilter.nf_conntrack_max      = 1000000
+		vm.overcommit_memory                = 1
+		EOF
+		sudo sysctl --system
+		{{ end }}
+
+		{{ define "journald-config" }}
+		sudo mkdir -p /etc/systemd/journald.conf.d
+		cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+		[Journal]
+		SystemMaxUse=5G
+		EOF
+		sudo systemctl force-reload systemd-journald
+		{{ end }}
+	`)
 )
 
 const (
-	libraryTemplate = `
-{{ define "detect-host-cpu-architecture" }}
-HOST_ARCH=""
-case $(uname -m) in
-x86_64)
-	HOST_ARCH="amd64"
-	;;
-aarch64)
-	HOST_ARCH="arm64"
-	;;
-*)
-	echo "unsupported CPU architecture, exiting"
-	exit 1
-	;;
-esac
-{{ end }}
-
-{{ define "docker-daemon-config" }}
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{{ dockerCfg .DOCKER_INSECURE_REGISTRY }}
-EOF
-{{ end }}
-
-{{ define "sysctl-k8s" }}
-sudo mkdir -p /etc/sysctl.d
-cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
-net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
-EOF
-sudo sysctl --system
-{{ end }}
-
-{{ define "journald-config" }}
-sudo mkdir -p /etc/systemd/journald.conf.d
-cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
-[Journal]
-SystemMaxUse=5G
-EOF
-sudo systemctl force-reload systemd-journald
-{{ end }}
-`
+	defaultDockerVersion       = "19.03.14"
+	defaultAmazonDockerVersion = "19.03.13"
+	defaultLegacyDockerVersion = "18.09.9"
+	defaultContainerdVersion   = "1.4.3"
 )
 
 type dockerConfig struct {
@@ -99,52 +113,4 @@ func dockerCfg(insecureRegistry string) (string, error) {
 	}
 
 	return string(b), nil
-}
-
-func aptDockerFunc(v string) (string, error) {
-	sver, err := semver.NewVersion(v)
-	if err != nil {
-		return "", err
-	}
-
-	lessThen117, _ := semver.NewConstraint("< 1.17")
-
-	if lessThen117.Check(sver) {
-		return "docker-ce=5:18.09.9~3-0~ubuntu-bionic docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic", nil
-	}
-
-	// return default
-	return "docker-ce=5:19.03.12~3-0~ubuntu-bionic docker-ce-cli=5:19.03.12~3-0~ubuntu-bionic", nil
-}
-
-func yumDockerFunc(v string) (string, error) {
-	sver, err := semver.NewVersion(v)
-	if err != nil {
-		return "", err
-	}
-
-	lessThen117, _ := semver.NewConstraint("< 1.17")
-
-	if lessThen117.Check(sver) {
-		return "docker-ce-18.09.9-3.el7 docker-ce-cli-18.09.9-3.el7", nil
-	}
-
-	// return default
-	return "docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7", nil
-}
-
-func amznYumDockerFunc(v string) (string, error) {
-	sver, err := semver.NewVersion(v)
-	if err != nil {
-		return "", err
-	}
-
-	lessThen117, _ := semver.NewConstraint("< 1.17")
-
-	if lessThen117.Check(sver) {
-		return "docker-18.09.9ce-2.amzn2", nil
-	}
-
-	// return default
-	return "docker-19.03.13ce-1.amzn2", nil
 }

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -20,23 +20,192 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/Masterminds/sprig"
 	"github.com/pkg/errors"
+)
+
+var (
+	containerRuntimeTemplates = map[string]string{
+		"apt-docker-ce": heredoc.Docf(`
+			{{ if .CONFIGURE_REPOSITORIES }}
+			curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+			# Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
+			# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+			# Therefore, we use bionic repo which has all Docker versions.
+			echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
+				sudo tee /etc/apt/sources.list.d/docker.list
+			sudo apt-get update
+			{{ end }}
+
+			{{- if or .FORCE .UPGRADE }}
+			sudo apt-mark unhold docker-ce docker-ce-cli
+			{{- end }}
+
+			{{ $DOCKER_VERSION_TO_INSTALL := "%s" }}
+			{{ if semverCompare "< 1.17" .KUBERNETES_VERSION }}
+			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
+			{{ end }}
+
+			sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+				--option "Dpkg::Options::=--force-confold" \
+				--no-install-recommends \
+				-y \
+				{{- if .FORCE }}
+				--allow-downgrades \
+				{{- end }}
+				docker-ce=5:{{ $DOCKER_VERSION_TO_INSTALL }}* docker-ce-cli=5:{{ $DOCKER_VERSION_TO_INSTALL }}*
+			sudo apt-mark hold docker-ce docker-ce-cli
+			sudo systemctl daemon-reload
+			sudo systemctl enable --now docker
+			`,
+			defaultDockerVersion,
+			defaultLegacyDockerVersion,
+		),
+
+		"yum-docker-ce-amzn": heredoc.Docf(`
+			{{- if or .FORCE .UPGRADE }}
+			sudo yum versionlock delete docker || true
+			{{- end }}
+
+			{{ $DOCKER_VERSION_TO_INSTALL := "%s" }}
+			{{ if semverCompare "< 1.17" .KUBERNETES_VERSION }}
+			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
+			{{ end }}
+
+			sudo yum install -y docker-{{ $DOCKER_VERSION_TO_INSTALL }}ce*
+			sudo yum versionlock add docker
+
+			sudo systemctl daemon-reload
+			sudo systemctl enable --now docker
+		`,
+			defaultAmazonDockerVersion,
+			defaultLegacyDockerVersion,
+		),
+
+		"yum-docker-ce": heredoc.Docf(`
+			{{ if .CONFIGURE_REPOSITORIES }}
+			sudo yum install -y yum-utils
+			sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+			sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+			# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
+			# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+			# Therefore, we use 7 repo which has all Docker versions.
+			sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+			{{ end }}
+
+			{{ if or .FORCE .UPGRADE }}
+			sudo yum versionlock delete docker-ce docker-ce-cli || true
+			{{- end }}
+
+			{{ $DOCKER_VERSION_TO_INSTALL := "%s" }}
+			{{ if semverCompare "< 1.17" .KUBERNETES_VERSION }}
+			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
+			{{ end }}
+
+			sudo yum install -y docker-ce-{{ $DOCKER_VERSION_TO_INSTALL }}* docker-ce-cli-{{ $DOCKER_VERSION_TO_INSTALL }}*
+			sudo yum versionlock add docker-ce docker-ce-cli
+			sudo systemctl daemon-reload
+			sudo systemctl enable --now docker
+			`,
+			defaultLegacyDockerVersion,
+			defaultDockerVersion,
+		),
+
+		"containerd-github": heredoc.Docf(`
+			{{ $CONTAINERD_VERSION := "%s" }}
+			mkdir -p /tmp/containerd-{{ $CONTAINERD_VERSION }}
+			pushd /tmp/containerd-{{ $CONTAINERD_VERSION }}
+			curl --location --continue-at - \
+				--output containerd-{{ $CONTAINERD_VERSION }}-linux-amd64.tar.gz.sha256sum \
+				https://github.com/containerd/containerd/releases/download/v{{ $CONTAINERD_VERSION }}/containerd-{{ $CONTAINERD_VERSION }}-linux-amd64.tar.gz.sha256sum \
+				--output containerd-{{ $CONTAINERD_VERSION }}-linux-amd64.tar.gz \
+				https://github.com/containerd/containerd/releases/download/v{{ $CONTAINERD_VERSION }}/containerd-{{ $CONTAINERD_VERSION }}-linux-amd64.tar.gz
+			sha256sum -c containerd-{{ $CONTAINERD_VERSION }}-linux-amd64.tar.gz.sha256sum
+			tar xvf containerd-{{ $CONTAINERD_VERSION }}-linux-amd64.tar.gz
+			sudo install --group=0 --owner=0 --preserve-timestamps ./bin/* --target-directory=/usr/local/bin/
+			sudo mkdir -p /etc/containerd /etc/cni/net.d /opt/cni/bin
+
+			cat <<EOF | sudo tee /etc/containerd/config.toml
+			version = 2
+
+			[metrics]
+			  # metrics available at http://127.0.0.1:1338/v1/metrics
+			  address = "127.0.0.1:1338"
+
+			[plugins]
+			[plugins."io.containerd.grpc.v1.cri"]
+			[plugins."io.containerd.grpc.v1.cri".containerd]
+			[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+			[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+			    runtime_type = "io.containerd.runc.v2"
+			[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+			    SystemdCgroup = true
+			EOF
+
+			cat <<EOF | sudo tee /etc/crictl.yaml
+			runtime-endpoint: unix:///run/containerd/containerd.sock
+			EOF
+
+			cat <<EOF | sudo tee /etc/systemd/system/containerd.service
+			[Unit]
+			Description=containerd container runtime
+			Documentation=https://containerd.io
+			After=network.target local-fs.target
+
+			[Service]
+			ExecStartPre=-/sbin/modprobe overlay
+			ExecStart=/usr/local/bin/containerd
+
+			Type=notify
+			Delegate=yes
+			KillMode=process
+			Restart=always
+			RestartSec=5
+			# Having non-zero Limit*s causes performance problems due to accounting overhead
+			# in the kernel. We recommend using cgroups to do container-local accounting.
+			LimitNPROC=infinity
+			LimitCORE=infinity
+			LimitNOFILE=1048576
+			# Comment TasksMax if your systemd version does not supports it.
+			# Only systemd 226 and above support this version.
+			TasksMax=infinity
+			OOMScoreAdjust=-999
+
+			[Install]
+			WantedBy=multi-user.target
+			EOF
+
+			sudo systemctl daemon-reload
+			sudo systemctl enable --now containerd
+			sudo systemctl restart containerd
+			popd
+			`,
+			defaultContainerdVersion,
+		),
+	}
 )
 
 type Data map[string]interface{}
 
 // Render text template with given `variables` Render-context
 func Render(cmd string, variables map[string]interface{}) (string, error) {
-	tpl := template.New("base").Funcs(template.FuncMap{
-		"yumDocker":     yumDockerFunc,
-		"amznYumDocker": amznYumDockerFunc,
-		"aptDocker":     aptDockerFunc,
-		"dockerCfg":     dockerCfg,
-	})
+	tpl := template.New("base").
+		Funcs(sprig.TxtFuncMap()).
+		Funcs(template.FuncMap{
+			"dockerCfg": dockerCfg,
+		})
 
 	_, err := tpl.New("library").Parse(libraryTemplate)
 	if err != nil {
 		return "", err
+	}
+
+	for tplName, tplBody := range containerRuntimeTemplates {
+		_, err = tpl.New(tplName).Parse(tplBody)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	_, err = tpl.Parse(cmd)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -74,11 +66,38 @@ sudo yum install -y \
 	ebtables \
 	socat \
 	iproute-tc
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
 sudo yum versionlock delete docker || true
 
-sudo yum install -y \
-	docker-19.03.13ce-1.amzn2
+
+
+
+sudo yum install -y docker-19.03.13ce*
 sudo yum versionlock add docker
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo mkdir -p /opt/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 
@@ -132,6 +151,5 @@ sudo ln -sf /opt/bin/kubectl /usr/bin/
 rm /tmp/k8s-binaries/kubectl
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -75,9 +67,36 @@ sudo yum install -y \
 	socat \
 	iproute-tc
 
-sudo yum install -y \
-	docker-19.03.13ce-1.amzn2
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+
+
+
+
+sudo yum install -y docker-19.03.13ce*
 sudo yum versionlock add docker
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo mkdir -p /opt/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 
@@ -131,6 +150,5 @@ sudo ln -sf /opt/bin/kubectl /usr/bin/
 rm /tmp/k8s-binaries/kubectl
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -11,33 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	},
-	"insecure-registries": [
-		"127.0.0.1:5000"
-	]
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -78,9 +67,39 @@ sudo yum install -y \
 	socat \
 	iproute-tc
 
-sudo yum install -y \
-	docker-19.03.13ce-1.amzn2
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	},
+	"insecure-registries": [
+		"127.0.0.1:5000"
+	]
+}
+EOF
+
+
+
+
+
+
+sudo yum install -y docker-19.03.13ce*
 sudo yum versionlock add docker
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo mkdir -p /opt/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 
@@ -134,6 +153,5 @@ sudo ln -sf /opt/bin/kubectl /usr/bin/
 rm /tmp/k8s-binaries/kubectl
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -75,9 +67,36 @@ sudo yum install -y \
 	socat \
 	iproute-tc
 
-sudo yum install -y \
-	docker-19.03.13ce-1.amzn2
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+
+
+
+
+sudo yum install -y docker-19.03.13ce*
 sudo yum versionlock add docker
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo mkdir -p /opt/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 
@@ -131,6 +150,5 @@ sudo ln -sf /opt/bin/kubectl /usr/bin/
 rm /tmp/k8s-binaries/kubectl
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -75,9 +67,36 @@ sudo yum install -y \
 	socat \
 	iproute-tc
 
-sudo yum install -y \
-	docker-19.03.13ce-1.amzn2
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+
+
+
+
+sudo yum install -y docker-19.03.13ce*
 sudo yum versionlock add docker
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo mkdir -p /opt/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 
@@ -131,6 +150,5 @@ sudo ln -sf /opt/bin/kubectl /usr/bin/
 rm /tmp/k8s-binaries/kubectl
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -75,9 +67,38 @@ sudo yum install -y \
 	socat \
 	iproute-tc
 
-sudo yum install -y \
-	docker-18.09.9ce-2.amzn2
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+
+
+
+
+
+
+sudo yum install -y docker-18.09.9ce*
 sudo yum versionlock add docker
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo mkdir -p /opt/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 
@@ -131,6 +152,5 @@ sudo ln -sf /opt/bin/kubectl /usr/bin/
 rm /tmp/k8s-binaries/kubectl
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -1,0 +1,152 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+sudo swapoff -a
+sudo sed -i '/.*swap.*/d' /etc/fstab
+sudo setenforce 0 || true
+sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/sysconfig/selinux
+sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
+sudo systemctl disable --now firewalld || true
+
+source /etc/kubeone/proxy-env
+
+
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+yum_proxy=""
+yum_proxy="proxy=http://https.proxy #kubeone"
+
+grep -v '#kubeone' /etc/yum.conf > /tmp/yum.conf || true
+echo -n "${yum_proxy}" >> /tmp/yum.conf
+sudo mv /tmp/yum.conf /etc/yum.conf
+
+
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+
+
+sudo yum install -y \
+	yum-plugin-versionlock \
+	device-mapper-persistent-data \
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
+
+
+
+
+sudo yum install runc -y
+
+mkdir -p /tmp/containerd-1.4.3
+pushd /tmp/containerd-1.4.3
+curl --location --continue-at - \
+	--output containerd-1.4.3-linux-amd64.tar.gz.sha256sum \
+	https://github.com/containerd/containerd/releases/download/v1.4.3/containerd-1.4.3-linux-amd64.tar.gz.sha256sum \
+	--output containerd-1.4.3-linux-amd64.tar.gz \
+	https://github.com/containerd/containerd/releases/download/v1.4.3/containerd-1.4.3-linux-amd64.tar.gz
+sha256sum -c containerd-1.4.3-linux-amd64.tar.gz.sha256sum
+tar xvf containerd-1.4.3-linux-amd64.tar.gz
+sudo install --group=0 --owner=0 --preserve-timestamps ./bin/* --target-directory=/usr/local/bin/
+sudo mkdir -p /etc/containerd /etc/cni/net.d /opt/cni/bin
+
+cat <<EOF | sudo tee /etc/containerd/config.toml
+version = 2
+
+[metrics]
+  # metrics available at http://127.0.0.1:1338/v1/metrics
+  address = "127.0.0.1:1338"
+
+[plugins]
+[plugins."io.containerd.grpc.v1.cri"]
+[plugins."io.containerd.grpc.v1.cri".containerd]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+    runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true
+EOF
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///run/containerd/containerd.sock
+EOF
+
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=1048576
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now containerd
+sudo systemctl restart containerd
+popd
+
+
+
+sudo mkdir -p /opt/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+
+rm -rf /tmp/k8s-binaries
+mkdir -p /tmp/k8s-binaries
+cd /tmp/k8s-binaries
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -65,30 +57,66 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
-# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
-# Therefore, we use CentOS7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 sudo yum install -y \
 	yum-plugin-versionlock \
 	device-mapper-persistent-data \
-	lvm2
-sudo yum versionlock delete docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni || true
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
 
-sudo yum install -y \
-	kubelet-v1.17.4 \
-	kubeadm-v1.17.4 \
-	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.7 \
-	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use 7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+
+sudo yum versionlock delete docker-ce docker-ce-cli || true
+
+
+
+
+sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
+
+
+
+
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+
+sudo yum install -y \
+	kubelet-1.17.4 \
+	kubeadm-1.17.4 \
+	kubectl-1.17.4 \
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet
+

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -65,29 +57,64 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
-# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
-# Therefore, we use CentOS7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 sudo yum install -y \
 	yum-plugin-versionlock \
 	device-mapper-persistent-data \
-	lvm2
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
 
-sudo yum install -y \
-	kubelet-v1.17.4 \
-	kubeadm-v1.17.4 \
-	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.7 \
-	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use 7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+
+
+
+
+
+sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
+
+
+
+
+
+sudo yum install -y \
+	kubelet-1.17.4 \
+	kubeadm-1.17.4 \
+	kubectl-1.17.4 \
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet
+

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -11,33 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	},
-	"insecure-registries": [
-		"127.0.0.1:5000"
-	]
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -68,29 +57,67 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
-# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
-# Therefore, we use CentOS7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 sudo yum install -y \
 	yum-plugin-versionlock \
 	device-mapper-persistent-data \
-	lvm2
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
 
-sudo yum install -y \
-	kubelet-v1.17.4 \
-	kubeadm-v1.17.4 \
-	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.7 \
-	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	},
+	"insecure-registries": [
+		"127.0.0.1:5000"
+	]
+}
+EOF
+
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use 7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+
+
+
+
+
+sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
+
+
+
+
+
+sudo yum install -y \
+	kubelet-1.17.4 \
+	kubeadm-1.17.4 \
+	kubectl-1.17.4 \
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet
+

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -65,29 +57,64 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
-# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
-# Therefore, we use CentOS7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 sudo yum install -y \
 	yum-plugin-versionlock \
 	device-mapper-persistent-data \
-	lvm2
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
 
-sudo yum install -y \
-	kubelet-v1.17.4 \
-	kubeadm-v1.17.4 \
-	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.7 \
-	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use 7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+
+
+
+
+
+sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
+
+
+
+
+
+sudo yum install -y \
+	kubelet-1.17.4 \
+	kubeadm-1.17.4 \
+	kubectl-1.17.4 \
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet
+

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -65,29 +57,64 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
-# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
-# Therefore, we use CentOS7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 sudo yum install -y \
 	yum-plugin-versionlock \
 	device-mapper-persistent-data \
-	lvm2
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
 
-sudo yum install -y \
-	kubelet-v1.17.4 \
-	kubeadm-v1.17.4 \
-	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.7 \
-	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use 7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+
+
+
+
+
+sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
+
+
+
+
+
+sudo yum install -y \
+	kubelet-1.17.4 \
+	kubeadm-1.17.4 \
+	kubectl-1.17.4 \
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet
+

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -65,29 +57,66 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
-# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
-# Therefore, we use CentOS7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 sudo yum install -y \
 	yum-plugin-versionlock \
 	device-mapper-persistent-data \
-	lvm2
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use 7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+
+
+
+
+
+
+
+sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
+sudo yum versionlock add docker-ce docker-ce-cli
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo yum install -y \
 	kubelet-v1.16.1 \
 	kubeadm-v1.16.1 \
 	kubectl-v1.16.1 \
-	kubernetes-cni-0.8.7 \
-	docker-ce-18.09.9-3.el7 docker-ce-cli-18.09.9-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet
+

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -1,0 +1,154 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+sudo swapoff -a
+sudo sed -i '/.*swap.*/d' /etc/fstab
+sudo setenforce 0 || true
+sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/sysconfig/selinux
+sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
+sudo systemctl disable --now firewalld || true
+
+source /etc/kubeone/proxy-env
+
+
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+yum_proxy=""
+yum_proxy="proxy=http://https.proxy #kubeone"
+
+grep -v '#kubeone' /etc/yum.conf > /tmp/yum.conf || true
+echo -n "${yum_proxy}" >> /tmp/yum.conf
+sudo mv /tmp/yum.conf /etc/yum.conf
+
+
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+
+
+sudo yum install -y \
+	yum-plugin-versionlock \
+	device-mapper-persistent-data \
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
+
+
+
+
+sudo yum install runc -y
+
+mkdir -p /tmp/containerd-1.4.3
+pushd /tmp/containerd-1.4.3
+curl --location --continue-at - \
+	--output containerd-1.4.3-linux-amd64.tar.gz.sha256sum \
+	https://github.com/containerd/containerd/releases/download/v1.4.3/containerd-1.4.3-linux-amd64.tar.gz.sha256sum \
+	--output containerd-1.4.3-linux-amd64.tar.gz \
+	https://github.com/containerd/containerd/releases/download/v1.4.3/containerd-1.4.3-linux-amd64.tar.gz
+sha256sum -c containerd-1.4.3-linux-amd64.tar.gz.sha256sum
+tar xvf containerd-1.4.3-linux-amd64.tar.gz
+sudo install --group=0 --owner=0 --preserve-timestamps ./bin/* --target-directory=/usr/local/bin/
+sudo mkdir -p /etc/containerd /etc/cni/net.d /opt/cni/bin
+
+cat <<EOF | sudo tee /etc/containerd/config.toml
+version = 2
+
+[metrics]
+  # metrics available at http://127.0.0.1:1338/v1/metrics
+  address = "127.0.0.1:1338"
+
+[plugins]
+[plugins."io.containerd.grpc.v1.cri"]
+[plugins."io.containerd.grpc.v1.cri".containerd]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+    runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true
+EOF
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///run/containerd/containerd.sock
+EOF
+
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=1048576
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now containerd
+sudo systemctl restart containerd
+popd
+
+
+
+sudo yum install -y \
+	kubelet-1.17.4 \
+	kubeadm-1.17.4 \
+	kubectl-1.17.4 \
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet
+

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-force.golden
@@ -34,15 +34,22 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 EOF
 
 
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -61,7 +68,7 @@ sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="vv1.17.4"
+RELEASE="v1.17.4"
 
 sudo mkdir -p /opt/bin
 cd /opt/bin

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-overwrite_registry.golden
@@ -34,15 +34,22 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 EOF
 
 
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -61,7 +68,7 @@ sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="vv1.17.4"
+RELEASE="v1.17.4"
 
 sudo mkdir -p /opt/bin
 cd /opt/bin

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-overwrite_registry_insecure.golden
@@ -37,15 +37,22 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 EOF
 
 
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -64,7 +71,7 @@ sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="vv1.17.4"
+RELEASE="v1.17.4"
 
 sudo mkdir -p /opt/bin
 cd /opt/bin

--- a/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCoreOS-simple.golden
@@ -34,15 +34,22 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 EOF
 
 
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -61,7 +68,7 @@ sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="vv1.17.4"
+RELEASE="v1.17.4"
 
 sudo mkdir -p /opt/bin
 cd /opt/bin

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -8,30 +8,22 @@ sudo systemctl disable --now ufw || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -58,9 +50,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	lsb-release \
 	rsync
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
-	sudo tee /etc/apt/sources.list.d/docker.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
@@ -68,8 +57,50 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 
 sudo apt-get update
 
-kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.7" | head -1 | awk '{print $3}')
+kube_ver="1.17.4*"
+cni_ver="0.8.7*"
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+# Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use bionic repo which has all Docker versions.
+echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
+	sudo tee /etc/apt/sources.list.d/docker.list
+sudo apt-get update
+
+
+
+
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+	--option "Dpkg::Options::=--force-confold" \
+	--no-install-recommends \
+	-y \
+	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
+sudo apt-mark hold docker-ce docker-ce-cli
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
@@ -78,12 +109,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver} \
-	docker-ce=5:19.03.12~3-0~ubuntu-bionic docker-ce-cli=5:19.03.12~3-0~ubuntu-bionic
+	kubernetes-cni=${cni_ver}
 
-sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -8,33 +8,22 @@ sudo systemctl disable --now ufw || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	},
-	"insecure-registries": [
-		"127.0.0.1:5000"
-	]
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -61,9 +50,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	lsb-release \
 	rsync
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
-	sudo tee /etc/apt/sources.list.d/docker.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
@@ -71,8 +57,53 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 
 sudo apt-get update
 
-kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.7" | head -1 | awk '{print $3}')
+kube_ver="1.17.4*"
+cni_ver="0.8.7*"
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	},
+	"insecure-registries": [
+		"127.0.0.1:5000"
+	]
+}
+EOF
+
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+# Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use bionic repo which has all Docker versions.
+echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
+	sudo tee /etc/apt/sources.list.d/docker.list
+sudo apt-get update
+
+
+
+
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+	--option "Dpkg::Options::=--force-confold" \
+	--no-install-recommends \
+	-y \
+	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
+sudo apt-mark hold docker-ce docker-ce-cli
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
@@ -81,12 +112,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver} \
-	docker-ce=5:19.03.12~3-0~ubuntu-bionic docker-ce-cli=5:19.03.12~3-0~ubuntu-bionic
+	kubernetes-cni=${cni_ver}
 
-sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -8,30 +8,22 @@ sudo systemctl disable --now ufw || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -58,9 +50,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	lsb-release \
 	rsync
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
-	sudo tee /etc/apt/sources.list.d/docker.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
@@ -68,8 +57,50 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 
 sudo apt-get update
 
-kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.7" | head -1 | awk '{print $3}')
+kube_ver="1.17.4*"
+cni_ver="0.8.7*"
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+# Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use bionic repo which has all Docker versions.
+echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
+	sudo tee /etc/apt/sources.list.d/docker.list
+sudo apt-get update
+
+
+
+
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+	--option "Dpkg::Options::=--force-confold" \
+	--no-install-recommends \
+	-y \
+	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
+sudo apt-mark hold docker-ce docker-ce-cli
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
@@ -78,12 +109,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver} \
-	docker-ce=5:19.03.12~3-0~ubuntu-bionic docker-ce-cli=5:19.03.12~3-0~ubuntu-bionic
+	kubernetes-cni=${cni_ver}
 
-sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -59,34 +59,6 @@ sudo apt-get update
 
 kube_ver="1.17.4*"
 cni_ver="0.8.7*"
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
-
-
-
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
-EOF
-
-
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-# Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
-# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-# Therefore, we use bionic repo which has all Docker versions.
-echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
-	sudo tee /etc/apt/sources.list.d/docker.list
-sudo apt-get update
-
-sudo apt-mark unhold docker-ce docker-ce-cli
 
 
 
@@ -95,12 +67,74 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
-sudo apt-mark hold docker-ce docker-ce-cli
+	runc
+
+mkdir -p /tmp/containerd-1.4.3
+pushd /tmp/containerd-1.4.3
+curl --location --continue-at - \
+	--output containerd-1.4.3-linux-amd64.tar.gz.sha256sum \
+	https://github.com/containerd/containerd/releases/download/v1.4.3/containerd-1.4.3-linux-amd64.tar.gz.sha256sum \
+	--output containerd-1.4.3-linux-amd64.tar.gz \
+	https://github.com/containerd/containerd/releases/download/v1.4.3/containerd-1.4.3-linux-amd64.tar.gz
+sha256sum -c containerd-1.4.3-linux-amd64.tar.gz.sha256sum
+tar xvf containerd-1.4.3-linux-amd64.tar.gz
+sudo install --group=0 --owner=0 --preserve-timestamps ./bin/* --target-directory=/usr/local/bin/
+sudo mkdir -p /etc/containerd /etc/cni/net.d /opt/cni/bin
+
+cat <<EOF | sudo tee /etc/containerd/config.toml
+version = 2
+
+[metrics]
+  # metrics available at http://127.0.0.1:1338/v1/metrics
+  address = "127.0.0.1:1338"
+
+[plugins]
+[plugins."io.containerd.grpc.v1.cri"]
+[plugins."io.containerd.grpc.v1.cri".containerd]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+    runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true
+EOF
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///run/containerd/containerd.sock
+EOF
+
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=1048576
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
-
-
+sudo systemctl enable --now containerd
+sudo systemctl restart containerd
+popd
 
 
 
@@ -109,6 +143,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--no-install-recommends \
 	-y \
 	kubelet=${kube_ver} \
+	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
 	kubernetes-cni=${cni_ver}
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -74,11 +66,38 @@ sudo yum install -y \
 	ebtables \
 	socat \
 	iproute-tc
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
 sudo yum versionlock delete docker || true
 
-sudo yum install -y \
-	docker-19.03.13ce-1.amzn2
+
+
+
+sudo yum install -y docker-19.03.13ce*
 sudo yum versionlock add docker
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo mkdir -p /opt/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 
@@ -94,5 +113,4 @@ sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -65,27 +57,62 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
-# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
-# Therefore, we use CentOS7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 sudo yum install -y \
 	yum-plugin-versionlock \
 	device-mapper-persistent-data \
-	lvm2
-sudo yum versionlock delete docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni || true
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
 
-sudo yum install -y \
-	kubeadm-v1.17.4 \
-	kubernetes-cni-0.8.7 \
-	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use 7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+
+sudo yum versionlock delete docker-ce docker-ce-cli || true
+
+
+
+
+sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
+
+
+
+
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+
+sudo yum install -y \
+	kubeadm-1.17.4 \
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -8,30 +8,22 @@ sudo systemctl disable --now ufw || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -58,9 +50,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	lsb-release \
 	rsync
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
-	sudo tee /etc/apt/sources.list.d/docker.list
 
 # You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
 # contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
@@ -68,20 +57,61 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 
 sudo apt-get update
 
-kube_ver=$(apt-cache madison kubelet | grep "v1.17.4" | head -1 | awk '{print $3}')
-cni_ver=$(apt-cache madison kubernetes-cni | grep "0.8.7" | head -1 | awk '{print $3}')
-sudo apt-mark unhold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+kube_ver="1.17.4*"
+cni_ver="0.8.7*"
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+# Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use bionic repo which has all Docker versions.
+echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
+	sudo tee /etc/apt/sources.list.d/docker.list
+sudo apt-get update
+
+sudo apt-mark unhold docker-ce docker-ce-cli
+
+
+
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+	--option "Dpkg::Options::=--force-confold" \
+	--no-install-recommends \
+	-y \
+	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
+sudo apt-mark hold docker-ce docker-ce-cli
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
 	kubeadm=${kube_ver} \
-	kubernetes-cni=${cni_ver} \
-	docker-ce=5:19.03.12~3-0~ubuntu-bionic docker-ce-cli=5:19.03.12~3-0~ubuntu-bionic
+	kubernetes-cni=${cni_ver}
 
-sudo apt-mark hold docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -74,11 +66,38 @@ sudo yum install -y \
 	ebtables \
 	socat \
 	iproute-tc
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
 sudo yum versionlock delete docker || true
 
-sudo yum install -y \
-	docker-19.03.13ce-1.amzn2
+
+
+
+sudo yum install -y docker-19.03.13ce*
 sudo yum versionlock add docker
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+
+
+
+
 
 sudo mkdir -p /opt/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 
@@ -127,6 +146,5 @@ sudo ln -sf /opt/bin/kubectl /usr/bin/
 rm /tmp/k8s-binaries/kubectl
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -11,30 +11,22 @@ sudo systemctl disable --now firewalld || true
 source /etc/kubeone/proxy-env
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
 EOF
-
-
+sudo modprobe overlay
+sudo modprobe br_netfilter
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
 net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-kernel.panic_on_oops = 1
-kernel.panic = 10
-net.ipv4.ip_forward = 1
-vm.overcommit_memory = 1
-fs.inotify.max_user_watches = 1048576
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
 EOF
 sudo sysctl --system
 
@@ -65,29 +57,65 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# CentOS has two different Docker repos for CentOS7 and CentOS8. The CentOS8 repo currently
-# contains only Docker 19.03.13, which is not validated for all Kubernetes version.
-# Therefore, we use CentOS7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 sudo yum install -y \
 	yum-plugin-versionlock \
 	device-mapper-persistent-data \
-	lvm2
-sudo yum versionlock delete docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni || true
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc
 
-sudo yum install -y \
-	kubelet-v1.17.4 \
-	kubectl-v1.17.4 \
-	kubernetes-cni-0.8.7 \
-	docker-ce-19.03.12-3.el7 docker-ce-cli-19.03.12-3.el7
-sudo yum versionlock add docker-ce docker-ce-cli kubelet kubeadm kubectl kubernetes-cni
 
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
+# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
+# Therefore, we use 7 repo which has all Docker versions.
+sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+
+
+
+sudo yum versionlock delete docker-ce docker-ce-cli || true
+
+
+
+
+sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
+
+
+
+
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+
+sudo yum install -y \
+	kubelet-1.17.4 \
+	kubectl-1.17.4 \
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
 sudo systemctl restart kubelet
+

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCoreOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCoreOS.golden
@@ -60,6 +60,6 @@ EnvironmentFile=-/etc/default/kubelet
 ExecStart=
 ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
-	 
+
 sudo systemctl daemon-reload
 sudo systemctl start kubelet

--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -60,12 +60,8 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		Name:   host.Hostname,
 		Taints: host.Taints,
 		KubeletExtraArgs: map[string]string{
-			"anonymous-auth":      "false",
-			"node-ip":             nodeIP,
-			"read-only-port":      "0",
-			"rotate-certificates": "true",
-			"cluster-dns":         nodelocaldns.VirtualIP,
-			"volume-plugin-dir":   "/var/lib/kubelet/volumeplugins",
+			"node-ip":           nodeIP,
+			"volume-plugin-dir": "/var/lib/kubelet/volumeplugins",
 		},
 	}
 
@@ -167,12 +163,21 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		},
 	}
 
+	bfalse := false
 	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "kubelet.config.k8s.io/v1beta1",
 			Kind:       "KubeletConfiguration",
 		},
-		CgroupDriver: "systemd",
+		CgroupDriver:       "systemd",
+		ReadOnlyPort:       0,
+		RotateCertificates: true,
+		ClusterDNS:         []string{nodelocaldns.VirtualIP},
+		Authentication: kubeletconfigv1beta1.KubeletAuthentication{
+			Anonymous: kubeletconfigv1beta1.KubeletAnonymousAuthentication{
+				Enabled: &bfalse,
+			},
+		},
 	}
 
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
@@ -269,12 +274,8 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 	nodeRegistration := kubeadmv1beta1.NodeRegistrationOptions{
 		Name: host.Hostname,
 		KubeletExtraArgs: map[string]string{
-			"anonymous-auth":      "false",
-			"node-ip":             nodeIP,
-			"read-only-port":      "0",
-			"rotate-certificates": "true",
-			"cluster-dns":         nodelocaldns.VirtualIP,
-			"volume-plugin-dir":   "/var/lib/kubelet/volumeplugins",
+			"node-ip":           nodeIP,
+			"volume-plugin-dir": "/var/lib/kubelet/volumeplugins",
 		},
 	}
 
@@ -294,12 +295,21 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 		},
 	}
 
+	bfalse := false
 	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "kubelet.config.k8s.io/v1beta1",
 			Kind:       "KubeletConfiguration",
 		},
-		CgroupDriver: "systemd",
+		CgroupDriver:       "systemd",
+		ReadOnlyPort:       0,
+		RotateCertificates: true,
+		ClusterDNS:         []string{nodelocaldns.VirtualIP},
+		Authentication: kubeletconfigv1beta1.KubeletAuthentication{
+			Anonymous: kubeletconfigv1beta1.KubeletAnonymousAuthentication{
+				Enabled: &bfalse,
+			},
+		},
 	}
 
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {

--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -60,12 +60,8 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		Name:   host.Hostname,
 		Taints: host.Taints,
 		KubeletExtraArgs: map[string]string{
-			"anonymous-auth":      "false",
-			"node-ip":             nodeIP,
-			"read-only-port":      "0",
-			"rotate-certificates": "true",
-			"cluster-dns":         nodelocaldns.VirtualIP,
-			"volume-plugin-dir":   "/var/lib/kubelet/volumeplugins",
+			"node-ip":           nodeIP,
+			"volume-plugin-dir": "/var/lib/kubelet/volumeplugins",
 		},
 	}
 
@@ -167,12 +163,21 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		},
 	}
 
+	bfalse := false
 	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "kubelet.config.k8s.io/v1beta1",
 			Kind:       "KubeletConfiguration",
 		},
-		CgroupDriver: "systemd",
+		CgroupDriver:       "systemd",
+		ReadOnlyPort:       0,
+		RotateCertificates: true,
+		ClusterDNS:         []string{nodelocaldns.VirtualIP},
+		Authentication: kubeletconfigv1beta1.KubeletAuthentication{
+			Anonymous: kubeletconfigv1beta1.KubeletAnonymousAuthentication{
+				Enabled: &bfalse,
+			},
+		},
 	}
 
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
@@ -269,12 +274,8 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 	nodeRegistration := kubeadmv1beta2.NodeRegistrationOptions{
 		Name: host.Hostname,
 		KubeletExtraArgs: map[string]string{
-			"anonymous-auth":      "false",
-			"node-ip":             nodeIP,
-			"read-only-port":      "0",
-			"rotate-certificates": "true",
-			"cluster-dns":         nodelocaldns.VirtualIP,
-			"volume-plugin-dir":   "/var/lib/kubelet/volumeplugins",
+			"node-ip":           nodeIP,
+			"volume-plugin-dir": "/var/lib/kubelet/volumeplugins",
 		},
 	}
 
@@ -294,12 +295,21 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 		},
 	}
 
+	bfalse := false
 	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "kubelet.config.k8s.io/v1beta1",
 			Kind:       "KubeletConfiguration",
 		},
-		CgroupDriver: "systemd",
+		CgroupDriver:       "systemd",
+		ReadOnlyPort:       0,
+		RotateCertificates: true,
+		ClusterDNS:         []string{nodelocaldns.VirtualIP},
+		Authentication: kubeletconfigv1beta1.KubeletAuthentication{
+			Anonymous: kubeletconfigv1beta1.KubeletAnonymousAuthentication{
+				Enabled: &bfalse,
+			},
+		},
 	}
 
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {


### PR DESCRIPTION
Containerd Supported on:
* ubuntu
* centos
* amazon linux 2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1085 

**Special notes for your reviewer**:
Automatic migration from docker to containerd in case of conflict is not supported.

Example config to testdrive containerd:
```yaml
apiVersion: kubeone.io/v1beta1
kind: KubeOneCluster

versions:
  kubernetes: "1.19.4"

containerRuntime:
  containerd: {}
```



**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Containerd Support
```
