### PR TITLE
Add Kubernetes 1.22 tests and remove 1.18 tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -167,6 +167,8 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
+            - name: TF_VAR_worker_deploy_ssh_key
+              value: "false"
             - name: TEST_OS_CONTROL_PLANE
               value: "flatcar"
             - name: TEST_OS_WORKERS

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -279,6 +279,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "aws"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: KUBEONE_TEST_RUN
@@ -382,6 +384,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "digitalocean"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: KUBEONE_TEST_RUN
@@ -485,6 +489,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "hetzner"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: KUBEONE_TEST_RUN
@@ -594,6 +600,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "gce"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: KUBEONE_TEST_RUN
@@ -699,6 +707,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "packet"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: KUBEONE_TEST_RUN
@@ -802,6 +812,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "openstack"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: KUBEONE_TEST_RUN
@@ -914,6 +926,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "aws"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
@@ -997,6 +1011,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "digitalocean"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -1078,6 +1094,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "hetzner"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -1163,6 +1181,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "gce"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -1246,6 +1266,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "packet"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -1327,6 +1349,8 @@ presubmits:
           env:
             - name: PROVIDER
               value: "openstack"
+            - name: CONTAINER_RUNTIME
+              value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -127,7 +127,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -156,7 +156,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -191,7 +191,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -218,7 +218,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -245,7 +245,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -270,7 +270,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -298,7 +298,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -323,7 +323,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -348,7 +348,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -373,7 +373,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -401,7 +401,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -426,7 +426,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -451,7 +451,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -476,7 +476,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -504,7 +504,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -531,7 +531,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -558,7 +558,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -585,7 +585,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -615,7 +615,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -640,7 +640,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -665,7 +665,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -690,7 +690,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -718,7 +718,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -743,7 +743,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -768,7 +768,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -793,7 +793,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -821,7 +821,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -851,7 +851,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -879,7 +879,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -905,7 +905,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -933,7 +933,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -964,7 +964,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -990,7 +990,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1016,7 +1016,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1042,7 +1042,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1071,7 +1071,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1097,7 +1097,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1123,7 +1123,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1149,7 +1149,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1178,7 +1178,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1206,7 +1206,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1234,7 +1234,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1262,7 +1262,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1293,7 +1293,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1319,7 +1319,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1345,7 +1345,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1371,7 +1371,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1400,7 +1400,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1426,7 +1426,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1452,7 +1452,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make
@@ -1478,7 +1478,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.16
+        - image: kubermatic/kubeone-e2e:v0.1.17
           imagePullPolicy: Always
           command:
             - make

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -203,7 +203,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -230,7 +230,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -255,7 +255,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -308,7 +308,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -333,7 +333,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -358,7 +358,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -411,7 +411,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -436,7 +436,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -461,7 +461,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -514,7 +514,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -541,7 +541,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -568,7 +568,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -625,7 +625,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -650,7 +650,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -675,7 +675,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -728,7 +728,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -753,7 +753,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -778,7 +778,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -837,7 +837,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -865,7 +865,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -889,9 +889,9 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -917,9 +917,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -945,7 +945,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: TEST_TIMEOUT
@@ -976,7 +976,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1000,9 +1000,9 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1026,9 +1026,9 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1052,7 +1052,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: TEST_TIMEOUT
@@ -1083,7 +1083,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1107,9 +1107,9 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1133,9 +1133,9 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1159,7 +1159,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: TEST_TIMEOUT
@@ -1190,7 +1190,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1216,9 +1216,9 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1244,9 +1244,9 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1272,7 +1272,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: TEST_TIMEOUT
@@ -1305,7 +1305,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1329,9 +1329,9 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1355,9 +1355,9 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1381,7 +1381,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: TEST_TIMEOUT
@@ -1412,7 +1412,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.18.20"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1436,9 +1436,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.12"
+              value: "1.19.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1462,9 +1462,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.8"
+              value: "1.20.10"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1488,7 +1488,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.2"
+              value: "1.21.4"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.0"
             - name: TEST_TIMEOUT

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -116,9 +116,9 @@ presubmits:
             limits:
               memory: 2Gi
   #########################################################
-  # E2E/Conformance tests (AWS, 1.18-1.22)
+  # E2E/Conformance tests (AWS, 1.19-1.22)
   #########################################################
-  - name: pull-kubeone-e2e-aws-containerd-conformance-1.18
+  - name: pull-kubeone-e2e-aws-containerd-conformance-1.19
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
@@ -141,13 +141,13 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
+              value: "1.19.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
             requests:
               cpu: 1
-  - name: pull-kubeone-e2e-aws-flatcar-containerd-conformance-1.18
+  - name: pull-kubeone-e2e-aws-flatcar-containerd-conformance-1.19
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
@@ -176,7 +176,7 @@ presubmits:
             - name: TF_VAR_bastion_user
               value: "core"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.18.20"
+              value: "1.19.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -812,7 +812,7 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (AWS)
   #########################################################
-  - name: pull-kubeone-e2e-aws-upgrade-containerd-1.18-1.19
+  - name: pull-kubeone-e2e-aws-upgrade-containerd-1.19-1.20
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
@@ -832,34 +832,6 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.20"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
-  - name: pull-kubeone-e2e-aws-upgrade-1.18-1.19
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-aws: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.17
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "aws"
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
@@ -955,32 +927,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (DigitalOcean)
   #########################################################
-  - name: pull-kubeone-e2e-digitalocean-upgrade-1.18-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-digitalocean: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.17
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "digitalocean"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.20"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-digitalocean-upgrade-1.19-1.20
     always_run: false
     decorate: true
