### PR TITLE
terraform/vsphere: Inherit firmware settings from the template VM

### DIFF
--- a/examples/terraform/vsphere/main.tf
+++ b/examples/terraform/vsphere/main.tf
@@ -66,6 +66,7 @@ resource "vsphere_virtual_machine" "control_plane" {
   memory           = var.control_plane_memory
   guest_id         = data.vsphere_virtual_machine.template.guest_id
   scsi_type        = data.vsphere_virtual_machine.template.scsi_type
+  firmware         = data.vsphere_virtual_machine.template.firmware
 
   network_interface {
     network_id   = data.vsphere_network.network.id


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the Terraform configs for vSphere to inherit the firmware settings from the template VM. By default, BIOS is used as firmware:

> firmware - (Optional) The firmware interface to use on the virtual machine. Can be one of bios or EFI. Default: bios.

This can cause a problem if the template was created with EFI. In that case, the created machine would use BIOS and it could be unbootable because the template machine was configured as an EFI machine.

**Does this PR introduce a user-facing change?**:
```release-note
Inherit the firmware settings from the template VM in the Terraform configs for vSphere
```

/assign @kron4eg 