### PR TITLE
Remove PriorityClassName from Cilium DaemonSet because it's already set

### DIFF
--- a/addons/cni-cilium/cilium.yaml
+++ b/addons/cni-cilium/cilium.yaml
@@ -670,7 +670,6 @@ spec:
       labels:
         k8s-app: cilium
     spec:
-      priorityClassName: system-cluster-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
**What this PR does / why we need it**:

I added PriorityClassName to the Cilium DaemonSet in #1627, but I haven't noticed it's already set actually.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 