### PR TITLE
[release/v1.2] Pass -node-external-cloud-provider to the MC webhook

### DIFF
--- a/pkg/templates/machinecontroller/deployment.go
+++ b/pkg/templates/machinecontroller/deployment.go
@@ -775,10 +775,6 @@ func machineControllerDeployment(cluster *kubeoneapi.KubeOneCluster, credentials
 		args = append(args, "-node-no-proxy", cluster.Proxy.NoProxy)
 	}
 
-	if cluster.CloudProvider.External {
-		args = append(args, "-external-cloud-provider")
-	}
-
 	insecureRegistry := cluster.RegistryConfiguration.InsecureRegistryAddress()
 	if insecureRegistry != "" {
 		args = append(args, "-node-insecure-registries", insecureRegistry)


### PR DESCRIPTION
**What this PR does / why we need it**:
Web hook has to take external-cloud provider information into account (forgotten change since machine-controller v1.27).

Without this, our API:
```
cloudProvider:
  external: true
```
is being ignored by the machine-controller.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Pass -node-external-cloud-provider to the MC webhook
```