@@ -1062,32 +1008,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (Hetzner)
   #########################################################
-  - name: pull-kubeone-e2e-hetzner-upgrade-1.18-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-hetzner: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.17
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "hetzner"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.20"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-hetzner-upgrade-1.19-1.20
     always_run: false
     decorate: true
@@ -1169,34 +1089,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (GCE)
   #########################################################
-  - name: pull-kubeone-e2e-gce-upgrade-1.18-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-gce: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.17
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "gce"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.20"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
-            - name: TF_VAR_project
-              value: "kubeone-terraform-test"
   - name: pull-kubeone-e2e-gce-upgrade-1.19-1.20
     always_run: false
     decorate: true
@@ -1284,32 +1176,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (Packet)
   #########################################################
-  - name: pull-kubeone-e2e-packet-upgrade-1.18-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-packet: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.17
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "packet"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.20"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-packet-upgrade-1.19-1.20
     always_run: false
     decorate: true
@@ -1391,32 +1257,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (OpenStack)
   #########################################################
-  - name: pull-kubeone-e2e-openstack-upgrade-1.18-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-openstack: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.17
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "openstack"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.20"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-openstack-upgrade-1.19-1.20
     always_run: false
     decorate: true

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -116,7 +116,7 @@ presubmits:
             limits:
               memory: 2Gi
   #########################################################
-  # E2E/Conformance tests (AWS, 1.18-1.21)
+  # E2E/Conformance tests (AWS, 1.18-1.22)
   #########################################################
   - name: pull-kubeone-e2e-aws-containerd-conformance-1.18
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
@@ -261,8 +261,33 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-aws-conformance-1.22
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-aws: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "aws"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
   #########################################################
-  # E2E/Conformance tests (DigitalOcean, 1.19-1.21)
+  # E2E/Conformance tests (DigitalOcean, 1.19-1.22)
   #########################################################
   - name: pull-kubeone-e2e-digitalocean-conformance-1.19
     always_run: false
@@ -339,8 +364,33 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-digitalocean-conformance-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-digitalocean: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
   #########################################################
-  # E2E/Conformance tests (Hetzner, 1.19-1.21)
+  # E2E/Conformance tests (Hetzner, 1.19-1.22)
   #########################################################
   - name: pull-kubeone-e2e-hetzner-conformance-1.19
     always_run: false
@@ -417,8 +467,33 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-hetzner-conformance-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-hetzner: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "hetzner"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
   #########################################################
-  # E2E/Conformance tests (GCE, 1.19-1.21)
+  # E2E/Conformance tests (GCE, 1.19-1.22)
   #########################################################
   - name: pull-kubeone-e2e-gce-conformance-1.19
     always_run: false
@@ -501,8 +576,35 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-gce-conformance-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-gce: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "gce"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+            - name: TF_VAR_project
+              value: "kubeone-terraform-test"
+          resources:
+            requests:
+              cpu: 1
   #########################################################
-  # E2E/Conformance tests (Packet, 1.19-1.21)
+  # E2E/Conformance tests (Packet, 1.19-1.22)
   #########################################################
   - name: pull-kubeone-e2e-packet-conformance-1.19
     always_run: false
@@ -579,8 +681,33 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-packet-conformance-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-packet: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "packet"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
   #########################################################
-  # E2E/Conformance tests (OpenStack, 1.19-1.21)
+  # E2E/Conformance tests (OpenStack, 1.19-1.22)
   #########################################################
   - name: pull-kubeone-e2e-openstack-conformance-1.19
     always_run: false
@@ -652,6 +779,31 @@ presubmits:
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.21.2"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
+  - name: pull-kubeone-e2e-openstack-conformance-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -772,6 +924,34 @@ presubmits:
               valut: "120m"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-aws-upgrade-1.21-1.22
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-aws: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "aws"
+            - name: TF_VAR_initial_machinedeployment_spotinstances
+              value: "true"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.21.2"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
   #########################################################
   # E2E/Upgrade tests (DigitalOcean)
   #########################################################
@@ -853,6 +1033,32 @@ presubmits:
               valut: "120m"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-digitalocean-upgrade-1.21-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-digitalocean: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.21.2"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
   #########################################################
   # E2E/Upgrade tests (Hetzner)
   #########################################################
@@ -930,6 +1136,32 @@ presubmits:
               value: "1.20.8"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.21.2"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-hetzner-upgrade-1.21-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-hetzner: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "hetzner"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.21.2"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1021,6 +1253,34 @@ presubmits:
               value: "TestClusterUpgrade"
             - name: TF_VAR_project
               value: "kubeone-terraform-test"
+  - name: pull-kubeone-e2e-gce-upgrade-1.21-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-gce: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "gce"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.21.2"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
+            - name: TF_VAR_project
+              value: "kubeone-terraform-test"
   #########################################################
   # E2E/Upgrade tests (Packet)
   #########################################################
@@ -1102,6 +1362,32 @@ presubmits:
               valut: "120m"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-packet-upgrade-1.21-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-packet: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "packet"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.21.2"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
   #########################################################
   # E2E/Upgrade tests (OpenStack)
   #########################################################
@@ -1179,6 +1465,32 @@ presubmits:
               value: "1.20.8"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.21.2"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-openstack-upgrade-1.21-1.22
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.16
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.21.2"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.22.0"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds tests for Kubernetes 1.22 and removes tests for Kubernetes 1.18 since it's EOL.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 