### PR TITLE
Use gocache in CI when building KubeOne

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ terraform.tfvars
 *kubeconfig
 !*kubeconfig/
 /vendor
+download-gocache

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1392,3 +1392,22 @@ postsubmits:
             requests:
               cpu: 100m
               memory: 1Gi
+  - name: post-kubeone-upload-gocache
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    branches:
+      - ^master$
+    spec:
+      containers:
+        # This must match the go version used for building, else go will rightfully
+        # not use the cache
+        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
+          command:
+            - ./hack/ci/upload-gocache.sh
+          resources:
+            requests:
+              # Make sure we get a node exclusively so this is fast and we do not disturb others
+              cpu: 3500m
+              memory: 6Gi
+            limits:
+              cpu: 4

--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,17 @@ build: dist/kubeone
 vendor: buildenv
 	go mod vendor
 
-dist/kubeone: buildenv
+dist/kubeone: buildenv download-gocache
 	go build -ldflags='$(GOLDFLAGS)' -v -o $@ .
 
 dist/kubeone-debug: buildenv
 	export GOFLAGS=-mod=readonly; \
 	go build -gcflags='all=-N -l' -v -o $@ .
+
+download-gocache:
+	@./hack/ci/download-gocache.sh
+	@# Prevent this from getting executed multiple times
+	@touch download-gocache
 
 .PHONY: generate-internal-groups
 generate-internal-groups: GOFLAGS = -mod=readonly

--- a/hack/ci/download-gocache.sh
+++ b/hack/ci/download-gocache.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This script is used when building Go binaries to download a prewarmed
+### cache for `$GOCACHE`. This is an uncompressed tar archive in a local
+### S3-compatible storage, which is just downloaded and extracted. This
+### significantly speeds up CI jobs, as much fewer packages have to be
+### compiled.
+###
+### A dedicated postsubmit job that runs after every change to the master
+### branch is keeping the cache up-to-date.
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+# The gocache needs a matching go version to work, so append that to the name
+GO_VERSION="$(go version | awk '{ print $3 }' | sed 's/go//g')"
+GOARCH="$(go env GOARCH)"
+
+# Make sure we never error, this is always best-effort only
+exit_gracefully() {
+  if [ $? -ne 0 ]; then
+    echodate "Encountered error when trying to download gocache"
+  fi
+  exit 0
+}
+trap exit_gracefully EXIT
+
+source $(dirname $0)/../lib.sh
+
+if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
+  echodate "env var GOCACHE_MINIO_ADDRESS unset, can not download gocache"
+  exit 0
+fi
+
+GOCACHE="$(go env GOCACHE)"
+# Make sure it actually exists
+mkdir -p "${GOCACHE}"
+
+# PULL_BASE_REF is the name of the current branch in case of a post-submit
+# or the name of the base branch in case of a PR.
+GIT_BRANCH="${PULL_BASE_REF:-}"
+CACHE_VERSION="${PULL_BASE_SHA:-}"
+
+# Periodics just use their head ref
+if [[ -z "${CACHE_VERSION}" ]]; then
+  CACHE_VERSION="$(git rev-parse HEAD)"
+  GIT_BRANCH="master"
+fi
+
+if [ -z "${PULL_NUMBER:-}" ]; then
+  # Special case: This is called in a Postsubmit. Go one revision back,
+  # as there can't be a cache for the current revision
+  CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
+fi
+
+# normalize branch name to prevent accidental directories being created
+GIT_BRANCH="$(echo "$GIT_BRANCH" | sed 's#/#-#g')"
+
+ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}-${GOARCH}.tar"
+URL="${GOCACHE_MINIO_ADDRESS}/kubeone/${GIT_BRANCH}/${ARCHIVE_NAME}"
+
+# Do not go through the retry loop when there is nothing, but do try the
+# first parent if no cache was found. This is helpful for retests happening
+# quickly after something got merged to master and no gocache for the most
+# recent commit exists yet. In this case, taking the previous commit's
+# cache is better than nothing.
+if ! curl --head --silent --fail "${URL}" > /dev/null; then
+  echodate "Remote has no gocache ${ARCHIVE_NAME}, trying previous commit as a fallback..."
+
+  CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
+  ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}-${GOARCH}.tar"
+  URL="${GOCACHE_MINIO_ADDRESS}/kubeone/${GIT_BRANCH}/${ARCHIVE_NAME}"
+
+  if ! curl --head --silent --fail "${URL}" > /dev/null; then
+    echodate "Remote has no gocache ${ARCHIVE_NAME}, giving up."
+    exit 0
+  fi
+fi
+
+echodate "Downloading and extracting gocache"
+TEST_NAME="Download and extract gocache"
+# Passing the Headers as space-separated literals doesn't seem to work
+# in conjunction with the retry func, so we just put them in a file instead
+echo 'Content-Type: application/octet-stream' > /tmp/headers
+retry 5 curl --fail -H @/tmp/headers "${URL}" | tar -C $GOCACHE -xf -
+
+echodate "Successfully fetched gocache into $GOCACHE"

