### PR TITLE
containerd is default container runtime for new clusters

### DIFF
--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -89,6 +89,28 @@ func (crc ContainerRuntimeConfig) String() string {
 	return "unknown"
 }
 
+func (crc ContainerRuntimeConfig) Default() ContainerRuntimeConfig {
+	switch {
+	case crc.Docker != nil:
+	case crc.Containerd != nil:
+	default:
+		crc.Containerd = &ContainerRuntimeContainerd{}
+	}
+
+	return crc
+}
+
+func (crc ContainerRuntimeConfig) CRISocket() string {
+	switch {
+	case crc.Containerd != nil:
+		return "/run/containerd/containerd.sock"
+	case crc.Docker != nil:
+		return "/var/run/dockershim.sock"
+	}
+
+	return ""
+}
+
 // CloudProviderName returns name of the cloud provider
 func (p CloudProviderSpec) CloudProviderName() string {
 	switch {

--- a/pkg/apis/kubeone/v1alpha1/conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/conversion.go
@@ -234,13 +234,6 @@ func Convert_v1alpha1_KubeOneCluster_To_kubeone_KubeOneCluster(in *KubeOneCluste
 		out.CloudProvider.Hetzner.NetworkID = in.ClusterNetwork.NetworkID
 	}
 
-	// Default to docker
-	out.ContainerRuntime = kubeoneapi.ContainerRuntimeConfig{
-		Docker: &kubeoneapi.ContainerRuntimeDocker{},
-	}
-
-	// The Credentials field has been dropped from v1beta1 API.
-
 	return nil
 }
 

--- a/pkg/apis/kubeone/v1alpha1/conversion_test.go
+++ b/pkg/apis/kubeone/v1alpha1/conversion_test.go
@@ -801,9 +801,6 @@ func TestKubeOneClusterRoundTripConversion(t *testing.T) {
 				Versions: kubeoneapi.VersionConfig{
 					Kubernetes: "1.18.2",
 				},
-				ContainerRuntime: kubeoneapi.ContainerRuntimeConfig{
-					Docker: &kubeoneapi.ContainerRuntimeDocker{},
-				},
 				CloudProvider: kubeoneapi.CloudProviderSpec{
 					AWS: &kubeoneapi.AWSSpec{},
 				},
@@ -927,9 +924,6 @@ func TestKubeOneClusterRoundTripConversion(t *testing.T) {
 			expectedInternalKubeOneCluster: &kubeoneapi.KubeOneCluster{
 				Versions: kubeoneapi.VersionConfig{
 					Kubernetes: "1.18.2",
-				},
-				ContainerRuntime: kubeoneapi.ContainerRuntimeConfig{
-					Docker: &kubeoneapi.ContainerRuntimeDocker{},
 				},
 				CloudProvider: kubeoneapi.CloudProviderSpec{
 					Hetzner: &kubeoneapi.HetznerSpec{

--- a/pkg/apis/kubeone/v1beta1/defaults.go
+++ b/pkg/apis/kubeone/v1beta1/defaults.go
@@ -46,7 +46,6 @@ func SetDefaults_KubeOneCluster(obj *KubeOneCluster) {
 	SetDefaults_Hosts(obj)
 	SetDefaults_APIEndpoints(obj)
 	SetDefaults_Versions(obj)
-	SetDefaults_ContainerRuntime(obj)
 	SetDefaults_ClusterNetwork(obj)
 	SetDefaults_Proxy(obj)
 	SetDefaults_MachineController(obj)
@@ -115,17 +114,6 @@ func SetDefaults_APIEndpoints(obj *KubeOneCluster) {
 func SetDefaults_Versions(obj *KubeOneCluster) {
 	// The cluster provisioning fails if there is a leading "v" in the version
 	obj.Versions.Kubernetes = strings.TrimPrefix(obj.Versions.Kubernetes, "v")
-}
-
-func SetDefaults_ContainerRuntime(obj *KubeOneCluster) {
-	switch {
-	case obj.ContainerRuntime.Docker != nil:
-	case obj.ContainerRuntime.Containerd != nil:
-	default:
-		obj.ContainerRuntime = ContainerRuntimeConfig{
-			Docker: &ContainerRuntimeDocker{},
-		}
-	}
 }
 
 func SetDefaults_ClusterNetwork(obj *KubeOneCluster) {

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -492,7 +492,7 @@ sudo systemctl start kubelet
 `
 )
 
-func KubeadmDebian(cluster *kubeone.KubeOneCluster, force bool) (string, error) {
+func KubeadmDebian(cluster *kubeone.KubeOneCluster, crConfig kubeone.ContainerRuntimeConfig, force bool) (string, error) {
 	return Render(kubeadmDebianTemplate, Data{
 		"KUBELET":                true,
 		"KUBEADM":                true,
@@ -504,12 +504,12 @@ func KubeadmDebian(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
 		"FORCE":                  force,
-		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
-		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_DOCKER":         crConfig.Docker,
+		"INSTALL_CONTAINERD":     crConfig.Containerd,
 	})
 }
 
-func KubeadmCentOS(cluster *kubeone.KubeOneCluster, force bool) (string, error) {
+func KubeadmCentOS(cluster *kubeone.KubeOneCluster, crConfig kubeone.ContainerRuntimeConfig, force bool) (string, error) {
 	proxy := cluster.Proxy.HTTPS
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
@@ -525,12 +525,12 @@ func KubeadmCentOS(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 		"INSECURE_REGISTRY":      cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"PROXY":                  proxy,
 		"FORCE":                  force,
-		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
-		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_DOCKER":         crConfig.Docker,
+		"INSTALL_CONTAINERD":     crConfig.Containerd,
 	})
 }
 
-func KubeadmAmazonLinux(cluster *kubeone.KubeOneCluster, force bool) (string, error) {
+func KubeadmAmazonLinux(cluster *kubeone.KubeOneCluster, crConfig kubeone.ContainerRuntimeConfig, force bool) (string, error) {
 	proxy := cluster.Proxy.HTTPS
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
@@ -549,8 +549,8 @@ func KubeadmAmazonLinux(cluster *kubeone.KubeOneCluster, force bool) (string, er
 		"INSECURE_REGISTRY":      cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"PROXY":                  proxy,
 		"FORCE":                  force,
-		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
-		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_DOCKER":         crConfig.Docker,
+		"INSTALL_CONTAINERD":     crConfig.Containerd,
 	})
 }
 
@@ -578,7 +578,7 @@ func RemoveBinariesCoreOS() (string, error) {
 	return Render(removeBinariesCoreOSScriptTemplate, nil)
 }
 
-func UpgradeKubeadmAndCNIDebian(cluster *kubeone.KubeOneCluster) (string, error) {
+func UpgradeKubeadmAndCNIDebian(cluster *kubeone.KubeOneCluster, crConfig kubeone.ContainerRuntimeConfig) (string, error) {
 	return Render(kubeadmDebianTemplate, Data{
 		"UPGRADE":                true,
 		"KUBEADM":                true,
@@ -588,12 +588,12 @@ func UpgradeKubeadmAndCNIDebian(cluster *kubeone.KubeOneCluster) (string, error)
 		"INSECURE_REGISTRY":      cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
-		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
-		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_DOCKER":         crConfig.Docker,
+		"INSTALL_CONTAINERD":     crConfig.Containerd,
 	})
 }
 
-func UpgradeKubeadmAndCNICentOS(cluster *kubeone.KubeOneCluster) (string, error) {
+func UpgradeKubeadmAndCNICentOS(cluster *kubeone.KubeOneCluster, crConfig kubeone.ContainerRuntimeConfig) (string, error) {
 	proxy := cluster.Proxy.HTTPS
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
@@ -607,12 +607,12 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeone.KubeOneCluster) (string, error)
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"INSECURE_REGISTRY":      cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"PROXY":                  proxy,
-		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
-		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_DOCKER":         crConfig.Docker,
+		"INSTALL_CONTAINERD":     crConfig.Containerd,
 	})
 }
 
-func UpgradeKubeadmAndCNIAmazonLinux(cluster *kubeone.KubeOneCluster) (string, error) {
+func UpgradeKubeadmAndCNIAmazonLinux(cluster *kubeone.KubeOneCluster, crConfig kubeone.ContainerRuntimeConfig) (string, error) {
 	proxy := cluster.Proxy.HTTPS
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
@@ -628,8 +628,8 @@ func UpgradeKubeadmAndCNIAmazonLinux(cluster *kubeone.KubeOneCluster) (string, e
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"INSECURE_REGISTRY":      cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"PROXY":                  proxy,
-		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
-		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_DOCKER":         crConfig.Docker,
+		"INSTALL_CONTAINERD":     crConfig.Containerd,
 	})
 }
 
@@ -640,7 +640,7 @@ func UpgradeKubeadmAndCNICoreOS(k8sVersion string) (string, error) {
 	})
 }
 
-func UpgradeKubeletAndKubectlDebian(cluster *kubeone.KubeOneCluster) (string, error) {
+func UpgradeKubeletAndKubectlDebian(cluster *kubeone.KubeOneCluster, crConfig kubeone.ContainerRuntimeConfig) (string, error) {
 	return Render(kubeadmDebianTemplate, Data{
 		"UPGRADE":                true,
 		"KUBELET":                true,
@@ -651,12 +651,12 @@ func UpgradeKubeletAndKubectlDebian(cluster *kubeone.KubeOneCluster) (string, er
 		"INSECURE_REGISTRY":      cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
-		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
-		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_DOCKER":         crConfig.Docker,
+		"INSTALL_CONTAINERD":     crConfig.Containerd,
 	})
 }
 
-func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, error) {
+func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster, crConfig kubeone.ContainerRuntimeConfig) (string, error) {
 	proxy := cluster.Proxy.HTTPS
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
@@ -671,12 +671,12 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, er
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"INSECURE_REGISTRY":      cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"PROXY":                  proxy,
-		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
-		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_DOCKER":         crConfig.Docker,
+		"INSTALL_CONTAINERD":     crConfig.Containerd,
 	})
 }
 
-func UpgradeKubeletAndKubectlAmazonLinux(cluster *kubeone.KubeOneCluster) (string, error) {
+func UpgradeKubeletAndKubectlAmazonLinux(cluster *kubeone.KubeOneCluster, crConfig kubeone.ContainerRuntimeConfig) (string, error) {
 	proxy := cluster.Proxy.HTTPS
 	if proxy == "" {
 		proxy = cluster.Proxy.HTTP
@@ -693,8 +693,8 @@ func UpgradeKubeletAndKubectlAmazonLinux(cluster *kubeone.KubeOneCluster) (strin
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"INSECURE_REGISTRY":      cluster.RegistryConfiguration.InsecureRegistryAddress(),
 		"PROXY":                  proxy,
-		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
-		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_DOCKER":         crConfig.Docker,
+		"INSTALL_CONTAINERD":     crConfig.Containerd,
 	})
 }
 

--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -150,7 +150,7 @@ func TestKubeadmDebian(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := KubeadmDebian(&tt.args.cluster, false)
+			got, err := KubeadmDebian(&tt.args.cluster, tt.args.cluster.ContainerRuntime, false)
 			if err != tt.err {
 				t.Errorf("KubeadmDebian() error = %v, wantErr %v", err, tt.err)
 				return
@@ -227,7 +227,7 @@ func TestKubeadmCentOS(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := KubeadmCentOS(&tt.args.cluster, tt.args.force)
+			got, err := KubeadmCentOS(&tt.args.cluster, tt.args.cluster.ContainerRuntime, tt.args.force)
 			if err != tt.err {
 				t.Errorf("KubeadmCentOS() error = %v, wantErr %v", err, tt.err)
 				return
@@ -326,7 +326,7 @@ func TestKubeadmAmazonLinux(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := KubeadmAmazonLinux(&tt.args.cluster, tt.args.force)
+			got, err := KubeadmAmazonLinux(&tt.args.cluster, tt.args.cluster.ContainerRuntime, tt.args.force)
 			if err != tt.err {
 				t.Errorf("KubeadmAmazonLinux() error = %v, wantErr %v", err, tt.err)
 				return
@@ -440,7 +440,7 @@ func TestUpgradeKubeadmAndCNIDebian(t *testing.T) {
 	t.Parallel()
 
 	cls := genCluster(withDocker)
-	got, err := UpgradeKubeadmAndCNIDebian(&cls)
+	got, err := UpgradeKubeadmAndCNIDebian(&cls, cls.ContainerRuntime)
 	if err != nil {
 		t.Errorf("UpgradeKubeadmAndCNIDebian() error = %v", err)
 		return
@@ -453,7 +453,7 @@ func TestUpgradeKubeadmAndCNICentOS(t *testing.T) {
 	t.Parallel()
 
 	cls := genCluster(withDocker)
-	got, err := UpgradeKubeadmAndCNICentOS(&cls)
+	got, err := UpgradeKubeadmAndCNICentOS(&cls, cls.ContainerRuntime)
 	if err != nil {
 		t.Errorf("UpgradeKubeadmAndCNICentOS() error = %v", err)
 		return
@@ -466,7 +466,7 @@ func TestUpgradeKubeadmAndCNIAmazonLinux(t *testing.T) {
 	t.Parallel()
 
 	cls := genCluster(withDocker, withDefaultAssetConfiguration)
-	got, err := UpgradeKubeadmAndCNIAmazonLinux(&cls)
+	got, err := UpgradeKubeadmAndCNIAmazonLinux(&cls, cls.ContainerRuntime)
 	if err != nil {
 		t.Errorf("UpgradeKubeadmAndCNIAmazonLinux() error = %v", err)
 		return
@@ -491,7 +491,7 @@ func TestUpgradeKubeletAndKubectlDebian(t *testing.T) {
 	t.Parallel()
 
 	cls := genCluster(withDocker)
-	got, err := UpgradeKubeletAndKubectlDebian(&cls)
+	got, err := UpgradeKubeletAndKubectlDebian(&cls, cls.ContainerRuntime)
 	if err != nil {
 		t.Errorf("UpgradeKubeletAndKubectlDebian() error = %v", err)
 		return
@@ -504,7 +504,7 @@ func TestUpgradeKubeletAndKubectlCentOS(t *testing.T) {
 	t.Parallel()
 
 	cls := genCluster(withDocker)
-	got, err := UpgradeKubeletAndKubectlCentOS(&cls)
+	got, err := UpgradeKubeletAndKubectlCentOS(&cls, cls.ContainerRuntime)
 	if err != nil {
 		t.Errorf("UpgradeKubeletAndKubectlCentOS() error = %v", err)
 		return
@@ -517,7 +517,7 @@ func TestUpgradeKubeletAndKubectlAmazonLinux(t *testing.T) {
 	t.Parallel()
 
 	cls := genCluster(withDocker, withDefaultAssetConfiguration)
-	got, err := UpgradeKubeletAndKubectlAmazonLinux(&cls)
+	got, err := UpgradeKubeletAndKubectlAmazonLinux(&cls, cls.ContainerRuntime)
 	if err != nil {
 		t.Errorf("UpgradeKubeletAndKubectlAmazonLinux() error = %v", err)
 		return

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -110,9 +110,9 @@ sudo systemctl enable --now docker
 
 
 sudo yum install -y \
-	kubelet-v1.16.1 \
-	kubeadm-v1.16.1 \
-	kubectl-v1.16.1 \
+	kubelet-1.16.1 \
+	kubeadm-1.16.1 \
+	kubectl-1.16.1 \
 	kubernetes-cni-0.8.7
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 

--- a/pkg/tasks/kubernetes_binaries.go
+++ b/pkg/tasks/kubernetes_binaries.go
@@ -47,7 +47,7 @@ func upgradeKubeadmAndCNIBinaries(s *state.State, node kubeoneapi.HostConfig) er
 }
 
 func upgradeKubeletAndKubectlBinariesDebian(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeletAndKubectlDebian(s.Cluster)
+	cmd, err := scripts.UpgradeKubeletAndKubectlDebian(s.Cluster, s.ContainerRuntimeConfig())
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func upgradeKubeletAndKubectlBinariesCoreOS(s *state.State) error {
 }
 
 func upgradeKubeletAndKubectlBinariesCentOS(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeletAndKubectlCentOS(s.Cluster)
+	cmd, err := scripts.UpgradeKubeletAndKubectlCentOS(s.Cluster, s.ContainerRuntimeConfig())
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func upgradeKubeletAndKubectlBinariesCentOS(s *state.State) error {
 }
 
 func upgradeKubeletAndKubectlBinariesAmazonLinux(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeletAndKubectlAmazonLinux(s.Cluster)
+	cmd, err := scripts.UpgradeKubeletAndKubectlAmazonLinux(s.Cluster, s.ContainerRuntimeConfig())
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func upgradeKubeletAndKubectlBinariesAmazonLinux(s *state.State) error {
 }
 
 func upgradeKubeadmAndCNIBinariesDebian(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeadmAndCNIDebian(s.Cluster)
+	cmd, err := scripts.UpgradeKubeadmAndCNIDebian(s.Cluster, s.ContainerRuntimeConfig())
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func upgradeKubeadmAndCNIBinariesDebian(s *state.State) error {
 }
 
 func upgradeKubeadmAndCNIBinariesCentOS(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeadmAndCNICentOS(s.Cluster)
+	cmd, err := scripts.UpgradeKubeadmAndCNICentOS(s.Cluster, s.ContainerRuntimeConfig())
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func upgradeKubeadmAndCNIBinariesCentOS(s *state.State) error {
 }
 
 func upgradeKubeadmAndCNIBinariesAmazonLinux(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeadmAndCNIAmazonLinux(s.Cluster)
+	cmd, err := scripts.UpgradeKubeadmAndCNIAmazonLinux(s.Cluster, s.ContainerRuntimeConfig())
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -95,10 +95,7 @@ func installKubeadm(s *state.State, node kubeoneapi.HostConfig) error {
 }
 
 func installKubeadmDebian(s *state.State) error {
-	cluster := s.Cluster.DeepCopy()
-	cluster.ContainerRuntime = s.ContainerRuntimeConfig()
-
-	cmd, err := scripts.KubeadmDebian(cluster, s.ForceInstall)
+	cmd, err := scripts.KubeadmDebian(s.Cluster, s.ContainerRuntimeConfig(), s.ForceInstall)
 	if err != nil {
 		return err
 	}
@@ -109,10 +106,7 @@ func installKubeadmDebian(s *state.State) error {
 }
 
 func installKubeadmCentOS(s *state.State) error {
-	cluster := s.Cluster.DeepCopy()
-	cluster.ContainerRuntime = s.ContainerRuntimeConfig()
-
-	cmd, err := scripts.KubeadmCentOS(cluster, s.ForceInstall)
+	cmd, err := scripts.KubeadmCentOS(s.Cluster, s.ContainerRuntimeConfig(), s.ForceInstall)
 	if err != nil {
 		return err
 	}
@@ -123,10 +117,7 @@ func installKubeadmCentOS(s *state.State) error {
 }
 
 func installKubeadmAmazonLinux(s *state.State) error {
-	cluster := s.Cluster.DeepCopy()
-	cluster.ContainerRuntime = s.ContainerRuntimeConfig()
-
-	cmd, err := scripts.KubeadmAmazonLinux(cluster, s.ForceInstall)
+	cmd, err := scripts.KubeadmAmazonLinux(s.Cluster, s.ContainerRuntimeConfig(), s.ForceInstall)
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -95,7 +95,10 @@ func installKubeadm(s *state.State, node kubeoneapi.HostConfig) error {
 }
 
 func installKubeadmDebian(s *state.State) error {
-	cmd, err := scripts.KubeadmDebian(s.Cluster, s.ForceInstall)
+	cluster := s.Cluster.DeepCopy()
+	cluster.ContainerRuntime = s.ContainerRuntimeConfig()
+
+	cmd, err := scripts.KubeadmDebian(cluster, s.ForceInstall)
 	if err != nil {
 		return err
 	}
@@ -106,7 +109,10 @@ func installKubeadmDebian(s *state.State) error {
 }
 
 func installKubeadmCentOS(s *state.State) error {
-	cmd, err := scripts.KubeadmCentOS(s.Cluster, s.ForceInstall)
+	cluster := s.Cluster.DeepCopy()
+	cluster.ContainerRuntime = s.ContainerRuntimeConfig()
+
+	cmd, err := scripts.KubeadmCentOS(cluster, s.ForceInstall)
 	if err != nil {
 		return err
 	}
@@ -117,7 +123,10 @@ func installKubeadmCentOS(s *state.State) error {
 }
 
 func installKubeadmAmazonLinux(s *state.State) error {
-	cmd, err := scripts.KubeadmAmazonLinux(s.Cluster, s.ForceInstall)
+	cluster := s.Cluster.DeepCopy()
+	cluster.ContainerRuntime = s.ContainerRuntimeConfig()
+
+	cmd, err := scripts.KubeadmAmazonLinux(cluster, s.ForceInstall)
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -53,7 +53,7 @@ func safeguard(s *state.State) error {
 		return err
 	}
 
-	configuredClusterContainerRuntime := s.Cluster.ContainerRuntime.String()
+	configuredClusterContainerRuntime := s.ContainerRuntimeConfig().String()
 
 	for _, node := range nodes.Items {
 		if !s.Cluster.IsManagedNode(node.Name) {

--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -274,6 +274,7 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 
 	nodeRegistration := kubeadmv1beta1.NodeRegistrationOptions{
 		Name:      host.Hostname,
+		Taints:    host.Taints,
 		CRISocket: s.ContainerRuntimeConfig().CRISocket(),
 		KubeletExtraArgs: map[string]string{
 			"node-ip":           nodeIP,

--- a/pkg/templates/kubeadm/v1beta1/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta1/kubeadm.go
@@ -57,8 +57,9 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 	}
 
 	nodeRegistration := kubeadmv1beta1.NodeRegistrationOptions{
-		Name:   host.Hostname,
-		Taints: host.Taints,
+		Name:      host.Hostname,
+		Taints:    host.Taints,
+		CRISocket: s.ContainerRuntimeConfig().CRISocket(),
 		KubeletExtraArgs: map[string]string{
 			"node-ip":           nodeIP,
 			"volume-plugin-dir": "/var/lib/kubelet/volumeplugins",
@@ -272,7 +273,8 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 	}
 
 	nodeRegistration := kubeadmv1beta1.NodeRegistrationOptions{
-		Name: host.Hostname,
+		Name:      host.Hostname,
+		CRISocket: s.ContainerRuntimeConfig().CRISocket(),
 		KubeletExtraArgs: map[string]string{
 			"node-ip":           nodeIP,
 			"volume-plugin-dir": "/var/lib/kubelet/volumeplugins",

--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -274,6 +274,7 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 
 	nodeRegistration := kubeadmv1beta2.NodeRegistrationOptions{
 		Name:      host.Hostname,
+		Taints:    host.Taints,
 		CRISocket: s.ContainerRuntimeConfig().CRISocket(),
 		KubeletExtraArgs: map[string]string{
 			"node-ip":           nodeIP,

--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -57,8 +57,9 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 	}
 
 	nodeRegistration := kubeadmv1beta2.NodeRegistrationOptions{
-		Name:   host.Hostname,
-		Taints: host.Taints,
+		Name:      host.Hostname,
+		Taints:    host.Taints,
+		CRISocket: s.ContainerRuntimeConfig().CRISocket(),
 		KubeletExtraArgs: map[string]string{
 			"node-ip":           nodeIP,
 			"volume-plugin-dir": "/var/lib/kubelet/volumeplugins",
@@ -272,7 +273,8 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 	}
 
 	nodeRegistration := kubeadmv1beta2.NodeRegistrationOptions{
-		Name: host.Hostname,
+		Name:      host.Hostname,
+		CRISocket: s.ContainerRuntimeConfig().CRISocket(),
 		KubeletExtraArgs: map[string]string{
 			"node-ip":           nodeIP,
 			"volume-plugin-dir": "/var/lib/kubelet/volumeplugins",


### PR DESCRIPTION
This PR in changes default container runtime from docker to containerd but only for NEW clusters.
Existing docker clusters will continue to use docker.

Fixes #1187 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
containerd is default container runtime for new clusters
```
