### PR TITLE
Fix NPE when migrating to containerd

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -102,7 +102,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 	// 	* if the CSI migration is already enabled
 	//	* if we are starting the CCM/CSI migration process
 	csiMigration := s.CCMMigration
-	if !csiMigration && s.LiveCluster.CCMStatus != nil {
+	if !csiMigration && s.LiveCluster != nil && s.LiveCluster.CCMStatus != nil {
 		csiMigration = s.LiveCluster.CCMStatus.CSIMigrationEnabled
 	}
 

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -135,5 +135,13 @@ func runInstall(opts *installOpts) error {
 		return errors.Wrap(tasks.WithBinariesOnly(nil).Run(s), "failed to install kubernetes binaries")
 	}
 
+	// Probe the cluster for the actual state and the needed tasks.
+	probbing := tasks.WithHostnameOS(nil)
+	probbing = tasks.WithProbes(probbing)
+
+	if err = probbing.Run(s); err != nil {
+		return err
+	}
+
 	return errors.Wrap(tasks.WithFullInstall(nil).Run(s), "failed to install the cluster")
 }

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -64,6 +64,21 @@ func runMigrateToContainerd(opts *globalOptions) error {
 		return errors.Wrap(err, "failed to initialize State")
 	}
 
+	// Probe the cluster for the actual state and the needed tasks.
+	probbing := tasks.WithHostnameOS(nil)
+	probbing = tasks.WithProbes(probbing)
+
+	if err = probbing.Run(s); err != nil {
+		return err
+	}
+
+	if !s.LiveCluster.IsProvisioned() {
+		return errors.New("the target cluster is not provisioned")
+	}
+	if !s.LiveCluster.Healthy() {
+		return errors.New("the target cluster is not healthy, please run 'kubeone apply' first")
+	}
+
 	return errors.Wrap(tasks.WithContainerDMigration(nil).Run(s), "failed to get cluster status")
 }
 

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -96,5 +96,13 @@ func runUpgrade(opts *upgradeOpts) error {
 		return errors.Wrap(err, "failed to validate credentials")
 	}
 
+	// Probe the cluster for the actual state and the needed tasks.
+	probbing := tasks.WithHostnameOS(nil)
+	probbing = tasks.WithProbes(probbing)
+
+	if err = probbing.Run(s); err != nil {
+		return err
+	}
+
 	return errors.Wrap(tasks.WithUpgrade(nil).Run(s), "failed to upgrade cluster")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrating to containerd using `kubeone migrate to-containerd` throws an NPE when trying to install the machine-controller addon. This is because we try to access the CCM migration status when deploying MC, but it's unavailable because we don't run probes and therefore we don't have the LiveCluster object.

**Does this PR introduce a user-facing change?**:
```release-note
Fix NPE when migrating to containerd
```