--- a/hack/ci/upload-gocache.sh
+++ b/hack/ci/upload-gocache.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Runs as a postsubmit and refreshes the gocache by downloading the
+### previous version, compiling everything and then tar'ing up the
+### Go cache again.
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
+  echodate "Fatal: env var GOCACHE_MINIO_ADDRESS unset"
+  exit 1
+fi
+
+# The gocache needs a matching go version to work, so append that to the name
+GO_VERSION="$(go version | awk '{ print $3 }' | sed 's/go//g')"
+GOARCH="$(go env GOARCH)"
+
+GOCACHE_DIR="$(mktemp -d)"
+export GOCACHE="${GOCACHE_DIR}"
+export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
+export CGO_ENABLED=0
+
+# PULL_BASE_REF is the name of the current branch in case of a post-submit
+# or the name of the base branch in case of a PR.
+GIT_BRANCH="${PULL_BASE_REF:-}"
+
+# normalize branch name to prevent accidental directories being created
+GIT_BRANCH="$(echo "$GIT_BRANCH" | sed 's#/#-#g')"
+
+echodate "Creating cache for revision ${GIT_BRANCH}/${GIT_HEAD_HASH} / Go ${GO_VERSION}/${GOARCH} ..."
+
+echodate "Building binaries"
+
+(
+  # prevent the Makefile from downloading the old Gocache. This ensures that
+  # our cache does not grow over time, as packages are added and removed,
+  # but makes creating the cache a tiny bit slower
+  touch download-gocache
+
+  make build
+)
+
+echodate "Building tests"
+
+(
+  go test -run thisTestDoesNotExist ./pkg/... ./test/...
+  go test -run thisTestDoesNotExist -tags e2e ./pkg/... ./test/...
+)
+
+TEST_NAME="Creating gocache archive"
+echodate "Creating gocache archive"
+
+ARCHIVE_FILE="/tmp/${GIT_HEAD_HASH}.tar"
+# No compression because that needs quite a bit of CPU
+retry 2 tar -C "$GOCACHE" -cf "$ARCHIVE_FILE" .
+
+TEST_NAME="Uploading gocache archive"
+echodate "Uploading gocache archive"
+
+# Passing the Headers as space-separated literals doesn't seem to work
+# in conjunction with the retry func, so we just put them in a file instead
+echo 'Content-Type: application/octet-stream' > /tmp/headers
+retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/kubeone/${GIT_BRANCH}/${GIT_HEAD_HASH}-${GO_VERSION}-${GOARCH}.tar"
+
+echodate "Upload complete."

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Contains commonly used functions for the other scripts.
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when a script
+# receives a SIGINT
+set -o monitor
+
+retry() {
+  # Works only with bash but doesn't fail on other shells
+  start_time=$(date +%s)
+  set +e
+  actual_retry $@
+  rc=$?
+  set -e
+  elapsed_time=$(($(date +%s) - $start_time))
+  write_junit "$rc" "$elapsed_time"
+  return $rc
+}
+
+# We use an extra wrapping to write junit and have a timer
+actual_retry() {
+  retries=$1
+  shift
+
+  count=0
+  delay=1
+  until "$@"; do
+    rc=$?
+    count=$((count + 1))
+    if [ $count -lt "$retries" ]; then
+      echo "Retry $count/$retries exited $rc, retrying in $delay seconds..." > /dev/stderr
+      sleep $delay
+    else
+      echo "Retry $count/$retries exited $rc, no more retries left." > /dev/stderr
+      return $rc
+    fi
+    delay=$((delay * 2))
+  done
+  return 0
+}
+
+echodate() {
+  # do not use -Is to keep this compatible with macOS
+  echo "[$(date +%Y-%m-%dT%H:%M:%S%:z)]" "$@"
+}
+
+write_junit() {
+  # Doesn't make any sense if we don't know a testname
+  if [ -z "${TEST_NAME:-}" ]; then return; fi
+  # Only run in CI
+  if [ -z "${ARTIFACTS:-}" ]; then return; fi
+
+  rc=$1
+  duration=${2:-0}
+  errors=0
+  failure=""
+  if [ "$rc" -ne 0 ]; then
+    errors=1
+    failure='<failure type="Failure">Step failed</failure>'
+  fi
+  TEST_NAME="[Kubermatic] ${TEST_NAME#\[Kubermatic\] }"
+  cat << EOF > ${ARTIFACTS}/junit.$(echo $TEST_NAME | sed 's/ /_/g').xml
+<?xml version="1.0" ?>
+<testsuites>
+    <testsuite errors="$errors" failures="$errors" name="$TEST_NAME" tests="1">
+        <testcase classname="$TEST_NAME" name="$TEST_NAME" time="$duration">
+          $failure
+        </testcase>
+    </testsuite>
+</testsuites>
+EOF
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR proposes using the gocache mechanism in the CI to speed up the build jobs. The build times right now are on average 2-3 minutes, but depending on the load, the build times can go up to 5-10 minutes. Building all the dependencies each time also requires more resources.

The gocache mechanism should solve this and reduce build times and resource consumption. Right now, we're only using it for building the binary, but if it works, we'll use it for other tasks as well.

The gocache scripts are based on work @xrstf did in #1075 and for KKP and other projects.

This PR also brings some utility functions from KKP which we'll use for other scripts in the future.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```