### PR TITLE
Update the kubeone-e2e image

### DIFF
--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,13 +14,13 @@
 
 # building image
 
-FROM golang:1.15.2 as builder
+FROM golang:1.15.7 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip \
     upx-ucl
 
-ENV TERRAFORM_VERSION "0.12.29"
+ENV TERRAFORM_VERSION "0.12.30"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform
 RUN chmod +x /usr/local/bin/terraform
 
@@ -37,11 +37,11 @@ RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
-FROM golang:1.15.2
+FROM golang:1.15.7
 
 ARG version
 
-LABEL "io.kubeone"="Loodse GmbH"
+LABEL "io.kubeone"="Kubermatic GmbH"
 LABEL version=${version}
 LABEL description="Set of kubernetes binaries to conduct kubeone E2E tests"
 LABEL maintainer="https://github.com/kubermatic/kubeone/blob/master/OWNERS"

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,10 +17,9 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.16"]="v1.16.15"
-full_versions["1.17"]="v1.17.12"
-full_versions["1.18"]="v1.18.9"
-full_versions["1.19"]="v1.19.2"
+full_versions["1.18"]="v1.18.15"
+full_versions["1.19"]="v1.19.7"
+full_versions["1.20"]="v1.20.2"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.12
+TAG=v0.1.13
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update Kubernetes versions to 1.20.2, 1.19.7, and 1.18.15
* Update Go version from 1.15.2 to 1.15.7
* Update Terraform version from 0.12.29 to 0.12.30

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1218

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 