### PR TITLE
Fix addind second container to machinecontroller webhook deployment

### DIFF
--- a/addons/machinecontroller/machine-controller.yaml
+++ b/addons/machinecontroller/machine-controller.yaml
@@ -583,7 +583,7 @@ spec:
       containers:
         - image: "{{ .InternalImages.Get "MachineController" }}"
           imagePullPolicy: IfNotPresent
-          name: webhook
+          name: machine-controller-webhook
           command:
             - /usr/local/bin/webhook
             - -logtostderr


### PR DESCRIPTION
Turns out, first kubectl apply with new labels somehow results to the machine-controller-webhook deployment with 2 identical containers, except the name! That means one of them will inevitably fail with "Bind Address" error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1432

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix addind second container to machinecontroller webhook deployment
```
