### PR TITLE
Add Kubernetes 1.21 binaries to the kubeone-e2e image

### DIFF
--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,9 +17,9 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.18"]="v1.18.15"
-full_versions["1.19"]="v1.19.7"
-full_versions["1.20"]="v1.20.2"
+full_versions["1.18"]="v1.18.17"
+full_versions["1.19"]="v1.19.9"
+full_versions["1.20"]="v1.20.5"
 full_versions["1.21"]="v1.21.0"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -20,6 +20,7 @@ declare -A full_versions
 full_versions["1.18"]="v1.18.15"
 full_versions["1.19"]="v1.19.7"
 full_versions["1.20"]="v1.20.2"
+full_versions["1.21"]="v1.21.0"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.14
+TAG=v0.1.15
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the Kubernetes 1.21 binaries to the kubeone-e2e image. This is needed for running 1.21 jobs.

**Special notes for your reviewer**:

/hold
until 1.21 is not released

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 