### PR TITLE
Containerd support for flatcar

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -147,6 +147,41 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-aws-flatcar-containerd-conformance-1.18
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-aws: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.15
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "aws"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_OS_CONTROL_PLANE
+              value: "flatcar"
+            - name: TEST_OS_WORKERS
+              value: "flatcar"
+            - name: TF_VAR_ssh_username
+              value: "core"
+            - name: TF_VAR_bastion_user
+              value: "core"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.18.17"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
   - name: pull-kubeone-e2e-aws-conformance-1.18
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
     decorate: true

--- a/pkg/scripts/node.go
+++ b/pkg/scripts/node.go
@@ -39,23 +39,8 @@ var (
 	{{ else }}
 		sudo crictl logs "$apiserver_id" > /tmp/kube-apiserver.log 2>&1
 		if sudo grep -q "etcdserver: no leader" /tmp/kube-apiserver.log; then
+			sudo crictl stop "$apiserver_id"
 			sudo crictl rm "$apiserver_id"
-			sleep 10
-		fi
-	{{ end }}
-	`)
-
-	restartKubeAPIServerDockerTemplate = heredoc.Doc(`
-		apiserver_id=$(sudo docker ps --filter="name=k8s_kube-apiserver" -q)
-		[ -z "$apiserver_id" ] && exit 1
-		
-	{{ if .ENSURE -}}
-		sudo docker rm -f "$apiserver_id"
-		sleep 30
-	{{ else }}
-		sudo docker logs "$apiserver_id" > /tmp/kube-apiserver.log 2>&1
-		if sudo grep -q "etcdserver: no leader" /tmp/kube-apiserver.log; then
-			sudo docker rm -f "$apiserver_id"
 			sleep 10
 		fi
 	{{ end }}
@@ -74,12 +59,6 @@ func Hostname() string {
 
 func RestartKubeAPIServerCrictl(ensure bool) (string, error) {
 	return Render(restartKubeAPIServerCrictlTemplate, Data{
-		"ENSURE": ensure,
-	})
-}
-
-func RestartKubeAPIServerDocker(ensure bool) (string, error) {
-	return Render(restartKubeAPIServerDockerTemplate, Data{
 		"ENSURE": ensure,
 	})
 }

--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -351,25 +351,37 @@ func TestKubeadmFlatcar(t *testing.T) {
 		{
 			name: "simple",
 			args: args{
-				cluster: genCluster(),
+				cluster: genCluster(withDocker),
 			},
 		},
 		{
 			name: "force",
 			args: args{
-				cluster: genCluster(),
+				cluster: genCluster(withDocker),
 			},
 		},
 		{
 			name: "overwrite registry",
 			args: args{
-				cluster: genCluster(withRegistry("127.0.0.1:5000")),
+				cluster: genCluster(
+					withDocker,
+					withRegistry("127.0.0.1:5000"),
+				),
 			},
 		},
 		{
 			name: "overwrite registry insecure",
 			args: args{
-				cluster: genCluster(withInsecureRegistry("127.0.0.1:5000")),
+				cluster: genCluster(
+					withDocker,
+					withInsecureRegistry("127.0.0.1:5000"),
+				),
+			},
+		},
+		{
+			name: "with containerd",
+			args: args{
+				cluster: genCluster(withContainerd),
 			},
 		},
 	}

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -228,6 +228,34 @@ var (
 			defaultAmazonContainerdVersion,
 			defaultAmazonCrictlVersion,
 		),
+
+		"flatcar-docker": heredoc.Doc(`
+			cat <<EOF | sudo tee /etc/crictl.yaml
+			runtime-endpoint: unix:///var/run/dockershim.sock
+			EOF
+
+			sudo systemctl daemon-reload
+			sudo systemctl enable --now docker
+			sudo systemctl restart docker
+			`),
+
+		"flatcar-containerd": heredoc.Doc(`
+			cat <<EOF | sudo tee /etc/crictl.yaml
+			runtime-endpoint: unix:///run/containerd/containerd.sock
+			EOF
+
+			sudo mkdir -p /etc/systemd/system/containerd.service.d
+			cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
+			[Service]
+			Restart=always
+			EnvironmentFile=-/etc/environment
+			EOF
+
+			sudo systemctl daemon-reload
+			sudo systemctl enable --now containerd
+			sudo systemctl restart containerd
+			`,
+		),
 	}
 )
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -19,21 +19,6 @@ aarch64)
 esac
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
-EOF
-
-
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
@@ -62,13 +47,43 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo systemctl restart docker
-
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"
+CRI_TOOLS_RELEASE="v1.21.0"
+
+curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
+	sudo tar -C /opt/bin -xz
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl restart docker
+
+
+
+
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
@@ -112,5 +127,4 @@ ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUB
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -19,21 +19,6 @@ aarch64)
 esac
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
-EOF
-
-
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
@@ -62,13 +47,43 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo systemctl restart docker
-
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"
+CRI_TOOLS_RELEASE="v1.21.0"
+
+curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
+	sudo tar -C /opt/bin -xz
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl restart docker
+
+
+
+
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
@@ -112,5 +127,4 @@ ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUB
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -19,21 +19,6 @@ aarch64)
 esac
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
-EOF
-
-
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
@@ -62,13 +47,43 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo systemctl restart docker
-
 sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"
