### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/pkg/addons/manifest_test.go
+++ b/pkg/addons/manifest_test.go
@@ -19,7 +19,6 @@ package addons
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -177,14 +176,10 @@ func TestEnsureAddonsLabelsOnResources(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			addonsDir, err := ioutil.TempDir("/tmp", "kubeone")
-			if err != nil {
-				t.Fatalf("unable to create temporary addons directory: %v", err)
-			}
-			defer os.RemoveAll(addonsDir)
+			addonsDir := t.TempDir()
 
-			if writeErr := ioutil.WriteFile(path.Join(addonsDir, "testManifest.yaml"), []byte(tc.addonManifest), 0600); writeErr != nil {
-				t.Fatalf("unable to create temporary addon manifest: %v", err)
+			if writeErr := os.WriteFile(path.Join(addonsDir, "testManifest.yaml"), []byte(tc.addonManifest), 0600); writeErr != nil {
+				t.Fatalf("unable to create temporary addon manifest: %v", writeErr)
 			}
 
 			td := templateData{
@@ -258,14 +253,10 @@ func TestImageRegistryParsing(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			addonsDir, err := ioutil.TempDir("/tmp", "kubeone")
-			if err != nil {
-				t.Fatalf("unable to create temporary addons directory: %v", err)
-			}
-			defer os.RemoveAll(addonsDir)
+			addonsDir := t.TempDir()
 
-			if writeErr := ioutil.WriteFile(path.Join(addonsDir, "testManifest.yaml"), []byte(tc.inputManifest), 0600); writeErr != nil {
-				t.Fatalf("unable to create temporary addon manifest: %v", err)
+			if writeErr := os.WriteFile(path.Join(addonsDir, "testManifest.yaml"), []byte(tc.inputManifest), 0600); writeErr != nil {
+				t.Fatalf("unable to create temporary addon manifest: %v", writeErr)
 			}
 
 			td := templateData{

--- a/pkg/apis/kubeone/config/config.go
+++ b/pkg/apis/kubeone/config/config.go
@@ -17,7 +17,7 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 
@@ -61,7 +61,7 @@ func LoadKubeOneCluster(clusterCfgPath, tfOutputPath, credentialsFilePath string
 		return nil, errors.New("cluster configuration path not provided")
 	}
 
-	cluster, err := ioutil.ReadFile(clusterCfgPath)
+	cluster, err := os.ReadFile(clusterCfgPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read the given cluster configuration file")
 	}
@@ -70,7 +70,7 @@ func LoadKubeOneCluster(clusterCfgPath, tfOutputPath, credentialsFilePath string
 
 	switch {
 	case tfOutputPath == "-":
-		if tfOutput, err = ioutil.ReadAll(os.Stdin); err != nil {
+		if tfOutput, err = io.ReadAll(os.Stdin); err != nil {
 			return nil, errors.Wrap(err, "unable to read terraform output from stdin")
 		}
 	case isDir(tfOutputPath):
@@ -80,14 +80,14 @@ func LoadKubeOneCluster(clusterCfgPath, tfOutputPath, credentialsFilePath string
 			return nil, errors.Wrapf(err, "unable to read terraform output from the %q directory", tfOutputPath)
 		}
 	case len(tfOutputPath) != 0:
-		if tfOutput, err = ioutil.ReadFile(tfOutputPath); err != nil {
+		if tfOutput, err = os.ReadFile(tfOutputPath); err != nil {
 			return nil, errors.Wrap(err, "unable to read the given terraform output file")
 		}
 	}
 
 	var credentialsFile []byte
 	if len(credentialsFilePath) != 0 {
-		credentialsFile, err = ioutil.ReadFile(credentialsFilePath)
+		credentialsFile, err = os.ReadFile(credentialsFilePath)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to read the given credentials file")
 		}

--- a/pkg/clusterstatus/apiserverstatus/apiserverstatus.go
+++ b/pkg/clusterstatus/apiserverstatus/apiserverstatus.go
@@ -19,7 +19,7 @@ package apiserverstatus
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
@@ -70,7 +70,7 @@ func apiserverHealth(t http.RoundTripper, nodeAddress string) (bool, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/clusterstatus/etcdstatus/etcdstatus.go
+++ b/pkg/clusterstatus/etcdstatus/etcdstatus.go
@@ -19,7 +19,7 @@ package etcdstatus
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -121,7 +121,7 @@ func memberHealth(t http.RoundTripper, nodeAddress string) (bool, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/configupload/configuration.go
+++ b/pkg/configupload/configuration.go
@@ -18,7 +18,7 @@ package configupload
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -60,7 +60,7 @@ func (c *Configuration) AddFilePath(filename, filePath, manifestFilePath string)
 		filePath = filepath.Join(manifestAbsPath, filePath)
 	}
 
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return errors.Wrap(err, "unable to open given file")
 	}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -18,7 +18,6 @@ package credentials
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -201,7 +200,7 @@ func newCredsFinder(credentialsFilePath string) (lookupFunc, error) {
 		return finder, nil
 	}
 
-	buf, err := ioutil.ReadFile(credentialsFilePath)
+	buf, err := os.ReadFile(credentialsFilePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to load credentials file")
 	}

--- a/pkg/ssh/connection.go
+++ b/pkg/ssh/connection.go
@@ -19,7 +19,6 @@ package ssh
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -84,7 +83,7 @@ func validateOptions(o Opts) (Opts, error) {
 	}
 
 	if len(o.KeyFile) > 0 {
-		content, err := ioutil.ReadFile(o.KeyFile)
+		content, err := os.ReadFile(o.KeyFile)
 		if err != nil {
 			return o, errors.Wrapf(err, "failed to read keyfile %q", o.KeyFile)
 		}

--- a/pkg/tasks/kubeconfig.go
+++ b/pkg/tasks/kubeconfig.go
@@ -18,7 +18,7 @@ package tasks
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -35,6 +35,6 @@ func saveKubeconfig(s *state.State) error {
 	}
 
 	fileName := fmt.Sprintf("%s-kubeconfig", s.Cluster.Name)
-	err = ioutil.WriteFile(fileName, kc, 0600)
+	err = os.WriteFile(fileName, kc, 0600)
 	return errors.Wrap(err, "error saving kubeconfig file to the local machine")
 }

--- a/pkg/testhelper/helper.go
+++ b/pkg/testhelper/helper.go
@@ -18,7 +18,7 @@ limitations under the License.
 package testhelper
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -37,12 +37,12 @@ func DiffOutput(t *testing.T, name, output string, update bool) {
 	}
 
 	if update {
-		if errw := ioutil.WriteFile(golden, []byte(output), 0600); errw != nil {
+		if errw := os.WriteFile(golden, []byte(output), 0600); errw != nil {
 			t.Fatalf("failed to write updated fixture: %v", errw)
 		}
 	}
 
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	if err != nil {
 		t.Fatalf("failed to read testdata file: %v", err)
 	}

--- a/pkg/yamled/document_test.go
+++ b/pkg/yamled/document_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package yamled
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -30,7 +30,7 @@ func getTestcaseYAML(t *testing.T, filename string) string {
 		filename = "document.yaml"
 	}
 
-	content, err := ioutil.ReadFile("testcases/" + filename)
+	content, err := os.ReadFile("testcases/" + filename)
 	if err != nil {
 		t.Fatalf("could not load document %s: %v", filename, err)
 	}

--- a/test/e2e/kubeone.go
+++ b/test/e2e/kubeone.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -97,7 +96,7 @@ func (k1 *Kubeone) CreateV1Beta1Config(
 	}
 
 	if credentialsFile != "" {
-		ymlbuf, err := ioutil.ReadFile(credentialsFile)
+		ymlbuf, err := os.ReadFile(credentialsFile)
 		if err != nil {
 			return errors.Wrap(err, "unable to read credentials file")
 		}
@@ -123,7 +122,7 @@ func (k1 *Kubeone) CreateV1Beta1Config(
 		return errors.Wrap(err, "unable to marshal kubeone KubeOneCluster")
 	}
 
-	err = ioutil.WriteFile(k1.ConfigurationFilePath, k1Config, 0600)
+	err = os.WriteFile(k1.ConfigurationFilePath, k1Config, 0600)
 	return errors.Wrap(err, "failed to write KubeOne configuration manifest")
 }
 
@@ -173,7 +172,7 @@ func (k1 *Kubeone) CreateV1Beta2Config(
 	}
 
 	if credentialsFile != "" {
-		ymlbuf, err := ioutil.ReadFile(credentialsFile)
+		ymlbuf, err := os.ReadFile(credentialsFile)
 		if err != nil {
 			return errors.Wrap(err, "unable to read credentials file")
 		}
@@ -191,7 +190,7 @@ func (k1 *Kubeone) CreateV1Beta2Config(
 		return errors.Wrap(err, "unable to marshal kubeone KubeOneCluster")
 	}
 
-	err = ioutil.WriteFile(k1.ConfigurationFilePath, k1Config, 0600)
+	err = os.WriteFile(k1.ConfigurationFilePath, k1Config, 0600)
 	return errors.Wrap(err, "failed to write KubeOne configuration manifest")
 }
 

--- a/test/e2e/testutil/testutil.go
+++ b/test/e2e/testutil/testutil.go
@@ -19,7 +19,6 @@ package testutil
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -51,7 +50,7 @@ func CreateFile(filepath, content string) error {
 	}
 
 	// Create the file.
-	err = ioutil.WriteFile(strings.Join([]string{basepath, filename}, "/"), []byte(content), os.ModePerm)
+	err = os.WriteFile(strings.Join([]string{basepath, filename}, "/"), []byte(content), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("unable to write data to file")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since kubeone has been upgraded to Go 1.17 (#1534), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```