### PR TITLE
Install cri-tools on Amazon Linux 2

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -88,6 +88,7 @@ const (
 	defaultLegacyDockerVersion     = "18.09.9"
 	defaultContainerdVersion       = "1.4.3"
 	defaultAmazonContainerdVersion = "1.4.1"
+	defaultAmazonCrictlVersion     = "1.13.0"
 )
 
 type dockerConfig struct {

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -85,13 +85,18 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 EOF
 
 
-sudo yum versionlock delete docker || true
+sudo yum versionlock delete docker cri-tools || true
 
 
 
 
-sudo yum install -y docker-19.03.13ce*
-sudo yum versionlock add docker
+
+sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum versionlock add docker cri-tools
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -89,8 +89,13 @@ EOF
 
 
 
-sudo yum install -y docker-19.03.13ce*
-sudo yum versionlock add docker
+
+sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum versionlock add docker cri-tools
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -92,8 +92,13 @@ EOF
 
 
 
-sudo yum install -y docker-19.03.13ce*
-sudo yum versionlock add docker
+
+sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum versionlock add docker cri-tools
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -89,8 +89,13 @@ EOF
 
 
 
-sudo yum install -y docker-19.03.13ce*
-sudo yum versionlock add docker
+
+sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum versionlock add docker cri-tools
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -89,8 +89,13 @@ EOF
 
 
 
-sudo yum install -y docker-19.03.13ce*
-sudo yum versionlock add docker
+
+sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum versionlock add docker cri-tools
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -91,8 +91,13 @@ EOF
 
 
 
-sudo yum install -y docker-18.09.9ce*
-sudo yum versionlock add docker
+
+sudo yum install -y docker-18.09.9ce* cri-tools-1.13.0*
+sudo yum versionlock add docker cri-tools
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 
 
 
-sudo yum install -y containerd-1.4.1*
-sudo yum versionlock add containerd
+sudo yum install -y containerd-1.4.1* cri-tools-1.13.0*
+sudo yum versionlock add containerd cri-tools
 
 cat <<EOF | sudo tee /etc/containerd/config.toml
 version = 2

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 
 
 
-sudo yum install -y containerd-1.4.1*
-sudo yum versionlock add containerd
+sudo yum install -y containerd-1.4.1* cri-tools-1.13.0*
+sudo yum versionlock add containerd cri-tools
 
 cat <<EOF | sudo tee /etc/containerd/config.toml
 version = 2

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -85,13 +85,18 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 EOF
 
 
-sudo yum versionlock delete docker || true
+sudo yum versionlock delete docker cri-tools || true
 
 
 
 
-sudo yum install -y docker-19.03.13ce*
-sudo yum versionlock add docker
+
+sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum versionlock add docker cri-tools
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -85,13 +85,18 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 EOF
 
 
-sudo yum versionlock delete docker || true
+sudo yum versionlock delete docker cri-tools || true
 
 
 
 
-sudo yum install -y docker-19.03.13ce*
-sudo yum versionlock add docker
+
+sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum versionlock add docker cri-tools
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker


### PR DESCRIPTION
**What this PR does / why we need it**:

Amazon Linux 2 doesn't install `crictl` by default. We use crictl to restart the API server if it's affected by #1222. Additionally, kubeadm verifies is `crictl` present if containerd is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1281

**Does this PR introduce a user-facing change?**:
```release-note
Install cri-tools (crictl) on Amazon Linux 2. This fixes the issue with provisioning Kubernetes and Amazon EKS-D clusters on Amazon Linux 2
```

/assign @kron4eg 