### PR TITLE
Update the kubeone-e2e image and build jobs to Go 1.16.1

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.15.7
+      - image: golang:1.16.1
         command:
         - make
         args:
@@ -46,7 +46,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/wwhrd:0.2.1-1
+      - image: quay.io/kubermatic/wwhrd:0.4.0-1
         command:
         - make
         args:
@@ -67,7 +67,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.15.7
+      - image: golang:1.16.1
         command:
         - make
         args:
@@ -88,7 +88,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.15.7
+      - image: golang:1.16.1
         command:
         - make
         args:

--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -1,11 +1,11 @@
-blacklist:
-- GPL-2.0
+denylist:
+  - GPL-2.0
+  - LGPL-3.0
 
-whitelist:
-- Apache-2.0
-- FreeBSD
-- ISC
-- LGPL-3.0
-- MIT
-- MPL-2.0
-- NewBSD
+allowlist:
+  - Apache-2.0
+  - MIT
+  - BSD-2-Clause
+  - BSD-2-Clause-FreeBSD
+  - BSD-3-Clause
+  - ISC

--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,7 +14,7 @@
 
 # building image
 
-FROM golang:1.15.7 as builder
+FROM golang:1.16.1 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip \
@@ -37,7 +37,7 @@ RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
-FROM golang:1.15.7
+FROM golang:1.16.1
 
 ARG version
 

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.13
+TAG=v0.1.14
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the kubeone-e2e image and build jobs to Go 1.16.1.

**Does this PR introduce a user-facing change?**:
```release-note
Update Go to 1.16.1
```

/assign @kron4eg 