### PR TITLE
Properly pass machine-controllers args

### DIFF
--- a/addons/machinecontroller/machine-controller.yaml
+++ b/addons/machinecontroller/machine-controller.yaml
@@ -501,6 +501,7 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - /usr/local/bin/machine-controller
+          args:
             - -logtostderr
             - -v=4
             - -health-probe-address=0.0.0.0:8085
@@ -586,6 +587,7 @@ spec:
           name: machine-controller-webhook
           command:
             - /usr/local/bin/webhook
+          args:
             - -logtostderr
             - -v=4
             - -listen-address=0.0.0.0:9876


### PR DESCRIPTION
**What this PR does / why we need it**:

The old Go template for machine-controller (used up to KubeOne 1.2) provided the machine-controller command-line flags via `args`. However, the command-line flags are now provided via `command`.

`kubectl apply` doesn't clean-up `args` if no args are provided, so machine-controller and machine-controller-webhook deployments will have:

* new flags set via `command`
* old flags set via `args`

`args` have higher precedence over `command`, so machine-controller will always run with old flags. This is causing various issues, for example, when migrating to containerd or external CCM/CSI.

**Does this PR introduce a user-facing change?**:
```release-note
Properly pass machine-controllers args. This fixes the issue causing machine-controller and machine-controller-webhook deployments to run with incorrect flags. If you created your cluster with KubeOne 1.2 or older, and already upgraded to KubeOne 1.3, we recommend running kubeone apply again to properly reconcile machine-controller deployments
```

/assign @kron4eg 