### PR TITLE
Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,4 +2,4 @@
 FROM qmcgaw/godevcontainer
 
 RUN apk add make curl bash
-RUN export GO111MODULE=on
+ENV GO111MODULE=on

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+# https://hub.docker.com/r/qmcgaw/godevcontainer
+FROM qmcgaw/godevcontainer
+
+RUN apk add make curl bash
+RUN export GO111MODULE=on

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,67 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go
+{
+	"name": "kubeone-devcontainer",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+	// This is required for delve to work
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"go.toolsManagement.autoUpdate": true,
+		"go.toolsManagement.checkForUpdates": "off",
+		"go.gopath": "/go",
+		"go.lintOnSave": "package",
+		"go.lintTool": "golangci-lint",
+		"go.vetOnSave": "package",
+		"go.formatTool": "goimports",
+		"go.useLanguageServer": true,
+		"go.gotoSymbol.includeImports": true,
+		"go.gotoSymbol.includeGoroot": true,
+		"codeQL.telemetry.enableTelemetry": false,
+		"codeQL.runningQueries.memory": 2048,
+		"codeQL.runningQueries.debug": true,
+		"git.autofetch": true,
+		"editor.renderFinalNewline": true,
+		"editor.codeLens": true,
+		"editor.insertSpaces": true,
+		"editor.formatOnSave": true,
+		"editor.formatOnPaste": true,
+		"editor.snippetSuggestions": "none",
+		"editor.codeActionsOnSave": {
+			"source.organizeImports": true,
+			"source.fixAll": true,
+		},
+		"terminal.integrated.defaultProfile.linux": "zsh",
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		// Language Specific Plugins
+		"golang.Go",
+		"ms-azuretools.vscode-docker",
+		// Linters, Formaters, Highlighters, ...
+		"davidanson.vscode-markdownlint",
+		"shardulm94.trailing-spaces",
+		"redhat.vscode-yaml",
+		// Working with the Repository
+		"github.vscode-pull-request-github",
+		"github.remotehub",
+		"eamodio.gitlens",
+		// Utilities
+		"bierner.emojisense",
+		"IBM.output-colorizer",
+		"lyyyuna.prow-sink",
+		"ms-kubernetes-tools.vscode-kubernetes-tools"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [9000],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	//"postCreateCommand": "make tools",
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	//"remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go
 {
-	"name": "kubeone-devcontainer",
+	"name": "kubermatic-devcontainer",
 	"build": {
 		"dockerfile": "Dockerfile",
 	},
@@ -21,18 +21,12 @@
 		"go.vetOnSave": "package",
 		"go.formatTool": "goimports",
 		"go.useLanguageServer": true,
-		"go.gotoSymbol.includeImports": true,
-		"go.gotoSymbol.includeGoroot": true,
-		"codeQL.telemetry.enableTelemetry": false,
-		"codeQL.runningQueries.memory": 2048,
-		"codeQL.runningQueries.debug": true,
 		"git.autofetch": true,
 		"editor.renderFinalNewline": true,
 		"editor.codeLens": true,
 		"editor.insertSpaces": true,
 		"editor.formatOnSave": true,
 		"editor.formatOnPaste": true,
-		"editor.snippetSuggestions": "none",
 		"editor.codeActionsOnSave": {
 			"source.organizeImports": true,
 			"source.fixAll": true,
@@ -45,8 +39,6 @@
 		"golang.Go",
 		"ms-azuretools.vscode-docker",
 		// Linters, Formaters, Highlighters, ...
-		"davidanson.vscode-markdownlint",
-		"shardulm94.trailing-spaces",
 		"redhat.vscode-yaml",
 		// Working with the Repository
 		"github.vscode-pull-request-github",


### PR DESCRIPTION
**What this PR does / why we need it**:

.devcontainer configuration for kubeone.

If you never worked with Devcontainers before, here is a good artical by
[Aaron Powell](https://www.aaron-powell.com/about) on why you should care about Devcontainers:
[your open source project needs a devcontainer - here's why](https://www.aaron-powell.com/posts/2021-03-08-your-open-source-project-needs-a-dev-container-heres-why/)

Tl;Dr:
Devcontainers are awesome and they help to define an isolated
development environment which is standardised across all contributors
setups and leverages the beauty of [GitHub Codespaces](https://github.com/features/codespaces) once, it's GA.

Just try it out once, before dismissing it.
Setting up your VScode to use the Devcontainer is easy:
1. Make sure you have the following plugin installed: `ms-vscode-remote.remote-containers`
2. Open VScode in the root-directory of the Repository
3. Click "Reopen in Container" once VScode shows you the popup, telling
you that it detected a devcontainer configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Just try it out once, before dismissing it.
Setting up your VScode to use the Devcontainer is easy:

Make sure you have the following plugin installed: ms-vscode-remote.remote-containers
Open VScode in the root-directory of the Repository
Click "Reopen in Container" once VScode shows you the popup, telling
you that it detected a devcontainer configuration.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
