### PR TITLE
New apply flag: --create-machine-deployments

### DIFF
--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -46,6 +46,7 @@ type applyOpts struct {
 	// Upgrade flags
 	ForceUpgrade              bool `longflag:"force-upgrade"`
 	UpgradeMachineDeployments bool `longflag:"upgrade-machine-deployments"`
+	CreateMachineDeployments  bool `longflag:"create-machine-deployments"`
 	RotateEncryptionKey       bool `longflag:"rotate-encryption-key"`
 }
 
@@ -59,6 +60,7 @@ func (opts *applyOpts) BuildState() (*state.State, error) {
 	s.ForceInstall = opts.ForceInstall
 	s.ForceUpgrade = opts.ForceUpgrade
 	s.UpgradeMachineDeployments = opts.UpgradeMachineDeployments
+	s.CreateMachineDeployments = opts.CreateMachineDeployments
 
 	if s.BackupFile == "" {
 		fullPath, _ := filepath.Abs(opts.ManifestFile)
@@ -148,6 +150,12 @@ func applyCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 		longFlagName(opts, "UpgradeMachineDeployments"),
 		false,
 		"upgrade MachineDeployments objects")
+
+	cmd.Flags().BoolVar(
+		&opts.CreateMachineDeployments,
+		longFlagName(opts, "CreateMachineDeployments"),
+		true,
+		"create MachineDeployments objects")
 
 	cmd.Flags().BoolVar(
 		&opts.RotateEncryptionKey,

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -33,9 +33,10 @@ import (
 
 type installOpts struct {
 	globalOptions
-	BackupFile string `longflag:"backup" shortflag:"b"`
-	NoInit     bool   `longflag:"no-init"`
-	Force      bool   `longflag:"force"`
+	BackupFile               string `longflag:"backup" shortflag:"b"`
+	NoInit                   bool   `longflag:"no-init"`
+	Force                    bool   `longflag:"force"`
+	CreateMachineDeployments bool   `longflag:"create-machine-deployments"`
 }
 
 func (opts *installOpts) BuildState() (*state.State, error) {
@@ -46,6 +47,8 @@ func (opts *installOpts) BuildState() (*state.State, error) {
 
 	s.ForceInstall = opts.Force
 	s.BackupFile = opts.BackupFile
+	s.CreateMachineDeployments = opts.CreateMachineDeployments
+
 	if s.BackupFile == "" {
 		fullPath, _ := filepath.Abs(opts.ManifestFile)
 		clusterName := s.Cluster.Name
@@ -108,6 +111,12 @@ func installCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 		longFlagName(opts, "NoInit"),
 		false,
 		"don't initialize the cluster (only install binaries)")
+
+	cmd.Flags().BoolVar(
+		&opts.CreateMachineDeployments,
+		longFlagName(opts, "CreateMachineDeployments"),
+		true,
+		"create MachineDeployments objects")
 
 	cmd.Flags().BoolVar(
 		&opts.Force,

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -97,6 +97,7 @@ type State struct {
 	ForceUpgrade              bool
 	ForceInstall              bool
 	UpgradeMachineDeployments bool
+	CreateMachineDeployments  bool
 	CCMMigration              bool
 	CCMMigrationComplete      bool
 	CredentialsFilePath       string

--- a/pkg/tasks/machine_deployments.go
+++ b/pkg/tasks/machine_deployments.go
@@ -35,7 +35,7 @@ func createMachineDeployments(s *state.State) error {
 	}
 
 	if !s.CreateMachineDeployments {
-		s.Logger.Info("skip creating MachineDeployments...")
+		s.Logger.Info("Skipped creating MachineDeployments...")
 		return nil
 	}
 

--- a/pkg/tasks/machine_deployments.go
+++ b/pkg/tasks/machine_deployments.go
@@ -29,18 +29,23 @@ import (
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	machineDeploymentsDocsLink = `https://docs.kubermatic.com/kubeone/v1.3/guides/machine_controller/`
+)
+
 func createMachineDeployments(s *state.State) error {
 	if len(s.Cluster.DynamicWorkers) == 0 {
 		return nil
 	}
 
 	if !s.CreateMachineDeployments {
-		s.Logger.Info("Skipped creating MachineDeployments...")
+		s.Logger.Info("Skipped creating MachineDeployments.")
 		return nil
 	}
 
 	s.Logger.Infoln("Creating worker machines...")
-	s.Logger.Warnln("KubeOne will not manage MachineDeployments objects besides creating one time...")
+	s.Logger.Warnln("KubeOne will not manage MachineDeployments objects besides initially creating them and optionally upgrading them...")
+	s.Logger.Warnf("For more info about MachineDeployments see: %s", machineDeploymentsDocsLink)
 	return errors.Wrap(machinecontroller.CreateMachineDeployments(s), "failed to deploy Machines")
 }
 

--- a/pkg/tasks/machine_deployments.go
+++ b/pkg/tasks/machine_deployments.go
@@ -40,6 +40,7 @@ func createMachineDeployments(s *state.State) error {
 	}
 
 	s.Logger.Infoln("Creating worker machines...")
+	s.Logger.Warnln("KubeOne will not manage MachineDeployments objects besides creating one time...")
 	return errors.Wrap(machinecontroller.CreateMachineDeployments(s), "failed to deploy Machines")
 }
 

--- a/pkg/tasks/machine_deployments.go
+++ b/pkg/tasks/machine_deployments.go
@@ -34,6 +34,11 @@ func createMachineDeployments(s *state.State) error {
 		return nil
 	}
 
+	if !s.CreateMachineDeployments {
+		s.Logger.Info("skip creating MachineDeployments...")
+		return nil
+	}
+
 	s.Logger.Infoln("Creating worker machines...")
 	return errors.Wrap(machinecontroller.CreateMachineDeployments(s), "failed to deploy Machines")
 }


### PR DESCRIPTION
Allows skipping creation of machineDeployments objects in kube-api

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1586

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New apply flag: --create-machine-deployments
```
