### PR TITLE
Add the changelog for the v1.2.0-rc.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# [v1.2.0-rc.1](https://github.com/kubermatic/kubeone/releases/tag/v1.2.0-rc.1) - 2021-03-12
+
+## Changed
+
+### General
+
+* Build KubeOne using Go 1.16.1 ([#1268](https://github.com/kubermatic/kubeone/pull/1268), [#1267](https://github.com/kubermatic/kubeone/pull/1267))
+
 # [v1.2.0-rc.0](https://github.com/kubermatic/kubeone/releases/tag/v1.2.0-rc.0) - 2021-03-08
 
 ## Attention Needed


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the changelog for the v1.2.0-rc.1 release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 