### PR TITLE
Remove holding containerd / docker

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -59,10 +59,7 @@ var (
 			sudo apt-get update
 			{{ end }}
 
-			{{- if or .FORCE .UPGRADE }}
 			sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true
-			{{- end }}
-
 			{{- $DOCKER_VERSION_TO_INSTALL := "%s" }}
 			{{- if semverCompare "< 1.17" .KUBERNETES_VERSION }}
 			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
@@ -95,9 +92,7 @@ var (
 		),
 
 		"yum-docker-ce-amzn": heredoc.Docf(`
-			{{- if or .FORCE .UPGRADE }}
 			sudo yum versionlock delete docker cri-tools containerd
-			{{- end }}
 
 			{{- $CRICTL_VERSION_TO_INSTALL := "%s" }}
 			{{- $DOCKER_VERSION_TO_INSTALL := "%s" }}
@@ -137,9 +132,7 @@ var (
 			sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 			{{- end }}
 
-			{{- if or .FORCE .UPGRADE }}
 			sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
-			{{- end }}
 
 			{{- $DOCKER_VERSION_TO_INSTALL := "%s" }}
 			{{- if semverCompare "< 1.17" .KUBERNETES_VERSION }}
@@ -192,10 +185,7 @@ var (
 			sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 			{{ end }}
 
-			{{ if or .FORCE .UPGRADE }}
 			sudo apt-mark unhold containerd.io || true
-			{{ end }}
-
 			sudo apt-get install -y containerd.io=%s
 			sudo apt-mark hold containerd.io
 
@@ -215,10 +205,7 @@ var (
 			sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 			{{ end }}
 
-			{{ if or .FORCE .UPGRADE }}
 			sudo yum versionlock delete containerd.io
-			{{- end }}
-
 			sudo yum install -y containerd.io-%s
 			sudo yum versionlock add containerd.io
 
@@ -228,10 +215,7 @@ var (
 		),
 
 		"yum-containerd-amzn": heredoc.Docf(`
-			{{- if or .FORCE .UPGRADE }}
 			sudo yum versionlock delete containerd cri-tools
-			{{- end }}
-
 			sudo yum install -y containerd-%s cri-tools-%s
 			sudo yum versionlock add containerd cri-tools
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -83,7 +83,6 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-
 sudo yum versionlock delete docker cri-tools containerd
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-
+sudo yum versionlock delete docker cri-tools containerd
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -86,7 +86,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-
+sudo yum versionlock delete docker cri-tools containerd
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-
+sudo yum versionlock delete docker cri-tools containerd
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-
+sudo yum versionlock delete docker cri-tools containerd
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-
+sudo yum versionlock delete docker cri-tools containerd
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -70,8 +70,7 @@ sudo yum install -y \
 
 
 
-
-
+sudo yum versionlock delete containerd cri-tools
 sudo yum install -y containerd-1.4.* cri-tools-1.13.0
 sudo yum versionlock add containerd cri-tools
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -70,8 +70,7 @@ sudo yum install -y \
 
 
 
-
-
+sudo yum versionlock delete containerd cri-tools
 sudo yum install -y containerd-1.4.* cri-tools-1.13.0
 sudo yum versionlock add containerd cri-tools
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -87,6 +87,7 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -88,6 +88,8 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+
 sudo yum install -y \
 	docker-ce-19.03.* \
 	docker-ce-cli-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -91,6 +91,8 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+
 sudo yum install -y \
 	docker-ce-19.03.* \
 	docker-ce-cli-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -88,6 +88,8 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+
 sudo yum install -y \
 	docker-ce-19.03.* \
 	docker-ce-cli-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -88,6 +88,8 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+
 sudo yum install -y \
 	docker-ce-19.03.* \
 	docker-ce-cli-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -87,6 +87,8 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
 # Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
 # contains only Docker 19.03.14, which is not validated for all Kubernetes version.
 # Therefore, we use 7 repo which has all Docker versions.

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -76,8 +76,7 @@ sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/dock
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
-
-
+sudo yum versionlock delete containerd.io
 sudo yum install -y containerd.io-1.4.*
 sudo yum versionlock add containerd.io
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -76,8 +76,7 @@ sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/dock
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
-
-
+sudo yum versionlock delete containerd.io
 sudo yum install -y containerd.io-1.4.*
 sudo yum versionlock add containerd.io
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -87,6 +87,8 @@ echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 sudo apt-get update
 
 
+sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true
+
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -90,6 +90,8 @@ echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 sudo apt-get update
 
 
+sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true
+
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -87,6 +87,8 @@ echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 sudo apt-get update
 
 
+sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true
+
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -72,8 +72,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
 sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 
 
-
-
+sudo apt-mark unhold containerd.io || true
 sudo apt-get install -y containerd.io=1.4.*
 sudo apt-mark hold containerd.io
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -72,8 +72,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
 sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 
 
-
-
+sudo apt-mark unhold containerd.io || true
 sudo apt-get install -y containerd.io=1.4.*
 sudo apt-mark hold containerd.io
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -83,7 +83,6 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-
 sudo yum versionlock delete docker cri-tools containerd
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -87,6 +87,7 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -87,6 +87,7 @@ echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 	sudo tee /etc/apt/sources.list.d/docker.list
 sudo apt-get update
 
+
 sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -83,7 +83,6 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-
 sudo yum versionlock delete docker cri-tools containerd
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -87,6 +87,7 @@ EOF
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -87,6 +87,7 @@ echo "deb https://download.docker.com/linux/ubuntu bionic stable" |
 	sudo tee /etc/apt/sources.list.d/docker.list
 sudo apt-get update
 
+
 sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install \


### PR DESCRIPTION
We removed fixed version but kept "hold"ing packages that a meant to be upgraded automatically when available. No more.

P.S.
But we still keep holding in between of kubeone runs to avoid upgrades to unexpected too high versions.

Fixes #1578

**Special notes for your reviewer**:
To trigger the issue from #1578, you need to downgrade a containerd, to simulate upstream package upgrade.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Let containerd/docker be upgraded automatically during kubeone run
```
