### PR TITLE
Fix missing ClusterRole rule for cluster autoscaler

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -80,6 +80,7 @@ rules:
     - cluster.k8s.io
     resources:
     - machinedeployments
+    - machinedeployments/scale
     - machines
     - machinesets
     verbs:


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1299 

**Special notes for your reviewer**:

```release-note
Fix missing ClusterRole rule for cluster autoscaler
```
