### PR TITLE
Remove upx from the kubeone-e2e image

### DIFF
--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -17,8 +17,7 @@
 FROM golang:1.16.7 as builder
 
 RUN apt-get update && apt-get install -y \
-    unzip \
-    upx-ucl
+    unzip
 
 ENV TERRAFORM_VERSION "1.0.4"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -53,9 +53,6 @@ for version in "${!full_versions[@]}"; do
     rm "${directory}"/kubernetes/platforms/linux/amd64/genyaml
     rm "${directory}"/kubernetes/platforms/linux/amd64/kubemark
     rm "${directory}"/kubernetes/platforms/linux/amd64/linkcheck
-    if [ "$(command -v upx)" ]; then
-      upx "${directory}"/kubernetes/platforms/linux/amd64/*
-    fi
   fi
 done
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The Kubernetes 1.22 binaries are not compatible with `upx`, so we decided to stop using it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 