### PR TITLE
Update hetzner CCM manifest to v1.9.1

### DIFF
--- a/addons/ccm-hetzner/ccm-hetzner.yaml
+++ b/addons/ccm-hetzner/ccm-hetzner.yaml
@@ -29,8 +29,6 @@ spec:
   selector:
     matchLabels:
       app: hcloud-cloud-controller-manager
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:
@@ -39,6 +37,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: cloud-controller-manager
+      dnsPolicy: Default
       tolerations:
         # this taint is set by all kubelets running `--cloud-provider=external`
         # so we should tolerate it to schedule the cloud controller manager
@@ -49,9 +48,11 @@ spec:
           operator: "Exists"
         # cloud controller manages should be able to run on masters
         - key: "node-role.kubernetes.io/master"
-          operator: "Exists"
           effect: NoSchedule
-      hostNetwork: true
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
+        - key: "node.kubernetes.io/not-ready"
+          effect: "NoSchedule"
       containers:
         - image: {{ .InternalImages.Get "HetznerCCM" }}
           name: hcloud-cloud-controller-manager
@@ -79,6 +80,8 @@ spec:
                   name: cloud-provider-credentials
                   key: HZ_TOKEN
             {{ if .Config.CloudProvider.Hetzner.NetworkID -}}
+            - name: HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP
+              value: "true"
             - name: HCLOUD_NETWORK
               value: "{{ .Config.CloudProvider.Hetzner.NetworkID }}"
             {{- end }}

--- a/addons/csi-hetzner/hcloud-csi.yml
+++ b/addons/csi-hetzner/hcloud-csi.yml
@@ -8,7 +8,6 @@ spec:
   podInfoOnMount: true
   volumeLifecycleModes:
     - Persistent
-
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -20,14 +19,12 @@ metadata:
 provisioner: csi.hetzner.cloud
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
-
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hcloud-csi
   namespace: kube-system
-
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -76,7 +73,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
-
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,7 +86,6 @@ roleRef:
   kind: ClusterRole
   name: hcloud-csi
   apiGroup: rbac.authorization.k8s.io
-
 ---
 kind: StatefulSet
 apiVersion: apps/v1
@@ -109,6 +104,13 @@ spec:
         app: hcloud-csi-controller
     spec:
       serviceAccount: hcloud-csi
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
       containers:
         - name: csi-attacher
           image: quay.io/k8scsi/csi-attacher:v2.2.0
@@ -202,7 +204,6 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
-
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -315,7 +316,6 @@ spec:
           hostPath:
             path: /dev
             type: Directory
-
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -75,7 +75,7 @@ func baseResources() map[Resource]string {
 func optionalResources() map[Resource]string {
 	return map[Resource]string{
 		DigitaloceanCCM: "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.23",
-		HetznerCCM:      "docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.8.1",
+		HetznerCCM:      "docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.9.1",
 		OpenstackCCM:    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.17.0",
 		PacketCCM:       "docker.io/packethost/packet-ccm:v1.0.0",
 		VsphereCCM:      "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1",


### PR DESCRIPTION
**What this PR does / why we need it**:

* update to v1.9.1
* add HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP=true to env if network is configured

xref #1426

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update hetzner CCM manifest to v1.9.1
```
