### PR TITLE
aws-terraform: open nodeports unconditionally

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -133,7 +133,6 @@ resource "aws_security_group_rule" "egress_allow_all" {
 }
 
 resource "aws_security_group_rule" "nodeports" {
-  count             = var.open_nodeports ? 1 : 0
   type              = "ingress"
   security_group_id = aws_security_group.common.id
 

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -177,12 +177,6 @@ variable "internal_api_lb" {
   type        = bool
 }
 
-variable "open_nodeports" {
-  default     = false
-  description = "open NodePorts flag"
-  type        = bool
-}
-
 variable "initial_machinedeployment_replicas" {
   default     = 1
   description = "number of replicas per MachineDeployment"


### PR DESCRIPTION
**What this PR does / why we need it**:
Conformance tests require NodePorts to be open on all node Address types

**Does this PR introduce a user-facing change?**:
```release-note
AWS terraform config opens nodeports unconditionally
```
