### PR TITLE
[Azure] Added 30 second delay in output so that publicIP for Azure VM is available

### DIFF
--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -130,8 +130,8 @@ resource "azurerm_lb" "lb" {
 }
 
 resource "azurerm_lb_backend_address_pool" "backend_pool" {
-  loadbalancer_id     = azurerm_lb.lb.id
-  name                = "ApiServers"
+  loadbalancer_id = azurerm_lb.lb.id
+  name            = "ApiServers"
 }
 
 resource "azurerm_lb_rule" "lb_rule" {
@@ -228,3 +228,17 @@ resource "azurerm_virtual_machine" "control_plane" {
   }
 }
 
+# Hack to ensure we get access to public ip in first attempt
+resource "time_sleep" "wait_30_seconds" {
+  depends_on      = [azurerm_virtual_machine.control_plane]
+  create_duration = "30s"
+}
+
+data "azurerm_public_ip" "control_plane" {
+  depends_on = [
+    time_sleep.wait_30_seconds
+  ]
+  count               = var.control_plane_vm_count
+  name                = "${var.cluster_name}-cp-${count.index}"
+  resource_group_name = azurerm_resource_group.rg.name
+}

--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -18,6 +18,9 @@ provider "azurerm" {
   features {}
 }
 
+provider "time" {
+}
+
 resource "azurerm_resource_group" "rg" {
   name     = "${var.cluster_name}-rg"
   location = var.location
@@ -97,7 +100,7 @@ resource "azurerm_public_ip" "lbip" {
 }
 
 resource "azurerm_public_ip" "control_plane" {
-  count = 3
+  count = var.control_plane_vm_count
 
   name                = "${var.cluster_name}-cp-${count.index}"
   location            = var.location
@@ -127,7 +130,6 @@ resource "azurerm_lb" "lb" {
 }
 
 resource "azurerm_lb_backend_address_pool" "backend_pool" {
-  resource_group_name = azurerm_resource_group.rg.name
   loadbalancer_id     = azurerm_lb.lb.id
   name                = "ApiServers"
 }
@@ -158,7 +160,7 @@ resource "azurerm_lb_probe" "lb_probe" {
 }
 
 resource "azurerm_network_interface" "control_plane" {
-  count = 3
+  count = var.control_plane_vm_count
 
   name                = "${var.cluster_name}-cp-${count.index}"
   location            = var.location
@@ -173,7 +175,7 @@ resource "azurerm_network_interface" "control_plane" {
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "control_plane" {
-  count = 3
+  count = var.control_plane_vm_count
 
   ip_configuration_name   = "${var.cluster_name}-cp-${count.index}"
   network_interface_id    = element(azurerm_network_interface.control_plane.*.id, count.index)
@@ -181,7 +183,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "control_p
 }
 
 resource "azurerm_virtual_machine" "control_plane" {
-  count = 3
+  count = var.control_plane_vm_count
 
   name                             = "${var.cluster_name}-cp-${count.index}"
   location                         = var.location

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -47,7 +47,7 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas = var.worker_node_vm_count
+      replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -22,21 +22,6 @@ output "kubeone_api" {
   }
 }
 
-# Hack to ensure we get access to public ip in first attempt
-resource "time_sleep" "wait_30_seconds" {
-  depends_on = [azurerm_virtual_machine.control_plane]
-  create_duration = "30s"
-}
-
-data "azurerm_public_ip" "control_plane" {
-  depends_on = [
-    time_sleep.wait_30_seconds
-  ]
-  count = var.control_plane_vm_count
-  name                = "${var.cluster_name}-cp-${count.index}"
-  resource_group_name = azurerm_resource_group.rg.name
-}
-
 output "kubeone_hosts" {
   description = "Control plane endpoints to SSH to"
 

--- a/examples/terraform/azure/variables.tf
+++ b/examples/terraform/azure/variables.tf
@@ -70,11 +70,11 @@ variable "worker_vm_size" {
 }
 
 variable "control_plane_vm_count" {
-  description = "VM Size for worker machines"
+  description = "Number of control plane instances"
   default     = 3
 }
 
-variable "worker_node_vm_count" {
-  description = "VM Size for worker machines"
-  default     = 3
+variable "initial_machinedeployment_replicas" {
+  description = "Number of replicas per MachineDeployment"
+  default     = 1
 }

--- a/examples/terraform/azure/variables.tf
+++ b/examples/terraform/azure/variables.tf
@@ -69,3 +69,12 @@ variable "worker_vm_size" {
   default     = "Standard_B2s"
 }
 
+variable "control_plane_vm_count" {
+  description = "VM Size for worker machines"
+  default     = 3
+}
+
+variable "worker_node_vm_count" {
+  description = "VM Size for worker machines"
+  default     = 3
+}


### PR DESCRIPTION
Also added variable for machine counts for master and worker nodes

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently, for Azure, we must always do `terraform refresh` to get public IP in the output before we can run `kubeone apply`. This step is not properly documented and is unnecessary.  This PR adds a 30 second delay in finishing the output of terraform and thereby ensures that terraform output _ALWAYS_ contains public ip for control plane VMs.

PR also adds variables for count of control plane and worker nodes for easy control of these from variable instead of controlling via terraform files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NA

**Special notes for your reviewer**:
NA

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
