### PR TITLE
Increase lint timeout to 5 min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ buildenv:
 .PHONY: lint
 lint:
 	@golangci-lint --version
-	golangci-lint run -v ./pkg/... ./test/...
+	golangci-lint run --timeout=5m -v ./pkg/... ./test/...
 
 .PHONY: verify-licence
 verify-licence: GOFLAGS = -mod=readonly


### PR DESCRIPTION
**What this PR does / why we need it**:

The lint job is often flaking because it's reaching the timeout, which is 1 minute by default. This PR increases the timeout to 5 minutes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
