### PR TITLE
ValidateName always prints empty string as value instead of actual value

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -69,7 +69,7 @@ func ValidateName(name string, fldPath *field.Path) field.ErrorList {
 	}
 	clusterNameRegex := regexp.MustCompile(`^[0-9a-z-]+$`)
 	if !clusterNameRegex.MatchString(name) {
-		allErrs = append(allErrs, field.Invalid(fldPath, "",
+		allErrs = append(allErrs, field.Invalid(fldPath, name,
 			".name should be lowercase and can only contain alphanumeric characters and hyphens(-)"))
 	}
 	return allErrs


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit fixes an rather annoying issue where `ValidateName` does not
print the correct value of the invalid cluster name which made the issue
hard to debug.

Background:
I recently upgraded from an earlier KubeOne version to master and my cluster-name contained dots (`.`).
However since https://github.com/kubermatic/kubeone/pull/1641 this is no longer valid.

The output of this validation looked like

```bash
$ kubeone apply --manifest kubeone.yaml --credentials credentials.yaml --tfjson output.json --auto-approve --verbose

Error: failed to initialize State: failed to build state: failed to load cluster: unable to load a given KubeOneCluster object: unable to validate the given KubeOneCluster object: name: Invalid value: "": .name should be lowercase and can only contain alphanumeric characters and hyphens(-)
```

With this commit in place the output looks like this:

```bash
$ kubeone install --manifest kubeone.yaml --credentials credentials.yaml --tfjson output.json --verbose
Error: failed to initialize State: failed to build state: failed to load cluster: unable to load a given KubeOneCluster object: unable to validate the given KubeOneCluster object: name: Invalid value: "k8s.cedi.dev": .name should be lowercase and can only contain alphanumeric characters and hyphens(-)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
