### PR TITLE
Use latest available (wildcard) docker and containerd version

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -83,11 +83,10 @@ var (
 )
 
 const (
-	defaultDockerVersion           = "19.03.14"
-	defaultAmazonDockerVersion     = "19.03.13"
-	defaultLegacyDockerVersion     = "18.09.9"
-	defaultContainerdVersion       = "1.4.3"
-	defaultAmazonContainerdVersion = "1.4.1"
+	defaultDockerVersion           = "19.03.*"
+	defaultLegacyDockerVersion     = "18.09.*"
+	defaultContainerdVersion       = "1.4.*"
+	defaultAmazonContainerdVersion = "1.4.*"
 	defaultAmazonCrictlVersion     = "1.13.0"
 )
 

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -84,6 +84,7 @@ var (
 
 const (
 	defaultDockerVersion           = "19.03.*"
+	latestDockerVersion            = "20.10.*"
 	defaultLegacyDockerVersion     = "18.09.*"
 	defaultContainerdVersion       = "1.4.*"
 	defaultAmazonContainerdVersion = "1.4.*"

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -86,11 +86,7 @@ EOF
 
 sudo yum versionlock delete docker cri-tools || true
 
-
-
-
-
-sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
+sudo yum install -y docker-19.03.* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -90,7 +90,7 @@ sudo yum versionlock delete docker cri-tools || true
 
 
 
-sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -89,7 +89,7 @@ EOF
 
 
 
-sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -85,11 +85,7 @@ EOF
 
 
 
-
-
-
-
-sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
+sudo yum install -y docker-19.03.* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -92,7 +92,7 @@ EOF
 
 
 
-sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -88,11 +88,7 @@ EOF
 
 
 
-
-
-
-
-sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
+sudo yum install -y docker-19.03.* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -89,7 +89,7 @@ EOF
 
 
 
-sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -85,11 +85,7 @@ EOF
 
 
 
-
-
-
-
-sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
+sudo yum install -y docker-19.03.* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -89,7 +89,7 @@ EOF
 
 
 
-sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -85,11 +85,7 @@ EOF
 
 
 
-
-
-
-
-sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
+sudo yum install -y docker-19.03.* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -86,12 +86,7 @@ EOF
 
 
 
-
-
-
-
-
-sudo yum install -y docker-18.09.*ce* cri-tools-1.13.0
+sudo yum install -y docker-18.09.* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -91,7 +91,7 @@ EOF
 
 
 
-sudo yum install -y docker-18.09.9ce* cri-tools-1.13.0*
+sudo yum install -y docker-18.09.*ce* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -72,7 +72,7 @@ sudo yum install -y \
 
 
 
-sudo yum install -y containerd-1.4.1* cri-tools-1.13.0*
+sudo yum install -y containerd-1.4.* cri-tools-1.13.0
 sudo yum versionlock add containerd cri-tools
 
 cat <<EOF | sudo tee /etc/containerd/config.toml

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -72,7 +72,7 @@ sudo yum install -y \
 
 
 
-sudo yum install -y containerd-1.4.1* cri-tools-1.13.0*
+sudo yum install -y containerd-1.4.* cri-tools-1.13.0
 sudo yum versionlock add containerd cri-tools
 
 cat <<EOF | sudo tee /etc/containerd/config.toml

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -88,13 +88,7 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-
-
 sudo yum versionlock delete docker-ce docker-ce-cli || true
-
-
-
 
 sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -88,10 +88,6 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
-# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-# Therefore, we use 7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
@@ -100,7 +96,7 @@ sudo yum versionlock delete docker-ce docker-ce-cli || true
 
 
 
-sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
+sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -89,12 +89,6 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-
-
-
-
-
-
 sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -88,10 +88,6 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
-# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-# Therefore, we use 7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
@@ -99,7 +95,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
+sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -91,10 +91,6 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
-# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-# Therefore, we use 7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
@@ -102,7 +98,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
+sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -92,12 +92,6 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-
-
-
-
-
-
 sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -89,12 +89,6 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-
-
-
-
-
-
 sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -88,10 +88,6 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
-# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-# Therefore, we use 7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
@@ -99,7 +95,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
+sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -89,12 +89,6 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-
-
-
-
-
-
 sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -88,10 +88,6 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
-# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-# Therefore, we use 7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
@@ -99,7 +95,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
+sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -88,17 +88,10 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-
-
-
-
-
 # Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
 # contains only Docker 19.03.14, which is not validated for all Kubernetes version.
 # Therefore, we use 7 repo which has all Docker versions.
 sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 
 sudo yum install -y docker-ce-18.09.* docker-ce-cli-18.09.*

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -88,6 +88,12 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
+
+
+
+
+
 # Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
 # contains only Docker 19.03.14, which is not validated for all Kubernetes version.
 # Therefore, we use 7 repo which has all Docker versions.
@@ -95,13 +101,7 @@ sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
-
-
-
-
-
-
-sudo yum install -y docker-ce-18.09.9* docker-ce-cli-18.09.9*
+sudo yum install -y docker-ce-18.09.* docker-ce-cli-18.09.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -81,7 +81,7 @@ sudo yum install -y yum-plugin-versionlock
 
 
 
-sudo yum install -y containerd.io-1.4.3
+sudo yum install -y containerd.io-1.4.*
 sudo yum versionlock add containerd.io
 
 cat <<EOF | sudo tee /etc/containerd/config.toml

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -81,7 +81,7 @@ sudo yum install -y yum-plugin-versionlock
 
 
 
-sudo yum install -y containerd.io-1.4.3
+sudo yum install -y containerd.io-1.4.*
 sudo yum versionlock add containerd.io
 
 cat <<EOF | sudo tee /etc/containerd/config.toml

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -86,9 +86,6 @@ echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 sudo apt-get update
 
 
-
-
-
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -93,7 +93,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
+	docker-ce=5:19.03.* docker-ce-cli=5:19.03.*
 sudo apt-mark hold docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -96,7 +96,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
+	docker-ce=5:19.03.* docker-ce-cli=5:19.03.*
 sudo apt-mark hold docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -89,9 +89,6 @@ echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 sudo apt-get update
 
 
-
-
-
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -86,9 +86,6 @@ echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 sudo apt-get update
 
 
-
-
-
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -93,7 +93,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
+	docker-ce=5:19.03.* docker-ce-cli=5:19.03.*
 sudo apt-mark hold docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -73,7 +73,7 @@ sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_rele
 
 
 
-sudo apt-get install -y containerd.io=1.4.3*
+sudo apt-get install -y containerd.io=1.4.*
 sudo apt-mark hold containerd.io
 
 cat <<EOF | sudo tee /etc/containerd/config.toml

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -73,7 +73,7 @@ sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_rele
 
 
 
-sudo apt-get install -y containerd.io=1.4.3*
+sudo apt-get install -y containerd.io=1.4.*
 sudo apt-mark hold containerd.io
 
 cat <<EOF | sudo tee /etc/containerd/config.toml

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -86,11 +86,7 @@ EOF
 
 sudo yum versionlock delete docker cri-tools || true
 
-
-
-
-
-sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
+sudo yum install -y docker-19.03.* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -90,7 +90,7 @@ sudo yum versionlock delete docker cri-tools || true
 
 
 
-sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -88,13 +88,7 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-
-
 sudo yum versionlock delete docker-ce docker-ce-cli || true
-
-
-
 
 sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -88,10 +88,6 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
-# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-# Therefore, we use 7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
@@ -100,7 +96,7 @@ sudo yum versionlock delete docker-ce docker-ce-cli || true
 
 
 
-sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
+sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -88,9 +88,6 @@ sudo apt-get update
 
 sudo apt-mark unhold docker-ce docker-ce-cli
 
-
-
-
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -95,7 +95,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
+	docker-ce=5:19.03.* docker-ce-cli=5:19.03.*
 sudo apt-mark hold docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -86,11 +86,7 @@ EOF
 
 sudo yum versionlock delete docker cri-tools || true
 
-
-
-
-
-sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
+sudo yum install -y docker-19.03.* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -90,7 +90,7 @@ sudo yum versionlock delete docker cri-tools || true
 
 
 
-sudo yum install -y docker-19.03.13ce* cri-tools-1.13.0*
+sudo yum install -y docker-19.03.*ce* cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -88,13 +88,7 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-
-
 sudo yum versionlock delete docker-ce docker-ce-cli || true
-
-
-
 
 sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -88,10 +88,6 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
-# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-# Therefore, we use 7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
 
 
 
@@ -100,7 +96,7 @@ sudo yum versionlock delete docker-ce docker-ce-cli || true
 
 
 
-sudo yum install -y docker-ce-19.03.14* docker-ce-cli-19.03.14*
+sudo yum install -y docker-ce-19.03.* docker-ce-cli-19.03.*
 sudo yum versionlock add docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -88,9 +88,6 @@ sudo apt-get update
 
 sudo apt-mark unhold docker-ce docker-ce-cli
 
-
-
-
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -95,7 +95,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.14* docker-ce-cli=5:19.03.14*
+	docker-ce=5:19.03.* docker-ce-cli=5:19.03.*
 sudo apt-mark hold docker-ce docker-ce-cli
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker


### PR DESCRIPTION
**What this PR does / why we need it**:
Since those latest versions usually bring in security fixes, version constraints are relaxed and "latest available" version will be installed automatically.

**Special notes for your reviewer**:
We already doing the same in machine-controller

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use latest available (wildcard) docker and containerd version
```
