### PR TITLE
Update machine-controller to v1.25.0

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -48,7 +48,7 @@ const (
 	MachineControllerAppLabelValue = "machine-controller"
 	MachineControllerImageRegistry = "docker.io"
 	MachineControllerImage         = "/kubermatic/machine-controller:"
-	MachineControllerTag           = "v1.24.3"
+	MachineControllerTag           = "v1.25.0"
 )
 
 func CRDs() []runtime.Object {


### PR DESCRIPTION
**What this PR does / why we need it**:

Update machine-controller to v1.25.0.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.25.0
```

/assign @kron4eg 