### PR TITLE
MachineAnnotations for DynamicWorkerConfig

### DIFF
--- a/docs/api_reference/v1beta1.en.md
+++ b/docs/api_reference/v1beta1.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta1 API Reference"
-date = 2021-10-28T12:33:26+05:00
+date = 2021-10-28T16:38:45+03:00
 weight = 11
 +++
 ## v1beta1
@@ -571,7 +571,8 @@ ProviderSpec describes a worker node
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | cloudProviderSpec | CloudProviderSpec | [json.RawMessage](https://golang.org/pkg/encoding/json/#RawMessage) | true |
-| annotations | Annotations | map[string]string | false |
+| annotations | Annotations set MachineDeployment.ObjectMeta.Annotations | map[string]string | false |
+| machineAnnotations | MachineAnnotations set MachineDeployment.Spec.Template.Spec.ObjectMeta.Annotations a way to annotate resulted Nodes | map[string]string | false |
 | labels | Labels | map[string]string | false |
 | taints | Taints | [][corev1.Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#taint-v1-core) | false |
 | sshPublicKeys | SSHPublicKeys | []string | false |

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -361,8 +361,11 @@ type DynamicWorkerConfig struct {
 type ProviderSpec struct {
 	// CloudProviderSpec
 	CloudProviderSpec json.RawMessage `json:"cloudProviderSpec"`
-	// Annotations
+	// Annotations set MachineDeployment.ObjectMeta.Annotations
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// MachineAnnotations set MachineDeployment.Spec.Template.Spec.ObjectMeta.Annotations
+	// a way to annotate resulted Nodes
+	MachineAnnotations map[string]string `json:"machineAnnotations,omitempty"`
 	// Labels
 	Labels map[string]string `json:"labels,omitempty"`
 	// Taints

--- a/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1alpha1/zz_generated.conversion.go
@@ -798,6 +798,7 @@ func Convert_v1alpha1_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, out
 func autoConvert_kubeone_ProviderSpec_To_v1alpha1_ProviderSpec(in *kubeone.ProviderSpec, out *ProviderSpec, s conversion.Scope) error {
 	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
 	// WARNING: in.Annotations requires manual conversion: does not exist in peer-type
+	// WARNING: in.MachineAnnotations requires manual conversion: does not exist in peer-type
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
 	out.SSHPublicKeys = *(*[]string)(unsafe.Pointer(&in.SSHPublicKeys))

--- a/pkg/apis/kubeone/v1beta1/types.go
+++ b/pkg/apis/kubeone/v1beta1/types.go
@@ -361,8 +361,11 @@ type DynamicWorkerConfig struct {
 type ProviderSpec struct {
 	// CloudProviderSpec
 	CloudProviderSpec json.RawMessage `json:"cloudProviderSpec"`
-	// Annotations
+	// Annotations set MachineDeployment.ObjectMeta.Annotations
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// MachineAnnotations set MachineDeployment.Spec.Template.Spec.ObjectMeta.Annotations
+	// a way to annotate resulted Nodes
+	MachineAnnotations map[string]string `json:"machineAnnotations,omitempty"`
 	// Labels
 	Labels map[string]string `json:"labels,omitempty"`
 	// Taints

--- a/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
@@ -1658,6 +1658,7 @@ func Convert_kubeone_PodSecurityPolicy_To_v1beta1_PodSecurityPolicy(in *kubeone.
 func autoConvert_v1beta1_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, out *kubeone.ProviderSpec, s conversion.Scope) error {
 	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
+	out.MachineAnnotations = *(*map[string]string)(unsafe.Pointer(&in.MachineAnnotations))
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
 	out.SSHPublicKeys = *(*[]string)(unsafe.Pointer(&in.SSHPublicKeys))
@@ -1676,6 +1677,7 @@ func Convert_v1beta1_ProviderSpec_To_kubeone_ProviderSpec(in *ProviderSpec, out 
 func autoConvert_kubeone_ProviderSpec_To_v1beta1_ProviderSpec(in *kubeone.ProviderSpec, out *ProviderSpec, s conversion.Scope) error {
 	out.CloudProviderSpec = *(*json.RawMessage)(unsafe.Pointer(&in.CloudProviderSpec))
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
+	out.MachineAnnotations = *(*map[string]string)(unsafe.Pointer(&in.MachineAnnotations))
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
 	out.SSHPublicKeys = *(*[]string)(unsafe.Pointer(&in.SSHPublicKeys))

--- a/pkg/apis/kubeone/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/v1beta1/zz_generated.deepcopy.go
@@ -960,6 +960,13 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.MachineAnnotations != nil {
+		in, out := &in.MachineAnnotations, &out.MachineAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))

--- a/pkg/apis/kubeone/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/zz_generated.deepcopy.go
@@ -960,6 +960,13 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.MachineAnnotations != nil {
+		in, out := &in.MachineAnnotations, &out.MachineAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/clusterstatus/apiserverstatus"
@@ -35,6 +34,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/pkg/templates/machinecontroller/machines.go
+++ b/pkg/templates/machinecontroller/machines.go
@@ -146,12 +146,13 @@ func createMachineDeployment(cluster *kubeoneapi.KubeOneCluster, workerset kubeo
 			MinReadySeconds: &minReadySeconds,
 			Template: clusterv1alpha1.MachineTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: metav1.NamespaceSystem,
 					Labels:    labels.Merge(workerset.Config.Labels, workersetNameLabels),
+					Namespace: metav1.NamespaceSystem,
 				},
 				Spec: clusterv1alpha1.MachineSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: labels.Merge(workerset.Config.Labels, workersetNameLabels),
+						Annotations: workerset.Config.MachineAnnotations,
+						Labels:      labels.Merge(workerset.Config.Labels, workersetNameLabels),
 					},
 					Versions: clusterv1alpha1.MachineVersionInfo{
 						Kubelet: cluster.Versions.Kubernetes,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #1591

```release-note
Copy annotations to initial MachineDeployment.Spec.Template.Spec.Annotations
```
