### PR TITLE
Add support for vSphere CCM/CSI migration

### DIFF
--- a/addons/csi-vsphere/validatingwebhook.yaml
+++ b/addons/csi-vsphere/validatingwebhook.yaml
@@ -1,0 +1,157 @@
+{{ if .CSIMigration }}
+# Requires k8s 1.19+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-webhook-certs
+  namespace: kube-system
+data:
+  "cert.pem": |
+{{ .Certificates.vSphereCSIWebhookCert | b64enc | indent 4 }}
+  "key.pem": |
+{{ .Certificates.vSphereCSIWebhookKey | b64enc | indent 4 }}
+  "webhook.config": |
+{{ vSphereCSIWebhookConfig | b64enc | indent 4 }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-webhook-svc
+  namespace: kube-system
+  labels:
+    app: vsphere-csi-webhook
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: vsphere-csi-webhook
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.csi.vsphere.vmware.com
+webhooks:
+  - name: validation.csi.vsphere.vmware.com
+    clientConfig:
+      service:
+        name: vsphere-webhook-svc
+        namespace: kube-system
+        path: "/validate"
+      caBundle: |
+{{ .Certificates.KubernetesCA | b64enc | indent 8 }}
+    rules:
+      - apiGroups:   ["storage.k8s.io"]
+        apiVersions: ["v1", "v1beta1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["storageclasses"]
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: kube-system
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-role
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-role-binding
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-webhook
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: vsphere-csi-webhook-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-webhook
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-webhook
+        role: vsphere-csi-webhook
+      annotations:
+        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "csiConfig-hash": "{{ .Config.CloudProvider.CSIConfig | sha256sum }}"
+    spec:
+      serviceAccountName: vsphere-csi-webhook
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        # uncomment below toleration if you need an aggressive pod eviction in case when
+        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
+        #- key: node.kubernetes.io/not-ready
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+        #- key: node.kubernetes.io/unreachable
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+      dnsPolicy: "Default"
+      containers:
+        - name: vsphere-webhook
+          image: {{ .InternalImages.Get "VsphereCSISyncer" }}
+          args:
+            - "--operation-mode=WEBHOOK_SERVER"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: WEBHOOK_CONFIG_PATH
+              value: "/etc/webhook/webhook.config"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
+          volumeMounts:
+            - mountPath: /etc/webhook
+              name: webhook-certs
+              readOnly: true
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: webhook-certs
+          secret:
+            secretName: vsphere-webhook-certs
+{{ if .Config.CABundle }}
+{{ caBundleVolume | indent 8 }}
+{{ end }}
+{{ end }}

--- a/addons/csi-vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi-vsphere/vsphere-csi-driver.yaml
@@ -8,7 +8,7 @@ data:
   csi-vsphere.conf: |
 {{ .Config.CloudProvider.CSIConfig | b64enc | indent 4 }}
 ---
-apiVersion: storage.k8s.io/v1 # For k8s 1.17 use storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.vsphere.vmware.com
@@ -106,7 +106,7 @@ roleRef:
 ---
 apiVersion: v1
 data:
-  "csi-migration": "false" # TODO(xmudrii)
+  "csi-migration": "{{ .CSIMigration }}"
   "csi-auth-check": "true"
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
@@ -133,6 +133,9 @@ spec:
       labels:
         app: vsphere-csi-controller
         role: vsphere-csi
+      annotations:
+        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "csiConfig-hash": "{{ .Config.CloudProvider.CSIConfig | sha256sum }}"
     spec:
       serviceAccountName: vsphere-csi-controller
       nodeSelector:
@@ -211,12 +214,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
             - mountPath: /csi
               name: socket-dir
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}
           ports:
             - name: healthz
               containerPort: 9808
@@ -266,10 +275,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}
         - name: csi-provisioner
           image: {{ .InternalImages.Get "CSIProvisioner" }}
           args:
@@ -295,6 +310,9 @@ spec:
             secretName: vsphere-csi-config-secret
         - name: socket-dir
           emptyDir: {}
+{{ if .Config.CABundle }}
+{{ caBundleVolume | indent 8 }}
+{{ end }}
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -314,6 +332,9 @@ spec:
       labels:
         app: vsphere-csi-node
         role: vsphere-csi
+      annotations:
+        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "csiConfig-hash": "{{ .Config.CloudProvider.CSIConfig | sha256sum }}"
     spec:
       serviceAccountName: vsphere-csi-node
       hostNetwork: true
@@ -375,6 +396,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
           securityContext:
             privileged: true
             capabilities:
@@ -398,6 +422,9 @@ spec:
               mountPath: /sys/block
             - name: sys-devices-dir
               mountPath: /sys/devices
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}
           ports:
             - name: healthz
               containerPort: 9808
@@ -446,6 +473,9 @@ spec:
           hostPath:
             path: /sys/devices
             type: Directory
