### PR TITLE
Ignore NodeLocalDNS when deploying user-provided addons

### DIFF
--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -39,6 +39,7 @@ var (
 	// binary. Those addons are skipped when applying the user-provided addons
 	embeddedAddons = map[string]string{
 		resources.AddonCCMDigitalOcean: "",
+		resources.AddonNodeLocalDNS:    "",
 	}
 )
 

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -28,6 +28,7 @@ import (
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/templates/externalccm"
 	"k8c.io/kubeone/pkg/templates/machinecontroller"
+	"k8c.io/kubeone/pkg/templates/resources"
 )
 
 type Tasks []Task
@@ -176,7 +177,7 @@ func WithResources(t Tasks) Tasks {
 			{
 				Fn: func(s *state.State) error {
 					s.Logger.Infoln("Ensure node local DNS cache...")
-					return addons.EnsureAddonByName(s, "nodelocaldns")
+					return addons.EnsureAddonByName(s, resources.AddonNodeLocalDNS)
 				},
 				ErrMsg:      "failed to deploy nodelocaldns",
 				Description: "ensure nodelocaldns",

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -18,6 +18,7 @@ package resources
 
 const (
 	AddonCCMDigitalOcean = "ccm-digitalocean"
+	AddonNodeLocalDNS    = "nodelocaldns"
 
 	NodeLocalDNSVirtualIP = "169.254.20.10"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore NodeLocalDNS when deploying user-provided addons.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 