### PR TITLE
Validate cluster name using RFC 1123 regexp

### DIFF
--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[0-9a-z-]+$", var.cluster_name))
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
     error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
   }
 }

--- a/examples/terraform/azure/variables.tf
+++ b/examples/terraform/azure/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[0-9a-z-]+$", var.cluster_name))
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
     error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
   }
 }

--- a/examples/terraform/digitalocean/variables.tf
+++ b/examples/terraform/digitalocean/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[0-9a-z-]+$", var.cluster_name))
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
     error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
   }
 }

--- a/examples/terraform/gce/variables.tf
+++ b/examples/terraform/gce/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[0-9a-z-]+$", var.cluster_name))
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
     error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
   }
 }

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -17,6 +17,11 @@ limitations under the License.
 variable "cluster_name" {
   description = "prefix for cloud resources"
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
+    error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
+  }
 }
 
 variable "apiserver_alternative_names" {

--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[0-9a-z-]+$", var.cluster_name))
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
     error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
   }
 }

--- a/examples/terraform/packet/variables.tf
+++ b/examples/terraform/packet/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[0-9a-z-]+$", var.cluster_name))
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
     error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
   }
 }

--- a/examples/terraform/vsphere/variables.tf
+++ b/examples/terraform/vsphere/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[0-9a-z-]+$", var.cluster_name))
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
     error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
   }
 }

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -21,13 +21,13 @@ import (
 	"crypto/x509"
 	"net"
 	"reflect"
-	"regexp"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
 
 	"k8c.io/kubeone/pkg/apis/kubeone"
 
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -64,14 +64,11 @@ func ValidateKubeOneCluster(c kubeone.KubeOneCluster) field.ErrorList {
 func ValidateName(name string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(name) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath, "cluster name `.name` is a required field."))
+	errs := validation.IsDNS1123Subdomain(name)
+	for _, err := range errs {
+		allErrs = append(allErrs, field.Invalid(fldPath, name, err))
 	}
-	clusterNameRegex := regexp.MustCompile(`^[0-9a-z-]+$`)
-	if !clusterNameRegex.MatchString(name) {
-		allErrs = append(allErrs, field.Invalid(fldPath, name,
-			".name should be lowercase and can only contain alphanumeric characters and hyphens(-)"))
-	}
+
 	return allErrs
 }
 

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -245,6 +245,74 @@ func TestValidateKubeOneCluster(t *testing.T) {
 	}
 }
 
+func TestValdiateName(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusterName   string
+		expectedError bool
+	}{
+		{
+			name:          "valid cluster name",
+			clusterName:   "test",
+			expectedError: false,
+		},
+		{
+			name:          "valid cluster name (with periods)",
+			clusterName:   "test-1",
+			expectedError: false,
+		},
+		{
+			name:          "valid cluster name (with dots)",
+			clusterName:   "test.example.com",
+			expectedError: false,
+		},
+		{
+			name:          "valid cluster name (with periods and dots)",
+			clusterName:   "test-1.example.com",
+			expectedError: false,
+		},
+		{
+			name:          "valid cluster name (starts with number)",
+			clusterName:   "1test",
+			expectedError: false,
+		},
+		{
+			name:          "invalid cluster name (empty)",
+			clusterName:   "",
+			expectedError: true,
+		},
+		{
+			name:          "invalid cluster name (underscore)",
+			clusterName:   "test_1.example.com",
+			expectedError: true,
+		},
+		{
+			name:          "invalid cluster name (uppercase)",
+			clusterName:   "Test",
+			expectedError: true,
+		},
+		{
+			name:          "invalid cluster name (starts with dot)",
+			clusterName:   ".test",
+			expectedError: true,
+		},
+		{
+			name:          "invalid cluster name (ends with dot)",
+			clusterName:   "test.",
+			expectedError: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			errs := ValidateName(tc.clusterName, nil)
+			if (len(errs) == 0) == tc.expectedError {
+				t.Errorf("test case failed: expected %v, but got %v", tc.expectedError, (len(errs) != 0))
+			}
+		})
+	}
+}
+
 func TestValidateControlPlaneConfig(t *testing.T) {
 	tests := []struct {
 		name               string


### PR DESCRIPTION
**What this PR does / why we need it**:

#1641 introduced validation for the cluster name to fix #1630. However, the regexp used in that PR is too restrictive because it doesn't allow dots, which are allowed by RFC 1123. Also, the original implementation doesn't cover other requirements defined by RFC 1123:

* contain no more than 253 characters
* start with an alphanumeric character
* end with an alphanumeric character

This PR uses the regexp used by Kubernetes to [validate RFC 1123 subdomains](https://github.com/kubernetes/kubernetes/blob/9a75e7b0fd1b567f774a3373be640e19b33e7ef1/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L209-L218).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1630

**Does this PR introduce a user-facing change?**:
```release-note
Validate cluster name using RFC 1123 regexp
```

/assign @kron4eg @ahmedwaleedmalik 