### PR TITLE
Use admissionregistration v1

### DIFF
--- a/pkg/tasks/machine_deployments.go
+++ b/pkg/tasks/machine_deployments.go
@@ -17,8 +17,6 @@ limitations under the License.
 package tasks
 
 import (
-	"context"
-
 	"github.com/pkg/errors"
 
 	"k8c.io/kubeone/pkg/state"
@@ -48,11 +46,9 @@ func upgradeMachineDeployments(s *state.State) error {
 
 	s.Logger.Info("Upgrade MachineDeployments...")
 
-	ctx := context.Background()
-
 	machineDeployments := clusterv1alpha1.MachineDeploymentList{}
 	err := s.DynamicClient.List(
-		ctx,
+		s.Context,
 		&machineDeployments,
 		dynclient.InNamespace(metav1.NamespaceSystem),
 	)
@@ -65,12 +61,12 @@ func upgradeMachineDeployments(s *state.State) error {
 
 		retErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			machine := clusterv1alpha1.MachineDeployment{}
-			if err := s.DynamicClient.Get(ctx, machineKey, &machine); err != nil {
+			if err := s.DynamicClient.Get(s.Context, machineKey, &machine); err != nil {
 				return err
 			}
 
 			machine.Spec.Template.Spec.Versions.Kubelet = s.Cluster.Versions.Kubernetes
-			return s.DynamicClient.Update(ctx, &machine)
+			return s.DynamicClient.Update(s.Context, &machine)
 		})
 
 		if retErr != nil {

--- a/pkg/tasks/reset.go
+++ b/pkg/tasks/reset.go
@@ -27,7 +27,6 @@ import (
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/templates/machinecontroller"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -55,7 +54,7 @@ func destroyWorkers(s *state.State) error {
 
 	mcCRDs := []string{}
 	for _, crd := range machinecontroller.CRDs() {
-		mcCRDs = append(mcCRDs, crd.(metav1.Object).GetName())
+		mcCRDs = append(mcCRDs, crd.GetName())
 	}
 
 	condFn := clientutil.CRDsReadyCondition(s.Context, s.DynamicClient, mcCRDs)

--- a/pkg/templates/machinecontroller/webhook.go
+++ b/pkg/templates/machinecontroller/webhook.go
@@ -31,7 +31,7 @@ import (
 	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/state"
 
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistration "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -327,36 +327,36 @@ func tlsServingCertificate(caKey crypto.Signer, caCert *x509.Certificate) (*core
 }
 
 // mutatingwebhookConfiguration returns the MutatingwebhookConfiguration for the machine controler
-func mutatingwebhookConfiguration(caCert *x509.Certificate) *admissionregistrationv1beta1.MutatingWebhookConfiguration {
-	sideEffectsNone := admissionregistrationv1beta1.SideEffectClassNone
+func mutatingwebhookConfiguration(caCert *x509.Certificate) *admissionregistration.MutatingWebhookConfiguration {
+	sideEffectsNone := admissionregistration.SideEffectClassNone
 
-	return &admissionregistrationv1beta1.MutatingWebhookConfiguration{
+	return &admissionregistration.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine-controller.kubermatic.io",
 			Namespace: WebhookNamespace,
 		},
-		Webhooks: []admissionregistrationv1beta1.MutatingWebhook{
+		Webhooks: []admissionregistration.MutatingWebhook{
 			{
 				Name:                    "machine-controller.kubermatic.io-machinedeployments",
 				NamespaceSelector:       &metav1.LabelSelector{},
-				FailurePolicy:           failurePolicyPtr(admissionregistrationv1beta1.Fail),
+				FailurePolicy:           failurePolicyPtr(admissionregistration.Fail),
 				SideEffects:             &sideEffectsNone,
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
-				Rules: []admissionregistrationv1beta1.RuleWithOperations{
+				Rules: []admissionregistration.RuleWithOperations{
 					{
-						Operations: []admissionregistrationv1beta1.OperationType{
-							admissionregistrationv1beta1.Create,
-							admissionregistrationv1beta1.Update,
+						Operations: []admissionregistration.OperationType{
+							admissionregistration.Create,
+							admissionregistration.Update,
 						},
-						Rule: admissionregistrationv1beta1.Rule{
+						Rule: admissionregistration.Rule{
 							APIGroups:   []string{"cluster.k8s.io"},
 							APIVersions: []string{"v1alpha1"},
 							Resources:   []string{"machinedeployments"},
 						},
 					},
 				},
-				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-					Service: &admissionregistrationv1beta1.ServiceReference{
+				ClientConfig: admissionregistration.WebhookClientConfig{
+					Service: &admissionregistration.ServiceReference{
 						Name:      WebhookName,
 						Namespace: WebhookNamespace,
 						Path:      strPtr("/machinedeployments"),
@@ -367,24 +367,24 @@ func mutatingwebhookConfiguration(caCert *x509.Certificate) *admissionregistrati
 			{
 				Name:                    "machine-controller.kubermatic.io-machines",
 				NamespaceSelector:       &metav1.LabelSelector{},
-				FailurePolicy:           failurePolicyPtr(admissionregistrationv1beta1.Fail),
+				FailurePolicy:           failurePolicyPtr(admissionregistration.Fail),
 				SideEffects:             &sideEffectsNone,
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
-				Rules: []admissionregistrationv1beta1.RuleWithOperations{
+				Rules: []admissionregistration.RuleWithOperations{
 					{
-						Operations: []admissionregistrationv1beta1.OperationType{
-							admissionregistrationv1beta1.Create,
-							admissionregistrationv1beta1.Update,
+						Operations: []admissionregistration.OperationType{
+							admissionregistration.Create,
+							admissionregistration.Update,
 						},
-						Rule: admissionregistrationv1beta1.Rule{
+						Rule: admissionregistration.Rule{
 							APIGroups:   []string{"cluster.k8s.io"},
 							APIVersions: []string{"v1alpha1"},
 							Resources:   []string{"machines"},
 						},
 					},
 				},
-				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-					Service: &admissionregistrationv1beta1.ServiceReference{
+				ClientConfig: admissionregistration.WebhookClientConfig{
+					Service: &admissionregistration.ServiceReference{
 						Name:      WebhookName,
 						Namespace: WebhookNamespace,
 						Path:      strPtr("/machines"),
@@ -400,6 +400,6 @@ func strPtr(a string) *string {
 	return &a
 }
 
-func failurePolicyPtr(a admissionregistrationv1beta1.FailurePolicyType) *admissionregistrationv1beta1.FailurePolicyType {
+func failurePolicyPtr(a admissionregistration.FailurePolicyType) *admissionregistration.FailurePolicyType {
 	return &a
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Use AdmissionRegistration v1 API for machine-controller registration. AdmissionRegistration v1beta1 started to give warnings.

**Does this PR introduce a user-facing change?**:
```release-note
[ACTION REQUIRED] Use AdmissionRegistration v1 API for machine-controller-webhook. Since AdmissionRegistartion v1 got introduced in Kubernetes 1.16, the minimum Kubernetes version that can be managed by KubeOne is now 1.16. If you're running the Kubernetes clusters running 1.15 or older, please use the older release of KubeOne to upgrade those clusters.
```
