### PR TITLE
Use kubeone.k8c.io/v1beta2 for the example config

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -278,7 +278,7 @@ func createAndPrintManifest(printOptions *printOpts) error {
 	cfg := &yamled.Document{}
 
 	// API data
-	cfg.Set(yamled.Path{"apiVersion"}, "kubeone.io/v1beta1")
+	cfg.Set(yamled.Path{"apiVersion"}, "kubeone.k8c.io/v1beta2")
 	cfg.Set(yamled.Path{"kind"}, "KubeOneCluster")
 
 	// Cluster name
@@ -496,7 +496,7 @@ func validateAndPrintConfig(cfgYaml interface{}) error {
 }
 
 const exampleManifest = `
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: {{ .ClusterName }}
 

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"k8c.io/kubeone/test/e2e/provisioner"
 	"k8c.io/kubeone/test/e2e/testutil"
@@ -269,10 +268,6 @@ func TestClusterConformance(t *testing.T) { //nolint:gocyclo
 			if tc.provider == provisioner.OpenStack {
 				installFlags = append(installFlags, "-c", "/tmp/credentials.yaml")
 			}
-
-			sleepTime := 2 * time.Minute
-			t.Logf("sleep %s", sleepTime)
-			time.Sleep(sleepTime)
 
 			err = target.Install(tf, installFlags)
 			if err != nil {

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -194,10 +194,6 @@ func TestClusterUpgrade(t *testing.T) {
 				installFlags = append(installFlags, "-c", "/tmp/credentials.yaml")
 			}
 
-			sleepTime := 2 * time.Minute
-			t.Logf("sleep %s", sleepTime)
-			time.Sleep(sleepTime)
-
 			err = target.Install(tf, installFlags)
 			if err != nil {
 				t.Fatalf("failed to install cluster ('kubeone install'): %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

I forgot to update the example config to use the new API, so this PR is a follow-up to fix this.

This PR also removes 2 minutes timeout from the E2E tests. That timeout is legacy from times before we retried reconnecting if the instances are not ready, so I don't think we need it anymore.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 