### PR TITLE
Add simple unit test for config print command

### DIFF
--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import "testing"
+
+func TestRunPrint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		printOptions *printOpts
+	}{
+		{
+			name: "simple config manifest",
+			printOptions: &printOpts{
+				ClusterName:       "test-cluster",
+				KubernetesVersion: "v1.21.0",
+				CloudProviderName: "aws",
+			},
+		},
+		{
+			name: "full config manifest",
+			printOptions: &printOpts{
+				FullConfig:        true,
+				ClusterName:       "test-cluster",
+				KubernetesVersion: "v1.21.0",
+				CloudProviderName: "aws",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := runPrint(tt.printOptions)
+			if err != nil {
+				t.Fatalf("Error generating example manifest = %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a very simple unit test to verify that the manifest generated by `kubeone config print` is a valid KubeOne Cluster manifest. This should prevent the errors such as the following one:

```
Error: failed to decode new config: error converting YAML to JSON: yaml: line 173: found character that cannot start any token
failed to decode new config: error converting YAML to JSON: yaml: line 173: found character that cannot start any token
```

Right now, such errors can be caught only at the runtime. This unit test doesn't verify the content of the generated manifest, only that it's valid. I think that this should be enough for the beginning.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 