### PR TITLE
Remove CCM/CSI migration fields from the example manifest

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -549,28 +549,6 @@ cloudProvider:
   {{ .CloudProviderName }}: {}
   # Set the kubelet flag '--cloud-provider=external' and deploy the external CCM for supported providers
   external: {{ .CloudProviderExternal }}
-  # csiMigration enables the CSIMigration and CSIMigration{Provider} feature gates
-  # for providers that support the CSI migration.
-  # The CSI migration stability depends on the provider.
-  # More details about stability can be found in the Feature Gates document:
-  # https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
-  #
-  # Note: Azure has two type of CSI drivers (AzureFile and AzureDisk) and two different
-  # feature gates (CSIMigrationAzureDisk and CSIMigrationAzureFile). Enabling CSI migration
-  # enables both feature gates. If one CSI driver is not deployed, the volume operations
-  # for volumes with missing CSI driver will fallback to the in-tree volume plugin.
-  csiMigration: false
-  # csiMigrationComplete enables the CSIMigration{Provider}Complete feature gate
-  # for providers that support the CSI migration.
-  # This feature gate disables fallback to the in-tree volume plugins, therefore,
-  # it should be enabled only if the CSI driver is deploy on all nodes, and after
-  # ensuring that the CSI driver works properly.
-  #
-  # Note: If you're running on Azure, make sure that you have both AzureFile
-  # and AzureDisk CSI drivers deployed, as enabling this feature disables the fallback
-  # to the in-tree volume plugins. See description for the CSIMigration field for
-  # more details.
-  csiMigrationComplete: false
   # Path to file that will be uploaded and used as custom '--cloud-config' file.
   cloudConfig: "{{ .CloudProviderCloudCfg }}"
 
@@ -687,7 +665,7 @@ features:
       # If set, the OpenID server's certificate will be verified by one of the
       # authorities in the oidc-ca-file, otherwise the host's root CA set will
       # be used.
-	  caFile: ""
+      caFile: ""
   # Enable Kubernetes Encryption Providers
   # For more information: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/
   encryptionProviders:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the CCM/CSI migration fields from the example manifest. Those fields were only added to the API, but the appropriate features were never implemented.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevant to #1317

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 