### PR TITLE
azure-terraform: allow nodeports

### DIFF
--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -71,12 +71,26 @@ resource "azurerm_network_security_group" "sg" {
 
   security_rule {
     name                       = "SSH"
+    description                = "Allow inbound SSH"
     priority                   = 1001
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "NodePorts"
+    description                = "Allow inbound NodePorts"
+    priority                   = 1010
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "30000-32767"
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }

--- a/examples/terraform/azure/variables.tf
+++ b/examples/terraform/azure/variables.tf
@@ -69,13 +69,13 @@ variable "location" {
 
 variable "control_plane_vm_size" {
   description = "VM Size for control plane machines"
-  default     = "Standard_B2s"
+  default     = "Standard_F2"
   type        = string
 }
 
 variable "worker_vm_size" {
   description = "VM Size for worker machines"
-  default     = "Standard_B2s"
+  default     = "Standard_F2"
   type        = string
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Open nodeports by default for azure cluster

**Special notes for your reviewer**:
Found during v1.3.0 testing

Potentially fixes `Azure ingress is not accessible via Load Balancer` #1307

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* azure-terraform: open azure nodeports in firewall
* azure-terraform: default VM type is changed to Standard_F2
```
