### PR TITLE
Update KubeOne CI jobs

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -126,7 +126,7 @@ presubmits:
   # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
-  - name: pull-kubeone-e2e-aws-containerd-conformance-1.16
+  - name: pull-kubeone-e2e-aws-containerd-conformance-1.18
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
@@ -147,7 +147,7 @@ presubmits:
         - name: CONTAINER_RUNTIME
           value: containerd
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.15"
+          value: "1.18.9"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -500,7 +500,7 @@ presubmits:
   # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
-  - name: pull-kubeone-e2e-aws-upgrade-containerd-1.16-1.17
+  - name: pull-kubeone-e2e-aws-upgrade-containerd-1.17-1.18
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
@@ -521,9 +521,9 @@ presubmits:
         - name: CONTAINER_RUNTIME
           value: containerd
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.15"
-        - name: TEST_CLUSTER_TARGET_VERSION
           value: "1.17.12"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.18.9"
         - name: TEST_SET
           value: "upgrades"
 

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: golang:1.15.7
         command:
         - make
         args:
@@ -67,7 +67,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: golang:1.15.7
         command:
         - make
         args:
@@ -88,7 +88,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: golang:1.15.7
         command:
         - make
         args:
@@ -122,36 +122,9 @@ presubmits:
             memory: 2Gi
 
   #########################################################
-  # E2E/Conformance tests (AWS, 1.16-1.19)
+  # E2E/Conformance tests (AWS, 1.18-1.19)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-aws-conformance-1.16
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-aws: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "aws"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.15"
-        - name: TEST_SET
-          value: "conformance"
-        - name: TF_VAR_ami
-          value: ami-08985edfecbbbcf52
-        resources:
-          requests:
-            cpu: 1
 
   - name: pull-kubeone-e2e-aws-containerd-conformance-1.16
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
@@ -180,32 +153,6 @@ presubmits:
         resources:
           requests:
             cpu: 1
-
-  - name: pull-kubeone-e2e-aws-conformance-1.17
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-aws: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "aws"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.12"
-            - name: TEST_SET
-              value: "conformance"
-          resources:
-            requests:
-              cpu: 1
 
   - name: pull-kubeone-e2e-aws-conformance-1.18
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
@@ -260,60 +207,9 @@ presubmits:
               cpu: 1
 
   #########################################################
-  # E2E/Conformance tests (DigitalOcean, 1.16-1.19)
+  # E2E/Conformance tests (DigitalOcean, 1.18-1.19)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-digitalocean-conformance-1.16
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-digitalocean: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "digitalocean"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.15"
-        - name: TEST_SET
-          value: "conformance"
-        resources:
-          requests:
-            cpu: 1
-
-  - name: pull-kubeone-e2e-digitalocean-conformance-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-digitalocean: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "digitalocean"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.12"
-            - name: TEST_SET
-              value: "conformance"
-          resources:
-            requests:
-              cpu: 1
 
   - name: pull-kubeone-e2e-digitalocean-conformance-1.18
     always_run: false
@@ -368,60 +264,9 @@ presubmits:
               cpu: 1
 
   #########################################################
-  # E2E/Conformance tests (Hetzner, 1.16-1.19)
+  # E2E/Conformance tests (Hetzner, 1.18-1.19)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-hetzner-conformance-1.16
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-hetzner: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "hetzner"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.15"
-        - name: TEST_SET
-          value: "conformance"
-        resources:
-          requests:
-            cpu: 1
-
-  - name: pull-kubeone-e2e-hetzner-conformance-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-hetzner: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "hetzner"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.12"
-            - name: TEST_SET
-              value: "conformance"
-          resources:
-            requests:
-              cpu: 1
 
   - name: pull-kubeone-e2e-hetzner-conformance-1.18
     always_run: false
@@ -476,64 +321,9 @@ presubmits:
               cpu: 1
 
   #########################################################
