### PR TITLE
Add Kubernetes 1.21 presubmits

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -146,7 +146,7 @@ presubmits:
         - name: CONTAINER_RUNTIME
           value: containerd
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: KUBEONE_TEST_RUN
           value: "TestClusterConformance"
         resources:
@@ -172,7 +172,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.15"
+              value: "1.18.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -198,7 +198,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.7"
+              value: "1.19.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -224,7 +224,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.2"
+              value: "1.20.5"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -280,7 +280,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.15"
+              value: "1.18.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -306,7 +306,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.7"
+              value: "1.19.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -332,7 +332,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.2"
+              value: "1.20.5"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -388,7 +388,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.15"
+              value: "1.18.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -414,7 +414,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.7"
+              value: "1.19.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -440,7 +440,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.2"
+              value: "1.20.5"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -496,7 +496,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.15"
+              value: "1.18.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -524,7 +524,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.7"
+              value: "1.19.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -552,7 +552,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.2"
+              value: "1.20.5"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -612,7 +612,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.15"
+              value: "1.18.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -638,7 +638,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.7"
+              value: "1.19.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -664,7 +664,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.2"
+              value: "1.20.5"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -720,7 +720,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.15"
+              value: "1.18.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -746,7 +746,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.7"
+              value: "1.19.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -772,7 +772,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.2"
+              value: "1.20.5"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -832,7 +832,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -859,7 +859,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -884,9 +884,9 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -911,9 +911,9 @@ presubmits:
         - name: PROVIDER
           value: "aws"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.20.2"
+          value: "1.20.5"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -971,7 +971,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -996,9 +996,9 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1023,9 +1023,9 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.20.2"
+          value: "1.20.5"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1083,7 +1083,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1108,9 +1108,9 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1135,9 +1135,9 @@ presubmits:
         - name: PROVIDER
           value: "hetzner"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.20.2"
+          value: "1.20.5"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1195,7 +1195,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1222,9 +1222,9 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1251,9 +1251,9 @@ presubmits:
         - name: PROVIDER
           value: "gce"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.20.2"
+          value: "1.20.5"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1316,7 +1316,7 @@ presubmits:
         - name: TEST_CLUSTER_INITIAL_VERSION
           value: "1.17.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1341,9 +1341,9 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.18.15"
+          value: "1.18.17"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1368,9 +1368,9 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         - name: TEST_CLUSTER_INITIAL_VERSION
-          value: "1.19.7"
+          value: "1.19.9"
         - name: TEST_CLUSTER_TARGET_VERSION
-          value: "1.20.2"
+          value: "1.20.5"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1428,7 +1428,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.17.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.15"
+              value: "1.18.17"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1453,9 +1453,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.15"
+              value: "1.18.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.7"
+              value: "1.19.9"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1480,9 +1480,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.7"
+              value: "1.19.9"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.2"
+              value: "1.20.5"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -134,7 +134,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -162,7 +162,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -188,7 +188,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -214,7 +214,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -244,7 +244,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -270,7 +270,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -296,7 +296,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -326,7 +326,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -352,7 +352,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -378,7 +378,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -408,7 +408,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -436,7 +436,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -464,7 +464,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -496,7 +496,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -522,7 +522,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -548,7 +548,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -578,7 +578,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -604,7 +604,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -630,7 +630,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -660,7 +660,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -689,7 +689,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -716,7 +716,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -743,7 +743,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -774,7 +774,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -801,7 +801,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -828,7 +828,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -859,7 +859,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -886,7 +886,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -913,7 +913,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -944,7 +944,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -973,7 +973,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -1002,7 +1002,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -1035,7 +1035,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -1062,7 +1062,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -1089,7 +1089,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-      - image: kubermatic/kubeone-e2e:v0.1.14
+      - image: kubermatic/kubeone-e2e:v0.1.15
         imagePullPolicy: Always
         command:
         - make
@@ -1120,7 +1120,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -1147,7 +1147,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make
@@ -1174,7 +1174,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.14
+        - image: kubermatic/kubeone-e2e:v0.1.15
           imagePullPolicy: Always
           command:
             - make

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -122,7 +122,7 @@ presubmits:
             memory: 2Gi
 
   #########################################################
-  # E2E/Conformance tests (AWS, 1.18-1.19)
+  # E2E/Conformance tests (AWS, 1.18-1.21)
   #########################################################
 
   - name: pull-kubeone-e2e-aws-containerd-conformance-1.18
@@ -230,9 +230,35 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  
+  - name: pull-kubeone-e2e-aws-conformance-1.21
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-aws: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.15
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "aws"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.21.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
 
   #########################################################
-  # E2E/Conformance tests (DigitalOcean, 1.18-1.19)
+  # E2E/Conformance tests (DigitalOcean, 1.18-1.21)
   #########################################################
 
   - name: pull-kubeone-e2e-digitalocean-conformance-1.18
@@ -313,8 +339,34 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-digitalocean-conformance-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-digitalocean: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.15
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.21.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
-  # E2E/Conformance tests (Hetzner, 1.18-1.19)
+  # E2E/Conformance tests (Hetzner, 1.18-1.21)
   #########################################################
 
   - name: pull-kubeone-e2e-hetzner-conformance-1.18
