### PR TITLE
machine-controller: Inject EnvVarBindings only for needed credentials

### DIFF
--- a/addons/machinecontroller/machine-controller.yaml
+++ b/addons/machinecontroller/machine-controller.yaml
@@ -500,13 +500,7 @@ spec:
               value: "{{ .Config.Proxy.HTTPS }}"
             - name: NO_PROXY
               value: "{{ .Config.Proxy.NoProxy }}"
-            {{ range $key, $val := .Credentials }}
-            - name: {{ $key }}
-              valueFrom:
-                secretKeyRef:
-                  name: "cloud-provider-credentials"
-                  key: {{ $key }}
-            {{ end }}
+{{ .MachineControllerCredentialsEnvVars | indent 12 }}
 {{ if .Config.CABundle }}
 {{ caBundleEnvVar | indent 12 }}
 {{ end }}
@@ -575,13 +569,7 @@ spec:
               value: "{{ .Config.Proxy.HTTPS }}"
             - name: NO_PROXY
               value: "{{ .Config.Proxy.NoProxy }}"
-            {{ range $key, $val := .Credentials }}
-            - name: {{ $key }}
-              valueFrom:
-                secretKeyRef:
-                  name: "cloud-provider-credentials"
-                  key: {{ $key }}
-            {{ end }}
+{{ .MachineControllerCredentialsEnvVars | indent 12 }}
 {{ if .Config.CABundle }}
 {{ caBundleEnvVar | indent 12 }}
 {{ end }}

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -32,6 +32,8 @@ import (
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/templates/images"
 	"k8c.io/kubeone/pkg/templates/resources"
+
+	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -50,11 +52,12 @@ type applier struct {
 
 // TemplateData is data available in the addons render template
 type templateData struct {
-	Config         *kubeoneapi.KubeOneCluster
-	Certificates   map[string]string
-	Credentials    map[string]string
-	InternalImages *internalImages
-	Resources      map[string]string
+	Config                              *kubeoneapi.KubeOneCluster
+	Certificates                        map[string]string
+	Credentials                         map[string]string
+	MachineControllerCredentialsEnvVars string
+	InternalImages                      *internalImages
+	Resources                           map[string]string
 }
 
 func newAddonsApplier(s *state.State) (*applier, error) {
@@ -75,6 +78,15 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 	creds, err := credentials.Any(s.CredentialsFilePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch credentials")
+	}
+
+	envVars, err := credentials.EnvVarBindings(s.Cluster.CloudProvider, s.CredentialsFilePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to fetch env var bindings for credentials")
+	}
+	credsEnvVars, err := yaml.Marshal(envVars)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to convert env var bindings for credentials to yaml")
 	}
 
 	kubeCAPrivateKey, kubeCACert, err := certificate.CAKeyPair(s.Configuration)
@@ -100,7 +112,8 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 			"MachineControllerWebhookKey":  certsMap[resources.MachineControllerWebhookKeyName],
 			"KubernetesCA":                 certsMap[resources.KubernetesCACertName],
 		},
-		Credentials: creds,
+		Credentials:                         creds,
+		MachineControllerCredentialsEnvVars: string(credsEnvVars),
 		InternalImages: &internalImages{
 			pauseImage: s.PauseImage,
 			resolver:   s.Images.Get,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes two bugs:

1) Inject EnvVarBindings only for the needed credentials. Currently, we inject bindings for all credentials EnvVars found in the environment. However, the Secret only contains the credentials for the cloud provider. This can cause the machine-controller to fail to start because it has envVarBindings for credentials that are not present in the Secret.
1) Use envVar names required by machine-controller. Currently, we use the same envVar names as used by KubeOne, however, machine-controller has different names for some variables.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 