### PR TITLE
Suppress client-go deprecation warnings

### DIFF
--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -18,6 +18,7 @@ package kubeconfig
 
 import (
 	"io/fs"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -25,6 +26,7 @@ import (
 	"k8c.io/kubeone/pkg/ssh/sshiofs"
 	"k8c.io/kubeone/pkg/state"
 
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -62,6 +64,10 @@ func BuildKubernetesClientset(s *state.State) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to build config from kubeconfig bytes")
 	}
+
+	s.RESTConfig.WarningHandler = rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{
+		Deduplicate: true,
+	})
 
 	tunn, err := s.Connector.Tunnel(s.Cluster.RandomHost())
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Running `kubeone apply` outputs a lot of deprecation warnings generated by client-go, such as:

```
W0621 13:40:51.223984   74422 warnings.go:67] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
```

The warnings are present even if verbose isn't enabled.

This PR configures the client-go to show only the first warning, while the subsequent warnings will be suppressed. This PR should make the `kubeone apply` output more readable.

There are several possible alternative approaches here:

1. Suppress all warnings, including the first warning.
2. Suppress all warnings if verbose isn't enabled, but show all warnings if it's enabled
3. Suppress all warnings if verbose isn't enabled, but show the first warning if it's enabled

**Does this PR introduce a user-facing change?**:
```release-note
Suppress client-go deprecation warnings
```

/assign @kron4eg 