### PR TITLE
Ignore preexisting static manifests kubeadm preflight error

### DIFF
--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -21,8 +21,7 @@ const (
 if [[ -f /etc/kubernetes/admin.conf ]]; then exit 0; fi
 
 sudo kubeadm join {{ .VERBOSE }} \
-	--config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml \
-	--ignore-preflight-errors=DirAvailable--var-lib-etcd,ImagePull
+	--config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
 `
 
 	kubeadmWorkerJoinScriptTemplate = `
@@ -49,8 +48,7 @@ if [[ -f /etc/kubernetes/admin.conf ]]; then
 	exit 0;
 fi
 sudo kubeadm {{ .VERBOSE }} \
-	init --config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml \
-	--ignore-preflight-errors=DirAvailable--var-lib-etcd,ImagePull
+	init --config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
 `
 
 	kubeadmResetScriptTemplate = `

--- a/pkg/scripts/testdata/TestKubeadmInit-not-verbose.golden
+++ b/pkg/scripts/testdata/TestKubeadmInit-not-verbose.golden
@@ -6,5 +6,4 @@ if [[ -f /etc/kubernetes/admin.conf ]]; then
 	exit 0;
 fi
 sudo kubeadm  \
-	init --config=test-wd/cfg/master_0.yaml \
-	--ignore-preflight-errors=DirAvailable--var-lib-etcd,ImagePull
+	init --config=test-wd/cfg/master_0.yaml

--- a/pkg/scripts/testdata/TestKubeadmInit-verbose.golden
+++ b/pkg/scripts/testdata/TestKubeadmInit-verbose.golden
@@ -6,5 +6,4 @@ if [[ -f /etc/kubernetes/admin.conf ]]; then
 	exit 0;
 fi
 sudo kubeadm --v=6 \
-	init --config=test-wd/cfg/master_0.yaml \
-	--ignore-preflight-errors=DirAvailable--var-lib-etcd,ImagePull
+	init --config=test-wd/cfg/master_0.yaml

--- a/pkg/scripts/testdata/TestKubeadmJoin-not-verbose.golden
+++ b/pkg/scripts/testdata/TestKubeadmJoin-not-verbose.golden
@@ -4,5 +4,4 @@ export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 if [[ -f /etc/kubernetes/admin.conf ]]; then exit 0; fi
 
 sudo kubeadm join  \
-	--config=test-wd/cfg/master_0.yaml \
-	--ignore-preflight-errors=DirAvailable--var-lib-etcd,ImagePull
+	--config=test-wd/cfg/master_0.yaml

--- a/pkg/scripts/testdata/TestKubeadmJoin-verbose.golden
+++ b/pkg/scripts/testdata/TestKubeadmJoin-verbose.golden
@@ -4,5 +4,4 @@ export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 if [[ -f /etc/kubernetes/admin.conf ]]; then exit 0; fi
 
 sudo kubeadm join --v=6 \
-	--config=test-wd/cfg/master_0.yaml \
-	--ignore-preflight-errors=DirAvailable--var-lib-etcd,ImagePull
+	--config=test-wd/cfg/master_0.yaml

--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -52,6 +52,11 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 	}
 
 	nodeRegistration := newNodeRegistration(s, host)
+	nodeRegistration.IgnorePreflightErrors = []string{
+		"DirAvailable--var-lib-etcd",
+		"DirAvailable--etc-kubernetes-manifests",
+		"ImagePull",
+	}
 
 	bootstrapToken, err := kubeadmv1beta2.NewBootstrapTokenString(s.JoinToken)
 	if err != nil {
@@ -285,6 +290,10 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 	cluster := s.Cluster
 
 	nodeRegistration := newNodeRegistration(s, host)
+	nodeRegistration.IgnorePreflightErrors = []string{
+		"DirAvailable--etc-kubernetes-manifests",
+	}
+
 	controlPlaneEndpoint := fmt.Sprintf("%s:%d", cluster.APIEndpoint.Host, cluster.APIEndpoint.Port)
 
 	joinConfig := &kubeadmv1beta2.JoinConfiguration{


### PR DESCRIPTION
**What this PR does / why we need it**:

The preexisting static manifests kubeadm preflight error (`DirAvailable--etc-kubernetes-manifests`) is now unconditionally ignored. This allows users to use Terraform to create static manifests that would be used once the cluster is provisioned.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1261 

**Special notes for your reviewer**:

Using the kubeadm configuration to ignore preflight errors works only with the kubeadm v1beta2 API. The v1beta2 API is used for 1.15+ clusters, which means that those preflight errors will not be ignored for clusters running Kubernetes 1.14 or older. We've discussed this internally and we believe this is okay because Kubernetes 1.14 has reached EOL a long time ago (December 2019).

**Does this PR introduce a user-facing change?**:
```release-note
Ignore the preexisting static manifests kubeadm preflight error
```

/assign @kron4eg 