### PR TITLE
Fix hetzner ssh_port terraform type

### DIFF
--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -38,7 +38,7 @@ variable "ssh_public_key_file" {
 variable "ssh_port" {
   description = "SSH port to be used to provision instances"
   default     = 22
-  type        = string
+  type        = number
 }
 
 variable "ssh_username" {


### PR DESCRIPTION
**What this PR does / why we need it**:
`ssh_port` should be a number (like in other providers) in hetzner terraform config, otherwise it blows up at JSON unmarshal time in kubeone.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix hetzner ssh_port terraform type
```
