### PR TITLE
Fix subsequent apply failures if CABundle is enabled

### DIFF
--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
-	"k8c.io/kubeone/pkg/certificate/cabundle"
 	"k8c.io/kubeone/pkg/scripts"
 	"k8c.io/kubeone/pkg/ssh"
 	"k8c.io/kubeone/pkg/state"
@@ -41,7 +40,6 @@ func installPrerequisites(s *state.State) error {
 
 func generateConfigurationFiles(s *state.State) error {
 	s.Configuration.AddFile("cfg/cloud-config", s.Cluster.CloudProvider.CloudConfig)
-	s.Configuration.AddFile("ca-certs/"+cabundle.FileName, s.Cluster.CABundle)
 
 	if s.Cluster.Features.StaticAuditLog != nil && s.Cluster.Features.StaticAuditLog.Enable {
 		if err := s.Configuration.AddFilePath("cfg/audit-policy.yaml", s.Cluster.Features.StaticAuditLog.Config.PolicyFilePath, s.ManifestFilePath); err != nil {

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -151,9 +151,7 @@ func WithResources(t Tasks) Tasks {
 	return t.append(
 		Tasks{
 			{
-				Fn: func(s *state.State) error {
-					return s.RunTaskOnControlPlane(saveCABundle, state.RunParallel)
-				},
+				Fn: saveCABundle,
 				Predicate: func(s *state.State) bool {
 					return s.Cluster.CABundle != ""
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

The subsequent `kubeone apply` runs are failing if the CA bundle is enabled:

```
[10.0.42.9] + export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/sbin:/usr/local/bin:/opt/bin
[10.0.42.9] + PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/sbin:/usr/local/bin:/opt/bin
[10.0.42.9] + sudo mkdir -p /etc/kubeone/certs
[10.0.42.9] + sudo mv ./kubeone/ca-certs/ca-certificates.crt /etc/kubeone/certs
[10.0.42.9] mv: cannot stat './kubeone/ca-certs/ca-certificates.crt': No such file or directory
ERRO[09:07:21 CEST] Process exited with status 1                  node=10.0.42.9
[10.0.42.5] + export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/sbin:/usr/local/bin:/opt/bin
[10.0.42.5] + PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/sbin:/usr/local/bin:/opt/bin
[10.0.42.5] + sudo mkdir -p /etc/kubeone/certs
[10.0.42.5] + sudo mv ./kubeone/ca-certs/ca-certificates.crt /etc/kubeone/certs
[10.0.42.5] mv: cannot stat './kubeone/ca-certs/ca-certificates.crt': No such file or directory
ERRO[09:07:21 CEST] Process exited with status 1                  node=10.0.42.5
[10.0.42.2] + export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/sbin:/usr/local/bin:/opt/bin
[10.0.42.2] + PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/sbin:/usr/local/bin:/opt/bin
[10.0.42.2] + sudo mkdir -p /etc/kubeone/certs
[10.0.42.2] + sudo mv ./kubeone/ca-certs/ca-certificates.crt /etc/kubeone/certs
[10.0.42.2] mv: cannot stat './kubeone/ca-certs/ca-certificates.crt': No such file or directory
ERRO[09:07:21 CEST] Process exited with status 1                  node=10.0.42.2
WARN[09:07:21 CEST] Task failed, error was: at least one of the tasks has encountered an error 
```

The reason is that we currently upload the CA bundle in [`generateConfigurationFiles` function](https://github.com/kubermatic/kubeone/blob/2f7c8350ab2a9c690b03f6c01fd9a81deba2ef9a/pkg/tasks/prerequisites.go#L42-L84) which we only run when provisioning and upgrading the cluster.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 