### PR TITLE
Quality of Life (QOL) changes

### DIFF
--- a/addons/ccm-digitalocean/ccm-digitalocean.yaml
+++ b/addons/ccm-digitalocean/ccm-digitalocean.yaml
@@ -14,9 +14,8 @@ spec:
     metadata:
       labels:
         app: digitalocean-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       dnsPolicy: Default
       serviceAccountName: cloud-controller-manager
       tolerations:

--- a/addons/ccm-hetzner/ccm-hetzner.yaml
+++ b/addons/ccm-hetzner/ccm-hetzner.yaml
@@ -33,9 +33,8 @@ spec:
     metadata:
       labels:
         app: hcloud-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
       tolerations:

--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -163,12 +163,12 @@ spec:
   template:
     metadata:
       annotations:
-         "scheduler.alpha.kubernetes.io/critical-pod": ""
          "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
          "cloudConfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
       labels:
         k8s-app: "openstack-cloud-controller-manager"
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         node-role.kubernetes.io/master: ""
       securityContext:

--- a/addons/ccm-packet/ccm-packet.yaml
+++ b/addons/ccm-packet/ccm-packet.yaml
@@ -15,9 +15,8 @@ spec:
     metadata:
       labels:
         app: packet-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
         # this taint is set by all kubelets running `--cloud-provider=external`

--- a/addons/ccm-vsphere/ccm-vsphere.yaml
+++ b/addons/ccm-vsphere/ccm-vsphere.yaml
@@ -147,8 +147,6 @@ metadata:
     component: cloud-controller-manager
     tier: control-plane
   namespace: kube-system
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
   selector:
     matchLabels:
@@ -162,10 +160,10 @@ spec:
         component: cloud-controller-manager
         tier: control-plane
       annotations:
-        "scheduler.alpha.kubernetes.io/critical-pod": ""
         "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
         "cloudConfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         node-role.kubernetes.io/master: ""
       securityContext:

--- a/addons/cni-cilium/cilium.yaml
+++ b/addons/cni-cilium/cilium.yaml
@@ -667,15 +667,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        # This annotation plus the CriticalAddonsOnly toleration makes
-        # cilium to be a critical pod in the cluster, which ensures cilium
-        # gets priority scheduling.
-        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: cilium
     spec:
+      priorityClassName: system-cluster-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -192,6 +192,11 @@ func runMigrateToCCMCSI(opts *migrateCCMOptions) error {
 	s.Logger.Warnln("This command will migrate your cluster from in-tree cloud provider to the external CCM and CSI plugin.")
 	s.Logger.Warnln("Make sure to familiarize yourself with the process by checking the following document:")
 	s.Logger.Warnln("https://docs.kubermatic.com/kubeone/v1.3/guides/ccm_csi_migration/")
+	if s.Cluster.CloudProvider.Openstack != nil {
+		s.Logger.Warnln("The OpenStack external CCM uses Octavia Load Balancers by default.")
+		s.Logger.Warnln("If you currently use Neutron Load Balancers, migrating to the external CCM/CSI will cause *ALL* Load Balancers to be recreated!")
+		s.Logger.Warnln("Make sure to check documentation for more details.")
+	}
 
 	confirm, err := confirmCommand(opts.AutoApprove)
 	if err != nil {

--- a/pkg/nodeutils/drain.go
+++ b/pkg/nodeutils/drain.go
@@ -75,8 +75,11 @@ func (dr *drainer) drainHelper(ctx context.Context) (*drain.Helper, error) {
 	}
 
 	return &drain.Helper{
-		Ctx:                 ctx,
-		Client:              kubeClinet,
+		Ctx:    ctx,
+		Client: kubeClinet,
+		// Force is used to force deleting standalone pods (i.e. not managed by
+		// ReplicaSet)
+		Force:               true,
 		GracePeriodSeconds:  -1,
 		IgnoreAllDaemonSets: true,
 		DeleteEmptyDirData:  true,

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -161,7 +161,11 @@ func WithFullInstall(t Tasks) Tasks {
 		}...).
 		append(WithResources(nil)...).
 		append(
-			Task{Fn: createMachineDeployments, ErrMsg: "failed to create worker machines"},
+			Task{
+				Fn:        createMachineDeployments,
+				ErrMsg:    "failed to create worker machines",
+				Predicate: func(s *state.State) bool { return !s.LiveCluster.IsProvisioned() },
+			},
 		)
 }
 

--- a/pkg/templates/kubeadm/kubeadm.go
+++ b/pkg/templates/kubeadm/kubeadm.go
@@ -28,10 +28,6 @@ const (
 	kubeadmUpgradeNodeCommand = "kubeadm upgrade node --certificate-renewal=true"
 )
 
-var (
-	lessThanv22x = mustParseConstraint(">= 1.15.0, < 1.22.0")
-)
-
 // Kubedm interface abstract differences between different kubeadm versions
 type Kubedm interface {
 	Config(s *state.State, instance kubeoneapi.HostConfig) (string, error)
@@ -49,18 +45,9 @@ func New(ver string) (Kubedm, error) {
 	}
 
 	switch {
-	case lessThanv22x.Check(sver):
+	case sver.Minor() < 22:
 		return &kubeadmv1beta2{version: ver}, nil
 	default:
 		return &kubeadmv1beta3{version: ver}, nil
 	}
-}
-
-func mustParseConstraint(constraint string) *semver.Constraints {
-	c, err := semver.NewConstraint(constraint)
-	if err != nil {
-		panic(err)
-	}
-
-	return c
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Replace critical-pod annotation with priorityClassName
    * The critical-pod annotation is not-functional since Kubernetes 1.16
* Show warning about LBs on CCM migration for OpenStack clusters
    * Triggering migration might cause all LBs to be recreated if Neutron LBs are used
    * This also requires updating docs
* Force drain nodes to remove standalone pods
    * If there's a standalone pod (not managed by ReplicaSet) on a control plane or static worker node, draining is going to fail. Force draining node also removes the standalone pods
* Check for minor version when choosing kubeadm API version
     * The constraint-based check doesn't work properly if there's any additional info in the version (alpha/beta/rc or EKS-D versions)
* Create MachineDeployments only for newly-provisioned clusters
    * MachineDeployments should be created only when provisioning the cluster for the first time. Right now, if you add new static worker nodes after creating the cluster, MachineDeployments will be reconciled again (this shouldn't happen)

**Does this PR introduce a user-facing change?**:
```release-note
Replace critical-pod annotation with priorityClassName
Show warning about LBs on CCM migration for OpenStack clusters
Force drain nodes to remove standalone pods
Check for minor version when choosing kubeadm API version
Create MachineDeployments only for newly-provisioned clusters
```

/assign @kron4eg 