+{{ if .Config.CABundle }}
+{{ caBundleVolume | indent 8 }}
+{{ end }}
       tolerations:
         - effect: NoExecute
           operator: Exists

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -162,8 +162,13 @@ func ValidateCloudProviderSpec(p kubeone.CloudProviderSpec, fldPath *field.Path)
 		allErrs = append(allErrs, field.Invalid(fldPath, "", "provider must be specified"))
 	}
 
-	if len(p.CSIConfig) > 0 && p.Vsphere == nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("csiConfig"), "", ".cloudProvider.csiConfig is currently supported only for vsphere clusters"))
+	if len(p.CSIConfig) > 0 {
+		if p.Vsphere == nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("csiConfig"), "", ".cloudProvider.csiConfig is currently supported only for vsphere clusters"))
+		}
+		if !p.External {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("csiConfig"), "", ".cloudProvider.csiConfig is supported only for clusters using external cloud provider (.cloudProvider.external)"))
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -573,10 +573,21 @@ func TestValidateCloudProviderSpec(t *testing.T) {
 			name: "vSphere provider config with csiConfig",
 			providerConfig: kubeone.CloudProviderSpec{
 				Vsphere:     &kubeone.VsphereSpec{},
+				External:    true,
 				CloudConfig: "test",
 				CSIConfig:   "test",
 			},
 			expectedError: false,
+		},
+		{
+			name: "vSphere provider config with csiConfig (external disabled)",
+			providerConfig: kubeone.CloudProviderSpec{
+				Vsphere:     &kubeone.VsphereSpec{},
+				External:    false,
+				CloudConfig: "test",
+				CSIConfig:   "test",
+			},
+			expectedError: true,
 		},
 		{
 			name: "OpenStack provider config without csiConfig",

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -100,7 +100,8 @@ func migrateToCCMCSICmd(fs *pflag.FlagSet) *cobra.Command {
 			Note: if your cluster was created with .cloudProvider.external enabled, the CCM/CSI migration is not needed
 			because the cluster is already using external CCM.
 
-			Migration is currently available for OpenStack. Other providers will be added in future KubeOne releases.
+			Migration is currently available for OpenStack and vSphere. Other providers will be added in future KubeOne releases.
+			Note: vSphere support is currently experimental!
 
 			The migration is done in two phases:
 
@@ -116,7 +117,7 @@ func migrateToCCMCSICmd(fs *pflag.FlagSet) *cobra.Command {
 			    users need to run "kubeone migrate to-ccm-csi" command with the "--complete" flag. This should be
 			    done after all worker nodes managed by machine-controller are rolled-out.
 
-			More information about the CCM/CSI migration can be found in the following document: TBD
+			Make sure to familiarize yourself with the CCM/CSI migration requirements by checking the following document: TBD
 		`),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(fs)
@@ -172,6 +173,20 @@ func runMigrateToCCMCSI(opts *migrateCCMOptions) error {
 	}
 	if !s.LiveCluster.Healthy() {
 		return errors.New("the target cluster is not healthy, please run 'kubeone apply' first")
+	}
+
+	s.Logger.Warnln("This command will migrate your cluster from in-tree cloud provider to the external CCM and CSI plugin.")
+	s.Logger.Warnln("Make sure to familiarize yourself with the process by checking the following document:")
+	s.Logger.Warnln("TBD")
+
+	confirm, err := confirmCommand(opts.AutoApprove)
+	if err != nil {
+		return err
+	}
+
+	if !confirm {
+		s.Logger.Println("Operation canceled.")
+		return nil
 	}
 
 	return errors.Wrap(tasks.WithCCMCSIMigration(nil).Run(s), "failed to migrate to ccm/csi")

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -79,7 +79,7 @@ func resetCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 		longFlagName(opts, "AutoApprove"),
 		shortFlagName(opts, "AutoApprove"),
 		false,
-		"auto approve reset (NO-OP/NOT YET ENABLED)")
+		"auto approve reset")
 
 	cmd.Flags().BoolVar(
 		&opts.DestroyWorkers,

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -471,7 +471,7 @@ func WithCCMCSIMigration(t Tasks) Tasks {
 		append(kubernetesConfigFiles()...).
 		append(
 			Task{Fn: regenerateControlPlaneManifests, ErrMsg: "failed to regenerate static pod manifests"},
-			Task{Fn: updateKubeletConfig, ErrMsg: "failed to update kubelet config"},
+			Task{Fn: updateKubeletConfig, ErrMsg: "failed to update kubelet config on control plane nodes"},
 		).
 		append(WithResources(nil)...).
 		append(

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -52,6 +52,9 @@ const (
 
 	MetricsServerName      = "metrics-server"
 	MetricsServerNamespace = metav1.NamespaceSystem
+
+	VsphereCSIWebhookName      = "vsphere-webhook-svc"
+	VsphereCSIWebhookNamespace = metav1.NamespaceSystem
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the CCM/CSI migration to support vSphere clusters. The support for vSphere is currently experimental because we're unable to properly test it.

Additionally, the vSphere CSI deployment has been modified to:

* deploy the vSphere validating webhook if CSI migration is enabled
* use the CA bundle if it's provided

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1471

**Special notes for your reviewer**:

/hold
for manual testing

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
