### PR TITLE
warn of explicit confirmation for reset

### DIFF
--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -28,6 +28,7 @@ import (
 
 type resetOpts struct {
 	globalOptions
+	AutoApprove    bool `longflag:"auto-approve" shortflag:"y"`
 	DestroyWorkers bool `longflag:"destroy-workers"`
 	RemoveBinaries bool `longflag:"remove-binaries"`
 }
@@ -68,6 +69,13 @@ func resetCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVarP(
+		&opts.AutoApprove,
+		longFlagName(opts, "AutoApprove"),
+		shortFlagName(opts, "AutoApprove"),
+		false,
+		"auto approve reset (NO-OP/NOT YET ENABLED)")
+
 	cmd.Flags().BoolVar(
 		&opts.DestroyWorkers,
 		longFlagName(opts, "DestroyWorkers"),
@@ -89,6 +97,8 @@ func runReset(opts *resetOpts) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize State")
 	}
+
+	s.Logger.Warnln("this command will require an explicit confirmation starting with the next minor release (v1.3)")
 
 	return errors.Wrap(tasks.WithReset(nil).Run(s), "failed to reset the cluster")
 }

--- a/test/e2e/kubeone.go
+++ b/test/e2e/kubeone.go
@@ -186,6 +186,7 @@ func (k1 *Kubeone) Kubeconfig() ([]byte, error) {
 func (k1 *Kubeone) Reset() error {
 	err := k1.run("reset",
 		"-v",
+		"--auto-approve",
 		"--tfjson", "tf.json",
 		"--destroy-workers",
 		"--manifest", k1.ConfigurationFilePath)


### PR DESCRIPTION
**What this PR does / why we need it**:

KubeOne 1.3 will have a new confirmation flag for the `reset` subcommand, hence we should warn users about this.

More information can be found in the corresponding PR: https://github.com/kubermatic/kubeone/pull/1251

```release-note
Warn of explicit confirmation for kubeone reset in the future
```