### PR TITLE
Update images

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,19 +16,19 @@ linters:
   - bodyclose
   - deadcode
   - errcheck
+  - exportloopref
   - goconst
   - gocritic
   - gocyclo
   - gofmt
   - goimports
-  - golint
   - gosec
   - gosimple
   - govet
   - ineffassign
   - misspell
   - nakedret
-  - scopelint
+  - revive
   - staticcheck
   - structcheck
   - stylecheck

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.16.1
+        - image: golang:1.16.7
           command:
             - make
           args:
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/wwhrd:0.4.0-1
+        - image: quay.io/kubermatic/wwhrd:0.4.0-2
           command:
             - make
           args:
@@ -64,7 +64,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.16.1
+        - image: golang:1.16.7
           command:
             - make
           args:
@@ -84,7 +84,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.16.1
+        - image: golang:1.16.7
           command:
             - make
           args:
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.38.0
+        - image: golangci/golangci-lint:v1.41.1
           command:
             - make
           args:
@@ -1184,7 +1184,7 @@ presubmits:
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
 postsubmits:
-  - name: ci-push-kubeone-e2e-image
+  - name: post-kubeone-push-e2e-image
     run_if_changed: "(hack/images/kubeone-e2e)"
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     decorate: true
@@ -1194,16 +1194,15 @@ postsubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/go-docker:16.1-1903-0
+        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-1
           command:
             - /bin/bash
             - -c
             - |
               set -euo pipefail
-
-              /usr/local/bin/entrypoint.sh && \
-              docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD && \
-              cd ./hack/images/kubeone-e2e && \
+              start-docker.sh
+              docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+              cd ./hack/images/kubeone-e2e
               ./release.sh
           # docker-in-docker needs privileged mode
           securityContext:

--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,13 +14,13 @@
 
 # building image
 
-FROM golang:1.16.5 as builder
+FROM golang:1.16.7 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip \
     upx-ucl
 
-ENV TERRAFORM_VERSION "1.0.0"
+ENV TERRAFORM_VERSION "1.0.4"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform
 RUN chmod +x /usr/local/bin/terraform
 
@@ -37,7 +37,7 @@ RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
-FROM golang:1.16.5
+FROM golang:1.16.7
 
 ARG version
 

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,10 +17,10 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.18"]="v1.18.17"
-full_versions["1.19"]="v1.19.9"
-full_versions["1.20"]="v1.20.5"
-full_versions["1.21"]="v1.21.0"
+full_versions["1.19"]="v1.19.14"
+full_versions["1.20"]="v1.20.10"
+full_versions["1.21"]="v1.21.4"
+full_versions["1.22"]="v1.22.0"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.16
+TAG=v0.1.17
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}

--- a/pkg/apis/kubeone/v1alpha1/conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/conversion.go
@@ -132,18 +132,11 @@ func Convert_kubeone_CloudProviderSpec_To_v1alpha1_CloudProviderSpec(in *kubeone
 }
 
 func Convert_kubeone_ClusterNetworkConfig_To_v1alpha1_ClusterNetworkConfig(in *kubeoneapi.ClusterNetworkConfig, out *ClusterNetworkConfig, s conversion.Scope) error {
-	if err := autoConvert_kubeone_ClusterNetworkConfig_To_v1alpha1_ClusterNetworkConfig(in, out, s); err != nil {
-		return err
-	}
-	return nil
+	return autoConvert_kubeone_ClusterNetworkConfig_To_v1alpha1_ClusterNetworkConfig(in, out, s)
 }
 
 func Convert_v1alpha1_ClusterNetworkConfig_To_kubeone_ClusterNetworkConfig(in *ClusterNetworkConfig, out *kubeoneapi.ClusterNetworkConfig, s conversion.Scope) error {
-	if err := autoConvert_v1alpha1_ClusterNetworkConfig_To_kubeone_ClusterNetworkConfig(in, out, s); err != nil {
-		return err
-	}
-
-	return nil
+	return autoConvert_v1alpha1_ClusterNetworkConfig_To_kubeone_ClusterNetworkConfig(in, out, s)
 }
 
 func Convert_v1alpha1_HostConfig_To_kubeone_HostConfig(in *HostConfig, out *kubeoneapi.HostConfig, s conversion.Scope) error {

--- a/pkg/features/podnodeselector.go
+++ b/pkg/features/podnodeselector.go
@@ -53,11 +53,8 @@ func installPodNodeSelector(ctx context.Context, c client.Client, feature *kubeo
 	if err := annotateKubeSystemNamespace(ctx, c); err != nil {
 		return err
 	}
-	if err := deletePendingPods(ctx, c); err != nil {
-		return err
-	}
 
-	return nil
+	return deletePendingPods(ctx, c)
 }
 
 // annotateKubeSystemNamespace adds the scheduler.alpha.kubernetes.io/node-selector: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update Go to 1.16.7
* Update golangci-lint to 1.41.1
  * Replece deprecated `golint` with `revive`
  * Replace deprecated `scopelint` with `exportloopref`
  * Fix lint errors after updating linters
* Rename `ci-push-kubeone-e2e-image` to `post-kubeone-push-e2e-image`
  * Change image to `quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-1`
* Update the `kubeone-e2e` image
  * Use Go 1.16.7
  * Update Kubernetes binaries to the latest versions
  * Remove 1.18 binaries and add 1.22 binaries

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 