### PR TITLE
Update the kubeone-e2e image to Go 1.17.1

### DIFF
--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,12 +14,12 @@
 
 # building image
 
-FROM golang:1.16.7 as builder
+FROM golang:1.17.1 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip
 
-ENV TERRAFORM_VERSION "1.0.4"
+ENV TERRAFORM_VERSION "1.0.7"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform
 RUN chmod +x /usr/local/bin/terraform
 
@@ -36,7 +36,7 @@ RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
-FROM golang:1.16.7
+FROM golang:1.17.1
 
 ARG version
 

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,10 +17,10 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.19"]="v1.19.14"
-full_versions["1.20"]="v1.20.10"
-full_versions["1.21"]="v1.21.4"
-full_versions["1.22"]="v1.22.0"
+full_versions["1.19"]="v1.19.15"
+full_versions["1.20"]="v1.20.11"
+full_versions["1.21"]="v1.21.5"
+full_versions["1.22"]="v1.22.2"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.17
+TAG=v0.1.18
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

xref #1540
/assign @kron4eg @xrstf 