### PR TITLE
Add support for vSphere CSI plugin

### DIFF
--- a/addons/csi-vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi-vsphere/vsphere-csi-driver.yaml
@@ -1,0 +1,473 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-csi-config-secret
+  namespace: kube-system
+data:
+  csi-vsphere.conf: |
+{{ .Config.CloudProvider.CSIConfig | b64enc | indent 4 }}
+---
+apiVersion: storage.k8s.io/v1 # For k8s 1.17 use storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: csi.vsphere.vmware.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumeclaims", "pods", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["triggercsifullsyncs"]
+    verbs: ["create", "get", "update", "watch", "list"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvspherevolumemigrations"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: kube-system
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-role
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-binding
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+data:
+  "csi-migration": "false" # TODO(xmudrii)
+  "csi-auth-check": "true"
+  "online-volume-extend": "true"
+  "trigger-csi-fullsync": "false"
+  "async-query-volume": "false"
+  "improved-csi-idempotency": "false"
+  "improved-volume-topology": "false"
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
+  namespace: kube-system
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+        role: vsphere-csi
+    spec:
+      serviceAccountName: vsphere-csi-controller
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        # uncomment below toleration if you need an aggressive pod eviction in case when
+        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
+        #- key: node.kubernetes.io/not-ready
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+        #- key: node.kubernetes.io/unreachable
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+      dnsPolicy: "Default"
+      containers:
+        - name: csi-attacher
+          image: {{ .InternalImages.Get "CSIAttacher" }}
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-resizer
+          image: {{ .InternalImages.Get "CSIResizer" }}
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--handle-volume-inuse-error=false"
+            - "--csi-address=$(ADDRESS)"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-csi-controller
+          image: {{ .InternalImages.Get "VsphereCSIDriver" }}
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: X_CSI_MODE
+              value: "controller"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/cloud/csi-vsphere.conf"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+            - name: prometheus
+              containerPort: 2112
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+        - name: liveness-probe
+          image: {{ .InternalImages.Get "CSILivenessProbe" }}
+          args:
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: vsphere-syncer
+          image: {{ .InternalImages.Get "VsphereCSISyncer" }}
+          args:
+            - "--leader-election"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
+          env:
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/cloud/csi-vsphere.conf"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+        - name: csi-provisioner
+          image: {{ .InternalImages.Get "CSIProvisioner" }}
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+            - "--leader-election"
+            - "--default-fstype=ext4"
+            # needed only for topology aware setup
+            #- "--feature-gates=Topology=true"
+            #- "--strict-topology"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - name: vsphere-config-volume
+          secret:
+            secretName: vsphere-csi-config-secret
+        - name: socket-dir
+          emptyDir: {}
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: vsphere-csi-node
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-node
+        role: vsphere-csi
+    spec:
+      serviceAccountName: vsphere-csi-node
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
+      containers:
+        - name: node-driver-registrar
+          image: {{ .InternalImages.Get "CSINodeDriverRegistar" }}
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            - "--health-port=9809"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          ports:
+            - containerPort: 9809
+              name: healthz
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+        - name: vsphere-csi-node
+          image: {{ .InternalImages.Get "VsphereCSIDriver" }}
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: MAX_VOLUMES_PER_NODE
+              value: "0" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
+            - name: X_CSI_MODE
+              value: "node"
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            # needed only for topology aware setups
+            #- name: VSPHERE_CSI_CONFIG
+            #  value: "/etc/cloud/csi-vsphere.conf" # here csi-vsphere.conf is the name of the file used for creating secret using "--from-file" flag
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          volumeMounts:
+            # needed only for topology aware setups
+            #- name: vsphere-config-volume
+            #  mountPath: /etc/cloud
+            #  readOnly: true
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - name: device-dir
+              mountPath: /dev
+            - name: blocks-dir
+              mountPath: /sys/block
+            - name: sys-devices-dir
+              mountPath: /sys/devices
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+        - name: liveness-probe
+          image: {{ .InternalImages.Get "CSILivenessProbe" }}
+          args:
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+      volumes:
+        # needed only for topology aware setups
+        #- name: vsphere-config-volume
+        #  secret:
+        #    secretName: vsphere-csi-config-secret
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+        - name: blocks-dir
+          hostPath:
+            path: /sys/block
+            type: Directory
+        - name: sys-devices-dir
+          hostPath:
+            path: /sys/devices
+            type: Directory
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -38,16 +38,20 @@ var (
 	// embeddedAddons is a list of addons that are embedded in the KubeOne
 	// binary. Those addons are skipped when applying the user-provided addons
 	embeddedAddons = map[string]string{
-		resources.AddonCCMDigitalOcean:   "",
-		resources.AddonCCMHetzner:        "",
-		resources.AddonCCMOpenStack:      "",
-		resources.AddonCCMPacket:         "",
-		resources.AddonCCMVsphere:        "",
-		resources.AddonCNICanal:          "",
-		resources.AddonCNIWeavenet:       "",
-		resources.AddonMachineController: "",
-		resources.AddonMetricsServer:     "",
-		resources.AddonNodeLocalDNS:      "",
+		resources.AddonCCMAzure:           "",
+		resources.AddonCCMDigitalOcean:    "",
+		resources.AddonCCMHetzner:         "",
+		resources.AddonCCMOpenStack:       "",
+		resources.AddonCCMPacket:          "",
+		resources.AddonCCMVsphere:         "",
+		resources.AddonCNICanal:           "",
+		resources.AddonCNIWeavenet:        "",
+		resources.AddonCSIHetnzer:         "",
+		resources.AddonCSIOpenStackCinder: "",
+		resources.AddonCSIVsphere:         "",
+		resources.AddonMachineController:  "",
+		resources.AddonMetricsServer:      "",
+		resources.AddonNodeLocalDNS:       "",
 	}
 )
 

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -161,6 +161,8 @@ type CloudProviderSpec struct {
 	External bool `json:"external,omitempty"`
 	// CloudConfig
 	CloudConfig string `json:"cloudConfig,omitempty"`
+	// CSIConfig
+	CSIConfig string `json:"csiConfig,omitempty"`
 	// AWS
 	AWS *AWSSpec `json:"aws,omitempty"`
 	// Azure

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
@@ -347,6 +347,7 @@ func autoConvert_v1alpha1_CloudProviderSpec_To_kubeone_CloudProviderSpec(in *Clo
 func autoConvert_kubeone_CloudProviderSpec_To_v1alpha1_CloudProviderSpec(in *kubeone.CloudProviderSpec, out *CloudProviderSpec, s conversion.Scope) error {
 	out.External = in.External
 	out.CloudConfig = in.CloudConfig
+	// WARNING: in.CSIConfig requires manual conversion: does not exist in peer-type
 	// WARNING: in.AWS requires manual conversion: does not exist in peer-type
 	// WARNING: in.Azure requires manual conversion: does not exist in peer-type
 	// WARNING: in.DigitalOcean requires manual conversion: does not exist in peer-type

--- a/pkg/apis/kubeone/v1beta1/types.go
+++ b/pkg/apis/kubeone/v1beta1/types.go
@@ -161,6 +161,8 @@ type CloudProviderSpec struct {
 	External bool `json:"external,omitempty"`
 	// CloudConfig
 	CloudConfig string `json:"cloudConfig,omitempty"`
+	// CSIConfig
+	CSIConfig string `json:"csiConfig,omitempty"`
 	// AWS
 	AWS *AWSSpec `json:"aws,omitempty"`
 	// Azure

--- a/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
@@ -763,6 +763,7 @@ func Convert_kubeone_CanalSpec_To_v1beta1_CanalSpec(in *kubeone.CanalSpec, out *
 func autoConvert_v1beta1_CloudProviderSpec_To_kubeone_CloudProviderSpec(in *CloudProviderSpec, out *kubeone.CloudProviderSpec, s conversion.Scope) error {
 	out.External = in.External
 	out.CloudConfig = in.CloudConfig
+	out.CSIConfig = in.CSIConfig
 	out.AWS = (*kubeone.AWSSpec)(unsafe.Pointer(in.AWS))
 	out.Azure = (*kubeone.AzureSpec)(unsafe.Pointer(in.Azure))
 	out.DigitalOcean = (*kubeone.DigitalOceanSpec)(unsafe.Pointer(in.DigitalOcean))
@@ -783,6 +784,7 @@ func Convert_v1beta1_CloudProviderSpec_To_kubeone_CloudProviderSpec(in *CloudPro
 func autoConvert_kubeone_CloudProviderSpec_To_v1beta1_CloudProviderSpec(in *kubeone.CloudProviderSpec, out *CloudProviderSpec, s conversion.Scope) error {
 	out.External = in.External
 	out.CloudConfig = in.CloudConfig
+	out.CSIConfig = in.CSIConfig
 	out.AWS = (*AWSSpec)(unsafe.Pointer(in.AWS))
 	out.Azure = (*AzureSpec)(unsafe.Pointer(in.Azure))
 	out.DigitalOcean = (*DigitalOceanSpec)(unsafe.Pointer(in.DigitalOcean))

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -571,6 +571,9 @@ cloudProvider:
   external: {{ .CloudProviderExternal }}
   # Path to file that will be uploaded and used as custom '--cloud-config' file.
   cloudConfig: "{{ .CloudProviderCloudCfg }}"
+  # CSIConfig is configuration passed to the CSI driver.
+  # This is currently used only for vSphere clusters.
+  csiConfig: ""
 
 # Controls which container runtime will be installed on instances.
 # By default:

--- a/pkg/templates/csi/csi.go
+++ b/pkg/templates/csi/csi.go
@@ -52,6 +52,12 @@ func Ensure(s *state.State) error {
 		}
 
 		err = addons.EnsureAddonByName(s, resources.AddonCSIOpenStackCinder)
+	case s.Cluster.CloudProvider.Vsphere != nil:
+		if s.Cluster.CloudProvider.CSIConfig == "" {
+			s.Logger.Warnln("vSphere CSI driver requires CSI config to be provided via .cloudProvider.csiConfig. Skipping...")
+			return nil
+		}
+		err = addons.EnsureAddonByName(s, resources.AddonCSIVsphere)
 	default:
 		s.Logger.Infof("CSI driver for %q not yet supported, skipping", s.Cluster.CloudProvider.CloudProviderName())
 		return nil

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -65,6 +65,8 @@ const (
 	OpenstackCSI
 	PacketCCM
 	VsphereCCM
+	VsphereCSIDriver
+	VsphereCSISyncer
 	WeaveNetCNIKube
 	WeaveNetCNINPC
 )
@@ -133,6 +135,10 @@ func optionalResources() map[Resource]map[string]string {
 
 		// vSphere CCM
 		VsphereCCM: {"*": "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1"},
+
+		// vSphere CSI
+		VsphereCSIDriver: {"*": "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.3.0"},
+		VsphereCSISyncer: {"*": "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.3.0"},
 
 		// WeaveNet CNI plugin
 		WeaveNetCNIKube: {"*": "docker.io/weaveworks/weave-kube:2.8.1"},

--- a/pkg/templates/images/resource_string.go
+++ b/pkg/templates/images/resource_string.go
@@ -29,13 +29,15 @@ func _() {
 	_ = x[OpenstackCSI-19]
 	_ = x[PacketCCM-20]
 	_ = x[VsphereCCM-21]
-	_ = x[WeaveNetCNIKube-22]
-	_ = x[WeaveNetCNINPC-23]
+	_ = x[VsphereCSIDriver-22]
+	_ = x[VsphereCSISyncer-23]
+	_ = x[WeaveNetCNIKube-24]
+	_ = x[WeaveNetCNINPC-25]
 }
 
-const _Resource_name = "AzureCCMAzureCNMCalicoCNICalicoControllerCalicoNodeCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeDigitaloceanCCMDNSNodeCacheFlannelHetznerCCMMachineControllerMetricsServerOpenstackCCMOpenstackCSIPacketCCMVsphereCCMWeaveNetCNIKubeWeaveNetCNINPC"
+const _Resource_name = "AzureCCMAzureCNMCalicoCNICalicoControllerCalicoNodeCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeDigitaloceanCCMDNSNodeCacheFlannelHetznerCCMMachineControllerMetricsServerOpenstackCCMOpenstackCSIPacketCCMVsphereCCMVsphereCSIDriverVsphereCSISyncerWeaveNetCNIKubeWeaveNetCNINPC"
 
-var _Resource_index = [...]uint16{0, 8, 16, 25, 41, 51, 62, 83, 97, 111, 121, 137, 152, 164, 171, 181, 198, 211, 223, 235, 244, 254, 269, 283}
+var _Resource_index = [...]uint16{0, 8, 16, 25, 41, 51, 62, 83, 97, 111, 121, 137, 152, 164, 171, 181, 198, 211, 223, 235, 244, 254, 270, 286, 301, 315}
 
 func (i Resource) String() string {
 	i -= 1

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -24,6 +24,7 @@ import (
 
 // Names of the internal addons
 const (
+	AddonCCMAzure           = "ccm-azure"
 	AddonCCMDigitalOcean    = "ccm-digitalocean"
 	AddonCCMHetzner         = "ccm-hetzner"
 	AddonCCMOpenStack       = "ccm-openstack"
@@ -31,6 +32,7 @@ const (
 	AddonCCMVsphere         = "ccm-vsphere"
 	AddonCSIHetnzer         = "csi-hetzner"
 	AddonCSIOpenStackCinder = "csi-openstack-cinder"
+	AddonCSIVsphere         = "csi-vsphere"
 	AddonCNICanal           = "cni-canal"
 	AddonCNIWeavenet        = "cni-weavenet"
 	AddonMachineController  = "machinecontroller"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:

* Adds a new embedded addon used to deploy the vSphere CSI plugin
  * This addon is deployed automatically if `.cloudProvider.csiConfig` is provided and `.cloudProvider.external` is enabled
    * This is the same behavior as for OpenStack
* Adds a new API field `.cloudProvider.csiConfig` to be used with CSI plugins
  * vSphere has different configuration file formats for CCM and CSI, therefore dedicated fields for cloudConfig and csiConfig are required
    * The CCM and CSI configs are very similar. There are two key differences:
       * The CSI plugin requires providing `cluster-id` property. Providing this property in the CCM configuration causes the CCM to crash because the field doesn't exist
       * The CSI driver requires credentials to be provided as plain-text instead of referring to the Kubernetes Secret
* Updates the list of embedded addons

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevants to #1471

**Does this PR introduce a user-facing change?**:
```release-note
* Add vSphere CSI addon
  * Deploying the CSI plugin/driver requires providing CSI config using a newly added .cloudProvider.csiConfig fields
  * The CSI plugin/driver is deployed automatically if .cloudProvider.csiConfig is provided and .cloudProvider.external is enabled
```

/assign @kron4eg 