### PR TITLE
Run E2E tests if addons are changed

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -119,7 +119,7 @@ presubmits:
   # E2E/Conformance tests (AWS, 1.18-1.21)
   #########################################################
   - name: pull-kubeone-e2e-aws-containerd-conformance-1.18
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
@@ -148,7 +148,7 @@ presubmits:
             requests:
               cpu: 1
   - name: pull-kubeone-e2e-aws-flatcar-containerd-conformance-1.18
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
@@ -183,7 +183,7 @@ presubmits:
             requests:
               cpu: 1
   - name: pull-kubeone-e2e-aws-conformance-1.19
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
@@ -210,7 +210,7 @@ presubmits:
             requests:
               cpu: 1
   - name: pull-kubeone-e2e-aws-conformance-1.20
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
@@ -237,7 +237,7 @@ presubmits:
             requests:
               cpu: 1
   - name: pull-kubeone-e2e-aws-conformance-1.21
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
@@ -661,7 +661,7 @@ presubmits:
   # E2E/Upgrade tests (AWS)
   #########################################################
   - name: pull-kubeone-e2e-aws-upgrade-containerd-1.18-1.19
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
@@ -691,7 +691,7 @@ presubmits:
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-aws-upgrade-1.18-1.19
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
@@ -719,7 +719,7 @@ presubmits:
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-aws-upgrade-1.19-1.20
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
@@ -745,7 +745,7 @@ presubmits:
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-aws-upgrade-1.20-1.21
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/)"
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Addons are now used for deploying core components, so we should run E2E tests if addons are changed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 