### PR TITLE
Use gocache in test and e2e-test Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ generate-internal-groups: vendor
 	./hack/update-codegen.sh
 
 .PHONY: test
-test:
+test: download-gocache
 	go test ./pkg/... ./test/...
 
 .PHONY: e2e-test
-e2e-test: install
+e2e-test: download-gocache install
 	./hack/run-ci-e2e-test.sh
 
 .PHONY: buildenv


### PR DESCRIPTION
**What this PR does / why we need it**:

We started using gocache for the build job with #1557. Since everything seems fine, this PR makes `test` and `e2e-test` Make targets download the cache before running tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```