### PR TITLE
Generate configs AFTER installing container-runtime

### DIFF
--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -60,7 +60,6 @@ var (
 		`),
 
 		"apt-docker-ce": heredoc.Docf(`
-			{{ template "container-runtime-daemon-config" . }}
 			{{ if .CONFIGURE_REPOSITORIES }}
 			curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 			# Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
@@ -92,7 +91,7 @@ var (
 				docker-ce-cli=5:{{ $DOCKER_VERSION_TO_INSTALL }} \
 				containerd.io=%s
 			sudo apt-mark hold docker-ce docker-ce-cli containerd.io
-
+			{{ template "container-runtime-daemon-config" . }}
 			{{ template "containerd-systemd-setup" . -}}
 			sudo systemctl enable --now docker
 			`,
@@ -103,7 +102,6 @@ var (
 		),
 
 		"yum-docker-ce-amzn": heredoc.Docf(`
-			{{ template "container-runtime-daemon-config" . }}
 			sudo yum versionlock delete docker cri-tools containerd || true
 
 			{{- $CRICTL_VERSION_TO_INSTALL := "%s" }}
@@ -121,6 +119,7 @@ var (
 				containerd.io-%s \
 				cri-tools-{{ $CRICTL_VERSION_TO_INSTALL }}
 			sudo yum versionlock add docker cri-tools containerd
+			{{ template "container-runtime-daemon-config" . }}
 			{{ template "containerd-systemd-setup" . -}}
 			sudo systemctl enable --now docker
 		`,
@@ -132,7 +131,6 @@ var (
 		),
 
 		"yum-docker-ce": heredoc.Docf(`
-			{{ template "container-runtime-daemon-config" . }}
 			{{- if .CONFIGURE_REPOSITORIES }}
 			sudo yum install -y yum-utils
 			sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
@@ -161,7 +159,7 @@ var (
 				docker-ce-cli-{{ $DOCKER_VERSION_TO_INSTALL }} \
 				containerd.io-%s
 			sudo yum versionlock add docker-ce docker-ce-cli containerd.io
-
+			{{ template "container-runtime-daemon-config" . }}
 			{{ template "containerd-systemd-setup" . -}}
 			sudo systemctl enable --now docker
 			`,
@@ -172,7 +170,6 @@ var (
 		),
 
 		"apt-containerd": heredoc.Docf(`
-			{{ template "container-runtime-daemon-config" . }}
 			{{ if .CONFIGURE_REPOSITORIES }}
 			sudo apt-get update
 			sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
@@ -185,13 +182,13 @@ var (
 			sudo apt-get install -y containerd.io=%s
 			sudo apt-mark hold containerd.io
 
+			{{ template "container-runtime-daemon-config" . }}
 			{{ template "containerd-systemd-setup" . -}}
 			`,
 			defaultContainerdVersion,
 		),
 
 		"yum-containerd": heredoc.Docf(`
-			{{ template "container-runtime-daemon-config" . }}
 			{{ if .CONFIGURE_REPOSITORIES }}
 			sudo yum install -y yum-utils
 			sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
@@ -206,17 +203,18 @@ var (
 			sudo yum install -y containerd.io-%s
 			sudo yum versionlock add containerd.io
 
+			{{ template "container-runtime-daemon-config" . }}
 			{{ template "containerd-systemd-setup" . -}}
 			`,
 			defaultContainerdVersion,
 		),
 
 		"yum-containerd-amzn": heredoc.Docf(`
-			{{ template "container-runtime-daemon-config" . }}
 			sudo yum versionlock delete containerd cri-tools || true
 			sudo yum install -y containerd-%s cri-tools-%s
 			sudo yum versionlock add containerd cri-tools
 
+			{{ template "container-runtime-daemon-config" . }}
 			{{ template "containerd-systemd-setup" . -}}
 			`,
 			defaultAmazonContainerdVersion,

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -70,6 +70,13 @@ sudo yum install -y \
 	rsync
 
 
+sudo yum versionlock delete docker cri-tools containerd || true
+
+sudo yum install -y \
+	docker-19.03.* \
+	containerd.io-1.4.* \
+	cri-tools-1.13.0
+sudo yum versionlock add docker cri-tools containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -88,13 +95,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd || true
-
-sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -70,6 +70,13 @@ sudo yum install -y \
 	rsync
 
 
+sudo yum versionlock delete docker cri-tools containerd || true
+
+sudo yum install -y \
+	docker-19.03.* \
+	containerd.io-1.4.* \
+	cri-tools-1.13.0
+sudo yum versionlock add docker cri-tools containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -88,13 +95,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd || true
-
-sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -70,6 +70,13 @@ sudo yum install -y \
 	rsync
 
 
+sudo yum versionlock delete docker cri-tools containerd || true
+
+sudo yum install -y \
+	docker-19.03.* \
+	containerd.io-1.4.* \
+	cri-tools-1.13.0
+sudo yum versionlock add docker cri-tools containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -91,13 +98,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd || true
-
-sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -70,6 +70,13 @@ sudo yum install -y \
 	rsync
 
 
+sudo yum versionlock delete docker cri-tools containerd || true
+
+sudo yum install -y \
+	docker-19.03.* \
+	containerd.io-1.4.* \
+	cri-tools-1.13.0
+sudo yum versionlock add docker cri-tools containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -88,13 +95,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd || true
-
-sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -70,6 +70,13 @@ sudo yum install -y \
 	rsync
 
 
+sudo yum versionlock delete docker cri-tools containerd || true
+
+sudo yum install -y \
+	docker-19.03.* \
+	containerd.io-1.4.* \
+	cri-tools-1.13.0
+sudo yum versionlock add docker cri-tools containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -88,13 +95,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd || true
-
-sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -70,6 +70,14 @@ sudo yum install -y \
 	rsync
 
 
+sudo yum versionlock delete docker cri-tools containerd || true
+
+
+sudo yum install -y \
+	docker-18.09.* \
+	containerd.io-1.4.* \
+	cri-tools-1.13.0
+sudo yum versionlock add docker cri-tools containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -88,14 +96,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd || true
-
-
-sudo yum install -y \
-	docker-18.09.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -72,6 +72,10 @@ sudo yum install -y \
 
 
 
+sudo yum versionlock delete containerd cri-tools || true
+sudo yum install -y containerd-1.4.* cri-tools-1.13.0
+sudo yum versionlock add containerd cri-tools
+
 
 sudo mkdir -p $(dirname /etc/containerd/config.toml)
 cat <<EOF | sudo tee /etc/containerd/config.toml
@@ -97,10 +101,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
-
-sudo yum versionlock delete containerd cri-tools || true
-sudo yum install -y containerd-1.4.* cri-tools-1.13.0
-sudo yum versionlock add containerd cri-tools
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -72,6 +72,10 @@ sudo yum install -y \
 
 
 
+sudo yum versionlock delete containerd cri-tools || true
+sudo yum install -y containerd-1.4.* cri-tools-1.13.0
+sudo yum versionlock add containerd cri-tools
+
 
 sudo mkdir -p $(dirname /etc/containerd/config.toml)
 cat <<EOF | sudo tee /etc/containerd/config.toml
@@ -99,10 +103,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
-
-sudo yum versionlock delete containerd cri-tools || true
-sudo yum install -y containerd-1.4.* cri-tools-1.13.0
-sudo yum versionlock add containerd cri-tools
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -71,6 +71,18 @@ sudo yum install -y \
 
 
 
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
+
+sudo yum install -y \
+	docker-ce-19.03.* \
+	docker-ce-cli-19.03.* \
+	containerd.io-1.4.*
+sudo yum versionlock add docker-ce docker-ce-cli containerd.io
+
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
 {
@@ -87,18 +99,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
-
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
-
-sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
-sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -71,6 +71,18 @@ sudo yum install -y \
 
 
 
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
+
+sudo yum install -y \
+	docker-ce-19.03.* \
+	docker-ce-cli-19.03.* \
+	containerd.io-1.4.*
+sudo yum versionlock add docker-ce docker-ce-cli containerd.io
+
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
 {
@@ -87,18 +99,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
-
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
-
-sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
-sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -71,6 +71,18 @@ sudo yum install -y \
 
 
 
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
+
+sudo yum install -y \
+	docker-ce-19.03.* \
+	docker-ce-cli-19.03.* \
+	containerd.io-1.4.*
+sudo yum versionlock add docker-ce docker-ce-cli containerd.io
+
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
 {
@@ -90,18 +102,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
-
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
-
-sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
-sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -71,6 +71,18 @@ sudo yum install -y \
 
 
 
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
+
+sudo yum install -y \
+	docker-ce-19.03.* \
+	docker-ce-cli-19.03.* \
+	containerd.io-1.4.*
+sudo yum versionlock add docker-ce docker-ce-cli containerd.io
+
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
 {
@@ -87,18 +99,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
-
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
-
-sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
-sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -71,6 +71,18 @@ sudo yum install -y \
 
 
 
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
+
+sudo yum install -y \
+	docker-ce-19.03.* \
+	docker-ce-cli-19.03.* \
+	containerd.io-1.4.*
+sudo yum versionlock add docker-ce docker-ce-cli containerd.io
+
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
 {
@@ -87,18 +99,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
-
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
-
-sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
-sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -71,23 +71,6 @@ sudo yum install -y \
 
 
 
-sudo mkdir -p $(dirname /etc/docker/daemon.json)
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
-EOF
-cat <<EOF | sudo tee /etc/crictl.yaml
-runtime-endpoint: unix:///var/run/dockershim.sock
-EOF
-
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
@@ -104,6 +87,23 @@ sudo yum install -y \
 	docker-ce-cli-18.09.* \
 	containerd.io-1.4.*
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
+
+sudo mkdir -p $(dirname /etc/docker/daemon.json)
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -73,6 +73,16 @@ sudo yum install -y \
 
 
 
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+
+
+sudo yum versionlock delete containerd.io || true
+sudo yum install -y containerd.io-1.4.*
+sudo yum versionlock add containerd.io
+
+
 sudo mkdir -p $(dirname /etc/containerd/config.toml)
 cat <<EOF | sudo tee /etc/containerd/config.toml
 version = 2
@@ -97,16 +107,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
-
-
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
-
-
-sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-1.4.*
-sudo yum versionlock add containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -73,6 +73,16 @@ sudo yum install -y \
 
 
 
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+
+
+sudo yum versionlock delete containerd.io || true
+sudo yum install -y containerd.io-1.4.*
+sudo yum versionlock add containerd.io
+
+
 sudo mkdir -p $(dirname /etc/containerd/config.toml)
 cat <<EOF | sudo tee /etc/containerd/config.toml
 version = 2
@@ -99,16 +109,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
-
-
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
-
-
-sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-1.4.*
-sudo yum versionlock add containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -65,24 +65,6 @@ cni_ver="0.8.7*"
 
 
 
-sudo mkdir -p $(dirname /etc/docker/daemon.json)
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
-EOF
-cat <<EOF | sudo tee /etc/crictl.yaml
-runtime-endpoint: unix:///var/run/dockershim.sock
-EOF
-
-
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
 # contains only Docker 19.03.14, which is not validated for all Kubernetes version.
@@ -102,6 +84,23 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	docker-ce-cli=5:19.03.* \
 	containerd.io=1.4.*
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
+
+sudo mkdir -p $(dirname /etc/docker/daemon.json)
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -65,27 +65,6 @@ cni_ver="0.8.7*"
 
 
 
-sudo mkdir -p $(dirname /etc/docker/daemon.json)
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	},
-	"insecure-registries": [
-		"127.0.0.1:5000"
-	]
-}
-EOF
-cat <<EOF | sudo tee /etc/crictl.yaml
-runtime-endpoint: unix:///var/run/dockershim.sock
-EOF
-
-
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
 # contains only Docker 19.03.14, which is not validated for all Kubernetes version.
@@ -105,6 +84,26 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	docker-ce-cli=5:19.03.* \
 	containerd.io=1.4.*
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
+
+sudo mkdir -p $(dirname /etc/docker/daemon.json)
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	},
+	"insecure-registries": [
+		"127.0.0.1:5000"
+	]
+}
+EOF
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -65,24 +65,6 @@ cni_ver="0.8.7*"
 
 
 
-sudo mkdir -p $(dirname /etc/docker/daemon.json)
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
-EOF
-cat <<EOF | sudo tee /etc/crictl.yaml
-runtime-endpoint: unix:///var/run/dockershim.sock
-EOF
-
-
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
 # contains only Docker 19.03.14, which is not validated for all Kubernetes version.
@@ -102,6 +84,23 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	docker-ce-cli=5:19.03.* \
 	containerd.io=1.4.*
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
+
+sudo mkdir -p $(dirname /etc/docker/daemon.json)
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -67,6 +67,18 @@ cni_ver="0.8.7*"
 
 
 
+sudo apt-get update
+sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
+	sudo apt-key add -
+sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+
+sudo apt-mark unhold containerd.io || true
+sudo apt-get install -y containerd.io=1.4.*
+sudo apt-mark hold containerd.io
+
+
 sudo mkdir -p $(dirname /etc/containerd/config.toml)
 cat <<EOF | sudo tee /etc/containerd/config.toml
 version = 2
@@ -91,18 +103,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
-
-
-sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
-	sudo apt-key add -
-sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-
-
-sudo apt-mark unhold containerd.io || true
-sudo apt-get install -y containerd.io=1.4.*
-sudo apt-mark hold containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -67,6 +67,18 @@ cni_ver="0.8.7*"
 
 
 
+sudo apt-get update
+sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
+	sudo apt-key add -
+sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+
+sudo apt-mark unhold containerd.io || true
+sudo apt-get install -y containerd.io=1.4.*
+sudo apt-mark hold containerd.io
+
+
 sudo mkdir -p $(dirname /etc/containerd/config.toml)
 cat <<EOF | sudo tee /etc/containerd/config.toml
 version = 2
@@ -93,18 +105,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
-
-
-sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
-	sudo apt-key add -
-sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-
-
-sudo apt-mark unhold containerd.io || true
-sudo apt-get install -y containerd.io=1.4.*
-sudo apt-mark hold containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -70,6 +70,13 @@ sudo yum install -y \
 	rsync
 
 
+sudo yum versionlock delete docker cri-tools containerd || true
+
+sudo yum install -y \
+	docker-19.03.* \
+	containerd.io-1.4.* \
+	cri-tools-1.13.0
+sudo yum versionlock add docker cri-tools containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -88,13 +95,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd || true
-
-sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -71,6 +71,18 @@ sudo yum install -y \
 
 
 
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
+
+sudo yum install -y \
+	docker-ce-19.03.* \
+	docker-ce-cli-19.03.* \
+	containerd.io-1.4.*
+sudo yum versionlock add docker-ce docker-ce-cli containerd.io
+
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
 {
@@ -87,18 +99,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
-
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
-
-sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
-sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -66,24 +66,6 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 
 
-sudo mkdir -p $(dirname /etc/docker/daemon.json)
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
-EOF
-cat <<EOF | sudo tee /etc/crictl.yaml
-runtime-endpoint: unix:///var/run/dockershim.sock
-EOF
-
-
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
 # contains only Docker 19.03.14, which is not validated for all Kubernetes version.
@@ -103,6 +85,23 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	docker-ce-cli=5:19.03.* \
 	containerd.io=1.4.*
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
+
+sudo mkdir -p $(dirname /etc/docker/daemon.json)
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -70,6 +70,13 @@ sudo yum install -y \
 	rsync
 
 
+sudo yum versionlock delete docker cri-tools containerd || true
+
+sudo yum install -y \
+	docker-19.03.* \
+	containerd.io-1.4.* \
+	cri-tools-1.13.0
+sudo yum versionlock add docker cri-tools containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -88,13 +95,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo yum versionlock delete docker cri-tools containerd || true
-
-sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -71,6 +71,18 @@ sudo yum install -y \
 
 
 
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
+
+sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
+
+sudo yum install -y \
+	docker-ce-19.03.* \
+	docker-ce-cli-19.03.* \
+	containerd.io-1.4.*
+sudo yum versionlock add docker-ce docker-ce-cli containerd.io
+
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
 {
@@ -87,18 +99,6 @@ EOF
 cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
-
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
-
-sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
-
-sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
-sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -66,24 +66,6 @@ sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 
 
-sudo mkdir -p $(dirname /etc/docker/daemon.json)
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-	"exec-opts": [
-		"native.cgroupdriver=systemd"
-	],
-	"storage-driver": "overlay2",
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "100m"
-	}
-}
-EOF
-cat <<EOF | sudo tee /etc/crictl.yaml
-runtime-endpoint: unix:///var/run/dockershim.sock
-EOF
-
-
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 # Docker provides two different apt repos for ubuntu, bionic and focal. The focal repo currently
 # contains only Docker 19.03.14, which is not validated for all Kubernetes version.
@@ -103,6 +85,23 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	docker-ce-cli=5:19.03.* \
 	containerd.io=1.4.*
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
+
+sudo mkdir -p $(dirname /etc/docker/daemon.json)
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "100m"
+	}
+}
+EOF
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes problem introduced in #1664

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```