### PR TITLE
Clean up CI jobs

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -182,33 +182,6 @@ presubmits:
           resources:
             requests:
               cpu: 1
-  - name: pull-kubeone-e2e-aws-conformance-1.18
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-aws: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "aws"
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-aws-conformance-1.19
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
     decorate: true
@@ -289,33 +262,8 @@ presubmits:
             requests:
               cpu: 1
   #########################################################
-  # E2E/Conformance tests (DigitalOcean, 1.18-1.21)
+  # E2E/Conformance tests (DigitalOcean, 1.19-1.21)
   #########################################################
-  - name: pull-kubeone-e2e-digitalocean-conformance-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-digitalocean: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "digitalocean"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-digitalocean-conformance-1.19
     always_run: false
     decorate: true
@@ -392,33 +340,8 @@ presubmits:
             requests:
               cpu: 1
   #########################################################
-  # E2E/Conformance tests (Hetzner, 1.18-1.21)
+  # E2E/Conformance tests (Hetzner, 1.19-1.21)
   #########################################################
-  - name: pull-kubeone-e2e-hetzner-conformance-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-hetzner: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "hetzner"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-hetzner-conformance-1.19
     always_run: false
     decorate: true
@@ -495,35 +418,8 @@ presubmits:
             requests:
               cpu: 1
   #########################################################
-  # E2E/Conformance tests (GCE, 1.18-1.21)
+  # E2E/Conformance tests (GCE, 1.19-1.21)
   #########################################################
-  - name: pull-kubeone-e2e-gce-conformance-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-gce: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "gce"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-            - name: TF_VAR_project
-              value: "kubeone-terraform-test"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-gce-conformance-1.19
     always_run: false
     decorate: true
@@ -606,33 +502,8 @@ presubmits:
             requests:
               cpu: 1
   #########################################################
-  # E2E/Conformance tests (Packet, 1.16-1.21)
+  # E2E/Conformance tests (Packet, 1.19-1.21)
   #########################################################
-  - name: pull-kubeone-e2e-packet-conformance-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-packet: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "packet"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-packet-conformance-1.19
     always_run: false
     decorate: true
@@ -709,33 +580,8 @@ presubmits:
             requests:
               cpu: 1
   #########################################################
-  # E2E/Conformance tests (OpenStack, 1.18-1.21)
+  # E2E/Conformance tests (OpenStack, 1.19-1.21)
   #########################################################
-  - name: pull-kubeone-e2e-openstack-conformance-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-openstack: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "openstack"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-openstack-conformance-1.19
     always_run: false
     decorate: true

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -690,34 +690,6 @@ presubmits:
               valut: "120m"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
-  - name: pull-kubeone-e2e-aws-upgrade-1.17-1.18
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-aws: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "aws"
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.17.17"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-aws-upgrade-1.18-1.19
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
     decorate: true
@@ -803,32 +775,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (DigitalOcean)
   #########################################################
-  - name: pull-kubeone-e2e-digitalocean-upgrade-1.17-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-digitalocean: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "digitalocean"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.17.17"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-digitalocean-upgrade-1.18-1.19
     always_run: false
     decorate: true
@@ -910,32 +856,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (Hetzner)
   #########################################################
-  - name: pull-kubeone-e2e-hetzner-upgrade-1.17-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-hetzner: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "hetzner"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.17.17"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-hetzner-upgrade-1.18-1.19
     always_run: false
     decorate: true
@@ -1017,34 +937,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (GCE)
   #########################################################
-  - name: pull-kubeone-e2e-gce-upgrade-1.17-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-gce: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "gce"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.17.17"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
-            - name: TF_VAR_project
-              value: "kubeone-terraform-test"
   - name: pull-kubeone-e2e-gce-upgrade-1.18-1.19
     always_run: false
     decorate: true
@@ -1132,32 +1024,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (Packet)
   #########################################################
-  - name: pull-kubeone-e2e-packet-upgrade-1.17-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-packet: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "packet"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.17.17"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-packet-upgrade-1.18-1.19
     always_run: false
     decorate: true
@@ -1239,32 +1105,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (OpenStack)
   #########################################################
-  - name: pull-kubeone-e2e-openstack-upgrade-1.17-1.18
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-openstack: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "openstack"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.17.17"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-openstack-upgrade-1.18-1.19
     always_run: false
     decorate: true

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -141,7 +141,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -176,7 +176,7 @@ presubmits:
             - name: TF_VAR_bastion_user
               value: "core"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -203,7 +203,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -230,7 +230,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -257,7 +257,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -282,7 +282,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -310,7 +310,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -335,7 +335,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -360,7 +360,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -385,7 +385,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -413,7 +413,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -438,7 +438,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -463,7 +463,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -488,7 +488,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -516,7 +516,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -543,7 +543,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -570,7 +570,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -597,7 +597,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -627,7 +627,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -652,7 +652,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -677,7 +677,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -702,7 +702,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -730,7 +730,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -755,7 +755,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -780,7 +780,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -805,7 +805,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -839,7 +839,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.17.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -867,7 +867,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.17.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -893,9 +893,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -919,9 +919,9 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -947,9 +947,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -978,7 +978,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.17.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1002,9 +1002,9 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1028,9 +1028,9 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1054,9 +1054,9 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1085,7 +1085,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.17.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1109,9 +1109,9 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1135,9 +1135,9 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1161,9 +1161,9 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1192,7 +1192,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.17.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1218,9 +1218,9 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1246,9 +1246,9 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1274,9 +1274,9 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1307,7 +1307,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.17.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1331,9 +1331,9 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1357,9 +1357,9 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1383,9 +1383,9 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1414,7 +1414,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.17.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1438,9 +1438,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.17"
+              value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1464,9 +1464,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.9"
+              value: "1.19.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1490,9 +1490,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.5"
+              value: "1.20.8"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.0"
+              value: "1.21.2"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update the Kubernetes versions to the latest
* Remove 1.18 conformance tests since 1.18 has reached EOL
* Remove 1.17 to 1.18 upgrade tests

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
