### PR TITLE
Replace stringData with data in Packet cloud-config Secret

### DIFF
--- a/addons/ccm-packet/ccm-packet.yaml
+++ b/addons/ccm-packet/ccm-packet.yaml
@@ -157,9 +157,5 @@ apiVersion: v1
 metadata:
   name: packet-cloud-config
   namespace: kube-system
-stringData:
-  cloud-sa.json: |
-    {
-      "apiKey": "{{ .Credentials.PACKET_AUTH_TOKEN }}",
-      "projectID": "{{ .Credentials.PACKET_PROJECT_ID }}"
-    }
+data:
+  cloud-sa.json: {{ PacketSecret .Credentials.PACKET_AUTH_TOKEN .Credentials.PACKET_PROJECT_ID | b64enc }}

--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -19,6 +19,7 @@ package addons
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"io"
 	"io/fs"
 	"path/filepath"
@@ -207,6 +208,19 @@ func txtFuncMap(overwriteRegistry string) template.FuncMap {
 
 	funcs["caBundleVolumeMount"] = func() (string, error) {
 		buf, err := yaml.Marshal([]corev1.VolumeMount{cabundle.VolumeMount()})
+		return string(buf), err
+	}
+
+	funcs["PacketSecret"] = func(apiKey, projectID string) (string, error) {
+		packetSecret := struct {
+			APIKey    string `json:"apiKey"`
+			ProjectID string `json:"projectID"`
+		}{
+			APIKey:    apiKey,
+			ProjectID: projectID,
+		}
+
+		buf, err := json.Marshal(packetSecret)
 		return string(buf), err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We've done this for vSphere and OpenStack in #1414, however, Packet is a bit different, so we left it for a follow-up.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 