### PR TITLE
CCM/CSI migration support for clusters with static worker nodes

### DIFF
--- a/pkg/scripts/ccm_csi_migration.go
+++ b/pkg/scripts/ccm_csi_migration.go
@@ -31,6 +31,10 @@ var (
 		sudo kubeadm {{ .VERBOSE }} init phase kubelet-start \
 			--config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
 	`)
+
+	ccmMigrationRestartKubelet = heredoc.Doc(`
+		sudo systemctl restart kubelet
+	`)
 )
 
 func CCMMigrationRegenerateControlPlaneManifests(workdir string, nodeID int, verboseFlag string) (string, error) {
@@ -47,4 +51,8 @@ func CCMMigrationUpdateKubeletConfig(workdir string, nodeID int, verboseFlag str
 		"NODE_ID":  nodeID,
 		"VERBOSE":  verboseFlag,
 	})
+}
+
+func CCMMigrationRestartKubelet() (string, error) {
+	return Render(ccmMigrationRestartKubelet, Data{})
 }

--- a/pkg/tasks/ccm_csi_migration.go
+++ b/pkg/tasks/ccm_csi_migration.go
@@ -17,7 +17,9 @@ limitations under the License.
 package tasks
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"strconv"
 	"time"
 
@@ -27,6 +29,7 @@ import (
 	"k8c.io/kubeone/pkg/nodeutils"
 	"k8c.io/kubeone/pkg/scripts"
 	"k8c.io/kubeone/pkg/ssh"
+	"k8c.io/kubeone/pkg/ssh/sshiofs"
 	"k8c.io/kubeone/pkg/state"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
@@ -44,7 +47,7 @@ const (
 	provisionedByOpenStackCSICinder    = "cinder.csi.openstack.org"
 )
 
-func validateExternalCloudProviderConfig(s *state.State) error {
+func ccmMigrationValidateConfig(s *state.State) error {
 	if !s.Cluster.CloudProvider.External {
 		return errors.New(".cloudProvider.external must be enabled to start the migration")
 	}
@@ -59,14 +62,11 @@ func validateExternalCloudProviderConfig(s *state.State) error {
 	if s.Cluster.CloudProvider.Vsphere != nil && s.Cluster.CloudProvider.CSIConfig == "" {
 		return errors.New("the ccm/csi migration for vsphere requires providing csi configuration using .cloudProvider.csiConfig field")
 	}
-	if len(s.Cluster.StaticWorkers.Hosts) > 0 {
-		return errors.New("the ccm/csi migration for cluster with static worker nodes is currently unsupported")
-	}
 
 	return nil
 }
 
-func readyToCompleteMigration(s *state.State) error {
+func readyToCompleteCCMMigration(s *state.State) error {
 	if s.DynamicClient == nil {
 		return errors.New("clientset not initialized")
 	}
@@ -92,11 +92,11 @@ func readyToCompleteMigration(s *state.State) error {
 	return nil
 }
 
-func regenerateControlPlaneManifests(s *state.State) error {
-	return s.RunTaskOnControlPlane(regenerateControlPlaneManifestsInternal, state.RunSequentially)
+func ccmMigrationRegenerateControlPlaneManifests(s *state.State) error {
+	return s.RunTaskOnControlPlane(ccmMigrationRegenerateControlPlaneManifestsInternal, state.RunSequentially)
 }
 
-func regenerateControlPlaneManifestsInternal(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
+func ccmMigrationRegenerateControlPlaneManifestsInternal(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	logger := s.Logger.WithField("node", node.PublicAddress)
 	logger.Info("Regenerating Kubernetes API server and kube-controller-manager manifests...")
 
@@ -134,11 +134,11 @@ func regenerateControlPlaneManifestsInternal(s *state.State, node *kubeoneapi.Ho
 	return nil
 }
 
-func updateKubeletConfig(s *state.State) error {
-	return s.RunTaskOnControlPlane(updateKubeletConfigInternal, state.RunSequentially)
+func ccmMigrationUpdateControlPlaneKubeletConfig(s *state.State) error {
+	return s.RunTaskOnControlPlane(ccmMigrationUpdateControlPlaneKubeletConfigInternal, state.RunSequentially)
 }
 
-func updateKubeletConfigInternal(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
+func ccmMigrationUpdateControlPlaneKubeletConfigInternal(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	logger := s.Logger.WithField("node", node.PublicAddress)
 	logger.Info("Updating config and restarting Kubelet...")
 
@@ -154,6 +154,7 @@ func updateKubeletConfigInternal(s *state.State, node *kubeoneapi.HostConfig, co
 		return errors.Wrap(err, "failed to drain follower control plane node")
 	}
 
+	logger.Info("Updating Kubelet config...")
 	cmd, err := scripts.CCMMigrationUpdateKubeletConfig(s.WorkDir, node.ID, s.KubeadmVerboseFlag())
 	if err != nil {
 		return err
@@ -165,25 +166,169 @@ func updateKubeletConfigInternal(s *state.State, node *kubeoneapi.HostConfig, co
 
 	timeout := 2 * time.Minute
 	logger.Debugf("Waiting up to %s for Kubelet to become running...", timeout)
-	err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
-		kubeletStatus, sErr := systemdStatus(conn, "kubelet")
-		if sErr != nil {
-			return false, sErr
-		}
-
-		if kubeletStatus&state.SystemDStatusRunning != 0 && kubeletStatus&state.SystemDStatusRestarting == 0 {
-			return true, nil
-		}
-
-		return false, nil
-	})
-	if err != nil {
-		return err
+	if err := waitForKubeletReady(conn, timeout); err != nil {
+		return errors.Wrapf(err, "kubelet failed to start for %s", timeout)
 	}
 
 	logger.Infoln("Uncordoning node...")
 	if err := drainer.Cordon(s.Context, node.Hostname, false); err != nil {
 		return errors.Wrap(err, "failed to uncordon follower control plane node")
+	}
+
+	return nil
+}
+
+func ccmMigrationUpdateStaticWorkersKubeletConfig(s *state.State) error {
+	return s.RunTaskOnStaticWorkers(ccmMigrationUpdateStaticWorkersKubeletConfigInternal, state.RunSequentially)
+}
+
+func ccmMigrationUpdateStaticWorkersKubeletConfigInternal(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
+	logger := s.Logger.WithField("node", node.PublicAddress)
+	logger.Info("Updating config and restarting Kubelet...")
+
+	drainer := nodeutils.NewDrainer(s.RESTConfig, logger)
+
+	logger.Infoln("Cordoning node...")
+	if err := drainer.Cordon(s.Context, node.Hostname, true); err != nil {
+		return errors.Wrap(err, "failed to cordon follower control plane node")
+	}
+
+	logger.Infoln("Draining node...")
+	if err := drainer.Drain(s.Context, node.Hostname); err != nil {
+		return errors.Wrap(err, "failed to drain follower control plane node")
+	}
+
+	// Update kubelet config and flags
+	logger.Info("Updating Kubelet config...")
+	if err := ccmMigrationUpdateKubeletConfigFile(s); err != nil {
+		return err
+	}
+	if err := ccmMigrationUpdateKubeletFlags(s); err != nil {
+		return err
+	}
+
+	// Restart Kubelet
+	logger.Info("Restarting Kubelet...")
+	script, err := scripts.CCMMigrationRestartKubelet()
+	if err != nil {
+		return err
+	}
+
+	_, _, err = s.Runner.RunRaw(script)
+	if err != nil {
+		return err
+	}
+
+	timeout := 2 * time.Minute
+	logger.Debugf("Waiting up to %s for Kubelet to become running...", timeout)
+	if err := waitForKubeletReady(conn, timeout); err != nil {
+		return errors.Wrapf(err, "kubelet failed to start for %s", timeout)
+	}
+
+	logger.Infoln("Uncordoning node...")
+	if err := drainer.Cordon(s.Context, node.Hostname, false); err != nil {
+		return errors.Wrap(err, "failed to uncordon follower control plane node")
+	}
+
+	return nil
+}
+
+func ccmMigrationUpdateKubeletConfigFile(s *state.State) error {
+	// Grab the Kubelet configuration file from the node
+	sshfs := s.Runner.NewFS()
+	f, err := sshfs.Open(kubeletConfigFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal and update the config
+	kubeletConfig, err := unmarshalKubeletConfig(buf)
+	if err != nil {
+		return err
+	}
+
+	if kubeletConfig.FeatureGates == nil {
+		kubeletConfig.FeatureGates = map[string]bool{}
+	}
+	if s.ShouldEnableCSIMigration() {
+		featureGates, _, fgErr := s.Cluster.CSIMigrationFeatureGates(s.ShouldUnregisterInTreeCloudProvider())
+		if fgErr != nil {
+			return fgErr
+		}
+		for k, v := range featureGates {
+			kubeletConfig.FeatureGates[k] = v
+		}
+	}
+
+	// Update the config on the node
+	buf, err = marshalKubeletConfig(kubeletConfig)
+	if err != nil {
+		return err
+	}
+
+	fw, ok := f.(sshiofs.ExtendedFile)
+	if !ok {
+		return errors.New("file is not writable")
+	}
+
+	if err = fw.Truncate(0); err != nil {
+		return err
+	}
+
+	if _, err = fw.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(fw, bytes.NewBuffer(buf)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ccmMigrationUpdateKubeletFlags(s *state.State) error {
+	sshfs := s.Runner.NewFS()
+	f, err := sshfs.Open(kubeadmEnvFlagsFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	kubeletFlags, err := unmarshalKubeletFlags(buf)
+	if err != nil {
+		return err
+	}
+
+	kubeletFlags["--cloud-provider"] = "external"
+	delete(kubeletFlags, "--cloud-config")
+
+	buf = marshalKubeletFlags(kubeletFlags)
+	fw, ok := f.(sshiofs.ExtendedFile)
+	if !ok {
+		return errors.New("file is not writable")
+	}
+
+	if err = fw.Truncate(0); err != nil {
+		return err
+	}
+
+	if _, err = fw.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(fw, bytes.NewBuffer(buf)); err != nil {
+		return err
 	}
 
 	return nil
@@ -241,6 +386,21 @@ func waitForStaticPodReady(s *state.State, timeout time.Duration, staticPodName,
 		}
 
 		return true, nil
+	})
+}
+
+func waitForKubeletReady(conn ssh.Connection, timeout time.Duration) error {
+	return wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		kubeletStatus, sErr := systemdStatus(conn, "kubelet")
+		if sErr != nil {
+			return false, sErr
+		}
+
+		if kubeletStatus&state.SystemDStatusRunning != 0 && kubeletStatus&state.SystemDStatusRestarting == 0 {
+			return true, nil
+		}
+
+		return false, nil
 	})
 }
 

--- a/pkg/tasks/common.go
+++ b/pkg/tasks/common.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	kubeadmEnvFlagsFile   = "/var/lib/kubelet/kubeadm-flags.env"
+	kubeletKubeadmArgsEnv = "KUBELET_KUBEADM_ARGS"
+	kubeletConfigFile     = "/var/lib/kubelet/config.yaml"
+)
+
+func unmarshalKubeletFlags(buf []byte) (map[string]string, error) {
+	// throw away KUBELET_KUBEADM_ARGS=
+	s1 := strings.SplitN(string(buf), "=", 2)
+	if len(s1) != 2 {
+		return nil, errors.New("can't parse: wrong split length")
+	}
+
+	envValue := strings.Trim(s1[1], `"`)
+	flagsvalues := strings.Split(envValue, " ")
+	kubeletflagsMap := map[string]string{}
+
+	for _, flg := range flagsvalues {
+		fl := strings.Split(flg, "=")
+		if len(fl) != 2 {
+			return nil, errors.New("wrong split length")
+		}
+		kubeletflagsMap[fl[0]] = fl[1]
+	}
+
+	return kubeletflagsMap, nil
+}
+
+func marshalKubeletFlags(kubeletflags map[string]string) []byte {
+	kvpairs := []string{}
+	for k, v := range kubeletflags {
+		kvpairs = append(kvpairs, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	sort.Strings(kvpairs)
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, `%s="`, kubeletKubeadmArgsEnv)
+
+	for i, val := range kvpairs {
+		format := "%s "
+		if i == len(kvpairs)-1 {
+			format = "%s"
+		}
+		fmt.Fprintf(&buf, format, val)
+	}
+
+	buf.WriteString(`"`)
+
+	return buf.Bytes()
+}
+
+func unmarshalKubeletConfig(configBytes []byte) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+	var config kubeletconfigv1beta1.KubeletConfiguration
+	err := yaml.Unmarshal(configBytes, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func marshalKubeletConfig(config *kubeletconfigv1beta1.KubeletConfiguration) ([]byte, error) {
+	encodedCfg, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal kubelet config")
+	}
+
+	return encodedCfg, nil
+}

--- a/pkg/tasks/common_test.go
+++ b/pkg/tasks/common_test.go
@@ -68,6 +68,15 @@ func Test_unmarshalKubeletFlags(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "key-values in a flag",
+			buf:  []byte(`KUBELET_KUBEADM_ARGS="--key1=val1=test1,val2=test2 --key2=val2"`),
+			want: map[string]string{
+				"--key1": "val1=test1,val2=test2",
+				"--key2": "val2",
+			},
+			wantErr: false,
+		},
+		{
 			name:    "error1",
 			buf:     []byte{},
 			wantErr: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces CCM/CSI migration support for clusters with the static worker nodes. As described in #1495, `kubeadm` cannot be used to handle updating kubelet configuration and flags. This is because `kubeadm init` (used for control plane nodes) works differently than `kubeadm join` (used for static worker nodes).

To mitigate that, we manually update the required files, which we already do for Docker to containerd migration.

The workflow is:

* Cordon and drain a static worker node
* Download the kubelet config file (`/var/lib/kubelet/config.yaml`)
* Add the required feature gates
* Upload the new kubelet config file
* Download the `kubeadm-flags.env` file (`/var/lib/kubelet/kubeadm-flags.env`)
* Set `--cloud-provider=external` and remove the `--cloud-config` flag
* Upload the updated `kubeadm-flags.env`
* Restart kubelet and wait up to 2 minutes for it to become running
* Uncordon the node

This PR has been already tested on an OpenStack cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1495
Fixes #1450

**Does this PR introduce a user-facing change?**:
```release-note
CCM/CSI migration support for clusters with static worker nodes
```
