### PR TITLE
Automatically deploy CSI plugin and driver for supported providers, and add support for OpenStack Cinder CSI

### DIFF
--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -68,6 +68,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - '*'
@@ -99,6 +105,32 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-node-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:cloud-controller-manager
@@ -109,6 +141,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-node-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-node-controller
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-controller
   namespace: kube-system
 ---
 apiVersion: apps/v1

--- a/addons/csi-openstack-cinder/controllerplugin-rbac.yaml
+++ b/addons/csi-openstack-cinder/controllerplugin-rbac.yaml
@@ -1,0 +1,196 @@
+# This YAML file contains RBAC API objects,
+# which are necessary to run csi controller plugin
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-cinder-controller-sa
+  namespace: kube-system
+
+---
+# external attacher
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# external Provisioner
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# external snapshotter
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+---
+
+# External Resizer
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role
+rules:
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: external-resizer-cfg
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role-cfg
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: external-resizer-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/addons/csi-openstack-cinder/controllerplugin.yaml
+++ b/addons/csi-openstack-cinder/controllerplugin.yaml
@@ -1,0 +1,170 @@
+# This YAML file contains CSI Controller Plugin Sidecars
+# external-attacher, external-provisioner, external-snapshotter
+# external-resize, liveness-probe
+{{ $version := semver .Config.Versions.Kubernetes }}
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-cinder-controller-service
+  namespace: kube-system
+  labels:
+    app: csi-cinder-controllerplugin
+spec:
+  selector:
+    app: csi-cinder-controllerplugin
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-cinder-controllerplugin
+  namespace: kube-system
+spec:
+  serviceName: "csi-cinder-controller-service"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-cinder-controllerplugin
+  template:
+    metadata:
+      labels:
+        app: csi-cinder-controllerplugin
+    spec:
+      serviceAccount: csi-cinder-controller-sa
+      containers:
+        - name: csi-attacher
+          image: {{ .InternalImages.Get "CSIAttacher" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-provisioner
+          image: {{ .InternalImages.Get "CSIProvisioner" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+{{ if ge $version.Minor 21 }}
+            # --default-fstype and --feature-gates is only used since CSI v1.21.0
+            - "--default-fstype=ext4"
+            - "--feature-gates=Topology=true"
+{{ end }}
+{{ if ge $version.Minor 20 }}
+            # --extra-create-metadata is only used since CSI v1.20.0
+            - "--extra-create-metadata"
+{{ end }}
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-snapshotter
+          image: {{ .InternalImages.Get "CSISnapshotter" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+{{ if ge $version.Minor 20 }}
+            # --extra-create-metadata is only used since CSI v1.20.0
+            - "--extra-create-metadata"
+{{ end }}
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+        - name: csi-resizer
+          image: {{ .InternalImages.Get "CSIResizer" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+            - "--handle-volume-inuse-error=false"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: liveness-probe
+          image: {{ .InternalImages.Get "CSILivenessProbe" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+        - name: cinder-csi-plugin
+          image: {{ .InternalImages.Get "OpenstackCSI" }}
+          args:
+            - /bin/cinder-csi-plugin
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--cloud-config=$(CLOUD_CONFIG)"
+            - "--cluster=$(CLUSTER_NAME)"
+{{ if lt $version.Minor 22 }}
+            # --nodeid is deprecated and no-op starting with CSI 1.22.0
+            - "--nodeid=$(NODE_ID)"
+{{ end }}
+          env:
+{{ if lt $version.Minor 22 }}
+            # --nodeid is deprecated and no-op starting with CSI 1.22.0
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+{{ end }}
+            - name: CSI_ENDPOINT
+              value: unix://csi/csi.sock
+            - name: CLOUD_CONFIG
+              value: /etc/config/cloud.conf
+            - name: CLUSTER_NAME
+              value: {{ .Config.Name }}
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          # The probe
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 60
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: secret-cinderplugin
+              mountPath: /etc/config
+              readOnly: true
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}
+      volumes:
+        - name: socket-dir
+          emptyDir:
+        - name: secret-cinderplugin
+          secret:
+            secretName: cloud-config
+{{ if .Config.CABundle }}
+{{ caBundleVolume | indent 8 }}
+{{ end }}

--- a/addons/csi-openstack-cinder/driver.yaml
+++ b/addons/csi-openstack-cinder/driver.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{ if lt $version.Minor 19 }}
+apiVersion: storage.k8s.io/v1beta1
+{{ else }}
+apiVersion: storage.k8s.io/v1 # the v1 API was introduced in 1.19
+{{ end }}
+kind: CSIDriver
+metadata:
+  name: cinder.csi.openstack.org
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+  volumeLifecycleModes:
+  - Persistent
+  - Ephemeral

--- a/addons/csi-openstack-cinder/nodeplugin-rbac.yaml
+++ b/addons/csi-openstack-cinder/nodeplugin-rbac.yaml
@@ -1,0 +1,30 @@
+# This YAML defines all API objects to create RBAC roles for csi node plugin.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-cinder-node-sa
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-node-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-nodeplugin-role
+  apiGroup: rbac.authorization.k8s.io

--- a/addons/csi-openstack-cinder/nodeplugin.yaml
+++ b/addons/csi-openstack-cinder/nodeplugin.yaml
@@ -1,0 +1,139 @@
+# This YAML file contains driver-registrar & csi driver nodeplugin API objects,
+# which are necessary to run csi nodeplugin for cinder.
+{{ $version := semver .Config.Versions.Kubernetes }}
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-cinder-nodeplugin
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-cinder-nodeplugin
+  template:
+    metadata:
+      labels:
+        app: csi-cinder-nodeplugin
+    spec:
+      tolerations:
+        - operator: Exists
+      serviceAccount: csi-cinder-node-sa
+      hostNetwork: true
+      containers:
+        - name: node-driver-registrar
+          image: {{ .InternalImages.Get "CSINodeDriverRegistar" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+{{ if lt $version.Minor 22 }}
+          # This is not used since CSI v1.22.0
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/cinder.csi.openstack.org /registration/cinder.csi.openstack.org-reg.sock"]
+{{ end }}
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/cinder.csi.openstack.org/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: liveness-probe
+          image: {{ .InternalImages.Get "CSILivenessProbe" }}
+          args:
+            - --csi-address=/csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: cinder-csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: {{ .InternalImages.Get "OpenstackCSI" }}
+          args:
+            - /bin/cinder-csi-plugin
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--cloud-config=$(CLOUD_CONFIG)"
+{{ if lt $version.Minor 22 }}
+            # --nodeid is deprecated and no-op starting with CSI 1.22.0
+            - "--nodeid=$(NODE_ID)"
+{{ end }}
+          env:
+{{ if lt $version.Minor 22 }}
+            # --nodeid is deprecated and no-op starting with CSI 1.22.0
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+{{ end }}
+            - name: CSI_ENDPOINT
+              value: unix://csi/csi.sock
+            - name: CLOUD_CONFIG
+              value: /etc/config/cloud.conf
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          # The probe
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: pods-probe-dir
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
+            - name: secret-cinderplugin
+              mountPath: /etc/config
+              readOnly: true
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/cinder.csi.openstack.org
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: pods-probe-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: secret-cinderplugin
+          secret:
+            secretName: cloud-config
+{{ if .Config.CABundle }}
+{{ caBundleVolume | indent 8 }}
+{{ end }}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -26,6 +26,7 @@ import (
 	"k8c.io/kubeone/pkg/features"
 	"k8c.io/kubeone/pkg/kubeconfig"
 	"k8c.io/kubeone/pkg/state"
+	"k8c.io/kubeone/pkg/templates/csi"
 	"k8c.io/kubeone/pkg/templates/externalccm"
 	"k8c.io/kubeone/pkg/templates/machinecontroller"
 	"k8c.io/kubeone/pkg/templates/resources"
@@ -222,6 +223,12 @@ func WithResources(t Tasks) Tasks {
 				Fn:          externalccm.Ensure,
 				ErrMsg:      "failed to ensure external CCM",
 				Description: "ensure external CCM",
+				Predicate:   func(s *state.State) bool { return s.Cluster.CloudProvider.External },
+			},
+			{
+				Fn:          csi.Ensure,
+				ErrMsg:      "failed to ensure CSI driver",
+				Description: "ensure CSI driver",
 				Predicate:   func(s *state.State) bool { return s.Cluster.CloudProvider.External },
 			},
 			{

--- a/pkg/templates/csi/csi.go
+++ b/pkg/templates/csi/csi.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/pkg/errors"
+
+	"k8c.io/kubeone/pkg/addons"
+	"k8c.io/kubeone/pkg/state"
+	"k8c.io/kubeone/pkg/templates/resources"
+)
+
+// Ensure external CCM deployen if Provider.External
+func Ensure(s *state.State) error {
+	if !s.Cluster.CloudProvider.External {
+		return nil
+	}
+
+	s.Logger.Info("Ensure CSI driver is up to date...")
+	var err error
+
+	switch {
+	case s.Cluster.CloudProvider.Hetzner != nil:
+		err = addons.EnsureAddonByName(s, resources.AddonCSIHetnzer)
+	case s.Cluster.CloudProvider.Openstack != nil:
+		if s.Cluster.CloudProvider.CloudConfig == "" {
+			return errors.New("cloudConfig not defined")
+		}
+		v, sErr := semver.NewVersion(s.Cluster.Versions.Kubernetes)
+		if sErr != nil {
+			return errors.Wrap(err, "failed to parse kubernetes version")
+		}
+		lessThan17, _ := semver.NewConstraint("< 1.17.0")
+		if lessThan17.Check(v) {
+			s.Logger.Infoln("CSI driver is not supported for OpenStack clusters running Kubernetes 1.16 or older, skipping")
+			return nil
+		}
+
+		err = addons.EnsureAddonByName(s, resources.AddonCSIOpenStackCinder)
+	default:
+		s.Logger.Infof("CSI driver for %q not yet supported, skipping", s.Cluster.CloudProvider.CloudProviderName())
+		return nil
+	}
+
+	return errors.Wrap(err, "failed to ensure CSI driver is installed")
+}

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -49,6 +49,12 @@ const (
 	CalicoCNI
 	CalicoController
 	CalicoNode
+	CSIAttacher
+	CSINodeDriverRegistar
+	CSIProvisioner
+	CSISnapshotter
+	CSIResizer
+	CSILivenessProbe
 	DigitaloceanCCM
 	DNSNodeCache
 	Flannel
@@ -56,6 +62,7 @@ const (
 	MachineController
 	MetricsServer
 	OpenstackCCM
+	OpenstackCSI
 	PacketCCM
 	VsphereCCM
 	WeaveNetCNIKube
@@ -86,13 +93,53 @@ func baseResources() map[Resource]map[string]string {
 
 func optionalResources() map[Resource]map[string]string {
 	return map[Resource]map[string]string{
-		AzureCCM:        {"*": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.1"},
-		AzureCNM:        {"*": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.1"},
+		// General CSI images (could be used for all providers)
+		CSIAttacher:           {">= 1.17.0": "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"},
+		CSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"},
+		CSIProvisioner:        {">= 1.17.0": "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"},
+		CSISnapshotter: {
+			">= 1.17.0, < 1.20.0": "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3",
+			">= 1.20.0":           "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0",
+		},
+		CSIResizer:       {">= 1.16.0": "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"},
+		CSILivenessProbe: {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.4.0"},
+
+		// Azure CCM
+		AzureCCM: {"*": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.1"},
+		AzureCNM: {"*": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.1"},
+
+		// DigitalOcean CCM
 		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.33"},
 		HetznerCCM:      {"*": "docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.9.1"},
-		OpenstackCCM:    {"*": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.17.0"},
-		PacketCCM:       {"*": "docker.io/packethost/packet-ccm:v1.0.0"},
-		VsphereCCM:      {"*": "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"},
+
+		// OpenStack CCM
+		OpenstackCCM: {
+			">= 1.16.0, < 1.18.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.17.0",
+			"1.18.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.18.2",
+			"1.19.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.19.2",
+			"1.20.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2",
+			"1.21.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0",
+			"1.22.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0",
+		},
+
+		// OpenStack CSI
+		OpenstackCSI: {
+			"1.16.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.16.0",
+			"1.17.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.17.0",
+			"1.18.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.18.0",
+			"1.19.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.19.0",
+			"1.20.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.3",
+			"1.21.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.21.0",
+			"1.22.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
+		},
+
+		// Packet CCM
+		PacketCCM: {"*": "docker.io/packethost/packet-ccm:v1.0.0"},
+
+		// vSphere CCM
+		VsphereCCM: {"*": "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"},
+
+		// WeaveNet CNI plugin
 		WeaveNetCNIKube: {"*": "docker.io/weaveworks/weave-kube:2.8.1"},
 		WeaveNetCNINPC:  {"*": "docker.io/weaveworks/weave-npc:2.8.1"},
 	}

--- a/pkg/templates/images/resource_string.go
+++ b/pkg/templates/images/resource_string.go
@@ -13,22 +13,29 @@ func _() {
 	_ = x[CalicoCNI-3]
 	_ = x[CalicoController-4]
 	_ = x[CalicoNode-5]
-	_ = x[DigitaloceanCCM-6]
-	_ = x[DNSNodeCache-7]
-	_ = x[Flannel-8]
-	_ = x[HetznerCCM-9]
-	_ = x[MachineController-10]
-	_ = x[MetricsServer-11]
-	_ = x[OpenstackCCM-12]
-	_ = x[PacketCCM-13]
-	_ = x[VsphereCCM-14]
-	_ = x[WeaveNetCNIKube-15]
-	_ = x[WeaveNetCNINPC-16]
+	_ = x[CSIAttacher-6]
+	_ = x[CSINodeDriverRegistar-7]
+	_ = x[CSIProvisioner-8]
+	_ = x[CSISnapshotter-9]
+	_ = x[CSIResizer-10]
+	_ = x[CSILivenessProbe-11]
+	_ = x[DigitaloceanCCM-12]
+	_ = x[DNSNodeCache-13]
+	_ = x[Flannel-14]
+	_ = x[HetznerCCM-15]
+	_ = x[MachineController-16]
+	_ = x[MetricsServer-17]
+	_ = x[OpenstackCCM-18]
+	_ = x[OpenstackCSI-19]
+	_ = x[PacketCCM-20]
+	_ = x[VsphereCCM-21]
+	_ = x[WeaveNetCNIKube-22]
+	_ = x[WeaveNetCNINPC-23]
 }
 
-const _Resource_name = "AzureCCMAzureCNMCalicoCNICalicoControllerCalicoNodeDigitaloceanCCMDNSNodeCacheFlannelHetznerCCMMachineControllerMetricsServerOpenstackCCMPacketCCMVsphereCCMWeaveNetCNIKubeWeaveNetCNINPC"
+const _Resource_name = "AzureCCMAzureCNMCalicoCNICalicoControllerCalicoNodeCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeDigitaloceanCCMDNSNodeCacheFlannelHetznerCCMMachineControllerMetricsServerOpenstackCCMOpenstackCSIPacketCCMVsphereCCMWeaveNetCNIKubeWeaveNetCNINPC"
 
-var _Resource_index = [...]uint8{0, 8, 16, 25, 41, 51, 66, 78, 85, 95, 112, 125, 137, 146, 156, 171, 185}
+var _Resource_index = [...]uint16{0, 8, 16, 25, 41, 51, 62, 83, 97, 111, 121, 137, 152, 164, 171, 181, 198, 211, 223, 235, 244, 254, 269, 283}
 
 func (i Resource) String() string {
 	i -= 1

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -24,16 +24,18 @@ import (
 
 // Names of the internal addons
 const (
-	AddonCCMDigitalOcean   = "ccm-digitalocean"
-	AddonCCMHetzner        = "ccm-hetzner"
-	AddonCCMOpenStack      = "ccm-openstack"
-	AddonCCMPacket         = "ccm-packet"
-	AddonCCMVsphere        = "ccm-vsphere"
-	AddonCNICanal          = "cni-canal"
-	AddonCNIWeavenet       = "cni-weavenet"
-	AddonMachineController = "machinecontroller"
-	AddonMetricsServer     = "metrics-server"
-	AddonNodeLocalDNS      = "nodelocaldns"
+	AddonCCMDigitalOcean    = "ccm-digitalocean"
+	AddonCCMHetzner         = "ccm-hetzner"
+	AddonCCMOpenStack       = "ccm-openstack"
+	AddonCCMPacket          = "ccm-packet"
+	AddonCCMVsphere         = "ccm-vsphere"
+	AddonCSIHetnzer         = "csi-hetzner"
+	AddonCSIOpenStackCinder = "csi-openstack-cinder"
+	AddonCNICanal           = "cni-canal"
+	AddonCNIWeavenet        = "cni-weavenet"
+	AddonMachineController  = "machinecontroller"
+	AddonMetricsServer      = "metrics-server"
+	AddonNodeLocalDNS       = "nodelocaldns"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces the following changes:

* OpenStack CCM version now depends on the Kubernetes version
    * Clusters running Kubernetes v1.17 and older will use OpenStack CCM v1.17, while newer clusters will use the recommended CCM version (e.g. 1.22 clusters will use CCM v1.22.0)
    * This ensures our users can use the latest features, while still respecting the compatibility matrix proposed by the OpenStack CCM team
* Deploy CSI plugin for supported clusters by default
    * Currently, this is supported only for Hetzner and OpenStack
    * The StorageClass is not created by default, so the user should do that manually
* Add support for OpenStack Cinder CSI plugin/driver
    * The minimum cluster version for OpenStack Cinder CSI is v1.17.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevant and required for #1451

**Special notes for your reviewer**:

I've used the following manifest to test the Cinder CSI plugin. I've tested it on 1.17 and 1.22 clusters. Other versions will follow up.

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    storageclass.beta.kubernetes.io/is-default-class: "true"
  labels:
    kubernetes.io/cluster-service: "true"
  name: cinder-csi
provisioner: cinder.csi.openstack.org
volumeBindingMode: WaitForFirstConsumer
---
# Source: https://github.com/kubernetes/cloud-provider-openstack/blob/master/examples/cinder-csi-plugin/resize/example.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: csi-pvc-cinderplugin
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: cinder-csi
---
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - image: nginx
    imagePullPolicy: IfNotPresent
    name: nginx
    ports:
    - containerPort: 80
      protocol: TCP
    volumeMounts:
      - mountPath: /var/lib/www/html
        name: csi-data-cinderplugin
  volumes:
  - name: csi-data-cinderplugin
    persistentVolumeClaim:
      claimName: csi-pvc-cinderplugin
      readOnly: false
```

**Does this PR introduce a user-facing change?**:
```release-note
* OpenStack CCM version now depends on the Kubernetes version. Clusters running Kubernetes v1.17 and older will use OpenStack CCM v1.17, while newer clusters will use the recommended CCM version (e.g. 1.22 clusters will use CCM v1.22.0)
* Deploy CSI plugin for supported clusters by default. Currently, this is supported for Hetzner and OpenStack (the minimum cluster version for OpenStack is v1.17.0). The StorageClass is not created by default, so the user should do that manually.
* Add support for OpenStack Cinder CSI plugin/driver
```

/assign @kron4eg 
/hold
for additional manual testing