### PR TITLE
fix(docs): fix broken master documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Amazon gift card among the respondents of our KubeOne Survey.
 
 ## Getting Started
 
-All user documentation is available at the
+All user documentation for the latest stable version is available at the
 [KubeOne docs website][docs].
 
 Information about the support policy (natively-supported providers, supported
@@ -118,12 +118,12 @@ See [the list of releases][changelog] to find out about feature changes.
 [upstream-supported-versions]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
 [cluster-api]: https://github.com/kubernetes-sigs/cluster-api
 [machine-controller]: https://github.com/kubermatic/machine-controller
-[docs]: https://docs.kubermatic.com/kubeone/master/
-[docs-compatibility]: https://docs.kubermatic.com/kubeone/master/compatibility_info/
-[docs-prerequisistes]: https://docs.kubermatic.com/kubeone/master/prerequisites/
-[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/infrastructure/
-[docs-provisioning]: https://docs.kubermatic.com/kubeone/master/provisioning/
-[docs-install]: https://docs.kubermatic.com/kubeone/master/getting_kubeone/
+[docs]: https://docs.kubermatic.com/kubeone/
+[docs-compatibility]: https://docs.kubermatic.com/kubeone/v1.2/compatibility_info/
+[docs-prerequisistes]: https://docs.kubermatic.com/kubeone/v1.2/prerequisites/
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/v1.2/infrastructure/
+[docs-provisioning]: https://docs.kubermatic.com/kubeone/v1.2/provisioning/
+[docs-install]: https://docs.kubermatic.com/kubeone/v1.2/getting_kubeone/
 [contributing-guide]: https://github.com/kubermatic/KubeOne/blob/master/CONTRIBUTING.md
 [k8s-slack-kubeone]: https://kubernetes.slack.com/messages/CNEV2UMT7
 [k8s-slack]: http://slack.k8s.io/


### PR DESCRIPTION
**What this PR does / why we need it**:

The links to the documentation are currently broken. This is a quickfix to link to the v1.0 documentation instead.
The v1.2 is still in beta, so I did not want to link against it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:

I am not sure if this is the right way to fix it. It would be actually better if the master documentation would have all necessary documents, but it seems that there are documents missing on the docs.kubermatic.com page.

**Does this PR introduce a user-facing change?**:

It fixes a bad impression. Doesn't look nice if a new user checks out the project, clicks on it and sees a 404.

```release-note
Fixed docs links
```