### PR TITLE
Upgrade machinecontroller addon apiextensions to v1 API

### DIFF
--- a/addons/machinecontroller/machine-controller.yaml
+++ b/addons/machinecontroller/machine-controller.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: machines.cluster.k8s.io
@@ -7,7 +7,6 @@ metadata:
     "api-approved.kubernetes.io": "unapproved, legacy API"
 spec:
   group: cluster.k8s.io
-  version: v1alpha1
   scope: Namespaced
   names:
     kind: Machine
@@ -15,32 +14,40 @@ spec:
     singular: machine
     listKind: MachineList
     shortNames: ["ma"]
-  additionalPrinterColumns:
-    - name: Provider
-      type: string
-      JSONPath: .spec.providerSpec.value.cloudProvider
-    - name: OS
-      type: string
-      JSONPath: .spec.providerSpec.value.operatingSystem
-    - name: Node
-      type: string
-      JSONPath: .status.nodeRef.name
-    - name: Kubelet
-      type: string
-      JSONPath: .spec.versions.kubelet
-    - name: Address
-      type: string
-      JSONPath: .status.addresses[0].address
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-    - name: Deleted
-      type: date
-      JSONPath: .metadata.deletionTimestamp
-      priority: 1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          x-kubernetes-preserve-unknown-fields: true
+          type: object
+      additionalPrinterColumns:
+        - name: Provider
+          type: string
+          jsonPath: .spec.providerSpec.value.cloudProvider
+        - name: OS
+          type: string
+          jsonPath: .spec.providerSpec.value.operatingSystem
+        - name: Node
+          type: string
+          jsonPath: .status.nodeRef.name
+        - name: Kubelet
+          type: string
+          jsonPath: .spec.versions.kubelet
+        - name: Address
+          type: string
+          jsonPath: .status.addresses[0].address
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: Deleted
+          type: date
+          jsonPath: .metadata.deletionTimestamp
+          priority: 1
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: machinesets.cluster.k8s.io
@@ -48,7 +55,6 @@ metadata:
     "api-approved.kubernetes.io": "unapproved, legacy API"
 spec:
   group: cluster.k8s.io
-  version: v1alpha1
   scope: Namespaced
   names:
     kind: MachineSet
@@ -56,37 +62,45 @@ spec:
     singular: machineset
     listKind: MachineSetList
     shortNames: ["ms"]
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-    - name: Replicas
-      type: integer
-      JSONPath: .spec.replicas
-    - name: Available-Replicas
-      type: integer
-      JSONPath: .status.availableReplicas
-    - name: Provider
-      type: string
-      JSONPath: .spec.template.spec.providerSpec.value.cloudProvider
-    - name: OS
-      type: string
-      JSONPath: .spec.template.spec.providerSpec.value.operatingSystem
-    - name: MachineDeployment
-      type: string
-      JSONPath: .metadata.ownerReferences[0].name
-    - name: Kubelet
-      type: string
-      JSONPath: .spec.template.spec.versions.kubelet
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-    - name: Deleted
-      type: date
-      JSONPath: .metadata.deletionTimestamp
-      priority: 1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          x-kubernetes-preserve-unknown-fields: true
+          type: object
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Replicas
+          type: integer
+          jsonPath: .spec.replicas
+        - name: Available-Replicas
+          type: integer
+          jsonPath: .status.availableReplicas
+        - name: Provider
+          type: string
+          jsonPath: .spec.template.spec.providerSpec.value.cloudProvider
+        - name: OS
+          type: string
+          jsonPath: .spec.template.spec.providerSpec.value.operatingSystem
+        - name: MachineDeployment
+          type: string
+          jsonPath: .metadata.ownerReferences[0].name
+        - name: Kubelet
+          type: string
+          jsonPath: .spec.template.spec.versions.kubelet
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: Deleted
+          type: date
+          jsonPath: .metadata.deletionTimestamp
+          priority: 1
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: machinedeployments.cluster.k8s.io
@@ -94,7 +108,6 @@ metadata:
     "api-approved.kubernetes.io": "unapproved, legacy API"
 spec:
   group: cluster.k8s.io
-  version: v1alpha1
   scope: Namespaced
   names:
     kind: MachineDeployment
@@ -102,37 +115,45 @@ spec:
     singular: machinedeployment
     listKind: MachineDeploymentList
     shortNames: ["md"]
-  subresources:
-    scale:
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  additionalPrinterColumns:
-    - name: Replicas
-      type: integer
-      JSONPath: .spec.replicas
-    - name: Available-Replicas
-      type: integer
-      JSONPath: .status.availableReplicas
-    - name: Provider
-      type: string
-      JSONPath: .spec.template.spec.providerSpec.value.cloudProvider
-    - name: OS
-      type: string
-      JSONPath: .spec.template.spec.providerSpec.value.operatingSystem
-    - name: Kubelet
-      type: string
-      JSONPath: .spec.template.spec.versions.kubelet
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-    - name: Deleted
-      type: date
-      JSONPath: .metadata.deletionTimestamp
-      priority: 1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          x-kubernetes-preserve-unknown-fields: true
+          type: object
+      subresources:
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+        status: {}
+      additionalPrinterColumns:
+        - name: Replicas
+          type: integer
+          jsonPath: .spec.replicas
+        - name: Available-Replicas
+          type: integer
+          jsonPath: .status.availableReplicas
+        - name: Provider
+          type: string
+          jsonPath: .spec.template.spec.providerSpec.value.cloudProvider
+        - name: OS
+          type: string
+          jsonPath: .spec.template.spec.providerSpec.value.operatingSystem
+        - name: Kubelet
+          type: string
+          jsonPath: .spec.template.spec.versions.kubelet
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: Deleted
+          type: date
+          jsonPath: .metadata.deletionTimestamp
+          priority: 1
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusters.cluster.k8s.io
@@ -140,14 +161,21 @@ metadata:
     "api-approved.kubernetes.io": "unapproved, legacy API"
 spec:
   group: cluster.k8s.io
-  version: v1alpha1
   scope: Namespaced
   names:
     kind: Cluster
     plural: clusters
-  subresources:
-    # status enables the status subresource.
-    status: {}
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          x-kubernetes-preserve-unknown-fields: true
+          type: object
+      subresources:
+        # status enables the status subresource.
+        status: {}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -619,7 +647,7 @@ webhooks:
   - name: machinedeployments.machine-controller.kubermatic.io
     failurePolicy: Fail
     sideEffects: None
-    admissionReviewVersions: ["v1", "v1beta1"]
+    admissionReviewVersions: ["v1"]
     rules:
       - apiGroups:
           - "cluster.k8s.io"
@@ -640,7 +668,7 @@ webhooks:
   - name: machines.machine-controller.kubermatic.io
     failurePolicy: Fail
     sideEffects: None
-    admissionReviewVersions: ["v1", "v1beta1"]
+    admissionReviewVersions: ["v1"]
     rules:
       - apiGroups:
           - "cluster.k8s.io"


### PR DESCRIPTION
**What this PR does / why we need it**:
In kubernetes 1.22 API apiextensions/v1beta1 will be deleted, so here's upgraded version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade machinecontroller addon apiextensions to v1 API
```