@@ -395,8 +447,34 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-hetzner-conformance-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-hetzner: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.15
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "hetzner"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.21.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
-  # E2E/Conformance tests (GCE, 1.18-1.19)
+  # E2E/Conformance tests (GCE, 1.18-1.21)
   #########################################################
 
   - name: pull-kubeone-e2e-gce-conformance-1.18
@@ -483,8 +561,36 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-gce-conformance-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-gce: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.15
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "gce"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.21.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+            - name: TF_VAR_project
+              value: "kubeone-terraform-test"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
-  # E2E/Conformance tests (Packet, 1.16-1.19)
+  # E2E/Conformance tests (Packet, 1.16-1.21)
   #########################################################
 
   - name: pull-kubeone-e2e-packet-conformance-1.18
@@ -565,8 +671,34 @@ presubmits:
             requests:
               cpu: 1
 
+  - name: pull-kubeone-e2e-packet-conformance-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-packet: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.15
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "packet"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.21.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
+
   #########################################################
-  # E2E/Conformance tests (OpenStack, 1.18-1.19)
+  # E2E/Conformance tests (OpenStack, 1.18-1.21)
   #########################################################
 
   - name: pull-kubeone-e2e-openstack-conformance-1.18
@@ -641,6 +773,32 @@ presubmits:
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.20.2"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
+
+  - name: pull-kubeone-e2e-openstack-conformance-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.15
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.21.0"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -761,6 +919,33 @@ presubmits:
         - name: KUBEONE_TEST_RUN
           value: "TestClusterUpgrade"
 
+  - name: pull-kubeone-e2e-aws-upgrade-1.20-1.21
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-aws: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.15
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "aws"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.20.5"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.21.0"
+        - name: TEST_TIMEOUT
+          valut: "120m"
+        - name: KUBEONE_TEST_RUN
+          value: "TestClusterUpgrade"
+
   #########################################################
   # E2E/Upgrade tests (DigitalOcean)
   #########################################################
@@ -846,6 +1031,33 @@ presubmits:
         - name: KUBEONE_TEST_RUN
           value: "TestClusterUpgrade"
 
+  - name: pull-kubeone-e2e-digitalocean-upgrade-1.20-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-digitalocean: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.15
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "digitalocean"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.20.5"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.21.0"
+        - name: TEST_TIMEOUT
+          valut: "120m"
+        - name: KUBEONE_TEST_RUN
+          value: "TestClusterUpgrade"
+
   #########################################################
   # E2E/Upgrade tests (Hetzner)
   #########################################################
@@ -926,6 +1138,33 @@ presubmits:
           value: "1.19.7"
         - name: TEST_CLUSTER_TARGET_VERSION
           value: "1.20.2"
+        - name: TEST_TIMEOUT
+          valut: "120m"
+        - name: KUBEONE_TEST_RUN
+          value: "TestClusterUpgrade"
+
+  - name: pull-kubeone-e2e-hetzner-upgrade-1.20-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-hetzner: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.15
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "hetzner"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.20.5"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.21.0"
         - name: TEST_TIMEOUT
           valut: "120m"
         - name: KUBEONE_TEST_RUN
@@ -1022,6 +1261,36 @@ presubmits:
         - name: TF_VAR_project
           value: "kubeone-terraform-test"
 
+
+  - name: pull-kubeone-e2e-gce-upgrade-1.20-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-gce: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.15
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "gce"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.20.5"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.21.0"
+        - name: TEST_TIMEOUT
+          valut: "120m"
+        - name: KUBEONE_TEST_RUN
+          value: "TestClusterUpgrade"
+        - name: TF_VAR_project
+          value: "kubeone-terraform-test"
+
   #########################################################
   # E2E/Upgrade tests (Packet)
   #########################################################
@@ -1107,6 +1376,33 @@ presubmits:
         - name: KUBEONE_TEST_RUN
           value: "TestClusterUpgrade"
 
+  - name: pull-kubeone-e2e-packet-upgrade-1.20-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-packet: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubeone-e2e:v0.1.15
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - e2e-test
+        env:
+        - name: PROVIDER
+          value: "packet"
+        - name: TEST_CLUSTER_INITIAL_VERSION
+          value: "1.20.5"
+        - name: TEST_CLUSTER_TARGET_VERSION
+          value: "1.21.0"
+        - name: TEST_TIMEOUT
+          valut: "120m"
+        - name: KUBEONE_TEST_RUN
+          value: "TestClusterUpgrade"
+
   #########################################################
   # E2E/Upgrade tests (OpenStack)
   #########################################################
@@ -1187,6 +1483,33 @@ presubmits:
               value: "1.19.7"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.20.2"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
+
+  - name: pull-kubeone-e2e-openstack-upgrade-1.20-1.21
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.15
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.20.5"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.21.0"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update kubeone-e2e image to v0.1.15
* Add presubmits for Kubernetes 1.21
* Update Kubernetes patch releases for other presubmits

**Special notes for your reviewer**:

/hold
until 1.21 is not released and #1311 is merged

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 