### PR TITLE
Increase the minimum Kubernetes version to v1.19

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -849,9 +849,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.18.20"
-            - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.19.14"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.20.10"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN

--- a/addons/csi-openstack-cinder/driver.yaml
+++ b/addons/csi-openstack-cinder/driver.yaml
@@ -1,9 +1,4 @@
-{{ $version := semver .Config.Versions.Kubernetes }}
-{{ if lt $version.Minor 19 }}
 apiVersion: storage.k8s.io/v1beta1
-{{ else }}
-apiVersion: storage.k8s.io/v1 # the v1 API was introduced in 1.19
-{{ end }}
 kind: CSIDriver
 metadata:
   name: cinder.csi.openstack.org

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -177,8 +177,8 @@ func ValidateVersionConfig(version kubeone.VersionConfig, fldPath *field.Path) f
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, ".versions.kubernetes is not a semver string"))
 		return allErrs
 	}
-	if v.Major() != 1 || v.Minor() < 14 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, "kubernetes versions lower than 1.14 are not supported"))
+	if v.Major() != 1 || v.Minor() < 19 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, "kubernetes versions lower than 1.19 are not supported. You need to use an older KubeOne version to upgrade your cluster to v1.19. Please refer to the Compatibility section of docs for more details."))
 	}
 	if strings.HasPrefix(version.Kubernetes, "v") {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, ".versions.kubernetes can't start with a leading 'v'"))

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -60,7 +60,7 @@ func TestValidateKubeOneCluster(t *testing.T) {
 					AWS: &kubeone.AWSSpec{},
 				},
 				Versions: kubeone.VersionConfig{
-					Kubernetes: "1.18.2",
+					Kubernetes: "1.22.1",
 				},
 				MachineController: &kubeone.MachineControllerConfig{
 					Deploy: true,
@@ -110,7 +110,7 @@ func TestValidateKubeOneCluster(t *testing.T) {
 					AWS: &kubeone.AWSSpec{},
 				},
 				Versions: kubeone.VersionConfig{
-					Kubernetes: "1.18.2",
+					Kubernetes: "1.22.1",
 				},
 				MachineController: &kubeone.MachineControllerConfig{
 					Deploy: false,
@@ -160,7 +160,7 @@ func TestValidateKubeOneCluster(t *testing.T) {
 					AWS: &kubeone.AWSSpec{},
 				},
 				Versions: kubeone.VersionConfig{
-					Kubernetes: "1.18.2",
+					Kubernetes: "1.22.1",
 				},
 				MachineController: &kubeone.MachineControllerConfig{
 					Deploy: true,
@@ -561,72 +561,72 @@ func TestValidateVersionConfig(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name: "valid version config (1.18.2)",
+			name: "valid version config (1.22.1)",
 			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.18.2",
+				Kubernetes: "1.22.1",
 			},
 			expectedError: false,
 		},
 		{
-			name: "valid version config (1.18.0)",
+			name: "valid version config (1.22.0)",
+			versionConfig: kubeone.VersionConfig{
+				Kubernetes: "1.22.2",
+			},
+			expectedError: false,
+		},
+		{
+			name: "valid version config (1.21.4)",
+			versionConfig: kubeone.VersionConfig{
+				Kubernetes: "1.21.4",
+			},
+			expectedError: false,
+		},
+		{
+			name: "valid version config (1.21.0)",
+			versionConfig: kubeone.VersionConfig{
+				Kubernetes: "1.21.0",
+			},
+			expectedError: false,
+		},
+		{
+			name: "valid version config (1.20.10)",
+			versionConfig: kubeone.VersionConfig{
+				Kubernetes: "1.20.10",
+			},
+			expectedError: false,
+		},
+		{
+			name: "valid version config (1.20.0)",
+			versionConfig: kubeone.VersionConfig{
+				Kubernetes: "1.20.0",
+			},
+			expectedError: false,
+		},
+		{
+			name: "valid version config (1.19.0)",
+			versionConfig: kubeone.VersionConfig{
+				Kubernetes: "1.19.0",
+			},
+			expectedError: false,
+		},
+		{
+			name: "not supported kubernetes version (1.18.19)",
+			versionConfig: kubeone.VersionConfig{
+				Kubernetes: "1.18.19",
+			},
+			expectedError: true,
+		},
+		{
+			name: "not supported kubernetes version (1.18.0)",
 			versionConfig: kubeone.VersionConfig{
 				Kubernetes: "1.18.0",
 			},
-			expectedError: false,
+			expectedError: true,
 		},
 		{
-			name: "valid version config (1.17.5)",
-			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.17.5",
-			},
-			expectedError: false,
-		},
-		{
-			name: "valid version config (1.17.0)",
+			name: "not supported kubernetes version (1.17.0)",
 			versionConfig: kubeone.VersionConfig{
 				Kubernetes: "1.17.0",
-			},
-			expectedError: false,
-		},
-		{
-			name: "valid version config (1.16.9)",
-			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.16.9",
-			},
-			expectedError: false,
-		},
-		{
-			name: "valid version config (1.16.0)",
-			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.16.0",
-			},
-			expectedError: false,
-		},
-		{
-			name: "valid version config (1.14.0)",
-			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.14.0",
-			},
-			expectedError: false,
-		},
-		{
-			name: "not supported kubernetes version (1.13.5)",
-			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.13.5",
-			},
-			expectedError: true,
-		},
-		{
-			name: "not supported kubernetes version (1.13.0)",
-			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.13.0",
-			},
-			expectedError: true,
-		},
-		{
-			name: "not supported kubernetes version (1.12.0)",
-			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.12.0",
 			},
 			expectedError: true,
 		},
