### PR TITLE
Disable colors for Terraform and Ginkgo in CI

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -42,6 +42,8 @@ PATH=$PATH:$(go env GOPATH)/bin
 TERRAFORM_DIR=$PWD/examples/terraform
 SSH_PRIVATE_KEY_FILE="${HOME}/.ssh/id_rsa_kubeone_e2e"
 
+export TF_IN_AUTOMATION=true
+export TF_CLI_ARGS="-no-color"
 export TF_VAR_cluster_name=k1-${BUILD_ID}
 export TF_VAR_subnets_cidr=28
 export SSH_PUBLIC_KEY_FILE="${SSH_PRIVATE_KEY_FILE}.pub"

--- a/test/e2e/kubetest.go
+++ b/test/e2e/kubetest.go
@@ -67,13 +67,13 @@ func (p *Kubetest) Verify(scenario, skip string) error {
 		testutil.WithArgs(
 			fmt.Sprintf("--ginkgo.focus=%s", scenario),
 			fmt.Sprintf("--ginkgo.skip=%s", skip),
-			"--ginkgo.noColor=true",
 			"--ginkgo.flakeAttempts=2",
 		),
 		testutil.WithMapEnv(p.envVars),
 		testutil.WithEnv(os.Environ()),
 		testutil.WithEnvs(
 			"GINKGO_PARALLEL=y",
+			"GINKGO_NO_COLOR=y",
 		),
 		testutil.InDir(kubetestPath),
 	).Run()


### PR DESCRIPTION
**What this PR does / why we need it**:

The colors in the CI are making Spyglass load much slower while previewing raw logs is hard because of all the ANSI escape characters. This PR disables colors for Terraform and Ginkgo (Kubernetes conformance tests) to fix this. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```