### PR TITLE
Ignore TLS verification for containerd insecure registries

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -151,11 +151,20 @@ type containerdCRIRuncOptions struct {
 }
 
 type containerdCRIRegistry struct {
-	Mirrors map[string]containerdMirror `toml:"mirrors"`
+	Mirrors map[string]containerdRegistryMirror `toml:"mirrors"`
+	Configs map[string]containerdRegistryConfig `toml:"configs"`
 }
 
-type containerdMirror struct {
+type containerdRegistryMirror struct {
 	Endpoint []string `toml:"endpoint"`
+}
+
+type containerdRegistryConfig struct {
+	TLS containerdRegistryTLSConfig `toml:"tls"`
+}
+
+type containerdRegistryTLSConfig struct {
+	InsecureSkipVerify bool `toml:"insecure_skip_verify"`
 }
 
 func containerdCfg(insecureRegistry string) (string, error) {
@@ -171,7 +180,7 @@ func containerdCfg(insecureRegistry string) (string, error) {
 			},
 		},
 		Registry: &containerdCRIRegistry{
-			Mirrors: map[string]containerdMirror{
+			Mirrors: map[string]containerdRegistryMirror{
 				"docker.io": {
 					Endpoint: []string{"https://registry-1.docker.io"},
 				},
@@ -180,8 +189,15 @@ func containerdCfg(insecureRegistry string) (string, error) {
 	}
 
 	if insecureRegistry != "" {
-		criPlugin.Registry.Mirrors[insecureRegistry] = containerdMirror{
+		criPlugin.Registry.Mirrors[insecureRegistry] = containerdRegistryMirror{
 			Endpoint: []string{fmt.Sprintf("http://%s", insecureRegistry)},
+		}
+		criPlugin.Registry.Configs = map[string]containerdRegistryConfig{
+			insecureRegistry: {
+				TLS: containerdRegistryTLSConfig{
+					InsecureSkipVerify: true,
+				},
+			},
 		}
 	}
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -96,6 +96,10 @@ SystemdCgroup = true
 endpoint = ["http://127.0.0.1:5000"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
 endpoint = ["https://registry-1.docker.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."127.0.0.1:5000"]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."127.0.0.1:5000".tls]
+insecure_skip_verify = true
 EOF
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -102,6 +102,10 @@ SystemdCgroup = true
 endpoint = ["http://127.0.0.1:5000"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
 endpoint = ["https://registry-1.docker.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."127.0.0.1:5000"]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."127.0.0.1:5000".tls]
+insecure_skip_verify = true
 EOF
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -98,6 +98,10 @@ SystemdCgroup = true
 endpoint = ["http://127.0.0.1:5000"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
 endpoint = ["https://registry-1.docker.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."127.0.0.1:5000"]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."127.0.0.1:5000".tls]
+insecure_skip_verify = true
 EOF
 
 cat <<EOF | sudo tee /etc/crictl.yaml

--- a/pkg/scripts/testdata/TestMigrateToContainerd-insecureRegistry.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-insecureRegistry.golden
@@ -24,6 +24,10 @@ SystemdCgroup = true
 endpoint = ["https://registry-1.docker.io"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."some.registry"]
 endpoint = ["http://some.registry"]
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."some.registry"]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."some.registry".tls]
+insecure_skip_verify = true
 EOF
 
 cat <<EOF | sudo tee /etc/crictl.yaml


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When using an insecure registry TLS verification should be ignored by default. This behaviour was missing when the user was using an insecure registry for containerd. This PR fixes that isue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1547 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip TLS verification when using containerd for insecure registries
```
