### PR TITLE
Update metrics-server to v0.5.0

### DIFF
--- a/addons/metrics-server/metrics-server.yaml
+++ b/addons/metrics-server/metrics-server.yaml
@@ -57,6 +57,7 @@ rules:
       - nodes
       - nodes/stats
       - namespaces
+      - configmaps
     verbs:
       - get
       - list
@@ -89,6 +90,17 @@ spec:
   groupPriorityMinimum: 100
   versionPriority: 100
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-server-serving-cert
+  namespace: kube-system
+data:
+  "cert.pem": |
+{{ .Certificates.MetricsServerCert | b64enc | indent 4 }}
+  "key.pem": |
+{{ .Certificates.MetricsServerKey | b64enc | indent 4 }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -100,6 +112,9 @@ spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       name: metrics-server
@@ -113,6 +128,10 @@ spec:
       # mount in tmp so we can safely use from-scratch images and/or read-only containers
       - name: tmp-dir
         emptyDir: {}
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
+      priorityClassName: system-cluster-critical
       containers:
       - name: metrics-server
         image: {{ .InternalImages.Get "MetricsServer" }}
@@ -120,9 +139,46 @@ spec:
         args:
           - --kubelet-insecure-tls
           - --kubelet-preferred-address-types=InternalIP,InternalDNS,ExternalDNS,ExternalIP
+          - --kubelet-use-node-status-port
+          - --metric-resolution=15s
+          - --tls-cert-file=/etc/serving-cert/cert.pem
+          - --tls-private-key-file=/etc/serving-cert/key.pem
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 1
+            memory: 512Mi
+        ports:
+        - name: https
+          containerPort: 443
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+          failureThreshold: 3
+          initialDelaySeconds: 20
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+          failureThreshold: 3
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp
+        - name: metrics-server-serving-cert
+          mountPath: /etc/serving-cert
+          readOnly: true
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -66,7 +66,7 @@ func CAKeyPair(config *configupload.Configuration) (*rsa.PrivateKey, *x509.Certi
 	return rsaKey, certs[0], nil
 }
 
-func NewSignedWebhookCert(name, namespace, domain string, caKey crypto.Signer, caCert *x509.Certificate) (map[string]string, error) {
+func NewSignedTLSCert(name, namespace, domain string, caKey crypto.Signer, caCert *x509.Certificate) (map[string]string, error) {
 	serviceCommonName := strings.Join([]string{name, namespace, "svc"}, ".")
 	serviceFQDNCommonName := strings.Join([]string{serviceCommonName, domain, ""}, ".")
 
@@ -94,8 +94,8 @@ func NewSignedWebhookCert(name, namespace, domain string, caKey crypto.Signer, c
 	}
 
 	return map[string]string{
-		resources.MachineControllerWebhookCertName: string(encodeCertPEM(newKPCert)),
-		resources.MachineControllerWebhookKeyName:  string(encodePrivateKeyPEM(newKPKey)),
-		resources.KubernetesCACertName:             string(encodeCertPEM(caCert)),
+		resources.TLSCertName:          string(encodeCertPEM(newKPCert)),
+		resources.TLSKeyName:           string(encodePrivateKeyPEM(newKPKey)),
+		resources.KubernetesCACertName: string(encodeCertPEM(caCert)),
 	}, nil
 }

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -87,7 +87,7 @@ func baseResources() map[Resource]map[string]string {
 		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
 		Flannel:           {"*": "quay.io/coreos/flannel:v0.13.0"},
 		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.35.1"},
-		MetricsServer:     {"*": "k8s.gcr.io/metrics-server:v0.3.6"},
+		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
 	}
 }
 

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -47,12 +47,15 @@ const (
 	MachineControllerName        = "machine-controller"
 	MachineControllerNameSpace   = metav1.NamespaceSystem
 	MachineControllerWebhookName = "machine-controller-webhook"
+
+	MetricsServerName      = "metrics-server"
+	MetricsServerNamespace = metav1.NamespaceSystem
 )
 
 const (
-	MachineControllerWebhookCertName = "cert.pem"
-	MachineControllerWebhookKeyName  = "key.pem"
-	KubernetesCACertName             = "ca.pem"
+	TLSCertName          = "cert.pem"
+	TLSKeyName           = "key.pem"
+	KubernetesCACertName = "ca.pem"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates metrics-server from v0.3.6 to v0.5.0. The old metrics-server was not working with Kubernetes 1.22, which was manifested by namespaces failing to get deleted. Affected namespaces had the following condition:

```
  conditions:
  - lastTransitionTime: "2021-08-31T17:25:50Z"
    message: 'Discovery failed for some groups, 1 failing: unable to retrieve the
      complete list of server APIs: metrics.k8s.io/v1beta1: an error on the server
      ("Internal Server Error: \"/apis/metrics.k8s.io/v1beta1?timeout=32s\": the server
      could not find the requested resource") has prevented the request from succeeding'
    reason: DiscoveryFailed
    status: "True"
    type: NamespaceDeletionDiscoveryFailure
```

This PR also refactors the way we deploy metrics-server, so metrics-server is now using serving certificates signed by the Kubernetes CA instead of self-signed certs.

The following resources were used along the way:

* https://github.com/kubernetes-sigs/metrics-server/blob/acd8b84a5e025c729c28d65577162c762b6154c9/manifests/base/deployment.yaml
* https://github.com/kubermatic/kubermatic/pull/7461/commits/a40e89d165fd1c487e97faad6a05336dd9d3260f

**Does this PR introduce a user-facing change?**:
```release-note
Update metrics-server to v0.5.0
```

/assign @kron4eg 