### PR TITLE
Fix cloud provider name for GCP in default-storage-class addon

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -123,7 +123,7 @@ provisioner: kubernetes.io/cinder
 {{ end }}
 {{ end }}
 
-{{ if eq .Config.CloudProvider.CloudProviderName "gcp" }}
+{{ if eq .Config.CloudProvider.CloudProviderName "gce" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The `default-storage-class` addon was ported from KKP and uses the value "gcp" to determine if the Kubernetes cluster uses the GCP cloud provider. However KubeOne uses "gce" as identifier for the GCP cloud provider and therefore the StorageClass was never rendered when provisioning a Kubernetes cluster with KubeOne on GCP.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deploy default StorageClass for GCP clusters if the `default-storage-class` addon is enabled
```
