### PR TITLE
Enable ip_tables modules and disable nm-cloud-setup for rhel on aws

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -57,6 +57,7 @@ var (
 		EOF
 		sudo modprobe overlay
 		sudo modprobe br_netfilter
+        sudo modprobe ip_tables
 		sudo mkdir -p /etc/sysctl.d
 		cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 		fs.inotify.max_user_watches         = 1048576
@@ -78,10 +79,6 @@ var (
 		SystemMaxUse=5G
 		EOF
 		sudo systemctl force-reload systemd-journald
-		{{ end }}
-
-		{{ define "load-iptables-modules" }}
-		sudo modprobe ip_tables
 		{{ end }}
 	`)
 )

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -79,6 +79,10 @@ var (
 		EOF
 		sudo systemctl force-reload systemd-journald
 		{{ end }}
+
+        {{ define "load-iptables-modules" }}
+        modprobe ip_tables
+        {{ end }}
 	`)
 )
 

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -80,9 +80,9 @@ var (
 		sudo systemctl force-reload systemd-journald
 		{{ end }}
 
-        {{ define "load-iptables-modules" }}
-        modprobe ip_tables
-        {{ end }}
+		{{ define "load-iptables-modules" }}
+		sudo modprobe ip_tables
+		{{ end }}
 	`)
 )
 

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -54,10 +54,11 @@ var (
 		cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 		overlay
 		br_netfilter
+		ip_tables
 		EOF
 		sudo modprobe overlay
 		sudo modprobe br_netfilter
-        sudo modprobe ip_tables
+		sudo modprobe ip_tables
 		sudo mkdir -p /etc/sysctl.d
 		cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 		fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -20,6 +20,9 @@ import "k8c.io/kubeone/pkg/apis/kubeone"
 
 const (
 	kubeadmCentOSTemplate = `
+{{ if .LOAD_IP_TABLES }}
+{{ template "load-iptables-modules" }}
+{{ end }}
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -102,6 +105,14 @@ sudo yum remove -y \
 	kubectl
 sudo yum remove -y kubernetes-cni || true
 `
+	disableNMCloudSetup = `
+if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+systemctl stop nm-cloud-setup.timer
+systemctl disable nm-cloud-setup.service
+systemctl disable nm-cloud-setup.timer
+reboot
+fi
+`
 )
 
 func KubeadmCentOS(cluster *kubeone.KubeOneCluster, force bool) (string, error) {
@@ -111,6 +122,7 @@ func KubeadmCentOS(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 	}
 
 	return Render(kubeadmCentOSTemplate, Data{
+		"LOAD_IP_TABLES":         isAWSCloudProvider(&cluster.CloudProvider),
 		"KUBELET":                true,
 		"KUBEADM":                true,
 		"KUBECTL":                true,
@@ -136,6 +148,7 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeone.KubeOneCluster) (string, error)
 	}
 
 	return Render(kubeadmCentOSTemplate, Data{
+		"LOAD_IP_TABLES":         isAWSCloudProvider(&cluster.CloudProvider),
 		"UPGRADE":                true,
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
@@ -155,6 +168,7 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, er
 	}
 
 	return Render(kubeadmCentOSTemplate, Data{
+		"LOAD_IP_TABLES":         isAWSCloudProvider(&cluster.CloudProvider),
 		"UPGRADE":                true,
 		"KUBELET":                true,
 		"KUBECTL":                true,
@@ -166,4 +180,16 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, er
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
 	})
+}
+
+func DisableNMCloudSetup() (string, error) {
+	return Render(disableNMCloudSetup, nil)
+}
+
+func isAWSCloudProvider(spec *kubeone.CloudProviderSpec) bool {
+	if spec.AWS != nil {
+		return true
+	}
+
+	return false
 }

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -20,9 +20,7 @@ import "k8c.io/kubeone/pkg/apis/kubeone"
 
 const (
 	kubeadmCentOSTemplate = `
-{{ if .LOAD_IP_TABLES }}
 {{ template "load-iptables-modules" }}
-{{ end }}
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -122,7 +120,6 @@ func KubeadmCentOS(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 	}
 
 	return Render(kubeadmCentOSTemplate, Data{
-		"LOAD_IP_TABLES":         isAWSCloudProvider(&cluster.CloudProvider),
 		"KUBELET":                true,
 		"KUBEADM":                true,
 		"KUBECTL":                true,
@@ -148,7 +145,6 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeone.KubeOneCluster) (string, error)
 	}
 
 	return Render(kubeadmCentOSTemplate, Data{
-		"LOAD_IP_TABLES":         isAWSCloudProvider(&cluster.CloudProvider),
 		"UPGRADE":                true,
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
@@ -168,7 +164,6 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, er
 	}
 
 	return Render(kubeadmCentOSTemplate, Data{
-		"LOAD_IP_TABLES":         isAWSCloudProvider(&cluster.CloudProvider),
 		"UPGRADE":                true,
 		"KUBELET":                true,
 		"KUBECTL":                true,
@@ -184,8 +179,4 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, er
 
 func DisableNMCloudSetup() (string, error) {
 	return Render(disableNMCloudSetup, nil)
-}
-
-func isAWSCloudProvider(spec *kubeone.CloudProviderSpec) bool {
-	return spec.AWS != nil
 }

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -20,7 +20,6 @@ import "k8c.io/kubeone/pkg/apis/kubeone"
 
 const (
 	kubeadmCentOSTemplate = `
-{{ template "load-iptables-modules" }}
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -187,9 +187,5 @@ func DisableNMCloudSetup() (string, error) {
 }
 
 func isAWSCloudProvider(spec *kubeone.CloudProviderSpec) bool {
-	if spec.AWS != nil {
-		return true
-	}
-
-	return false
+	return spec.AWS != nil
 }

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -11,9 +11,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -11,9 +11,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -11,9 +11,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -11,9 +11,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -11,9 +11,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -22,9 +22,11 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -22,9 +22,11 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -22,9 +22,11 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -22,9 +22,11 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -22,9 +22,11 @@ esac
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -11,9 +11,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -13,9 +13,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -1,6 +1,7 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -2,6 +2,8 @@ set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 
+sudo modprobe ip_tables
+
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -1,9 +1,6 @@
 set -xeu pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-
-sudo modprobe ip_tables
-
 sudo swapoff -a
 sudo sed -i '/.*swap.*/d' /etc/fstab
 sudo setenforce 0 || true
@@ -17,9 +14,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -11,9 +11,11 @@ source /etc/kubeone/proxy-env
 cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
+ip_tables
 EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
+sudo modprobe ip_tables
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -125,7 +125,7 @@ func disableNMCloudSetup(s *state.State, node *kubeoneapi.HostConfig, _ ssh.Conn
 				return err
 			}
 
-			s.Logger.Infoln("Disable nm-cloud-setup...the node will be rebooted…")
+			s.Logger.Infoln("Disable nm-cloud-setup...the node will be rebooted...")
 			_, _, err = s.Runner.RunRaw(cmd)
 
 			return err

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -83,7 +83,7 @@ func generateConfigurationFiles(s *state.State) error {
 	return nil
 }
 
-func installPrerequisitesOnNode(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
+func installPrerequisitesOnNode(s *state.State, node *kubeoneapi.HostConfig, _ ssh.Connection) error {
 	logger := s.Logger.WithField("os", node.OperatingSystem)
 
 	logger.Infoln("Creating environment file...")
@@ -109,6 +109,28 @@ func createEnvironmentFile(s *state.State) error {
 	_, _, err = s.Runner.RunRaw(cmd)
 
 	return err
+}
+
+func disableNMCloudSetup(s *state.State, node *kubeoneapi.HostConfig, _ ssh.Connection) error {
+	if node.OperatingSystem == kubeoneapi.OperatingSystemNameRHEL &&
+		s.Cluster.CloudProvider.AWS != nil {
+		var allHosts = s.LiveCluster.ControlPlane
+		allHosts = append(allHosts, s.LiveCluster.StaticWorkers...)
+		for _, node := range allHosts {
+			if !node.Initialized() {
+				cmd, err := scripts.DisableNMCloudSetup()
+				if err != nil {
+					return err
+				}
+
+				_, _, err = s.Runner.RunRaw(cmd)
+
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func installKubeadm(s *state.State, node kubeoneapi.HostConfig) error {
@@ -170,7 +192,7 @@ func uploadConfigurationFiles(s *state.State) error {
 	return s.RunTaskOnAllNodes(uploadConfigurationFilesToNode, state.RunParallel)
 }
 
-func uploadConfigurationFilesToNode(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
+func uploadConfigurationFilesToNode(s *state.State, _ *kubeoneapi.HostConfig, conn ssh.Connection) error {
 	s.Logger.Infoln("Uploading config files...")
 
 	if err := s.Configuration.UploadTo(conn, s.WorkDir); err != nil {

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -112,12 +112,11 @@ func createEnvironmentFile(s *state.State) error {
 }
 
 func disableNMCloudSetup(s *state.State, node *kubeoneapi.HostConfig, _ ssh.Connection) error {
-	if node.OperatingSystem == kubeoneapi.OperatingSystemNameRHEL &&
-		s.Cluster.CloudProvider.AWS != nil {
+	if node.OperatingSystem == kubeoneapi.OperatingSystemNameRHEL {
 		var allHosts = s.LiveCluster.ControlPlane
 		allHosts = append(allHosts, s.LiveCluster.StaticWorkers...)
-		for _, node := range allHosts {
-			if !node.Initialized() {
+		for _, host := range allHosts {
+			if node.ID == host.Config.ID && !host.Initialized() {
 				cmd, err := scripts.DisableNMCloudSetup()
 				if err != nil {
 					return err

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -112,20 +112,23 @@ func createEnvironmentFile(s *state.State) error {
 }
 
 func disableNMCloudSetup(s *state.State, node *kubeoneapi.HostConfig, _ ssh.Connection) error {
-	if node.OperatingSystem == kubeoneapi.OperatingSystemNameRHEL {
-		var allHosts = s.LiveCluster.ControlPlane
-		allHosts = append(allHosts, s.LiveCluster.StaticWorkers...)
-		for _, host := range allHosts {
-			if node.ID == host.Config.ID && !host.Initialized() {
-				cmd, err := scripts.DisableNMCloudSetup()
-				if err != nil {
-					return err
-				}
+	if node.OperatingSystem != kubeoneapi.OperatingSystemNameRHEL {
+		return nil
+	}
 
-				_, _, err = s.Runner.RunRaw(cmd)
-
+	var allHosts = s.LiveCluster.ControlPlane
+	allHosts = append(allHosts, s.LiveCluster.StaticWorkers...)
+	for _, host := range allHosts {
+		if node.ID == host.Config.ID && !host.Initialized() {
+			cmd, err := scripts.DisableNMCloudSetup()
+			if err != nil {
 				return err
 			}
+
+			s.Logger.Infoln("Disable nm-cloud-setup...the node will be rebooted…")
+			_, _, err = s.Runner.RunRaw(cmd)
+
+			return err
 		}
 	}
 

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -109,6 +109,13 @@ func WithFullInstall(t Tasks) Tasks {
 		append(Tasks{
 			{
 				Fn: func(s *state.State) error {
+					s.Logger.Infoln("Disable nm-cloud-setup on aws rhel nodes...")
+					return s.RunTaskOnLeader(disableNMCloudSetup)
+				},
+				ErrMsg: "failed to disable nm-cloud-setup",
+			},
+			{
+				Fn: func(s *state.State) error {
 					s.Logger.Infoln("Configuring certs and etcd on control plane node...")
 					return s.RunTaskOnLeader(kubeadmCertsExecutor)
 				},

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -104,14 +104,18 @@ func WithHostnameOSAndProbes(t Tasks) Tasks {
 // WithFullInstall with install binaries (using WithBinariesOnly) and
 // orchestrate complete cluster init
 func WithFullInstall(t Tasks) Tasks {
-	return Tasks{
+	return WithHostnameOSAndProbes(t).append(Tasks{
 		{
 			Fn: func(s *state.State) error {
 				return s.RunTaskOnAllNodes(disableNMCloudSetup, state.RunParallel)
 			},
 			ErrMsg: "failed to disable nm-cloud-setup",
 		},
-	}.append(WithBinariesOnly(t)...).
+		{
+			Fn:     installPrerequisites,
+			ErrMsg: "failed to install prerequisites",
+		},
+	}...).
 		append(kubernetesConfigFiles()...).
 		append(Tasks{
 			{

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -107,7 +107,7 @@ func WithFullInstall(t Tasks) Tasks {
 	return Tasks{
 		{
 			Fn: func(s *state.State) error {
-				s.Logger.Infoln("Disable nm-cloud-setup on aws rhel nodes...")
+				s.Logger.Infoln("Disable nm-cloud-setup nodes...")
 				return s.RunTaskOnLeader(disableNMCloudSetup)
 			},
 			ErrMsg: "failed to disable nm-cloud-setup",
@@ -115,13 +115,6 @@ func WithFullInstall(t Tasks) Tasks {
 	}.append(WithBinariesOnly(t)...).
 		append(kubernetesConfigFiles()...).
 		append(Tasks{
-			{
-				Fn: func(s *state.State) error {
-					s.Logger.Infoln("Disable nm-cloud-setup on aws rhel nodes...")
-					return s.RunTaskOnLeader(disableNMCloudSetup)
-				},
-				ErrMsg: "failed to disable nm-cloud-setup",
-			},
 			{
 				Fn: func(s *state.State) error {
 					s.Logger.Infoln("Configuring certs and etcd on control plane node...")

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -107,8 +107,7 @@ func WithFullInstall(t Tasks) Tasks {
 	return Tasks{
 		{
 			Fn: func(s *state.State) error {
-				s.Logger.Infoln("Disable nm-cloud-setup nodes...")
-				return s.RunTaskOnLeader(disableNMCloudSetup)
+				return s.RunTaskOnAllNodes(disableNMCloudSetup, state.RunParallel)
 			},
 			ErrMsg: "failed to disable nm-cloud-setup",
 		},

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -104,7 +104,15 @@ func WithHostnameOSAndProbes(t Tasks) Tasks {
 // WithFullInstall with install binaries (using WithBinariesOnly) and
 // orchestrate complete cluster init
 func WithFullInstall(t Tasks) Tasks {
-	return WithBinariesOnly(t).
+	return Tasks{
+		{
+			Fn: func(s *state.State) error {
+				s.Logger.Infoln("Disable nm-cloud-setup on aws rhel nodes...")
+				return s.RunTaskOnLeader(disableNMCloudSetup)
+			},
+			ErrMsg: "failed to disable nm-cloud-setup",
+		},
+	}.append(WithBinariesOnly(t)...).
 		append(kubernetesConfigFiles()...).
 		append(Tasks{
 			{


### PR DESCRIPTION
Signed-off-by: Moath Qasim <moad.qassem@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Enable ip_tables related kernel modules and disable nm-cloud-setup tool on aws for rhel machines  in order to fix canal support in KubeOne for RHEL machines on AWS. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1573

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable ip_tables related kernel modules and disable nm-cloud-setup tool on aws for rhel machines 
```
