### PR TITLE
config: change default k8s version

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	// defaultKubernetesVersion is default Kubernetes version for the example configuration file
-	defaultKubernetesVersion = "1.18.2"
+	defaultKubernetesVersion = "1.22.3"
 	// defaultCloudProviderName is cloud provider to build the example configuration file for
 	defaultCloudProviderName = "aws"
 )


### PR DESCRIPTION
This little commit bumps the default k8s version. Kubernetes 1.18.3 is EOL for a while now. Let's use the current stable version instead.

```release-note
NONE
```