### PR TITLE
Validate does addons directory exist at the beginning

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -19,7 +19,6 @@ package addons
 import (
 	"io/fs"
 	"os"
-	"path/filepath"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
@@ -70,14 +69,10 @@ type templateData struct {
 func newAddonsApplier(s *state.State) (*applier, error) {
 	var localFS fs.FS
 
-	if s.Cluster.Addons != nil && s.Cluster.Addons.Enable {
-		addonsPath := s.Cluster.Addons.Path
-		if !filepath.IsAbs(addonsPath) && s.ManifestFilePath != "" {
-			manifestAbsPath, err := filepath.Abs(filepath.Dir(s.ManifestFilePath))
-			if err != nil {
-				return nil, errors.Wrap(err, "unable to get absolute path to the cluster manifest")
-			}
-			addonsPath = filepath.Join(manifestAbsPath, addonsPath)
+	if s.Cluster.Addons.Enabled() {
+		addonsPath, err := s.Cluster.Addons.RelativePath(s.ManifestFilePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get addons path")
 		}
 
 		localFS = os.DirFS(addonsPath)

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -254,4 +255,19 @@ func (r *RegistryConfiguration) InsecureRegistryAddress() string {
 
 func (ads *Addons) Enabled() bool {
 	return ads != nil && ads.Enable
+}
+
+// RelativePath returns addons path relative to the KubeOneCluster manifest file
+// path
+func (ads *Addons) RelativePath(manifestFilePath string) (string, error) {
+	addonsPath := ads.Path
+	if !filepath.IsAbs(addonsPath) && manifestFilePath != "" {
+		manifestAbsPath, err := filepath.Abs(filepath.Dir(manifestFilePath))
+		if err != nil {
+			return "", errors.Wrap(err, "unable to get absolute path to the cluster manifest")
+		}
+		addonsPath = filepath.Join(manifestAbsPath, addonsPath)
+	}
+
+	return addonsPath, nil
 }

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -62,6 +62,17 @@ func (opts *globalOptions) BuildState() (*state.State, error) {
 	s.CredentialsFilePath = opts.CredentialsFile
 	s.Verbose = opts.Verbose
 
+	// Validate Addons path if provided
+	if s.Cluster.Addons.Enabled() {
+		addonsPath, err := s.Cluster.Addons.RelativePath(s.ManifestFilePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get addons path")
+		}
+		if _, err := os.Stat(addonsPath); os.IsNotExist(err) {
+			return nil, errors.Wrapf(err, "failed to validate addons path, make sure that directory %q exists", s.Cluster.Addons.Path)
+		}
+	}
+
 	return s, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR mitigates a bug causing cluster provisioning to fail if embedded addons are used, but the addons directory doesn't exist. The issue is also triggered even if the user doesn't want to provide any addons and therefore doesn't need the addons directory.

A more permanent fix will be implemented in KubeOne 1.4.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Mitigates #1496

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 