### PR TITLE
Mark vSphere CCM/CSI migration as non-experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@
 * It's currently **not** possible to provision or upgrade to Kubernetes 1.22 for clusters running on vSphere. This is because vSphere CCM and CSI don't support Kubernetes 1.22. We'll introduce Kubernetes 1.22 support for vSphere as soon as new CCM and CSI releases with support for Kubernetes 1.22 are out.
 * Clusters provisioned with Kubernetes 1.22 or upgraded from 1.21 to 1.22 using KubeOne 1.3.0-alpha.1 use a metrics-server version incompatible with Kubernetes 1.22. This might cause issues with deleting Namespaces that manifests by the Namespace being stuck in the Terminating state. This can be fixed by upgrading the metrics-server by running `kubeone apply`.
 * The new Addons API requires the addons directory path (`.addons.path`) to be provided and the directory must exist (it can be empty), even if only embedded addons are used. If the path is not provided, it'll default to `./addons`.
-* The CSI migration for vSphere is currently experimental and not tested.
 
 ## Added
 
@@ -68,6 +67,7 @@
 ### Fixed
 
 * Make `kubeone apply` skip already provisioned static worker nodes ([#1485](https://github.com/kubermatic/kubeone/pull/1485))
+* Fix NPE when migrating to containerd ([#1499](https://github.com/kubermatic/kubeone/pull/1499))
 
 ### Updated
 

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -115,7 +115,6 @@ func migrateToCCMCSICmd(fs *pflag.FlagSet) *cobra.Command {
 			because the cluster is already using external CCM.
 
 			Migration is currently available for OpenStack and vSphere. Other providers will be added in future KubeOne releases.
-			Note: vSphere support is currently experimental!
 
 			The migration is done in two phases:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes notes related to the experimental vSphere CCM/CSI migration support. @WeirdMachine tested in on vSphere 7.0u3 and both CCM and CSI migration work as expected.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 