### PR TITLE
Added availability set for workers and security group to allow ingress access

### DIFF
--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -45,8 +45,8 @@ resource "azurerm_availability_set" "avset" {
   }
 }
 
-resource "azurerm_availability_set" "avset_worker" {
-  name                         = "${var.cluster_name}-avset-worker"
+resource "azurerm_availability_set" "avset_workers" {
+  name                         = "${var.cluster_name}-avset-workers"
   location                     = var.location
   resource_group_name          = azurerm_resource_group.rg.name
   platform_fault_domain_count  = 2
@@ -108,29 +108,7 @@ resource "azurerm_network_security_group" "sg" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
-  security_rule {
-    name                       = "Azure_LB_to_VMs_https"
-    priority                   = 1002
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "443"
-    source_address_prefix      = "AzureLoadBalancer"
-    destination_address_prefix = "*"
-  }
-  security_rule {
-    name                       = "Azure_LB_to_VMs_http"
-    priority                   = 1003
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "80"
-    source_address_prefix      = "AzureLoadBalancer"
-    destination_address_prefix = "*"
-  }
-
+  
   tags = {
     environment = "kubeone"
     cluster     = var.cluster_name

--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -45,6 +45,20 @@ resource "azurerm_availability_set" "avset" {
   }
 }
 
+resource "azurerm_availability_set" "avset_worker" {
+  name                         = "${var.cluster_name}-avset-worker"
+  location                     = var.location
+  resource_group_name          = azurerm_resource_group.rg.name
+  platform_fault_domain_count  = 2
+  platform_update_domain_count = 2
+  managed                      = true
+
+  tags = {
+    environment = "kubeone"
+    cluster     = var.cluster_name
+  }
+}
+
 resource "azurerm_virtual_network" "vpc" {
   name                = "${var.cluster_name}-vpc"
   address_space       = ["172.16.0.0/12"]
@@ -92,6 +106,28 @@ resource "azurerm_network_security_group" "sg" {
     source_port_range          = "*"
     destination_port_range     = "30000-32767"
     source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name                       = "Azure_LB_to_VMs_https"
+    priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "AzureLoadBalancer"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name                       = "Azure_LB_to_VMs_http"
+    priority                   = 1003
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "AzureLoadBalancer"
     destination_address_prefix = "*"
   }
 

--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -108,7 +108,6 @@ resource "azurerm_network_security_group" "sg" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
-  
   tags = {
     environment = "kubeone"
     cluster     = var.cluster_name

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -59,7 +59,7 @@ output "kubeone_workers" {
           # see example under `cloudProviderSpec` section at: 
           # https://github.com/kubermatic/machine-controller/blob/master/examples/azure-machinedeployment.yaml
           assignPublicIP    = true
-          availabilitySet   = azurerm_availability_set.avset_worker.name
+          availabilitySet   = azurerm_availability_set.avset_workers.name
           location          = var.location
           resourceGroup     = azurerm_resource_group.rg.name
           routeTableName    = ""

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -59,7 +59,7 @@ output "kubeone_workers" {
           # see example under `cloudProviderSpec` section at: 
           # https://github.com/kubermatic/machine-controller/blob/master/examples/azure-machinedeployment.yaml
           assignPublicIP    = true
-          availabilitySet   = azurerm_availability_set.avset.name
+          availabilitySet   = azurerm_availability_set.avset_worker.name
           location          = var.location
           resourceGroup     = azurerm_resource_group.rg.name
           routeTableName    = ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently, Azure terraform example has two issues:
1. If we install any service of type LoadBalancer, it does not provide LoadBalancer. this is because of Azure having some restriction on number of LoadBalancers in a given availability set. We are having a single AV set in the code for masters as well as workers and we already provision one load balancer for api-server. So we cannot provision any service of type LoadBalancer (e.g. nginx ingress)
2. If we get 2nd AVset for above issue and then install nginx-ingress, we cannot reach the ingress endpoints due to security group restrictions.

This PR solves both above issues by adding an additional avset for worker machines and also relaxing security group to reach on port 80 and 443 from LB.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
Partially related #1307 . Need documentation fix though.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
