### PR TITLE
Add support for versioned images

### DIFF
--- a/pkg/cmd/config-images.go
+++ b/pkg/cmd/config-images.go
@@ -116,7 +116,10 @@ func listImages(opts *listImagesOpts) error {
 			}
 			return ""
 		})
-		resolveropts = append(resolveropts, overRegGetter)
+		kubeVerGetter := images.WithKubernetesVersionGetter(func() string {
+			return conf.Versions.Kubernetes
+		})
+		resolveropts = append(resolveropts, overRegGetter, kubeVerGetter)
 	}
 
 	imgResolver := images.NewResolver(resolveropts...)

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -62,6 +62,13 @@ func New(ctx context.Context) (*State, error) {
 
 			return s.Cluster.RegistryConfiguration.OverwriteRegistry
 		}),
+		images.WithKubernetesVersionGetter(func() string {
+			if s.Cluster == nil {
+				return "0.0.0"
+			}
+
+			return s.Cluster.Versions.Kubernetes
+		}),
 	)
 
 	return s, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Some components and addons, such as external CCMs and CSI drivers, have different images for different Kubernetes versions. This PR extends the package we use to handle images to select the image based on the Kubernetes version.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 