### PR TITLE
Support organizing addons into subdirectories

### DIFF
--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -98,11 +98,11 @@ func applyAddons(s *state.State, manifest string, addonName string) error {
 	return s.RunTaskOnLeader(func(s *state.State, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {
 		var (
 			cmd            = fmt.Sprintf(kubectlApplyScript, addonLabel, addonName)
-			r              = strings.NewReader(manifest)
+			stdin          = strings.NewReader(manifest)
 			stdout, stderr strings.Builder
 		)
 
-		_, err := conn.POpen(cmd, r, &stdout, &stderr)
+		_, err := conn.POpen(cmd, stdin, &stdout, &stderr)
 		if s.Verbose {
 			fmt.Printf("+ %s\n", cmd)
 			fmt.Printf("%s", stderr.String())

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -18,22 +18,26 @@ package addons
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/credentials"
-	"k8c.io/kubeone/pkg/runner"
 	"k8c.io/kubeone/pkg/ssh"
 	"k8c.io/kubeone/pkg/state"
 )
 
 const (
-	addonLabel         = "kubeone.io/addon"
-	kubectlApplyScript = `
-sudo KUBECONFIG=/etc/kubernetes/admin.conf \
-    kubectl apply -f {{.FILE_NAME}} --prune -l "%s"
-`
+	addonLabel = "kubeone.io/addon"
+)
+
+var (
+	kubectlApplyScript = heredoc.Doc(`
+		sudo KUBECONFIG=/etc/kubernetes/admin.conf \
+		kubectl apply -f - --prune -l "%s=%s"
+	`)
 )
 
 // TemplateData is data available in the addons render template
@@ -58,27 +62,53 @@ func Ensure(s *state.State) error {
 		Config:      s.Cluster,
 		Credentials: creds,
 	}
-	if err := getManifests(s, templateData); err != nil {
-		return errors.WithStack(err)
+
+	addonsPath, dirs, err := traverseAddonsDirectory(s)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse the addons directory")
 	}
 
-	if err := applyAddons(s); err != nil {
-		return errors.Wrap(err, "failed to apply addons")
+	for _, addonDir := range dirs {
+		if len(addonDir) == 0 {
+			s.Logger.Info("Applying addons from the root directory...")
+		} else {
+			s.Logger.Infof("Applying addon %q...", addonDir)
+		}
+
+		manifest, err := getManifestsFromDirectory(s, templateData, addonsPath, addonDir)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if len(strings.TrimSpace(manifest)) == 0 {
+			if len(addonDir) != 0 {
+				s.Logger.Warnf("Addon directory %q is empty, skipping...", addonDir)
+			}
+			continue
+		}
+
+		if err := applyAddons(s, manifest, addonDir); err != nil {
+			return errors.Wrap(err, "failed to apply addons")
+		}
 	}
 
 	return nil
 }
 
-func applyAddons(s *state.State) error {
-	return errors.Wrap(s.RunTaskOnLeader(runKubectl), "failed to apply addons")
-}
+func applyAddons(s *state.State, manifest string, addonName string) error {
+	return s.RunTaskOnLeader(func(s *state.State, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {
+		var (
+			cmd            = fmt.Sprintf(kubectlApplyScript, addonLabel, addonName)
+			r              = strings.NewReader(manifest)
+			stdout, stderr strings.Builder
+		)
 
-func runKubectl(s *state.State, _ *kubeoneapi.HostConfig, _ ssh.Connection) error {
-	if err := s.Configuration.UploadTo(s.Runner.Conn, s.WorkDir); err != nil {
-		return errors.Wrap(err, "failed to upload manifests")
-	}
-	_, _, err := s.Runner.Run(fmt.Sprintf(kubectlApplyScript, addonLabel), runner.TemplateVariables{
-		"FILE_NAME": fmt.Sprintf("%s/addons/", s.WorkDir),
+		_, err := conn.POpen(cmd, r, &stdout, &stderr)
+		if s.Verbose {
+			fmt.Printf("+ %s\n", cmd)
+			fmt.Printf("%s", stderr.String())
+			fmt.Printf("%s", stdout.String())
+		}
+
+		return err
 	})
-	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Support organizing addons into subdirectories
  * Storing addons in the addons directory's root is still supported but is considered deprecated
  * We strongly recommend reorganizing your addons into subdirectories
* Update unit tests to test the new behavior

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1363

**Special notes for your reviewer**:

/hold
to manually test the backward compatibility

**Does this PR introduce a user-facing change?**:
```release-note
Support organizing addons into subdirectories
[DEPRECATED] Storing addons manifests in the addons directory's root is not recommended any longer and is considered deprecated. It currently remains possible to store addons in the addons directory's root, but this might be removed in the future KubeOne version. We strongly recommend reorganizing your addons into subdirectories.
```

/assign @kron4eg 