### PR TITLE
Add worker_deploy_ssh_key Terraform variable to the AWS configs

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -19,15 +19,16 @@ provider "aws" {
 }
 
 locals {
-  kube_cluster_tag = "kubernetes.io/cluster/${var.cluster_name}"
-  ami              = var.ami == "" ? data.aws_ami.ami.id : var.ami
-  zoneA            = data.aws_availability_zones.available.names[0]
-  zoneB            = data.aws_availability_zones.available.names[1]
-  zoneC            = data.aws_availability_zones.available.names[2]
-  vpc_mask         = parseint(split("/", data.aws_vpc.selected.cidr_block)[1], 10)
-  subnet_total     = pow(2, var.subnets_cidr - local.vpc_mask)
-  subnet_newbits   = var.subnets_cidr - (32 - local.vpc_mask)
-  worker_os        = var.worker_os == "" ? var.os : var.worker_os
+  kube_cluster_tag      = "kubernetes.io/cluster/${var.cluster_name}"
+  ami                   = var.ami == "" ? data.aws_ami.ami.id : var.ami
+  zoneA                 = data.aws_availability_zones.available.names[0]
+  zoneB                 = data.aws_availability_zones.available.names[1]
+  zoneC                 = data.aws_availability_zones.available.names[2]
+  vpc_mask              = parseint(split("/", data.aws_vpc.selected.cidr_block)[1], 10)
+  subnet_total          = pow(2, var.subnets_cidr - local.vpc_mask)
+  subnet_newbits        = var.subnets_cidr - (32 - local.vpc_mask)
+  worker_os             = var.worker_os == "" ? var.os : var.worker_os
+  worker_deploy_ssh_key = var.worker_deploy_ssh_key ? [aws_key_pair.deployer.public_key] : []
 
   subnets = {
     (local.zoneA) = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[0].id : ""

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -73,7 +73,7 @@ output "kubeone_workers" {
     "${var.cluster_name}-${local.zoneA}" = {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
-        sshPublicKeys   = [aws_key_pair.deployer.public_key]
+        sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot = false
@@ -110,7 +110,7 @@ output "kubeone_workers" {
     "${var.cluster_name}-${local.zoneB}" = {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
-        sshPublicKeys   = [aws_key_pair.deployer.public_key]
+        sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot = false
@@ -147,7 +147,7 @@ output "kubeone_workers" {
     "${var.cluster_name}-${local.zoneC}" = {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
-        sshPublicKeys   = [aws_key_pair.deployer.public_key]
+        sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot = false

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -176,3 +176,9 @@ variable "initial_machinedeployment_spotinstances" {
   default     = false
   type        = bool
 }
+
+variable "worker_deploy_ssh_key" {
+  description = "add provided ssh public key to MachineDeployments"
+  default     = true
+  type        = bool
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `worker_deploy_ssh_key` Terraform variable to the AWS configs. This variable controls should the provided SSH public key be embedded into the MachineDeployment objects. The default value is `true`, i.e. the key will be embedded.

The main use case for this feature is to disable embedding SSH keys for Flatcar MachineDeploments. That's because the Flatcar Machines can reach the AWS user-data limit if the SSH key is provided. This is a known issue and we're working on resolving it. In meanwhile, this approach can be used as a workaround.

**Does this PR introduce a user-facing change?**:
```release-note
Add `worker_deploy_ssh_key` Terraform variable to the AWS configs. This variable controls should the provided SSH public key be embedded into the MachineDeployment objects. The default value is `true`, i.e. the key will be embedded.
```

/assign @kron4eg 