### PR TITLE
Drain and cordon control plane nodes when doing CSI migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
     * More information about the CSI plugin configuration can be found in the vSphere CSI docs: https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create_csi_vsphereconf
   * The CSI plugin is deployed automatically if `.cloudProvider.csiConfig` is provided and `.cloudProvider.external` is enabled
   * Check out the Attention Needed section of the changelog for more information.
-* Implement the CCM/CSI migration for OpenStack and vSphere ([#1468](https://github.com/kubermatic/kubeone/pull/1468), [#1469](https://github.com/kubermatic/kubeone/pull/1469), [#1472](https://github.com/kubermatic/kubeone/pull/1472), [#1482](https://github.com/kubermatic/kubeone/pull/1482), [#1487](https://github.com/kubermatic/kubeone/pull/1487))
+* Implement the CCM/CSI migration for OpenStack and vSphere ([#1468](https://github.com/kubermatic/kubeone/pull/1468), [#1469](https://github.com/kubermatic/kubeone/pull/1469), [#1472](https://github.com/kubermatic/kubeone/pull/1472), [#1482](https://github.com/kubermatic/kubeone/pull/1482), [#1487](https://github.com/kubermatic/kubeone/pull/1487), [#1494](https://github.com/kubermatic/kubeone/pull/1494))
   * The CCM/CSI migration is used to migrate clusters running in-tree cloud provider (i.e. with `.cloudProvider.external` set to `false`) to the external CCM (cloud-controller-manager) and CSI plugin.
   * The migration is implemented with the `kubeone migrate to-ccm-csi` command.
   * The CCM/CSI migration for vSphere is currently experimental and not tested.

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -799,6 +799,8 @@ addons:
   enable: false
   # In case when the relative path is provided, the path is relative
   # to the KubeOne configuration file.
+  # This path must be always provided and the directory must exist, even if
+  # using only embedded addons.
   path: "./addons"
   # globalParams is a key-value map of values passed to the addons templating engine,
   # to be used in the addons' manifests. The values defined here are passed to all
@@ -806,7 +808,11 @@ addons:
   globalParams:
     key: value
   # addons is used to enable addons embedded in the KubeOne binary.
-  # Currently backups-restic and unattended-upgrades are available addons.
+  # Currently backups-restic, default-storage-class, and unattended-upgrades are
+  # available addons.
+  # Check out the documentation to find more information about what are embedded
+  # addons and how to use them:
+  # https://docs.kubermatic.com/kubeone/v1.3/guides/addons/
   addons:
     # name of the addon to be enabled/deployed (e.g. backups-restic)
     - name: ""

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -91,7 +91,6 @@ func migrateToCCMCSICmd(fs *pflag.FlagSet) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "to-ccm-csi",
 		Short: "Migrate live cluster from the in-tree cloud provider to external cloud-controller-manager (CCM) and CSI plugin",
-		// TODO(xmudrii): insert link to docs once it's available.
 		Long: heredoc.Doc(`
 			Following the in-tree cloud provider deprecation (http://kep.k8s.io/2395),
 			this command helps to migrate existing clusters from the in-tree cloud provider to external
@@ -117,7 +116,8 @@ func migrateToCCMCSICmd(fs *pflag.FlagSet) *cobra.Command {
 			    users need to run "kubeone migrate to-ccm-csi" command with the "--complete" flag. This should be
 			    done after all worker nodes managed by machine-controller are rolled-out.
 
-			Make sure to familiarize yourself with the CCM/CSI migration requirements by checking the following document: TBD
+			Make sure to familiarize yourself with the CCM/CSI migration requirements by checking the following document:
+			https://docs.kubermatic.com/kubeone/v1.3/guides/ccm_csi_migration/
 		`),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(fs)
@@ -177,7 +177,7 @@ func runMigrateToCCMCSI(opts *migrateCCMOptions) error {
 
 	s.Logger.Warnln("This command will migrate your cluster from in-tree cloud provider to the external CCM and CSI plugin.")
 	s.Logger.Warnln("Make sure to familiarize yourself with the process by checking the following document:")
-	s.Logger.Warnln("TBD")
+	s.Logger.Warnln("https://docs.kubermatic.com/kubeone/v1.3/guides/ccm_csi_migration/")
 
 	confirm, err := confirmCommand(opts.AutoApprove)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

It's required to drain nodes when changing the Kubelet configuration, so the existing workload can use the new configuration.  This was forgotten for control plane nodes, but since we're migrating them in place, we should drain them.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 