### PR TITLE
Restart unhealthy API servers when provisioning/upgrading clusters

### DIFF
--- a/pkg/tasks/nodes.go
+++ b/pkg/tasks/nodes.go
@@ -56,3 +56,15 @@ func uncordonNode(s *state.State, host kubeoneapi.HostConfig) error {
 
 	return errors.WithStack(updateErr)
 }
+
+func restartKubeAPIServer(s *state.State) error {
+	s.Logger.Infoln("Restarting unhealthy API servers if needed...")
+	return s.RunTaskOnControlPlane(func(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
+		_, _, err := s.Runner.Run(scripts.RestartKubeAPIServer(), nil)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, state.RunSequentially)
+}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -114,6 +114,7 @@ func WithFullInstall(t Tasks) Tasks {
 			{Fn: repairClusterIfNeeded, ErrMsg: "failed to repair cluster"},
 			{Fn: joinControlplaneNode, ErrMsg: "failed to join other masters a cluster"},
 			{Fn: saveKubeconfig, ErrMsg: "failed to save kubeconfig to the local machine"},
+			{Fn: restartKubeAPIServer, ErrMsg: "failed to restart unhealthy kube-apiserver"},
 		}...).
 		append(kubernetesResources()...).
 		append(
@@ -188,6 +189,7 @@ func WithUpgrade(t Tasks) Tasks {
 		}...).
 		append(kubernetesResources()...).
 		append(
+			Task{Fn: restartKubeAPIServer, ErrMsg: "failed to restart unhealthy kube-apiserver"},
 			Task{Fn: upgradeStaticWorkers, ErrMsg: "unable to upgrade static worker nodes"},
 			Task{
 				Fn:         upgradeMachineDeployments,


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a temporary solution for the [API server issue](https://github.com/kubermatic/kubeone/issues/1222).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1222

**Does this PR introduce a user-facing change?**:
```release-note
Restart the unhealthy API servers when provisioning and upgrading clusters. This should temporarily fix issues with provisioning the Kubernetes 1.20 clusters
```

/assign @kron4eg 