-  # E2E/Conformance tests (GCE, 1.16-1.19)
+  # E2E/Conformance tests (GCE, 1.18-1.19)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-gce-conformance-1.16
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-gce: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "gce"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.15"
-        - name: TEST_SET
-          value: "conformance"
-        - name: TF_VAR_project
-          value: "kubeone-terraform-test"
-        resources:
-          requests:
-            cpu: 1
-
-  - name: pull-kubeone-e2e-gce-conformance-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-gce: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "gce"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.12"
-            - name: TEST_SET
-              value: "conformance"
-            - name: TF_VAR_project
-              value: "kubeone-terraform-test"
-          resources:
-            requests:
-              cpu: 1
 
   - name: pull-kubeone-e2e-gce-conformance-1.18
     always_run: false
@@ -593,59 +383,8 @@ presubmits:
 
   #########################################################
   # E2E/Conformance tests (Packet, 1.16-1.19)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-packet-conformance-1.16
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-packet: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "packet"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.16.15"
-        - name: TEST_SET
-          value: "conformance"
-        resources:
-          requests:
-            cpu: 1
-
-  - name: pull-kubeone-e2e-packet-conformance-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-packet: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "packet"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.12"
-            - name: TEST_SET
-              value: "conformance"
-          resources:
-            requests:
-              cpu: 1
 
   - name: pull-kubeone-e2e-packet-conformance-1.18
     always_run: false
@@ -700,60 +439,9 @@ presubmits:
               cpu: 1
 
   #########################################################
-  # E2E/Conformance tests (OpenStack, 1.16-1.19)
+  # E2E/Conformance tests (OpenStack, 1.18-1.19)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-openstack-conformance-1.16
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-openstack: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "openstack"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.16.15"
-            - name: TEST_SET
-              value: "conformance"
-          resources:
-            requests:
-              cpu: 1
-
-  - name: pull-kubeone-e2e-openstack-conformance-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-openstack: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "openstack"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.12"
-            - name: TEST_SET
-              value: "conformance"
-          resources:
-            requests:
-              cpu: 1
 
   - name: pull-kubeone-e2e-openstack-conformance-1.18
     always_run: false
@@ -809,34 +497,8 @@ presubmits:
 
   #########################################################
   # E2E/Upgrade tests (AWS)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-aws-upgrade-1.16-1.17
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-aws: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "aws"
-        - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.15"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.12"
-        - name: TEST_SET
-          value: "upgrades"
-        - name: TF_VAR_ami
-          value: ami-08985edfecbbbcf52
 
   - name: pull-kubeone-e2e-aws-upgrade-containerd-1.16-1.17
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
@@ -917,32 +579,8 @@ presubmits:
 
   #########################################################
   # E2E/Upgrade tests (DigitalOcean)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-digitalocean-upgrade-1.16-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-digitalocean: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "digitalocean"
-        - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.15"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.12"
-        - name: TEST_SET
-          value: "upgrades"
 
   - name: pull-kubeone-e2e-digitalocean-upgrade-1.17-1.18
     always_run: false
@@ -996,32 +634,8 @@ presubmits:
 
   #########################################################
   # E2E/Upgrade tests (Hetzner)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-hetzner-upgrade-1.16-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-hetzner: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "hetzner"
-        - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.15"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.12"
-        - name: TEST_SET
-          value: "upgrades"
 
   - name: pull-kubeone-e2e-hetzner-upgrade-1.17-1.18
     always_run: false
@@ -1075,34 +689,8 @@ presubmits:
 
   #########################################################
   # E2E/Upgrade tests (GCE)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-gce-upgrade-1.16-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-gce: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "gce"
-        - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.15"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.12"
-        - name: TEST_SET
-          value: "upgrades"
-        - name: TF_VAR_project
-          value: "kubeone-terraform-test"
 
   - name: pull-kubeone-e2e-gce-upgrade-1.17-1.18
     always_run: false
@@ -1160,32 +748,8 @@ presubmits:
 
   #########################################################
   # E2E/Upgrade tests (Packet)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-packet-upgrade-1.16-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-packet: "true"
-    spec:
-      containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
-        imagePullPolicy: Always
-        command:
-        - make
-        args:
-        - e2e-test
-        env:
-        - name: PROVIDER
-          value: "packet"
-        - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.16.15"
-        - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.17.12"
-        - name: TEST_SET
-          value: "upgrades"
 
   - name: pull-kubeone-e2e-packet-upgrade-1.17-1.18
     always_run: false
