### PR TITLE
Add the Kubernetes 1.20 jobs

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -123,7 +123,6 @@ presubmits:
 
   #########################################################
   # E2E/Conformance tests (AWS, 1.18-1.19)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-aws-containerd-conformance-1.18
@@ -135,7 +134,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -163,7 +162,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -189,7 +188,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -205,10 +204,35 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  
+  - name: pull-kubeone-e2e-aws-conformance-1.20
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-aws: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.13
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "aws"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.20.2"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
 
   #########################################################
   # E2E/Conformance tests (DigitalOcean, 1.18-1.19)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-digitalocean-conformance-1.18
@@ -220,7 +244,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -246,7 +270,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -263,9 +287,34 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-digitalocean-conformance-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-digitalocean: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.13
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.20.2"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
   # E2E/Conformance tests (Hetzner, 1.18-1.19)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-hetzner-conformance-1.18
@@ -277,7 +326,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -303,7 +352,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -320,9 +369,34 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-hetzner-conformance-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-hetzner: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.13
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "hetzner"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.20.2"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
   # E2E/Conformance tests (GCE, 1.18-1.19)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-gce-conformance-1.18
@@ -334,7 +408,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -362,7 +436,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -381,9 +455,36 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-gce-conformance-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-gce: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.13
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "gce"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.20.2"
+            - name: TEST_SET
+              value: "conformance"
+            - name: TF_VAR_project
+              value: "kubeone-terraform-test"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
   # E2E/Conformance tests (Packet, 1.16-1.19)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-packet-conformance-1.18
@@ -395,7 +496,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -421,7 +522,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -437,10 +538,35 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  
+  - name: pull-kubeone-e2e-packet-conformance-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-packet: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.13
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "packet"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.20.2"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
 
   #########################################################
   # E2E/Conformance tests (OpenStack, 1.18-1.19)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-openstack-conformance-1.18
@@ -452,7 +578,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -478,7 +604,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -494,10 +620,35 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  
+  - name: pull-kubeone-e2e-openstack-conformance-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.13
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.20.2"
+            - name: TEST_SET
+              value: "conformance"
+          resources:
+            requests:
+              cpu: 1
 
   #########################################################
   # E2E/Upgrade tests (AWS)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-aws-upgrade-containerd-1.17-1.18
@@ -509,7 +660,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -536,7 +687,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -561,7 +712,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -576,10 +727,34 @@ presubmits:
           value: "1.19.7"
         - name: TEST_SET
           value: "upgrades"
+  
+  - name: pull-kubeone-e2e-aws-upgrade-1.19-1.20
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-aws: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.13
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "aws"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.19.7"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.20.2"
+        - name: TEST_SET
+          value: "upgrades"
 
   #########################################################
   # E2E/Upgrade tests (DigitalOcean)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-digitalocean-upgrade-1.17-1.18
@@ -591,7 +766,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -616,7 +791,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -631,10 +806,34 @@ presubmits:
           value: "1.19.7"
         - name: TEST_SET
           value: "upgrades"
+  
+  - name: pull-kubeone-e2e-digitalocean-upgrade-1.19-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-digitalocean: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.13
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "digitalocean"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.19.7"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.20.2"
+        - name: TEST_SET
+          value: "upgrades"
 
   #########################################################
   # E2E/Upgrade tests (Hetzner)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-hetzner-upgrade-1.17-1.18
@@ -646,7 +845,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -671,7 +870,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -686,10 +885,34 @@ presubmits:
           value: "1.19.7"
         - name: TEST_SET
           value: "upgrades"
+  
+  - name: pull-kubeone-e2e-hetzner-upgrade-1.19-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-hetzner: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.13
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "hetzner"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.19.7"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.20.2"
+        - name: TEST_SET
+          value: "upgrades"
 
   #########################################################
   # E2E/Upgrade tests (GCE)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-gce-upgrade-1.17-1.18
@@ -701,7 +924,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -728,7 +951,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -745,10 +968,36 @@ presubmits:
           value: "upgrades"
         - name: TF_VAR_project
           value: "kubeone-terraform-test"
+  
+  - name: pull-kubeone-e2e-gce-upgrade-1.19-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-gce: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.13
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "gce"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.19.7"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.20.2"
+        - name: TEST_SET
+          value: "upgrades"
+        - name: TF_VAR_project
+          value: "kubeone-terraform-test"
 
   #########################################################
   # E2E/Upgrade tests (Packet)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-packet-upgrade-1.17-1.18
@@ -760,7 +1009,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -785,7 +1034,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.12
+      - image: kubermatic/kubeone-e2e:v0.1.13
         imagePullPolicy: Always
         command:
         - make
@@ -800,10 +1049,34 @@ presubmits:
           value: "1.19.7"
         - name: TEST_SET
           value: "upgrades"
+  
+  - name: pull-kubeone-e2e-packet-upgrade-1.19-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-packet: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.13
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "packet"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.19.7"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.20.2"
+        - name: TEST_SET
+          value: "upgrades"
 
   #########################################################
   # E2E/Upgrade tests (OpenStack)
-  # TODO: Add 1.20 tests once #1222 is fixed
   #########################################################
 
   - name: pull-kubeone-e2e-openstack-upgrade-1.17-1.18
@@ -815,7 +1088,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -840,7 +1113,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.12
+        - image: kubermatic/kubeone-e2e:v0.1.13
           imagePullPolicy: Always
           command:
             - make
@@ -853,6 +1126,31 @@ presubmits:
               value: "1.18.15"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.19.7"
+            - name: TEST_SET
+              value: "upgrades"
+  
+  - name: pull-kubeone-e2e-openstack-upgrade-1.19-1.20
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.13
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.19.7"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.20.2"
             - name: TEST_SET
               value: "upgrades"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Considering that the API server issue will be fixed in #1243, We can now add the Kubernetes 1.20 jobs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1218

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 