### PR TITLE
Integrate Azure CCM addon with KubeOne

### DIFF
--- a/addons/ccm-azure/ccm-azure.yaml
+++ b/addons/ccm-azure/ccm-azure.yaml
@@ -1,3 +1,4 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -147,6 +148,8 @@ spec:
     - key: "node.cloudprovider.kubernetes.io/uninitialized"
       value: "true"
       effect: "NoSchedule"
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
   containers:
     - name: cloud-controller-manager
       image: "{{ .InternalImages.Get "AzureCCM" }}"
@@ -154,10 +157,10 @@ spec:
       command: ["cloud-controller-manager"]
       args:
         - "--allocate-node-cidrs=true"
-        - "--cloud-config=/etc/kubernetes/azure.json"
+        - "--cloud-config=/etc/kubernetes/cloud-config"
         - "--cloud-provider=azure"
-        - "--cluster-cidr=10.244.0.0/16"
-        - "--cluster-name=k8s"
+        - "--cluster-cidr={{.Config.ClusterNetwork.PodSubnet }}"
+        - "--cluster-name={{ .Config.Name }}"
         - "--controllers=*,-cloud-node" # disable cloud-node controller
         - "--configure-cloud-routes=true" # "false" for Azure CNI and "true" for other network plugins
         - "--leader-elect=true"
@@ -284,7 +287,9 @@ spec:
           command:
             - cloud-node-manager
             - --node-name=$(NODE_NAME)
+            {{ if ge $version.Minor 20 }}
             - --wait-routes=true # only set to true when --configure-cloud-routes=true in cloud-controller-manager.
+            {{ end }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -59,6 +59,18 @@ resource "azurerm_availability_set" "avset_workers" {
   }
 }
 
+resource "azurerm_route_table" "rt" {
+  name                          = "${var.cluster_name}-rt"
+  location                      = azurerm_resource_group.rg.location
+  resource_group_name           = azurerm_resource_group.rg.name
+  disable_bgp_route_propagation = false
+
+  tags = {
+    environment = "kubeone"
+    cluster     = var.cluster_name
+  }
+}
+
 resource "azurerm_virtual_network" "vpc" {
   name                = "${var.cluster_name}-vpc"
   address_space       = ["172.16.0.0/12"]

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -62,7 +62,7 @@ output "kubeone_workers" {
           availabilitySet   = azurerm_availability_set.avset_workers.name
           location          = var.location
           resourceGroup     = azurerm_resource_group.rg.name
-          routeTableName    = ""
+          routeTableName    = azurerm_route_table.rt.name
           securityGroupName = azurerm_network_security_group.sg.name
           subnetName        = azurerm_subnet.subnet.name
           vmSize            = var.worker_vm_size

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -148,9 +148,9 @@ func (p CloudProviderSpec) CloudProviderName() string {
 // CloudProviderInTree detects is there in-tree cloud provider implementation for specified provider.
 // List of in-tree provider can be found here: https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider
 func (p CloudProviderSpec) CloudProviderInTree() bool {
-	if p.Openstack != nil || p.Vsphere != nil {
+	if p.Azure != nil || p.Openstack != nil || p.Vsphere != nil {
 		return !p.External
-	} else if p.AWS != nil || p.GCE != nil || p.Azure != nil {
+	} else if p.AWS != nil || p.GCE != nil {
 		return true
 	}
 

--- a/pkg/templates/externalccm/ccm.go
+++ b/pkg/templates/externalccm/ccm.go
@@ -44,6 +44,11 @@ func Ensure(s *state.State) error {
 	var err error
 
 	switch {
+	case s.Cluster.CloudProvider.Azure != nil:
+		if s.Cluster.CloudProvider.CloudConfig == "" {
+			return errors.New("cloudConfig not defined")
+		}
+		err = addons.EnsureAddonByName(s, resources.AddonCCMAzure)
 	case s.Cluster.CloudProvider.Hetzner != nil:
 		err = addons.EnsureAddonByName(s, resources.AddonCCMHetzner)
 	case s.Cluster.CloudProvider.DigitalOcean != nil:

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -109,8 +109,18 @@ func optionalResources() map[Resource]map[string]string {
 		},
 
 		// Azure CCM
-		AzureCCM: {"*": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.1"},
-		AzureCNM: {"*": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.1"},
+		AzureCCM: {
+			"1.19.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.6.0",
+			"1.20.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.7.8",
+			"1.21.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.5",
+			">= 1.22.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.1.1",
+		},
+		AzureCNM: {
+			"1.19.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.6.0",
+			"1.20.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.8",
+			"1.21.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.5",
+			">= 1.22.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.1.1",
+		},
 
 		// DigitalOcean CCM
 		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.33"},


### PR DESCRIPTION
**What this PR does / why we need it**:

The Azure CCM addon has been added in #1438 but it has never been integrated with KubeOne. This means the addon couldn't be deployed to an Azure cluster.

This PR integrates the addon with KubeOne, so when `.cloudProvider.external` is enabled, the addon will be automatically deployed and the in-tree cloud provider will be disabled.

Note: this option cannot be enabled for existing Azure clusters. Instead, those clusters must go through the CCM/CSI migration process once it's available for Azure.

Fixes #1257

**Does this PR introduce a user-facing change?**:
```release-note
Integrate Azure CCM addon with KubeOne. The Azure CCM is now deployed if the external cloud provider (.cloudProvider.external) is enabled. This option cannot be enabled for existing Azure clusters running in-tree cloud provider, instead, those clusters must go through the CCM/CSI migration process.
```

/assign @WeirdMachine 