### PR TITLE
Fix yum versionlock delete containerd.io

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -92,7 +92,7 @@ var (
 		),
 
 		"yum-docker-ce-amzn": heredoc.Docf(`
-			sudo yum versionlock delete docker cri-tools containerd
+			sudo yum versionlock delete docker cri-tools containerd || true
 
 			{{- $CRICTL_VERSION_TO_INSTALL := "%s" }}
 			{{- $DOCKER_VERSION_TO_INSTALL := "%s" }}
@@ -132,7 +132,7 @@ var (
 			sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 			{{- end }}
 
-			sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+			sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 			{{- $DOCKER_VERSION_TO_INSTALL := "%s" }}
 			{{- if semverCompare "< 1.17" .KUBERNETES_VERSION }}
@@ -205,7 +205,7 @@ var (
 			sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 			{{ end }}
 
-			sudo yum versionlock delete containerd.io
+			sudo yum versionlock delete containerd.io || true
 			sudo yum install -y containerd.io-%s
 			sudo yum versionlock add containerd.io
 
@@ -215,7 +215,7 @@ var (
 		),
 
 		"yum-containerd-amzn": heredoc.Docf(`
-			sudo yum versionlock delete containerd cri-tools
+			sudo yum versionlock delete containerd cri-tools || true
 			sudo yum install -y containerd-%s cri-tools-%s
 			sudo yum versionlock add containerd cri-tools
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd
+sudo yum versionlock delete docker cri-tools containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd
+sudo yum versionlock delete docker cri-tools containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -86,7 +86,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd
+sudo yum versionlock delete docker cri-tools containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd
+sudo yum versionlock delete docker cri-tools containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd
+sudo yum versionlock delete docker cri-tools containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd
+sudo yum versionlock delete docker cri-tools containerd || true
 
 
 sudo yum install -y \

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -70,7 +70,7 @@ sudo yum install -y \
 
 
 
-sudo yum versionlock delete containerd cri-tools
+sudo yum versionlock delete containerd cri-tools || true
 sudo yum install -y containerd-1.4.* cri-tools-1.13.0
 sudo yum versionlock add containerd cri-tools
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -70,7 +70,7 @@ sudo yum install -y \
 
 
 
-sudo yum versionlock delete containerd cri-tools
+sudo yum versionlock delete containerd cri-tools || true
 sudo yum install -y containerd-1.4.* cri-tools-1.13.0
 sudo yum versionlock add containerd cri-tools
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -88,7 +88,7 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
 	docker-ce-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -88,7 +88,7 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
 	docker-ce-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -91,7 +91,7 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
 	docker-ce-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -88,7 +88,7 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
 	docker-ce-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -88,7 +88,7 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
 	docker-ce-19.03.* \

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -88,7 +88,7 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 # Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
 # contains only Docker 19.03.14, which is not validated for all Kubernetes version.
 # Therefore, we use 7 repo which has all Docker versions.

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -76,7 +76,7 @@ sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/dock
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
-sudo yum versionlock delete containerd.io
+sudo yum versionlock delete containerd.io || true
 sudo yum install -y containerd.io-1.4.*
 sudo yum versionlock add containerd.io
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -76,7 +76,7 @@ sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/dock
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
-sudo yum versionlock delete containerd.io
+sudo yum versionlock delete containerd.io || true
 sudo yum install -y containerd.io-1.4.*
 sudo yum versionlock add containerd.io
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd
+sudo yum versionlock delete docker cri-tools containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -88,7 +88,7 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
 	docker-ce-19.03.* \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -83,7 +83,7 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd
+sudo yum versionlock delete docker cri-tools containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -88,7 +88,7 @@ sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
 	docker-ce-19.03.* \


### PR DESCRIPTION
**What this PR does / why we need it**:

`yum versionlock delete containerd.io` gives none-0 exit status if containerd.io is not installed and everything fails

Fixes #1598

```release-note
Fix yum versionlock delete containerd.io error
```
