### PR TITLE
image-loader: Update Calico to v3.16.5

### DIFF
--- a/hack/image-loader.sh
+++ b/hack/image-loader.sh
@@ -105,9 +105,9 @@ k8simages=$("$kubeadm" config images list --kubernetes-version="$KUBERNETES_VERS
 k1images=(
   # Core images deployed by default
   # Canal
-  "docker.io/calico/cni:v3.15.1"
-  "docker.io/calico/node:v3.15.1"
-  "docker.io/calico/kube-controllers:v3.15.1"
+  "docker.io/calico/cni:v3.16.5"
+  "docker.io/calico/node:v3.16.5"
+  "docker.io/calico/kube-controllers:v3.16.5"
   "quay.io/coreos/flannel:v0.13.0"
   # machine-controller
   "docker.io/kubermatic/machine-controller:v1.19.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

Update Calico to v3.16.5 in the image-loader scripts. We've updated Calico in #1163, but that PR updated only the deployment manifest, and not the image-loader script as well.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 