### PR TITLE
[release/v1.3] Provide --cluster-name flag to the OpenStack external CCM

### DIFF
--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -201,6 +201,9 @@ spec:
             - --cloud-provider=openstack
             - --use-service-account-credentials=true
             - --bind-address=127.0.0.1
+            {{ if .CCMClusterName }}
+            - --cluster-name={{ .CCMClusterName }}
+            {{ end }}
 {{ if .Config.CABundle }}
           env:
 {{ caBundleEnvVar | indent 12 }}

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -58,6 +58,7 @@ type templateData struct {
 	Config                              *kubeoneapi.KubeOneCluster
 	Certificates                        map[string]string
 	Credentials                         map[string]string
+	CCMClusterName                      string
 	CSIMigration                        bool
 	CSIMigrationFeatureGates            string
 	MachineControllerCredentialsEnvVars string
@@ -155,6 +156,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 			"KubernetesCA":                 mcCertsMap[resources.KubernetesCACertName],
 		},
 		Credentials:                         creds,
+		CCMClusterName:                      s.LiveCluster.CCMClusterName,
 		CSIMigration:                        csiMigration,
 		CSIMigrationFeatureGates:            csiMigrationFeatureGates,
 		MachineControllerCredentialsEnvVars: string(credsEnvVars),

--- a/pkg/state/cluster.go
+++ b/pkg/state/cluster.go
@@ -35,6 +35,7 @@ type Cluster struct {
 	StaticWorkers           []Host
 	ExpectedVersion         *semver.Version
 	EncryptionConfiguration *EncryptionConfiguration
+	CCMClusterName          string
 	CCMStatus               *CCMStatus
 	Lock                    sync.Mutex
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of https://github.com/kubermatic/kubeone/pull/1619 to the `release/v1.3` branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1613

**Does this PR introduce a user-facing change?**:
```release-note
Provide --cluster-name flag to the OpenStack external CCM (read PR description for more details)
```

/assign @kron4eg 