### PR TITLE
Fix wrong legacy docker version on RPM systems

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -108,8 +108,8 @@ var (
 			sudo systemctl daemon-reload
 			sudo systemctl enable --now docker
 			`,
-			defaultLegacyDockerVersion,
 			defaultDockerVersion,
+			defaultLegacyDockerVersion,
 		),
 
 		"containerd-github": heredoc.Docf(`

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -99,7 +99,7 @@ sudo yum versionlock delete docker-ce docker-ce-cli || true
 
 
 
-sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -98,7 +98,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -101,7 +101,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -98,7 +98,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -98,7 +98,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -100,7 +100,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
+sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -99,7 +99,7 @@ sudo yum versionlock delete docker-ce docker-ce-cli || true
 
 
 
-sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -99,7 +99,7 @@ sudo yum versionlock delete docker-ce docker-ce-cli || true
 
 
 
-sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes bug where legacy and contemporary docker versions were confused and interchanged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix wrong legacy docker version on RPM systems
```
