### PR TITLE
Improve kubeone reset output

### DIFF
--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -103,9 +103,12 @@ func runReset(opts *resetOpts) error {
 		return errors.Wrap(err, "failed to initialize State")
 	}
 
-	s.Logger.Warnln("this command will require an explicit confirmation starting with the next minor release (v1.3)")
+	// We intentionally ignore error because "kubeone reset" might also be used
+	// on clusters that are not yet provisioned or broken
+	_ = kubeconfig.BuildKubernetesClientset(s)
 
-	fmt.Println("The following nodes will be reset. The Kubernetes cluster running on those nodes will be permanently destroyed ")
+	s.Logger.Warnln("This command will PERMANENTLY destroy the Kubernetes cluster running on the following nodes:")
+
 	for _, node := range s.Cluster.ControlPlane.Hosts {
 		fmt.Printf("\t- reset control plane node %q (%s)\n", node.Hostname, node.PrivateAddress)
 	}
@@ -113,19 +116,28 @@ func runReset(opts *resetOpts) error {
 		fmt.Printf("\t- reset static worker nodes %q (%s)\n", node.Hostname, node.PrivateAddress)
 	}
 
-	err = kubeconfig.BuildKubernetesClientset(s)
-	if err == nil {
+	if s.DynamicClient != nil {
 		// Gather information about machine-controller managed nodes
 		machines := clusterv1alpha1.MachineList{}
 		if err = s.DynamicClient.List(s.Context, &machines); err != nil {
-			s.Logger.Warnln("Failed to list Machines. Worker nodes will not be deleted. If there are worker nodes in the cluster, you might have to delete them manually.")
+			s.Logger.Errorln("Failed to list machine-controller managed Machines.")
+			s.Logger.Warnln("Worker nodes might not be deleted. If there are worker nodes in the cluster, you might have to delete them manually.")
 		}
-		for _, machine := range machines.Items {
-			fmt.Printf("\t- reset machine-controller managed machine %q\n", machine.Name)
+
+		if len(machines.Items) > 0 {
+			fmt.Printf("\nThe following machine-controller managed worker nodes will be destroyed:\n")
+			for _, machine := range machines.Items {
+				fmt.Printf("\t- %s/%s\n", machine.Namespace, machine.Name)
+			}
 		}
 	} else {
-		s.Logger.Warnln("Failed to list Machines. Worker nodes will not be deleted. If there are worker nodes in the cluster, you might have to delete them manually.")
+		s.Logger.Warnln("Failed to list machine-controller managed Machines.")
+		s.Logger.Warnln("Worker nodes might not be deleted.")
+		s.Logger.Warnln("If there are worker nodes in the cluster, you might have to delete them manually.")
+		s.Logger.Warnln("You can ignore this warning if the cluster isn't provisioned.")
 	}
+
+	fmt.Printf("\nAfter the command is complete, there's NO way to recover the cluster or its data!\n")
 
 	confirm, err := confirmCommand(opts.AutoApprove)
 	if err != nil {

--- a/pkg/tasks/reset.go
+++ b/pkg/tasks/reset.go
@@ -39,6 +39,10 @@ func destroyWorkers(s *state.State) error {
 	s.Logger.Infoln("Destroying worker nodes...")
 
 	_ = wait.ExponentialBackoff(defaultRetryBackoff(3), func() (bool, error) {
+		if s.DynamicClient != nil {
+			return true, nil
+		}
+
 		lastErr = kubeconfig.BuildKubernetesClientset(s)
 		if lastErr != nil {
 			s.Logger.Warn("Unable to connect to the control plane API. Retrying...")


### PR DESCRIPTION
**What this PR does / why we need it**:

The `kubeone reset` output currently looks like this:

```
WARN[16:53:00 CEST] this command will require an explicit confirmation starting with the next minor release (v1.3) 
The following nodes will be reset. The Kubernetes cluster running on those nodes will be permanently destroyed 
	- reset control plane node "marko-1-cp-0" (10.0.42.9)
	- reset control plane node "marko-1-cp-1" (10.0.42.14)
	- reset control plane node "marko-1-cp-2" (10.0.42.5)
INFO[16:53:00 CEST] Building Kubernetes clientset...             
	- reset machine-controller managed machine "marko-1-pool1-57494466fb-rsx4b"
```

There are several issues with the output:

* the `Building Kubernetes clientset...` is in between a list of control plane nodes and Machines, which doesn't look nice
* `reset machine-controller managed machine` is wrong in this context because the Machine is actually destroyed
* the warning is outdated because the command already requires an explicit confirmation
* the Kubernetes clientset will be built again after confirming the command which is not needed at all

This PR is supposed to fix those issues and add some additional context to the output. With this PR, the output looks like this:

```
INFO[18:25:44 CEST] Building Kubernetes clientset...             
WARN[18:25:50 CEST] This command will PERMANENTLY destroy the Kubernetes cluster running on the following nodes: 
	- reset control plane node "marko-1-cp-0" (10.0.42.3)
	- reset control plane node "marko-1-cp-1" (10.0.42.8)
	- reset control plane node "marko-1-cp-2" (10.0.42.14)

The following machine-controller managed worker nodes will be destroyed:
	- kube-system/marko-1-pool1-5df867f674-vp8kg

After the command is complete, there's NO way to recover the cluster or its data! 
Do you want to proceed (yes/no): yes

INFO[18:25:54 CEST] Destroying worker nodes...                   
INFO[18:25:55 CEST] Annotating nodes to skip eviction...         
INFO[18:25:56 CEST] Deleting MachineDeployment objects...   
...
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 