@@ -640,7 +640,7 @@ func TestValidateVersionConfig(t *testing.T) {
 		{
 			name: "kubernetes version with a leading 'v'",
 			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "v1.18.2",
+				Kubernetes: "v1.22.1",
 			},
 			expectedError: true,
 		},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -94,15 +94,15 @@ func baseResources() map[Resource]map[string]string {
 func optionalResources() map[Resource]map[string]string {
 	return map[Resource]map[string]string{
 		// General CSI images (could be used for all providers)
-		CSIAttacher:           {">= 1.17.0": "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"},
 		CSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"},
-		CSIProvisioner:        {">= 1.17.0": "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"},
+		CSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.4.0"},
+		CSIAttacher:           {">= 1.19.0": "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"},
+		CSIProvisioner:        {">= 1.19.0": "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"},
+		CSIResizer:            {">= 1.19.0": "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"},
 		CSISnapshotter: {
-			">= 1.17.0, < 1.20.0": "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3",
+			">= 1.19.0, < 1.20.0": "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3",
 			">= 1.20.0":           "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0",
 		},
-		CSIResizer:       {">= 1.16.0": "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"},
-		CSILivenessProbe: {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.4.0"},
 
 		// Azure CCM
 		AzureCCM: {"*": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.1"},
@@ -114,23 +114,18 @@ func optionalResources() map[Resource]map[string]string {
 
 		// OpenStack CCM
 		OpenstackCCM: {
-			">= 1.16.0, < 1.18.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.17.0",
-			"1.18.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.18.2",
-			"1.19.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.19.2",
-			"1.20.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2",
-			"1.21.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0",
-			"1.22.x":              "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0",
+			"1.19.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.19.2",
+			"1.20.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2",
+			"1.21.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0",
+			">= 1.22.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0",
 		},
 
 		// OpenStack CSI
 		OpenstackCSI: {
-			"1.16.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.16.0",
-			"1.17.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.17.0",
-			"1.18.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.18.0",
-			"1.19.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.19.0",
-			"1.20.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.3",
-			"1.21.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.21.0",
-			"1.22.x": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
+			"1.19.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.19.0",
+			"1.20.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.3",
+			"1.21.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.21.0",
+			">= 1.22.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
 		},
 
 		// Packet CCM


### PR DESCRIPTION
**What this PR does / why we need it**:

The minimum Kubernetes version that can be managed by KubeOne is now 1.19. Users running older Kubernetes versions have to use an older KubeOne release to upgrade their clusters to Kubernetes 1.19 or newer.

**Does this PR introduce a user-facing change?**:
```release-note
The minimum Kubernetes version that can be managed by KubeOne is now 1.19. Users running Kubernetes 1.18 or older must use an older KubeOne release to upgrade their clusters to Kubernetes 1.19 or newer.
```

/assign @kron4eg @shaase-ctrl 