### PR TITLE
Fix missing confirmation for reset

### DIFF
--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -312,7 +312,7 @@ func runApplyInstall(s *state.State, opts *applyOpts) error { // Print the expec
 	}
 
 	fmt.Println()
-	confirm, err := confirmApply(opts.AutoApprove)
+	confirm, err := confirmCommand(opts.AutoApprove)
 	if err != nil {
 		return err
 	}
@@ -416,7 +416,7 @@ func runApplyUpgradeIfNeeded(s *state.State, opts *applyOpts) error {
 	}
 
 	fmt.Println()
-	confirm, err := confirmApply(opts.AutoApprove)
+	confirm, err := confirmCommand(opts.AutoApprove)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -18,6 +18,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
@@ -26,9 +30,6 @@ import (
 	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
-	"os"
-	"path/filepath"
-	"reflect"
 
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	kyaml "sigs.k8s.io/yaml"

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -17,29 +17,22 @@ limitations under the License.
 package cmd
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"path/filepath"
-	"reflect"
-	"strings"
-
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/term"
-
 	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
+	"os"
+	"path/filepath"
+	"reflect"
 
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	kyaml "sigs.k8s.io/yaml"
 )
-
-const yes = "yes"
 
 type applyOpts struct {
 	globalOptions
@@ -450,7 +443,7 @@ func runApplyRotateKey(s *state.State, opts *applyOpts) error {
 	}
 
 	fmt.Println()
-	confirm, err := confirmApply(opts.AutoApprove)
+	confirm, err := confirmCommand(opts.AutoApprove)
 	if err != nil {
 		return err
 	}
@@ -460,28 +453,6 @@ func runApplyRotateKey(s *state.State, opts *applyOpts) error {
 		return nil
 	}
 	return errors.Wrap(tasksToRun.Run(s), "failed to reconcile the cluster")
-}
-
-func confirmApply(autoApprove bool) (bool, error) {
-	if autoApprove {
-		return true, nil
-	}
-
-	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
-		return false, errors.New("not running in the terminal")
-	}
-
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Do you want to proceed (yes/no): ")
-
-	confirmation, err := reader.ReadString('\n')
-	if err != nil {
-		return false, err
-	}
-
-	fmt.Println()
-
-	return strings.Trim(confirmation, "\n") == yes, nil
 }
 
 func printHostInformation(host state.Host) {

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -39,6 +39,8 @@ import (
 	kyaml "sigs.k8s.io/yaml"
 )
 
+const yes = "yes"
+
 type applyOpts struct {
 	globalOptions
 	AutoApprove bool `longflag:"auto-approve" shortflag:"y"`
@@ -479,7 +481,7 @@ func confirmApply(autoApprove bool) (bool, error) {
 
 	fmt.Println()
 
-	return strings.Trim(confirmation, "\n") == "yes", nil
+	return strings.Trim(confirmation, "\n") == yes, nil
 }
 
 func printHostInformation(host state.Host) {
@@ -518,7 +520,7 @@ func componentStatusReport(component state.ComponentStatus) {
 
 func boolStr(b bool) string {
 	if b {
-		return "yes"
+		return yes
 	}
 	return "no"
 }

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/kubermatic/machine-controller/pkg/machines/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/kubermatic/machine-controller/pkg/machines/v1alpha1"
 	"k8c.io/kubeone/pkg/kubeconfig"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
@@ -120,7 +120,7 @@ func runReset(opts *resetOpts) error {
 			s.Logger.Warnln("Failed to list Machines. Worker nodes will not be deleted. If there are worker nodes in the cluster, you might have to delete them manually.")
 		}
 		for _, machine := range machines.Items {
-			fmt.Printf("\t+ reset machine-controller managed machines %q\n", machine.Name)
+			fmt.Printf("\t- reset machine-controller managed machines %q\n", machine.Name)
 		}
 	} else {
 		s.Logger.Warnln("Failed to list Machines. Worker nodes will not be deleted. If there are worker nodes in the cluster, you might have to delete them manually.")

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"k8c.io/kubeone/pkg/kubeconfig"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -28,8 +29,6 @@ import (
 
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 type resetOpts struct {
@@ -123,13 +122,13 @@ func runReset(opts *resetOpts) error {
 
 	// Gather information about machine-controller managed nodes
 	ctx := context.Background()
-	nodes := &corev1.NodeList{}
-	if err := s.DynamicClient.List(ctx, nodes); err != nil {
-		return errors.Wrap(err, "unable to list nodes")
+	machines := v1alpha1.MachineList{}
+	if err := s.DynamicClient.List(ctx, &machines); err != nil {
+		s.Logger.Debugln("unable to list machines: ", err.Error())
 	}
 
-	for _, node := range nodes.Items {
-		fmt.Printf("\t+ reset machine-controller managed nodes %q\n", node.Name)
+	for _, machine := range machines.Items {
+		fmt.Printf("\t+ reset machine-controller managed machines %q\n", machine.Name)
 	}
 
 	confirm, err := confirmCommand(opts.AutoApprove)

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -114,10 +114,6 @@ func runReset(opts *resetOpts) error {
 		fmt.Printf("\t+ reset static worker nodes %q (%s)\n", node.Hostname, node.PrivateAddress)
 	}
 
-	if !s.Cluster.MachineController.Deploy {
-		s.Logger.Info("Skipping deleting workers because machine-controller is disabled in configuration.")
-	}
-
 	if s.DynamicClient == nil {
 		err = kubeconfig.BuildKubernetesClientset(s)
 		if err != nil {

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -24,10 +24,11 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/kubermatic/machine-controller/pkg/machines/v1alpha1"
 	"k8c.io/kubeone/pkg/kubeconfig"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
+
+	"github.com/kubermatic/machine-controller/pkg/machines/v1alpha1"
 )
 
 type resetOpts struct {

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -116,7 +116,7 @@ func runReset(opts *resetOpts) error {
 	if err == nil {
 		// Gather information about machine-controller managed nodes
 		machines := v1alpha1.MachineList{}
-		if err := s.DynamicClient.List(s.Context, &machines); err != nil {
+		if err = s.DynamicClient.List(s.Context, &machines); err != nil {
 			s.Logger.Warnln("Failed to list Machines. Worker nodes will not be deleted. If there are worker nodes in the cluster, you might have to delete them manually.")
 		}
 		for _, machine := range machines.Items {

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"k8c.io/kubeone/pkg/kubeconfig"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
@@ -118,7 +119,10 @@ func runReset(opts *resetOpts) error {
 	}
 
 	if s.DynamicClient == nil {
-		return errors.New("kubernetes client not initialized")
+		err = kubeconfig.BuildKubernetesClientset(s)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Gather information about machine-controller managed nodes

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -17,18 +17,18 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	"k8c.io/kubeone/pkg/kubeconfig"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"k8c.io/kubeone/pkg/kubeconfig"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 )
 
 type resetOpts struct {
@@ -107,24 +107,23 @@ func runReset(opts *resetOpts) error {
 
 	fmt.Println("The following nodes will be reset. The Kubernetes cluster running on those nodes will be permanently destroyed ")
 	for _, node := range s.Cluster.ControlPlane.Hosts {
-		fmt.Printf("\t+ reset control plane node %q (%s)\n", node.Hostname, node.PrivateAddress)
+		fmt.Printf("\t- reset control plane node %q (%s)\n", node.Hostname, node.PrivateAddress)
 	}
 	for _, node := range s.Cluster.StaticWorkers.Hosts {
-		fmt.Printf("\t+ reset static worker nodes %q (%s)\n", node.Hostname, node.PrivateAddress)
+		fmt.Printf("\t- reset static worker nodes %q (%s)\n", node.Hostname, node.PrivateAddress)
 	}
 
 	if s.DynamicClient == nil {
 		err = kubeconfig.BuildKubernetesClientset(s)
 		if err != nil {
-			return err
+			s.Logger.Warnln("Failed to build Kubernetes client set.")
 		}
 	}
 
 	// Gather information about machine-controller managed nodes
-	ctx := context.Background()
 	machines := v1alpha1.MachineList{}
-	if err := s.DynamicClient.List(ctx, &machines); err != nil {
-		s.Logger.Debugln("unable to list machines: ", err.Error())
+	if err := s.DynamicClient.List(s.Context, &machines); err != nil {
+		s.Logger.Warnln("Failed to list Machines. Worker nodes will not be deleted. If there are worker nodes in the cluster, you might have to delete them manually.")
 	}
 
 	for _, machine := range machines.Items {

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -24,11 +24,10 @@ import (
 	"reflect"
 	"strings"
 
-	"golang.org/x/term"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	"golang.org/x/term"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/apis/kubeone/config"

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -34,6 +34,8 @@ import (
 	"k8c.io/kubeone/pkg/state"
 )
 
+const yes = "yes"
+
 type globalOptions struct {
 	ManifestFile    string `longflag:"manifest" shortflag:"m"`
 	TerraformState  string `longflag:"tfjson" shortflag:"t"`
@@ -151,5 +153,5 @@ func confirmCommand(autoApprove bool) (bool, error) {
 
 	fmt.Println()
 
-	return strings.Trim(confirmation, "\n") == "yes", nil
+	return strings.Trim(confirmation, "\n") == yes, nil
 }

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -17,9 +17,14 @@ limitations under the License.
 package cmd
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"os"
 	"reflect"
 	"strings"
+
+	"golang.org/x/term"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -126,4 +131,26 @@ func loadClusterConfig(filename, terraformOutputPath, credentialsFilePath string
 	}
 
 	return a, nil
+}
+
+func confirmCommand(autoApprove bool) (bool, error) {
+	if autoApprove {
+		return true, nil
+	}
+
+	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+		return false, errors.New("not running in the terminal")
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Do you want to proceed (yes/no): ")
+
+	confirmation, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	fmt.Println()
+
+	return strings.Trim(confirmation, "\n") == "yes", nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a request for confirmation for the `reset` subcommand.
We have a request for confirmation already in the `apply` subcommand, hence it should not be much work
adding the same question to `reset`. I really think `reset` should have such a question, because it destroys
the whole cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None

**Special notes for your reviewer**:

The functionality works so far, but I am not sure about the implementation. Actually it would be nicer to have access to the
`LiveCluster` object inside of `reset`, because the `Cluster` object doesn't seem to be "Dynamic Worker"-aware.
Furthermore it looks like the hostnames are missing when I test it:

```
The following nodes will be resetted: 
        + reset control plane node "" (10.88.10.2)
        + reset control plane node "" (10.88.10.3)
        + reset control plane node "" (10.88.10.4)
        + reset static worker nodes "" (10.88.10.11)
        + reset static worker nodes "" (10.88.10.12)
        + reset static worker nodes "" (10.88.10.13)
Do you want to proceed (yes/no): no

INFO[01:49:46 CET] Operation canceled.     
```

Does this have something to do with missing network access? I tested this without the VPN connection to my cluster (I did not have another cluster to test right now and I did not want to delete one of our company clusters out of a mistake).

**Does this PR introduce a user-facing change?**:
```release-note
[BREAKING/ACTION REQUIRED] The kubeone reset command requires an explicit confirmation like the apply command. The command can be automatically approved by using the --auto-approve flag.
```
