### PR TITLE
Add instanceReadyCheckPeriod and instanceReadyCheckTimeout to default config

### DIFF
--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -72,6 +72,10 @@ output "kubeone_workers" {
           # rootDiskSizeGB = 50
           # Optional: limit how many volumes can be attached to a node
           # nodeVolumeAttachLimit = 25
+          # Optional: Some OpenStack installations are rather slow to
+          # spawn VMs. Adjust the instanceReadyCheck's accordingly
+          instanceReadyCheckPeriod: 10s
+          instanceReadyCheckTimeout: 5m
           tags = {
             "${var.cluster_name}-workers" = "pool1"
           }


### PR DESCRIPTION
@kron4eg the current example leads to broken clusters on our OpenStack where the machine-controller cannot deploy any VMs due to the timeouts.
This affected a new hire in the team (junior) who "blindly" followed the example from KubeOne to deploy to OpenStack.
I would at least have the commented out fields with their default values in the config here with a "Optional note, that one should change those if the timeouts keep failing.

I think it would be better to have the example fixed short-term by adding those two flags, rather than waiting an undefined amount of time, until the machine-controller fix is released and the latest machine-controller is used in the latest version of KubeOne.
I can't estimate how long it will take for the whole process, but I imagine it's at least a couple of months, while merging this would help immediately and can be removed later on, once the latest machine-controller which includes the fix is available in KuebOne.
Generally speaking: I would rather have longer timeouts but working clusters than the other way round