### PR TITLE
Add support for OpenStack application credentials and update validation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,3 +60,6 @@ issues:
 
   - path: pkg/scripts
     text: "`registry` always receives `\"127.0.0.1:5000\"`"
+
+  - path: pkg/credentials
+    text: "cyclomatic complexity 32 of func `openstackValidationFunc` is high"

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -160,7 +160,7 @@ func ProviderCredentials(cloudProvider kubeone.CloudProviderSpec, credentialsFil
 			{Name: OpenStackAuthURL},
 			{Name: OpenStackUserName, MachineControllerName: OpenStackUserNameMC},
 			{Name: OpenStackPassword},
-			{Name: OpenStackApplicationCredentialID, MachineControllerName: OpenStackUserNameMC},
+			{Name: OpenStackApplicationCredentialID},
 			{Name: OpenStackApplicationCredentialSecret},
 			{Name: OpenStackDomainName},
 			{Name: OpenStackRegionName},

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -296,14 +296,14 @@ func openstackValidationFunc(creds map[string]string) error {
 	}
 
 	var (
-		appCredsIdOkay        bool
+		appCredsIDOkay        bool
 		appCredsSecretOkay    bool
 		userCredsUsernameOkay bool
 		userCredsPasswordOkay bool
 	)
 
 	if v, ok := creds[OpenStackApplicationCredentialID]; ok && len(v) != 0 {
-		appCredsIdOkay = true
+		appCredsIDOkay = true
 	}
 
 	if v, ok := creds[OpenStackApplicationCredentialSecret]; ok && len(v) != 0 {
@@ -318,13 +318,13 @@ func openstackValidationFunc(creds map[string]string) error {
 		userCredsPasswordOkay = true
 	}
 
-	if (appCredsIdOkay || appCredsSecretOkay) && (userCredsUsernameOkay || userCredsPasswordOkay) {
+	if (appCredsIDOkay || appCredsSecretOkay) && (userCredsUsernameOkay || userCredsPasswordOkay) {
 		return errors.Errorf("both app credentials (%s %s) and user credentials (%s %s) found",
 			OpenStackApplicationCredentialID, OpenStackApplicationCredentialSecret,
 			OpenStackUserName, OpenStackPassword)
 	}
 
-	if (appCredsIdOkay && !appCredsSecretOkay) || (!appCredsIdOkay && appCredsSecretOkay) {
+	if (appCredsIDOkay && !appCredsSecretOkay) || (!appCredsIDOkay && appCredsSecretOkay) {
 		return errors.Errorf("only one of %s, %s is set for application credentials",
 			OpenStackApplicationCredentialID, OpenStackApplicationCredentialSecret)
 	}
@@ -334,7 +334,7 @@ func openstackValidationFunc(creds map[string]string) error {
 			OpenStackUserName, OpenStackPassword)
 	}
 
-	if (!appCredsIdOkay && !appCredsSecretOkay) && (!userCredsUsernameOkay && !userCredsPasswordOkay) {
+	if (!appCredsIDOkay && !appCredsSecretOkay) && (!userCredsUsernameOkay && !userCredsPasswordOkay) {
 		return errors.New("no valid credentials (either application or user) found")
 	}
 

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2021 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestOpenstackValidationFunc(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		creds map[string]string
+		err   error
+	}{
+		{
+			name:  "no-credentials",
+			creds: map[string]string{},
+			err:   errors.New("key OS_AUTH_URL is required but is not present"),
+		},
+		{
+			name: "application-credentials",
+			creds: map[string]string{
+				"OS_TENANT_NAME":                   "test",
+				"OS_AUTH_URL":                      "https://localhost:5000",
+				"OS_DOMAIN_NAME":                   "test",
+				"OS_REGION_NAME":                   "de",
+				"OS_APPLICATION_CREDENTIAL_ID":     "1234",
+				"OS_APPLICATION_CREDENTIAL_SECRET": "5678",
+			},
+			err: nil,
+		},
+		{
+			name: "no-credential-secret",
+			creds: map[string]string{
+				"OS_TENANT_NAME":               "test",
+				"OS_AUTH_URL":                  "https://localhost:5000",
+				"OS_DOMAIN_NAME":               "test",
+				"OS_REGION_NAME":               "de",
+				"OS_APPLICATION_CREDENTIAL_ID": "1234",
+			},
+			err: errors.New("only one of OS_APPLICATION_CREDENTIAL_ID, OS_APPLICATION_CREDENTIAL_SECRET is set for application credentials"),
+		},
+		{
+			name: "no-credential-id",
+			creds: map[string]string{
+				"OS_TENANT_NAME":                   "test",
+				"OS_AUTH_URL":                      "https://localhost:5000",
+				"OS_DOMAIN_NAME":                   "test",
+				"OS_REGION_NAME":                   "de",
+				"OS_APPLICATION_CREDENTIAL_SECRET": "5678",
+			},
+			err: errors.New("only one of OS_APPLICATION_CREDENTIAL_ID, OS_APPLICATION_CREDENTIAL_SECRET is set for application credentials"),
+		},
+		{
+			name: "user-credentials",
+			creds: map[string]string{
+				"OS_TENANT_NAME": "test",
+				"OS_AUTH_URL":    "https://localhost:5000",
+				"OS_DOMAIN_NAME": "test",
+				"OS_REGION_NAME": "de",
+				"OS_USERNAME":    "1234",
+				"OS_PASSWORD":    "5678",
+			},
+			err: nil,
+		},
+		{
+			name: "no-password",
+			creds: map[string]string{
+				"OS_TENANT_NAME": "test",
+				"OS_AUTH_URL":    "https://localhost:5000",
+				"OS_DOMAIN_NAME": "test",
+				"OS_REGION_NAME": "de",
+				"OS_USERNAME":    "1234",
+			},
+			err: errors.New("only one of OS_USERNAME, OS_PASSWORD is set for user credentials"),
+		},
+		{
+			name: "no-username",
+			creds: map[string]string{
+				"OS_TENANT_NAME": "test",
+				"OS_AUTH_URL":    "https://localhost:5000",
+				"OS_DOMAIN_NAME": "test",
+				"OS_REGION_NAME": "de",
+				"OS_PASSWORD":    "5678",
+			},
+			err: errors.New("only one of OS_USERNAME, OS_PASSWORD is set for user credentials"),
+		},
+		{
+			name: "mixed-credentials-1",
+			creds: map[string]string{
+				"OS_TENANT_NAME":               "test",
+				"OS_AUTH_URL":                  "https://localhost:5000",
+				"OS_DOMAIN_NAME":               "test",
+				"OS_REGION_NAME":               "de",
+				"OS_APPLICATION_CREDENTIAL_ID": "1234",
+				"OS_PASSWORD":                  "5678",
+			},
+			err: errors.New("both app credentials (OS_APPLICATION_CREDENTIAL_ID OS_APPLICATION_CREDENTIAL_SECRET) and user credentials (OS_USERNAME OS_PASSWORD) found"),
+		},
+		{
+			name: "mixed-credentials-2",
+			creds: map[string]string{
+				"OS_TENANT_NAME":                   "test",
+				"OS_AUTH_URL":                      "https://localhost:5000",
+				"OS_DOMAIN_NAME":                   "test",
+				"OS_REGION_NAME":                   "de",
+				"OS_APPLICATION_CREDENTIAL_SECRET": "5678",
+				"OS_USERNAME":                      "1234",
+			},
+			err: errors.New("both app credentials (OS_APPLICATION_CREDENTIAL_ID OS_APPLICATION_CREDENTIAL_SECRET) and user credentials (OS_USERNAME OS_PASSWORD) found"),
+		},
+		{
+			name: "mixed-credentials-3",
+			creds: map[string]string{
+				"OS_TENANT_NAME":                   "test",
+				"OS_AUTH_URL":                      "https://localhost:5000",
+				"OS_DOMAIN_NAME":                   "test",
+				"OS_REGION_NAME":                   "de",
+				"OS_APPLICATION_CREDENTIAL_ID":     "1234",
+				"OS_APPLICATION_CREDENTIAL_SECRET": "5678",
+				"OS_USERNAME":                      "1234",
+				"OS_PASSWORD":                      "5678",
+			},
+			err: errors.New("both app credentials (OS_APPLICATION_CREDENTIAL_ID OS_APPLICATION_CREDENTIAL_SECRET) and user credentials (OS_USERNAME OS_PASSWORD) found"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := openstackValidationFunc(tt.creds)
+			if tt.err != nil && err != nil {
+				if err.Error() != tt.err.Error() {
+					t.Errorf("expected error = '%v', got error = '%v'", tt.err.Error(), err.Error())
+				}
+			} else if err != tt.err {
+				t.Errorf("%s: expected error = %v, got error = %v", tt.name, tt.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
machine-controller supports OpenStack application credentials since https://github.com/kubermatic/machine-controller/pull/900. This PR adds support for picking that up and passing it as part of the credentials secret.

It also adjusts the validation function for OpenStack to make sure we're not passing both application and user credentials at the same time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1659 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for OpenStack application credentials
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>