### PR TITLE
Fix the overwrite registry functionality

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -316,7 +316,7 @@ func NewResolver(opts ...Opt) *Resolver {
 	// so that we can at least get images that are version-independent.
 	if r.kubernetesVersionGetter == nil {
 		r.kubernetesVersionGetter = func() string {
-			return "0.0.0"
+			return "9.9.9"
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the first phase of fixing the overwrite registry functionality and the image loader script, which includes:

* The image loader script now supports KubeOne 1.3+ and Kubernetes 1.22+
  * The image list from KubeOne is now properly parsed
  * Images are now filtered by the Kubernetes version as well (using the newly-added `--kubernetes-version` flag)
  * The CoreDNS image regression is properly handled by checking if the Kubernetes version is 1.21 or not
      * For 1.21 clusters => tag CoreDNS as `<registry>/coredns/coredns`
      * For other versions (including 1.22+) => tag CoreDNS as `<registry>/coredns`
  * The Kubelet image is not anymore preloaded because machine-controller doesn't use it any longer for Flatcar clusters
* Add the `--kubernetes-version` flag to the `kubeone config images` command
  * Many optional images depend on the Kubernetes version. When preloading the images, it's critical to have images that you'll be using for the concrete Kubernetes version
* The `kubeone config images` command now returns images for the latest Kubernetes version instead of for the oldest
  * There are more chances that users will run the latest or latest-1 Kubernetes than 1.19 or 1.20

The problem with the current approach is that the `kubeone config images` command includes all images, even those that are not applicable for the desired cloud provider. For example, the command will include images for Azure CCM and CSI even if the provider is AWS.

This problem will be fixed in the second phase. The reason for doing this in two phases is to make it easier to cherry-pick this fix to the `release/v1.3` branch. My current plan is to use the addons list implemented in #1642 to get the images that will be deployed on the concrete cluster, but cherry-picking that would be too complicated. A follow-up issue will be created for this.

The accomplishing docs PR is available here: https://github.com/kubermatic/docs/pull/868

Related to #1612

**Does this PR introduce a user-facing change?**:
```release-note
* Fix the image loader script to support KubeOne 1.3+ and Kubernetes 1.22+
* The `kubeone config images` command now shows images for the latest Kubernetes version (instead of for the oldest)
* Add a new `--kubernetes-version` flag to the `kubeone config images` command. This flag is used to filter images for a particular Kubernetes version. The flag cannot be used along with the KubeOneCluster manifest (`--manifest` flag)
```

/assign @kron4eg @embik 