### PR TITLE
Update API doc for the AssetConfiguration API

### DIFF
--- a/docs/api_reference/v1beta1.en.md
+++ b/docs/api_reference/v1beta1.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta1 API Reference"
-date = 2021-12-01T19:11:08+01:00
+date = 2021-12-02T14:38:54+01:00
 weight = 11
 +++
 ## v1beta1

--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2021-12-01T19:11:08+01:00
+date = 2021-12-02T14:38:54+01:00
 weight = 11
 +++
 ## v1beta2
@@ -109,7 +109,9 @@ Addons config
 
 AssetConfiguration controls how assets (e.g. CNI, Kubelet, kube-apiserver, and more)
 are pulled.
-The AssetConfiguration API is an alpha API currently working only on Amazon Linux 2.
+The AssetConfiguration API is a deprecated API, planned to be remmoved in
+KubeOne 1.4. Currently, configuring BinaryAssets working only on
+Amazon Linux 2.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -444,7 +444,9 @@ type SystemPackages struct {
 
 // AssetConfiguration controls how assets (e.g. CNI, Kubelet, kube-apiserver, and more)
 // are pulled.
-// The AssetConfiguration API is an alpha API currently working only on Amazon Linux 2.
+// The AssetConfiguration API is a deprecated API, planned to be remmoved in
+// KubeOne 1.4. Currently, configuring BinaryAssets working only on
+// Amazon Linux 2.
 type AssetConfiguration struct {
 	// Kubernetes configures the image registry and repository for the core Kubernetes
 	// images (kube-apiserver, kube-controller-manager, kube-scheduler, and kube-proxy).

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -444,7 +444,9 @@ type SystemPackages struct {
 
 // AssetConfiguration controls how assets (e.g. CNI, Kubelet, kube-apiserver, and more)
 // are pulled.
-// The AssetConfiguration API is an alpha API currently working only on Amazon Linux 2.
+// The AssetConfiguration API is a deprecated API, planned to be remmoved in
+// KubeOne 1.4. Currently, configuring BinaryAssets working only on
+// Amazon Linux 2.
 type AssetConfiguration struct {
 	// Kubernetes configures the image registry and repository for the core Kubernetes
 	// images (kube-apiserver, kube-controller-manager, kube-scheduler, and kube-proxy).


### PR DESCRIPTION
**What this PR does / why we need it**:

A simple change to trigger the API docs sync automation.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 
/hold