### PR TITLE
Explicitly enable DynamicKubeletConfig for kubernetes 1.22+

### DIFF
--- a/addons/machinecontroller/machine-controller.yaml
+++ b/addons/machinecontroller/machine-controller.yaml
@@ -589,6 +589,7 @@ spec:
             - -logtostderr
             - -v=4
             - -listen-address=0.0.0.0:9876
+            - -node-kubelet-feature-gates={{ .Config.KubeletFeatureGates }}
             {{ if .Config.CloudProvider.External }}
             - -node-external-cloud-provider
             {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Support kubernetes v1.22+

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support kubernetes v1.22+
```
