### PR TITLE
Default image in the cluster-autoscaler addon

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -147,7 +147,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-      - image: {{ Registry "k8s.gcr.io" }}/autoscaling/cluster-autoscaler:${AUTOSCALER_VERSION}
+      - image: {{ default (.InternalImages.Get "ClusterAutoscaler") .Params.CLUSTER_AUTOSCALER_IMAGE }}
         name: cluster-autoscaler
         command:
         - /cluster-autoscaler

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -49,6 +49,7 @@ const (
 	CalicoCNI
 	CalicoController
 	CalicoNode
+	ClusterAutoscaler
 	CSIAttacher
 	CSINodeDriverRegistar
 	CSIProvisioner
@@ -153,6 +154,14 @@ func optionalResources() map[Resource]map[string]string {
 		// WeaveNet CNI plugin
 		WeaveNetCNIKube: {"*": "docker.io/weaveworks/weave-kube:2.8.1"},
 		WeaveNetCNINPC:  {"*": "docker.io/weaveworks/weave-npc:2.8.1"},
+
+		// Cluster-autoscaler addon
+		ClusterAutoscaler: {
+			"1.19.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.0",
+			"1.20.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0",
+			"1.21.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0",
+			">= 1.22.0": "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.0",
+		},
 	}
 }
 

--- a/pkg/templates/images/resource_string.go
+++ b/pkg/templates/images/resource_string.go
@@ -13,32 +13,33 @@ func _() {
 	_ = x[CalicoCNI-3]
 	_ = x[CalicoController-4]
 	_ = x[CalicoNode-5]
-	_ = x[CSIAttacher-6]
-	_ = x[CSINodeDriverRegistar-7]
-	_ = x[CSIProvisioner-8]
-	_ = x[CSISnapshotter-9]
-	_ = x[CSIResizer-10]
-	_ = x[CSILivenessProbe-11]
-	_ = x[DigitaloceanCCM-12]
-	_ = x[DNSNodeCache-13]
-	_ = x[Flannel-14]
-	_ = x[HetznerCCM-15]
-	_ = x[HetznerCSI-16]
-	_ = x[MachineController-17]
-	_ = x[MetricsServer-18]
-	_ = x[OpenstackCCM-19]
-	_ = x[OpenstackCSI-20]
-	_ = x[PacketCCM-21]
-	_ = x[VsphereCCM-22]
-	_ = x[VsphereCSIDriver-23]
-	_ = x[VsphereCSISyncer-24]
-	_ = x[WeaveNetCNIKube-25]
-	_ = x[WeaveNetCNINPC-26]
+	_ = x[ClusterAutoscaler-6]
+	_ = x[CSIAttacher-7]
+	_ = x[CSINodeDriverRegistar-8]
+	_ = x[CSIProvisioner-9]
+	_ = x[CSISnapshotter-10]
+	_ = x[CSIResizer-11]
+	_ = x[CSILivenessProbe-12]
+	_ = x[DigitaloceanCCM-13]
+	_ = x[DNSNodeCache-14]
+	_ = x[Flannel-15]
+	_ = x[HetznerCCM-16]
+	_ = x[HetznerCSI-17]
+	_ = x[MachineController-18]
+	_ = x[MetricsServer-19]
+	_ = x[OpenstackCCM-20]
+	_ = x[OpenstackCSI-21]
+	_ = x[PacketCCM-22]
+	_ = x[VsphereCCM-23]
+	_ = x[VsphereCSIDriver-24]
+	_ = x[VsphereCSISyncer-25]
+	_ = x[WeaveNetCNIKube-26]
+	_ = x[WeaveNetCNINPC-27]
 }
 
-const _Resource_name = "AzureCCMAzureCNMCalicoCNICalicoControllerCalicoNodeCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeDigitaloceanCCMDNSNodeCacheFlannelHetznerCCMHetznerCSIMachineControllerMetricsServerOpenstackCCMOpenstackCSIPacketCCMVsphereCCMVsphereCSIDriverVsphereCSISyncerWeaveNetCNIKubeWeaveNetCNINPC"
+const _Resource_name = "AzureCCMAzureCNMCalicoCNICalicoControllerCalicoNodeClusterAutoscalerCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeDigitaloceanCCMDNSNodeCacheFlannelHetznerCCMHetznerCSIMachineControllerMetricsServerOpenstackCCMOpenstackCSIPacketCCMVsphereCCMVsphereCSIDriverVsphereCSISyncerWeaveNetCNIKubeWeaveNetCNINPC"
 
-var _Resource_index = [...]uint16{0, 8, 16, 25, 41, 51, 62, 83, 97, 111, 121, 137, 152, 164, 171, 181, 191, 208, 221, 233, 245, 254, 264, 280, 296, 311, 325}
+var _Resource_index = [...]uint16{0, 8, 16, 25, 41, 51, 68, 79, 100, 114, 128, 138, 154, 169, 181, 188, 198, 208, 225, 238, 250, 262, 271, 281, 297, 313, 328, 342}
 
 func (i Resource) String() string {
 	i -= 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the cluster-autoscaler addon cannot be used as an embedded addon because we don't default the image/version. Instead, users still have to copy the addon to their addons directory and then manually modify the image.

The embedded addons are supposed to be used without having to copy and modify them, and this PR modifies the cluster-autoscaler addon to support this use case.

There are two changes in this PR:

* The image is now defaulted depending on the Kubernetes version of the cluster
* The image can be overridden via addon parameters:

```yaml
...
addons:
  enable: true
  path: "./addons"
  addons:
  - name: cluster-autoscaler
    params:
      CLUSTER_AUTOSCALER_IMAGE: "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0"
```

**Does this PR introduce a user-facing change?**:
```release-note
Default image in the cluster-autoscaler addon and allow the image to be overridden using addon parameters
```