### PR TITLE
[release/v1.3] Update machine-controller to v1.37.2

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -90,7 +90,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:        {"*": "docker.io/calico/node:v3.19.1"},
 		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
 		Flannel:           {"*": "quay.io/coreos/flannel:v0.13.0"},
-		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.35.2"},
+		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.37.2"},
 		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of #1661.

Update machine-controller to v1.37.2.

This release defaults the provisioning utility for Flatcar machines on AWS to cloud-init (previously ignition). Ignition is currently not working on AWS Flatcar machines because of the user data limit. If you have provisioning utility explicitly set to Ignition, you'll not be able to provision new Flatcar machines. In that case, changing the provisioning utility to cloud-init is recommended.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.37.1
* machine-controller is now using Ubuntu 20.04 instead of 18.04 by default for all newly-created Machines on AWS, Azure, DO, GCE, Hetzner, Openstack, and Equinix Metal
* This release defaults the provisioning utility for Flatcar machines on AWS to cloud-init (previously ignition). Ignition is currently not working on AWS because of the user data limit.
* If you have provisioning utility explicitly set to Ignition, you'll not be able to provision new Flatcar machines. In that case, changing the provisioning utility to cloud-init is recommended.
```

/assign @kron4eg 