### PR TITLE
Minor improvements to addons

### DIFF
--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -127,7 +127,8 @@ spec:
   template:
     metadata:
       annotations:
-         scheduler.alpha.kubernetes.io/critical-pod: ""
+         "scheduler.alpha.kubernetes.io/critical-pod": ""
+         "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
       labels:
         k8s-app: "openstack-cloud-controller-manager"
     spec:

--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -129,6 +129,7 @@ spec:
       annotations:
          "scheduler.alpha.kubernetes.io/critical-pod": ""
          "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+         "cloudConfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
       labels:
         k8s-app: "openstack-cloud-controller-manager"
     spec:

--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -10,9 +10,9 @@ apiVersion: v1
 metadata:
   name: cloud-config
   namespace: kube-system
-stringData:
+data:
   cloud.conf: |
-{{ .Config.CloudProvider.CloudConfig | indent 4 }}
+{{ .Config.CloudProvider.CloudConfig | b64enc | indent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/addons/ccm-vsphere/ccm-vsphere.yaml
+++ b/addons/ccm-vsphere/ccm-vsphere.yaml
@@ -176,6 +176,7 @@ spec:
       annotations:
         "scheduler.alpha.kubernetes.io/critical-pod": ""
         "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "cloudConfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/addons/ccm-vsphere/ccm-vsphere.yaml
+++ b/addons/ccm-vsphere/ccm-vsphere.yaml
@@ -174,7 +174,8 @@ spec:
         component: cloud-controller-manager
         tier: control-plane
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
+        "scheduler.alpha.kubernetes.io/critical-pod": ""
+        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/addons/ccm-vsphere/ccm-vsphere.yaml
+++ b/addons/ccm-vsphere/ccm-vsphere.yaml
@@ -16,9 +16,9 @@ metadata:
     vsphere-cpi-infra: config
     component: cloud-controller-manager
   namespace: kube-system
-stringData:
+data:
   vsphere.conf: |
-{{ .Config.CloudProvider.CloudConfig | indent 4 }}
+{{ .Config.CloudProvider.CloudConfig | b64enc | indent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/addons/machinecontroller/machine-controller.yaml
+++ b/addons/machinecontroller/machine-controller.yaml
@@ -614,13 +614,13 @@ kind: Secret
 metadata:
   name: machinecontroller-webhook-serving-cert
   namespace: kube-system
-stringData:
+data:
   "cert.pem": |
-{{ .Certificates.MachineControllerWebhookCert | indent 4 }}
+{{ .Certificates.MachineControllerWebhookCert | b64enc | indent 4 }}
   "key.pem": |
-{{ .Certificates.MachineControllerWebhookKey | indent 4 }}
+{{ .Certificates.MachineControllerWebhookKey | b64enc | indent 4 }}
   "ca.crt": |
-{{ .Certificates.KubernetesCA | indent 4 }}
+{{ .Certificates.KubernetesCA | b64enc | indent 4 }}
 
 ---
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces the following changes to addons:

1) Replace `stringData` with `data` in Secrets
    - `kubectl apply` is keeping the manifest used to apply the object in the `kubectl.kubernetes.io/last-applied-configuration` annotation
    - If `stringData` is used for creating the Secret, the annotation will contain the plain-text Secret instead of base64 encoded
    - Packet CCM is still using `stringData`. This will be fixed in a follow-up
2) Add `caBundle-hash` annotation to vSphere and OpenStack CCM addons
    - This was forgotten when migrating from the Go templates
3) Add `cloudConfig-hash` annotation to vSphere and OpenStack CCM addons
    - This is a new annotation. It's used to restart the CCM pods if the cloud-config is changed
    - Some CCMs can automatically reload the config, but it might be delayed. I believe it's safer to explicitly restart the pods using the annotation (similar as we do for the CA bundle)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 