### PR TITLE
Addon directory path should be optional when using embedded addons

### DIFF
--- a/pkg/addons/helpers.go
+++ b/pkg/addons/helpers.go
@@ -47,8 +47,8 @@ func vSphereService() *corev1.Service {
 	}
 }
 
-// AreEmbeddedAddons checks if all specified addons are embedded addons
-func AreEmbeddedAddons(addons []kubeoneapi.Addon) (bool, error) {
+// EmbeddedAddonsOnly checks if all specified addons are embedded addons
+func EmbeddedAddonsOnly(addons []kubeoneapi.Addon) (bool, error) {
 	// Read the directory entries for embedded addons
 	embeddedAddons, err := fs.ReadDir(embeddedaddons.FS, ".")
 	if err != nil {
@@ -62,7 +62,7 @@ func AreEmbeddedAddons(addons []kubeoneapi.Addon) (bool, error) {
 		for _, embeddedAddon := range embeddedAddons {
 			if embeddedAddon.Name() == addon.Name {
 				embedded = true
-				continue
+				break
 			}
 		}
 		// At each iteration of the outer loop check if the "addon" was a customer/non-embedded addon

--- a/pkg/addons/helpers.go
+++ b/pkg/addons/helpers.go
@@ -17,6 +17,10 @@ limitations under the License.
 package addons
 
 import (
+	"io/fs"
+
+	embeddedaddons "k8c.io/kubeone/addons"
+	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/clientutil"
 	"k8c.io/kubeone/pkg/state"
 
@@ -41,4 +45,30 @@ func vSphereService() *corev1.Service {
 			Namespace: metav1.NamespaceSystem,
 		},
 	}
+}
+
+// AreEmbeddedAddons checks if all specified addons are embedded addons
+func AreEmbeddedAddons(addons []kubeoneapi.Addon) (bool, error) {
+	// Read the directory entries for embedded addons
+	embeddedAddons, err := fs.ReadDir(embeddedaddons.FS, ".")
+	if err != nil {
+		return false, err
+	}
+
+	// Iterate over addons specified in the KubeOneCluster object
+	for _, addon := range addons {
+		embedded := false
+		// Iterate over embedded addons directory to check if the addon exists
+		for _, embeddedAddon := range embeddedAddons {
+			if embeddedAddon.Name() == addon.Name {
+				embedded = true
+				continue
+			}
+		}
+		// At each iteration of the outer loop check if the "addon" was a customer/non-embedded addon
+		if !embedded {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/pkg/apis/kubeone/v1beta2/defaults.go
+++ b/pkg/apis/kubeone/v1beta2/defaults.go
@@ -55,7 +55,6 @@ func SetDefaults_KubeOneCluster(obj *KubeOneCluster) {
 	SetDefaults_SystemPackages(obj)
 	SetDefaults_AssetConfiguration(obj)
 	SetDefaults_Features(obj)
-	SetDefaults_Addons(obj)
 }
 
 func SetDefaults_Hosts(obj *KubeOneCluster) {
@@ -246,12 +245,6 @@ func defaultOpenIDConnect(config *OpenIDConnectConfig) {
 	config.GroupsClaim = defaults(config.GroupsClaim, "groups")
 	config.GroupsPrefix = defaults(config.GroupsPrefix, "oidc:")
 	config.SigningAlgs = defaults(config.SigningAlgs, "RS256")
-}
-
-func SetDefaults_Addons(obj *KubeOneCluster) {
-	if obj.Addons != nil && obj.Addons.Enable {
-		obj.Addons.Path = defaults(obj.Addons.Path, "./addons")
-	}
 }
 
 func defaultStaticAuditLogConfig(obj *StaticAuditLogConfig) {

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -462,6 +462,11 @@ func ValidateAddons(o *kubeone.Addons, fldPath *field.Path) field.ErrorList {
 		return allErrs
 	}
 	if o.Enable && len(o.Path) == 0 {
+		// Addons are enabled, path is empty, and no embedded addon is specified
+		if len(o.Addons) == 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("enable"), o.Enable, ".addons.enable cannot be set to true without specifying either custom addon path or embedded addon"))
+		}
+
 		// Check if only embedded addons are being used; path is not required for embedded addons
 		embeddedAddonsOnly, err := addons.EmbeddedAddonsOnly(o.Addons)
 		if err != nil {

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -463,10 +463,10 @@ func ValidateAddons(o *kubeone.Addons, fldPath *field.Path) field.ErrorList {
 	}
 	if o.Enable && len(o.Path) == 0 {
 		// Check if only embedded addons are being used; path is not required for embedded addons
-		areEmbeddedAddons, err := addons.AreEmbeddedAddons(o.Addons)
+		embeddedAddonsOnly, err := addons.EmbeddedAddonsOnly(o.Addons)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath, "", "failed to read embedded addons directory"))
-		} else if !areEmbeddedAddons {
+		} else if !embeddedAddonsOnly {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("path"), "", ".addons.path must be specified when using non-embedded addon(s)"))
 		}
 	}

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -1548,12 +1548,12 @@ func TestValidateAddons(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "addons enabled, no path set",
+			name: "addons enabled, no path set and no embedded addons specified",
 			addons: &kubeone.Addons{
 				Enable: true,
 				Path:   "",
 			},
-			expectedError: false,
+			expectedError: true,
 		},
 		{
 			name: "embedded addon enabled, no path set",

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 
 	"k8c.io/kubeone/pkg/apis/kubeone"
+	"k8c.io/kubeone/pkg/templates/resources"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -1552,7 +1553,20 @@ func TestValidateAddons(t *testing.T) {
 				Enable: true,
 				Path:   "",
 			},
-			expectedError: true,
+			expectedError: false,
+		},
+		{
+			name: "embedded addon enabled, no path set",
+			addons: &kubeone.Addons{
+				Enable: true,
+				Path:   "",
+				Addons: []kubeone.Addon{
+					{
+						Name: resources.AddonMachineController,
+					},
+				},
+			},
+			expectedError: false,
 		},
 		{
 			name: "valid addons config (disabled)",
@@ -1570,13 +1584,6 @@ func TestValidateAddons(t *testing.T) {
 			name:          "valid addons config (nil)",
 			addons:        nil,
 			expectedError: false,
-		},
-		{
-			name: "invalid addons config (enabled without path)",
-			addons: &kubeone.Addons{
-				Enable: true,
-			},
-			expectedError: true,
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -801,8 +801,8 @@ addons:
   enable: false
   # In case when the relative path is provided, the path is relative
   # to the KubeOne configuration file.
-  # This path must be always provided and the directory must exist, even if
-  # using only embedded addons.
+  # This path must be provided and the directory must exist, when using
+  # custom addons.
   path: "./addons"
   # globalParams is a key-value map of values passed to the addons templating engine,
   # to be used in the addons' manifests. The values defined here are passed to all

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -801,8 +801,8 @@ addons:
   enable: false
   # In case when the relative path is provided, the path is relative
   # to the KubeOne configuration file.
-  # This path must be provided and the directory must exist, when using
-  # custom addons.
+  # This path is required only if you want to provide custom addons or override
+  # embedded addons.
   path: "./addons"
   # globalParams is a key-value map of values passed to the addons templating engine,
   # to be used in the addons' manifests. The values defined here are passed to all

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -71,12 +71,12 @@ func (opts *globalOptions) BuildState() (*state.State, error) {
 		}
 
 		// Check if only embedded addons are being used; path is not required for embedded addons and no validation is required
-		areEmbeddedAddons, err := addons.AreEmbeddedAddons(s.Cluster.Addons.Addons)
+		embeddedAddonsOnly, err := addons.EmbeddedAddonsOnly(s.Cluster.Addons.Addons)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read embedded addons directory")
 		}
 		// If custom addons are being used then addons path is required and should be a valid directory
-		if !areEmbeddedAddons {
+		if !embeddedAddonsOnly {
 			if _, err := os.Stat(addonsPath); os.IsNotExist(err) {
 				return nil, errors.Wrapf(err, "failed to validate addons path, make sure that directory %q exists", s.Cluster.Addons.Path)
 			}

--- a/test/e2e/kubeone.go
+++ b/test/e2e/kubeone.go
@@ -268,7 +268,7 @@ func (k1 *Kubeone) Reset() error {
 		"--destroy-workers",
 		"--manifest", k1.ConfigurationFilePath)
 	if err != nil {
-		return fmt.Errorf("destroing workers failed: %w", err)
+		return fmt.Errorf("destroying workers failed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Specifying `.addons.path` is considered a hard requirement even if a user is using embedded addons, that do not need any addon directory. This PR removes this unnecessary requirement.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1496

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Addon path is not required when using only embedded addons
* Defaulting of `.addons.path` to "./addons" removed
```

Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>