### PR TITLE
Enable PodSecurity admission controller for 1.22 clusters

### DIFF
--- a/pkg/kubeflags/data.go
+++ b/pkg/kubeflags/data.go
@@ -62,11 +62,32 @@ var (
 		"ResourceQuota",
 	}
 
-	defaultAdmissionControllersv118x = []string{
+	defaultAdmissionControllersv118xv121x = []string{
 		"NamespaceLifecycle",
 		"LimitRanger",
 		"ServiceAccount",
 		"TaintNodesByCondition",
+		"Priority",
+		"DefaultTolerationSeconds",
+		"DefaultStorageClass",
+		"StorageObjectInUseProtection",
+		"PersistentVolumeClaimResize",
+		"RuntimeClass",
+		"CertificateApproval",
+		"CertificateSigning",
+		"CertificateSubjectRestriction",
+		"DefaultIngressClass",
+		"MutatingAdmissionWebhook",
+		"ValidatingAdmissionWebhook",
+		"ResourceQuota",
+	}
+
+	defaultAdmissionControllersv122x = []string{
+		"NamespaceLifecycle",
+		"LimitRanger",
+		"ServiceAccount",
+		"TaintNodesByCondition",
+		"PodSecurity",
 		"Priority",
 		"DefaultTolerationSeconds",
 		"DefaultStorageClass",

--- a/pkg/kubeflags/flags.go
+++ b/pkg/kubeflags/flags.go
@@ -26,7 +26,8 @@ var (
 	constrainv114x      = mustConstraint(">= 1.14.0, < 1.15.0")
 	constrainv115x      = mustConstraint("1.15.x")
 	constrainv116xv117x = mustConstraint(">= 1.16.0, < 1.18.0")
-	constrainv118x      = mustConstraint("1.18.x")
+	constrainv118xv121x = mustConstraint(">= 1.18.0, < 1.22.0")
+	constrainv122x      = mustConstraint("1.22.x")
 )
 
 // DefaultAdmissionControllers return list of default admission controllers for
@@ -39,12 +40,14 @@ func DefaultAdmissionControllers(kubeVersion *semver.Version) string {
 		return strings.Join(defaultAdmissionControllersv115x, ",")
 	case constrainv116xv117x.Check(kubeVersion):
 		return strings.Join(defaultAdmissionControllersv116xv117x, ",")
-	case constrainv118x.Check(kubeVersion):
-		return strings.Join(defaultAdmissionControllersv118x, ",")
+	case constrainv118xv121x.Check(kubeVersion):
+		return strings.Join(defaultAdmissionControllersv118xv121x, ",")
+	case constrainv122x.Check(kubeVersion):
+		return strings.Join(defaultAdmissionControllersv122x, ",")
 	}
 
 	// return same as for last known release
-	return strings.Join(defaultAdmissionControllersv118x, ",")
+	return strings.Join(defaultAdmissionControllersv122x, ",")
 }
 
 func mustConstraint(c string) *semver.Constraints {


### PR DESCRIPTION
**What this PR does / why we need it**:

`PodSecurity` is a new admission controller that's enabled by default on the 1.22 API server.

**Does this PR introduce a user-facing change?**:
```release-note
Enable PodSecurity admission controller for 1.22 clusters
```

/assign @kron4eg 