### PR TITLE
Add support for KMS mounts in kubeapi

### DIFF
--- a/docs/proposals/20210112-encryption-roviders.md
+++ b/docs/proposals/20210112-encryption-roviders.md
@@ -1,7 +1,7 @@
 # Encryption Providers for encrypted secrets at rest
 
 **Auther**: Mohamed Elsayed (@moelsayed)
-**Status**: Draft
+**Status**: Implemented
 
 
 ## Abstract
@@ -17,12 +17,13 @@ KubeOne needs to support this feature natively. Meaning the user should be able 
 
 * Provide a safe path to enable/disable Encryption Providers.
 * Support atomic(?) rotation for existing keys.
+* Support custom configuration files and external KMS.
 * Rewriting all secret resources (no just secrets) after enable/disable/rotate operations.
 
 ## Non-Goals
 
 * Deploy External KMS.
-* Safely manage (disable/enable/rotate) configuration when a custom configuration file is used. 
+* Safely rotate configuration when a custom configuration file is used. 
 
 ## Challenges
 
@@ -106,6 +107,7 @@ This use case is useful for users who would like to utilize an external KMS prov
 * Sync the configuration file to all control plane nodes.
 * Restart KubeAPI on all nodes. 
 
+Additionally, if an external KMS is used, KubeOne will detect that and add a specific file mount for the KMS unix socket file in the KubeAPI static pod spec. This is necessary to allow KubeAPI to communicate with the external KMS service.
 ## Tasks & effort
 
 * Implement the needed pre-flight checks.

--- a/pkg/state/cluster.go
+++ b/pkg/state/cluster.go
@@ -247,6 +247,14 @@ func (c *Cluster) SafeToRepair(targetVersion string) (bool, string) {
 	return true, targetVer.String()
 }
 
+func (c *Cluster) EncryptionEnabled() bool {
+	return c.EncryptionConfiguration != nil && c.EncryptionConfiguration.Enable
+}
+
+func (c *Cluster) CustomEncryptionEnabled() bool {
+	return c.EncryptionEnabled() && c.EncryptionConfiguration.Custom && c.EncryptionConfiguration.Config != nil
+}
+
 /*
 	Host level checks
 */

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -130,17 +130,15 @@ func (s *State) GetKMSSocketPath() (string, error) {
 			return "", err
 		}
 	}
-	endpoint := ""
-Resources:
+
 	for _, r := range config.Resources {
 		for _, p := range r.Providers {
 			if p.KMS == nil {
 				continue
 			}
-			endpoint = p.KMS.Endpoint
-			break Resources
+			return path.Clean(strings.ReplaceAll(p.KMS.Endpoint, "unix:", "")), nil
 		}
 	}
 
-	return path.Clean(strings.ReplaceAll(endpoint, "unix:", "")), nil
+	return "", nil
 }

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -334,6 +334,10 @@ func investigateCluster(s *state.State) error {
 		s.LiveCluster.Lock.Lock()
 		s.LiveCluster.EncryptionConfiguration = &state.EncryptionConfiguration{Enable: true, Custom: encryptionEnabled.Custom}
 		s.LiveCluster.Lock.Unlock()
+		// no need to lock around FetchEncryptionProvidersFile because it handles locking internally.
+		if err := FetchEncryptionProvidersFile(s); err != nil {
+			return errors.Wrap(err, "failed to fetch EncryptionProviders configuration")
+		}
 	}
 	return nil
 }

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -315,6 +315,21 @@ func WithRewriteSecrets(t Tasks) Tasks {
 		})
 }
 
+func WithCustomEncryptionConfigUpdated(t Tasks) Tasks {
+	return t.append(Tasks{
+		{
+			Fn:          ensureRestartKubeAPIServer,
+			ErrMsg:      "failed to restart KubeAPI",
+			Description: "restart KubeAPI containers",
+		},
+		{
+			Fn:          RewriteClusterSecrets,
+			ErrMsg:      "failed to rewrite cluster secrets",
+			Description: "rewrite all cluster secrets",
+		},
+	}...)
+}
+
 func WithRotateKey(t Tasks) Tasks {
 	return WithHostnameOSAndProbes(t).
 		append(Tasks{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
To enabled external KMS support, KubeAPI pod static pod must be able to bind-mount the KMS encryption provider unix socket. This PR adds support for detecting the socket and enabling the mount.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1242

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
