### PR TITLE
Add default-storage-class optional addon

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -1,0 +1,107 @@
+{{ if eq .Config.CloudProvider.CloudProviderName "azure" }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: Managed
+  storageaccounttype: Standard_LRS
+{{ end }}
+
+{{ if eq .Config.CloudProvider.CloudProviderName "aws" }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard-v2
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+volumeBindingMode: WaitForFirstConsumer
+{{ end }}
+
+{{ if eq .Config.CloudProvider.CloudProviderName "vsphere" }}
+{{ if .Config.CloudProvider.External }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: vsphere-csi
+provisioner: csi.vsphere.vmware.com
+{{ else }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+  diskformat: thin
+{{ end }}
+{{ end }}
+
+{{ if eq .Config.CloudProvider.CloudProviderName "openstack" }}
+{{ if .Config.CloudProvider.External }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: cinder-csi
+provisioner: cinder.csi.openstack.org
+volumeBindingMode: WaitForFirstConsumer
+{{ else }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard
+provisioner: kubernetes.io/cinder
+{{ end }}
+{{ end }}
+
+{{ if eq .Config.CloudProvider.CloudProviderName "gcp" }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+{{ end }}
+
+{{ if eq .Config.CloudProvider.CloudProviderName "hetzner" }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: hcloud-volumes
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.hetzner.cloud
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ports the `default-storage-class` addon from KKP: https://github.com/kubermatic/kubermatic/tree/master/addons/default-storage-class

This is an optional addon that can be deployed using the new Addons API:

```yaml
addons:
  enable: true
  addons:
  - name: default-storage-class
```

This should make it easier to test the CCM/CSI migration. 

**Does this PR introduce a user-facing change?**:
```release-note
Add an optional default-storage-class addon used to create StorageClass for AWS, Azure, GCP, OpenStack, vSphere, and Hetzner clusters. The addon can be enabled using the Addons API.
```