+CRI_TOOLS_RELEASE="v1.21.0"
+
+curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
+	sudo tar -C /opt/bin -xz
+
+
+
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl restart docker
+
+
+
+
 
 sudo mkdir -p /opt/bin
 cd /opt/bin
@@ -112,5 +127,4 @@ ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUB
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -59,32 +59,21 @@ curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOO
 
 
 
-sudo mkdir -p /etc/docker
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	},
-	"insecure-registries": [
-		"127.0.0.1:5000"
-	]
-}
-EOF
 
 cat <<EOF | sudo tee /etc/crictl.yaml
-runtime-endpoint: unix:///var/run/dockershim.sock
+runtime-endpoint: unix:///run/containerd/containerd.sock
+EOF
+
+sudo mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
+[Service]
+Restart=always
+EnvironmentFile=-/etc/environment
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now docker
-sudo systemctl restart docker
-
-
+sudo systemctl enable --now containerd
+sudo systemctl restart containerd
 
 
 

--- a/pkg/tasks/nodes.go
+++ b/pkg/tasks/nodes.go
@@ -86,7 +86,7 @@ func restartKubeAPIServerOnOS(s *state.State, node kubeoneapi.HostConfig) error 
 		kubeoneapi.OperatingSystemNameAmazon:  restartKubeAPIServerCrictl,
 		kubeoneapi.OperatingSystemNameCentOS:  restartKubeAPIServerCrictl,
 		kubeoneapi.OperatingSystemNameDebian:  restartKubeAPIServerCrictl,
-		kubeoneapi.OperatingSystemNameFlatcar: restartKubeAPIServerDocker,
+		kubeoneapi.OperatingSystemNameFlatcar: restartKubeAPIServerCrictl,
 		kubeoneapi.OperatingSystemNameRHEL:    restartKubeAPIServerCrictl,
 		kubeoneapi.OperatingSystemNameUbuntu:  restartKubeAPIServerCrictl,
 	})
@@ -97,7 +97,7 @@ func ensureRestartKubeAPIServerOnOS(s *state.State, node kubeoneapi.HostConfig) 
 		kubeoneapi.OperatingSystemNameAmazon:  ensureRestartKubeAPIServerCrictl,
 		kubeoneapi.OperatingSystemNameCentOS:  ensureRestartKubeAPIServerCrictl,
 		kubeoneapi.OperatingSystemNameDebian:  ensureRestartKubeAPIServerCrictl,
-		kubeoneapi.OperatingSystemNameFlatcar: ensureRestartKubeAPIServerDocker,
+		kubeoneapi.OperatingSystemNameFlatcar: ensureRestartKubeAPIServerCrictl,
 		kubeoneapi.OperatingSystemNameRHEL:    ensureRestartKubeAPIServerCrictl,
 		kubeoneapi.OperatingSystemNameUbuntu:  ensureRestartKubeAPIServerCrictl,
 	})
@@ -113,28 +113,8 @@ func restartKubeAPIServerCrictl(s *state.State) error {
 	return errors.WithStack(err)
 }
 
-func restartKubeAPIServerDocker(s *state.State) error {
-	cmd, err := scripts.RestartKubeAPIServerDocker(false)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	_, _, err = s.Runner.RunRaw(cmd)
-
-	return errors.WithStack(err)
-}
-
 func ensureRestartKubeAPIServerCrictl(s *state.State) error {
 	cmd, err := scripts.RestartKubeAPIServerCrictl(true)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	_, _, err = s.Runner.RunRaw(cmd)
-
-	return errors.WithStack(err)
-}
-
-func ensureRestartKubeAPIServerDocker(s *state.State) error {
-	cmd, err := scripts.RestartKubeAPIServerDocker(true)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -113,12 +113,6 @@ func runProbes(s *state.State) error {
 		}
 	}
 
-	for _, host := range s.Cluster.ControlPlane.Hosts {
-		if host.OperatingSystem == kubeoneapi.OperatingSystemNameFlatcar {
-			s.Cluster.ContainerRuntime.Docker = &kubeoneapi.ContainerRuntimeDocker{}
-		}
-	}
-
 	switch {
 	case s.Cluster.ContainerRuntime.Containerd != nil:
 		return nil

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -53,7 +53,7 @@ func baseResources() map[Resource]string {
 		CalicoNode:        "docker.io/calico/node:v3.16.5",
 		DNSNodeCache:      "k8s.gcr.io/k8s-dns-node-cache:1.15.13",
 		Flannel:           "quay.io/coreos/flannel:v0.13.0",
-		MachineController: "docker.io/kubermatic/machine-controller:v1.28.0",
+		MachineController: "docker.io/kubermatic/machine-controller:v1.29.0",
 		MetricsServer:     "k8s.gcr.io/metrics-server:v0.3.6",
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Since Flatcar now enables the CRI plugin by default, this PR introduces its support to containerd.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1333 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