@@ -1239,32 +803,8 @@ presubmits:
 
   #########################################################
   # E2E/Upgrade tests (OpenStack)
+  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
-
-  - name: pull-kubeone-e2e-openstack-upgrade-1.16-1.17
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-openstack: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "openstack"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.16.15"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.17.12"
-            - name: TEST_SET
-              value: "upgrades"
 
   - name: pull-kubeone-e2e-openstack-upgrade-1.17-1.18
     always_run: false

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -147,7 +147,7 @@ presubmits:
         - name: CONTAINER_RUNTIME
           value: containerd
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_SET
           value: "conformance"
         resources:
@@ -173,7 +173,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.9"
+              value: "1.18.15"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -199,7 +199,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.2"
+              value: "1.19.7"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -230,7 +230,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.9"
+              value: "1.18.15"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -256,7 +256,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.2"
+              value: "1.19.7"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -287,7 +287,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.9"
+              value: "1.18.15"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -313,7 +313,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.2"
+              value: "1.19.7"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -344,7 +344,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.9"
+              value: "1.18.15"
             - name: TEST_SET
               value: "conformance"
             - name: TF_VAR_project
@@ -372,7 +372,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.2"
+              value: "1.19.7"
             - name: TEST_SET
               value: "conformance"
             - name: TF_VAR_project
@@ -405,7 +405,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.9"
+              value: "1.18.15"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -431,7 +431,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.2"
+              value: "1.19.7"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -462,7 +462,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.9"
+              value: "1.18.15"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -488,7 +488,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.2"
+              value: "1.19.7"
             - name: TEST_SET
               value: "conformance"
           resources:
@@ -521,9 +521,9 @@ presubmits:
         - name: CONTAINER_RUNTIME
           value: containerd
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.12"
+          value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_SET
           value: "upgrades"
 
@@ -546,9 +546,9 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.12"
+          value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_SET
           value: "upgrades"
 
@@ -571,9 +571,9 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.2"
+          value: "1.19.7"
         - name: TEST_SET
           value: "upgrades"
 
@@ -601,9 +601,9 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.12"
+          value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_SET
           value: "upgrades"
 
@@ -626,9 +626,9 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.2"
+          value: "1.19.7"
         - name: TEST_SET
           value: "upgrades"
 
@@ -656,9 +656,9 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.12"
+          value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_SET
           value: "upgrades"
 
@@ -681,9 +681,9 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.2"
+          value: "1.19.7"
         - name: TEST_SET
           value: "upgrades"
 
@@ -711,9 +711,9 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.12"
+          value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_SET
           value: "upgrades"
         - name: TF_VAR_project
@@ -738,9 +738,9 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.2"
+          value: "1.19.7"
         - name: TEST_SET
           value: "upgrades"
         - name: TF_VAR_project
@@ -770,9 +770,9 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.17.12"
+          value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_SET
           value: "upgrades"
 
@@ -795,9 +795,9 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.9"
+          value: "1.18.15"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.2"
+          value: "1.19.7"
         - name: TEST_SET
           value: "upgrades"
 
@@ -825,9 +825,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.17.12"
+              value: "1.17.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.9"
+              value: "1.18.15"
             - name: TEST_SET
               value: "upgrades"
 
@@ -850,9 +850,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.9"
+              value: "1.18.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.2"
+              value: "1.19.7"
             - name: TEST_SET
               value: "upgrades"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update Golang image to 1.15.7
* Remove 1.16 and 1.17 conformance tests
* Remove 1.16 to 1.17 upgrade tests
* Update the containerd E2E tests to a newer Kubernetes version
* Update Kubernetes versions used in tests
  * 1.19.2 -> 1.19.7
  * 1.18.9 -> 1.18.15
  * 1.17.12 -> 1.17.17

1.17 to 1.18 upgrade tests were intentionally left in place because we still support upgrading to a supported Kubernetes version.

As we don't support Kubernetes 1.20 and until #1222 is not fixed, I've not added 1.20 tests. I'll add 1.20 tests as daily non-blocking periodics, so we have some signal.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1218

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 