### PR TITLE
hetzner-terraform: add firewall

### DIFF
--- a/examples/terraform/hetzner/main.tf
+++ b/examples/terraform/hetzner/main.tf
@@ -24,6 +24,67 @@ resource "hcloud_network" "net" {
   ip_range = var.ip_range
 }
 
+resource "hcloud_firewall" "cluster" {
+  name = "${var.cluster_name}-fw"
+
+  labels = {
+    "kubeone_cluster_name" = var.cluster_name
+  }
+
+  apply_to {
+    label_selector = "kubeone_cluster_name=${var.cluster_name}"
+  }
+
+  rule {
+    description = "allow ICMP"
+    direction   = "in"
+    protocol    = "icmp"
+    source_ips = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  rule {
+    description = "allow all TCP inside cluster"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "any"
+    source_ips = [
+      var.ip_range,
+    ]
+  }
+
+  rule {
+    description = "allow all UDP inside cluster"
+    direction   = "in"
+    protocol    = "udp"
+    port        = "any"
+    source_ips = [
+      var.ip_range,
+    ]
+  }
+
+  rule {
+    description = "allow SSH from any"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "22"
+    source_ips = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  rule {
+    description = "allow NodePorts from any"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "30000-32767"
+    source_ips = [
+      "0.0.0.0/0",
+    ]
+  }
+}
+
 resource "hcloud_network_subnet" "kubeone" {
   network_id   = hcloud_network.net.id
   type         = "server"
@@ -32,13 +93,13 @@ resource "hcloud_network_subnet" "kubeone" {
 }
 
 resource "hcloud_server_network" "control_plane" {
-  count     = 3
+  count     = var.control_plane_replicas
   server_id = element(hcloud_server.control_plane.*.id, count.index)
   subnet_id = hcloud_network_subnet.kubeone.id
 }
 
 resource "hcloud_server" "control_plane" {
-  count       = 3
+  count       = var.control_plane_replicas
   name        = "${var.cluster_name}-control-plane-${count.index + 1}"
   server_type = var.control_plane_type
   image       = var.image
@@ -71,9 +132,9 @@ resource "hcloud_load_balancer" "load_balancer" {
 }
 
 resource "hcloud_load_balancer_target" "load_balancer_target" {
+  count            = var.control_plane_replicas
   type             = "server"
   load_balancer_id = hcloud_load_balancer.load_balancer.id
-  count            = 3
   server_id        = element(hcloud_server.control_plane.*.id, count.index)
   use_private_ip   = true
   depends_on = [

--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -72,6 +72,7 @@ output "kubeone_workers" {
           # Datacenter (optional)
           # datacenter = ""
           labels = {
+            "kubeone_cluster_name"        = var.cluster_name
             "${var.cluster_name}-workers" = "pool1"
           }
         }

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -66,6 +66,11 @@ variable "control_plane_type" {
   type    = string
 }
 
+variable "control_plane_replicas" {
+  default = 3
+  type    = number
+}
+
 variable "worker_type" {
   default = "cx21"
   type    = string

--- a/examples/terraform/hetzner/versions.tf
+++ b/examples/terraform/hetzner/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "~> 1.26.0"
+      version = "~> 1.31.0"
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Finally, hetzner cloud started to support firewall, and it's possible to target VMs with just labels so we can support it without any code changes!

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
hetzner-terraform: add firewall
```
