### PR TITLE
Add flag for API endpoint alternative names

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -878,7 +878,7 @@ addons:
 # external address of your load balancer or the public addresses of
 # the first control plane nodes.
 apiEndpoint:
-  alternativeNames: '{{ .APIEndpointAlternativeNames }}'
+  alternativeNames: {{ .APIEndpointAlternativeNames }}
 #   host: '{{ .APIEndpointHost }}'
 #   port: {{ .APIEndpointPort }}
 

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -880,7 +880,7 @@ addons:
 # apiEndpoint:
 #   host: '{{ .APIEndpointHost }}'
 #   port: {{ .APIEndpointPort }}
-#	alternativeNames: {{ .APIEndpointAlternativeNames }}
+#   alternativeNames: {{ .APIEndpointAlternativeNames }}
 
 # If the cluster runs on bare metal or an unsupported cloud provider,
 # you can disable the machine-controller deployment entirely. In this

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -57,9 +57,9 @@ type printOpts struct {
 
 	ControlPlaneHosts string `longflag:"control-plane-hosts"`
 
-	APIEndpointHost string `longflag:"api-endpoint-host"`
-	APIEndpointPort int    `longflag:"api-endpoint-port"`
-	APIEndpointAlternativeNames string    `longflag:"api-endpoint-alternative-names"`
+	APIEndpointHost             string `longflag:"api-endpoint-host"`
+	APIEndpointPort             int    `longflag:"api-endpoint-port"`
+	APIEndpointAlternativeNames string `longflag:"api-endpoint-alternative-names"`
 
 	PodSubnet     string `longflag:"pod-subnet"`
 	ServiceSubnet string `longflag:"service-subnet"`
@@ -450,7 +450,6 @@ func parseControlPlaneHosts(cfg *yamled.Document, hostList string) error {
 
 	return nil
 }
-
 
 // runMigrate migrates the KubeOneCluster manifest from v1alpha1 to v1beta1
 func runMigrate(opts *globalOptions) error {

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -877,10 +877,10 @@ addons:
 # The API server can also be overwritten by Terraform. Provide the
 # external address of your load balancer or the public addresses of
 # the first control plane nodes.
-apiEndpoint:
-  alternativeNames: {{ .APIEndpointAlternativeNames }}
+# apiEndpoint:
 #   host: '{{ .APIEndpointHost }}'
 #   port: {{ .APIEndpointPort }}
+#	alternativeNames: {{ .APIEndpointAlternativeNames }}
 
 # If the cluster runs on bare metal or an unsupported cloud provider,
 # you can disable the machine-controller deployment entirely. In this


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add flag for API endpoint alternative names

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New flag `--api-endpoint-alternative-names` for kubeone
```
