### PR TITLE
Check does kubelet.conf exists before trying to join static worker node

### DIFF
--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -27,7 +27,7 @@ var (
 	`)
 
 	kubeadmWorkerJoinScriptTemplate = heredoc.Doc(`
-		[[ -f /etc/kubernetes/admin.conf ]] && exit 0
+		[[ -f /etc/kubernetes/kubelet.conf ]] && exit 0
 
 		sudo kubeadm {{ .VERBOSE }} join \
 			--config={{ .WORK_DIR }}/cfg/worker_{{ .NODE_ID }}.yaml

--- a/pkg/scripts/testdata/TestKubeadmJoinWorker-not-verbose.golden
+++ b/pkg/scripts/testdata/TestKubeadmJoinWorker-not-verbose.golden
@@ -1,6 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
-[[ -f /etc/kubernetes/admin.conf ]] && exit 0
+[[ -f /etc/kubernetes/kubelet.conf ]] && exit 0
 
 sudo kubeadm  join \
 	--config=test-wd/cfg/worker_0.yaml

--- a/pkg/scripts/testdata/TestKubeadmJoinWorker-verbose.golden
+++ b/pkg/scripts/testdata/TestKubeadmJoinWorker-verbose.golden
@@ -1,6 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
-[[ -f /etc/kubernetes/admin.conf ]] && exit 0
+[[ -f /etc/kubernetes/kubelet.conf ]] && exit 0
 
 sudo kubeadm --v=6 join \
 	--config=test-wd/cfg/worker_0.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubeone apply` determines if the static worker node is already joined to the cluster by verifying does `/etc/kubernetes/kubelet.conf` file exists. We introduced a regression between 1.2.3 and 1.3.0-alpha.0 by checking for `admin.conf` instead of `kubelet.conf`, which is fixed by this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1461

**Does this PR introduce a user-facing change?**:
```release-note
Skip already provisioned static worker nodes on kubeone apply
```