### PR TITLE
Default MTU in calico-vxlan addon

### DIFF
--- a/addons/calico-vxlan/README.md
+++ b/addons/calico-vxlan/README.md
@@ -2,27 +2,17 @@
 
 ## Setup
 
-```shell
-mkdir addons
-curl https://raw.githubusercontent.com/kubermatic/kubeone/master/addons/calico-vxlan/calico-vxlan.yaml > addons/calico-vxlan.yaml
-```
+Since this addon is now shipped together with KubeOne, it's possible to simply
+configure it in kubeone.yaml.
 
-## MTU
-
-Please edit the `addons/calico-vxlan.yaml` and change `veth_mtu: "1450"` to appropriate MTU size. Please see more
-documentation how to find MTU size for your cluster https://docs.projectcalico.org/networking/mtu#determine-mtu-size.
-
-Example AWS kubeone config to use Calico addon.
+Example kubeone config:
 
 ```yaml
 apiVersion: kubeone.io/v1beta1
 kind: KubeOneCluster
 
 versions:
-  kubernetes: 1.18.5
-
-cloudProvider:
-  aws: {}
+  kubernetes: 1.20.4
 
 clusterNetwork:
   cni:
@@ -30,5 +20,32 @@ clusterNetwork:
 
 addons:
   enable: true
-  path: "./addons"
+  addons:
+  - name: calico-vxlan
 ```
+
+## Custom MTU
+
+MTU is set to 0 by default and is autodetected by the calico itself, but in case
+when you'd like to set own custom MTU it's possible to use [addon params mechanism][addon_params]:
+
+```yaml
+apiVersion: kubeone.io/v1beta1
+kind: KubeOneCluster
+
+versions:
+  kubernetes: 1.20.4
+
+clusterNetwork:
+  cni:
+    external: {}
+
+addons:
+  enable: true
+  addons:
+  - name: calico-vxlan
+    params:
+      MTU: 1400 # custom MTU
+```
+
+[addon_params]: https://docs.kubermatic.com/kubeone/v1.3/guides/addons/#parameters

--- a/addons/calico-vxlan/calico-vxlan.yaml
+++ b/addons/calico-vxlan/calico-vxlan.yaml
@@ -17,7 +17,7 @@ data:
   # - Otherwise, if VXLAN or BPF mode is enabled, set to your network MTU - 50
   # - Otherwise, if IPIP is enabled, set to your network MTU - 20
   # - Otherwise, if not using any encapsulation, set to your network MTU.
-  veth_mtu: ""
+  veth_mtu: "{{ default 0 .Params.MTU }}"
   # veth_mtu: "" # auto-detect MTU
   # veth_mtu: "8951" # use this if provider is AWS
   # veth_mtu: "1400" # use this if provider is OpenStack


### PR DESCRIPTION
**What this PR does / why we need it**:
Otherwise it causes crashloop since MTU is not defaulted and results to JSON error

**Special notes for your reviewer**:

```release-note
Default MTU in calico-vxlan addon
```
