### PR TITLE
Disallow and deprecate the PodPresets feature

### DIFF
--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -351,6 +351,7 @@ type Features struct {
 	// PodNodeSelector
 	PodNodeSelector *PodNodeSelector `json:"podNodeSelector,omitempty"`
 	// PodPresets
+	// Deprecated: will be removed once Kubernetes 1.19 reaches EOL
 	PodPresets *PodPresets `json:"podPresets,omitempty"`
 	// PodSecurityPolicy
 	PodSecurityPolicy *PodSecurityPolicy `json:"podSecurityPolicy,omitempty"`
@@ -473,6 +474,9 @@ type PodNodeSelectorConfig struct {
 }
 
 // PodPresets feature flag
+// The PodPresets feature has been removed in Kubernetes 1.20.
+// This feature is deprecated and will be removed from the API once
+// Kubernetes 1.19 reaches EOL.
 type PodPresets struct {
 	// Enable
 	Enable bool `json:"enable,omitempty"`

--- a/pkg/apis/kubeone/v1alpha1/types.go
+++ b/pkg/apis/kubeone/v1alpha1/types.go
@@ -215,7 +215,8 @@ type MachineControllerConfig struct {
 
 // Features controls what features will be enabled on the cluster
 type Features struct {
-	PodNodeSelector   *PodNodeSelector   `json:"podNodeSelector"`
+	PodNodeSelector *PodNodeSelector `json:"podNodeSelector"`
+	// Deprecated: will be removed once Kubernetes 1.19 reaches EOL
 	PodPresets        *PodPresets        `json:"podPresets"`
 	PodSecurityPolicy *PodSecurityPolicy `json:"podSecurityPolicy"`
 	StaticAuditLog    *StaticAuditLog    `json:"staticAuditLog"`
@@ -247,6 +248,9 @@ type PodNodeSelectorConfig struct {
 }
 
 // PodPresets feature flag
+// The PodPresets feature has been removed in Kubernetes 1.20.
+// This feature is deprecated and will be removed from the API once
+// Kubernetes 1.19 reaches EOL.
 type PodPresets struct {
 	Enable bool `json:"enable"`
 }

--- a/pkg/apis/kubeone/v1beta1/types.go
+++ b/pkg/apis/kubeone/v1beta1/types.go
@@ -351,6 +351,7 @@ type Features struct {
 	// PodNodeSelector
 	PodNodeSelector *PodNodeSelector `json:"podNodeSelector,omitempty"`
 	// PodPresets
+	// Deprecated: will be removed once Kubernetes 1.19 reaches EOL
 	PodPresets *PodPresets `json:"podPresets,omitempty"`
 	// PodSecurityPolicy
 	PodSecurityPolicy *PodSecurityPolicy `json:"podSecurityPolicy,omitempty"`
@@ -473,6 +474,9 @@ type PodNodeSelectorConfig struct {
 }
 
 // PodPresets feature flag
+// The PodPresets feature has been removed in Kubernetes 1.20.
+// This feature is deprecated and will be removed from the API once
+// Kubernetes 1.19 reaches EOL.
 type PodPresets struct {
 	// Enable
 	Enable bool `json:"enable,omitempty"`

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -1003,6 +1003,7 @@ func TestValidateFeatures(t *testing.T) {
 	tests := []struct {
 		name          string
 		features      kubeone.Features
+		versions      kubeone.VersionConfig
 		expectedError bool
 	}{
 		{
@@ -1015,6 +1016,9 @@ func TestValidateFeatures(t *testing.T) {
 					Enable: true,
 				},
 			},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.20.2",
+			},
 			expectedError: false,
 		},
 		{
@@ -1024,11 +1028,17 @@ func TestValidateFeatures(t *testing.T) {
 					Enable: false,
 				},
 			},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.20.2",
+			},
 			expectedError: false,
 		},
 		{
-			name:          "no feature configured",
-			features:      kubeone.Features{},
+			name:     "no feature configured",
+			features: kubeone.Features{},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.20.2",
+			},
 			expectedError: false,
 		},
 		{
@@ -1043,6 +1053,9 @@ func TestValidateFeatures(t *testing.T) {
 					},
 				},
 			},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.20.2",
+			},
 			expectedError: false,
 		},
 		{
@@ -1052,6 +1065,9 @@ func TestValidateFeatures(t *testing.T) {
 					Enable: true,
 					Config: kubeone.StaticAuditLogConfig{},
 				},
+			},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.20.2",
 			},
 			expectedError: true,
 		},
@@ -1063,6 +1079,9 @@ func TestValidateFeatures(t *testing.T) {
 					Config: kubeone.OpenIDConnectConfig{},
 				},
 			},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.20.2",
+			},
 			expectedError: true,
 		},
 		{
@@ -1073,13 +1092,52 @@ func TestValidateFeatures(t *testing.T) {
 					Config: kubeone.PodNodeSelectorConfig{},
 				},
 			},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.20.2",
+			},
+			expectedError: true,
+		},
+		{
+			name: "podPresets enabled on 1.19 cluster",
+			features: kubeone.Features{
+				PodPresets: &kubeone.PodPresets{
+					Enable: true,
+				},
+			},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.19.7",
+			},
+			expectedError: false,
+		},
+		{
+			name: "podPresets enabled on 1.20 cluster",
+			features: kubeone.Features{
+				PodPresets: &kubeone.PodPresets{
+					Enable: true,
+				},
+			},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.20.2",
+			},
+			expectedError: true,
+		},
+		{
+			name: "podPresets enabled on 1.21 cluster",
+			features: kubeone.Features{
+				PodPresets: &kubeone.PodPresets{
+					Enable: true,
+				},
+			},
+			versions: kubeone.VersionConfig{
+				Kubernetes: "1.21.0",
+			},
 			expectedError: true,
 		},
 	}
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			errs := ValidateFeatures(tc.features, nil)
+			errs := ValidateFeatures(tc.features, tc.versions, nil)
 			if (len(errs) == 0) == tc.expectedError {
 				t.Errorf("test case failed: expected %v, but got %v", tc.expectedError, (len(errs) != 0))
 			}

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -603,6 +603,11 @@ features:
   podSecurityPolicy:
     enable: {{ .EnablePodSecurityPolicy }}
   # Enables PodPresets admission plugin in API server.
+  # The PodPresets feature has been removed in Kubernetes 1.20.
+  # This feature is deprecated and will be removed from the API once
+  # Kubernetes 1.19 reaches EOL.
+  # Provisioning a Kubernetes 1.20 cluster or upgrading an existing cluster to
+  # the Kubernetes 1.20 requires this feature to be disabled.
   podPresets:
     enable: {{ .EnablePodPresets }}
   # Enables and configures audit log backend.


### PR DESCRIPTION
**What this PR does / why we need it**:

* Disallow the PodPresets feature for 1.20 clusters
  * The PodPresets feature has been removed from the Kubernetes 1.20
* Deprecate the PodPresets feature
  * The PodPresets feature will be removed from the API once Kubernetes 1.19 reaches EOL

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1220

**Does this PR introduce a user-facing change?**:
```release-note
Disallow the PodPresets feature for 1.20 clusters. The PodPresets feature has been removed from the Kubernetes 1.20.
Deprecate the PodPresets feature. The PodPresets feature will be removed from the KubeOne API once Kubernetes 1.19 reaches EOL.
```

/assign @kron4eg 