### PR TITLE
Remove legacy docker support (kubernetes < 1.17)

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -75,7 +75,6 @@ var (
 const (
 	defaultDockerVersion           = "19.03.*"
 	latestDockerVersion            = "20.10.*"
-	defaultLegacyDockerVersion     = "18.09.*"
 	defaultContainerdVersion       = "1.4.*"
 	defaultAmazonContainerdVersion = "1.4.*"
 	defaultAmazonCrictlVersion     = "1.13.0"

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -72,9 +72,6 @@ var (
 
 			sudo apt-mark unhold docker-ce docker-ce-cli containerd.io || true
 			{{- $DOCKER_VERSION_TO_INSTALL := "%s" }}
-			{{- if semverCompare "< 1.17" .KUBERNETES_VERSION }}
-			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
-			{{- end }}
 
 			{{- if semverCompare ">= 1.21" .KUBERNETES_VERSION }}
 			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
@@ -96,7 +93,6 @@ var (
 			sudo systemctl enable --now docker
 			`,
 			defaultDockerVersion,
-			defaultLegacyDockerVersion,
 			latestDockerVersion,
 			defaultContainerdVersion,
 		),
@@ -106,10 +102,7 @@ var (
 
 			{{- $CRICTL_VERSION_TO_INSTALL := "%s" }}
 			{{- $DOCKER_VERSION_TO_INSTALL := "%s" }}
-			{{- if semverCompare "< 1.17" .KUBERNETES_VERSION }}
-			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
-			{{- end }}
-
+			
 			{{- if semverCompare ">= 1.21" .KUBERNETES_VERSION }}
 			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
 			{{- end }}
@@ -125,7 +118,6 @@ var (
 		`,
 			defaultAmazonCrictlVersion,
 			defaultDockerVersion,
-			defaultLegacyDockerVersion,
 			latestDockerVersion,
 			defaultContainerdVersion,
 		),
@@ -140,16 +132,6 @@ var (
 			sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 			{{- $DOCKER_VERSION_TO_INSTALL := "%s" }}
-			{{- if semverCompare "< 1.17" .KUBERNETES_VERSION }}
-			{{- if .CONFIGURE_REPOSITORIES }}
-			# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
-			# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-			# Therefore, we use 7 repo which has all Docker versions.
-			sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-			{{- end }}
-			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
-			{{- end }}
-
 			{{- if semverCompare ">= 1.21" .KUBERNETES_VERSION }}
 			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
 			{{- end }}
@@ -164,7 +146,6 @@ var (
 			sudo systemctl enable --now docker
 			`,
 			defaultDockerVersion,
-			defaultLegacyDockerVersion,
 			latestDockerVersion,
 			defaultContainerdVersion,
 		),

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -72,9 +72,8 @@ sudo yum install -y \
 
 sudo yum versionlock delete docker cri-tools containerd || true
 
-
 sudo yum install -y \
-	docker-18.09.* \
+	docker-19.03.* \
 	containerd.io-1.4.* \
 	cri-tools-1.13.0
 sudo yum versionlock add docker cri-tools containerd

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -76,15 +76,10 @@ sudo yum-config-manager --add-repo=https://download.docker.com/linux/centos/dock
 sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/dev/null
 
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
-# Docker provides two different apt repos for CentOS, 7 and 8. The 8 repo currently
-# contains only Docker 19.03.14, which is not validated for all Kubernetes version.
-# Therefore, we use 7 repo which has all Docker versions.
-sudo sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
-
 
 sudo yum install -y \
-	docker-ce-18.09.* \
-	docker-ce-cli-18.09.* \
+	docker-ce-19.03.* \
+	docker-ce-cli-19.03.* \
 	containerd.io-1.4.*
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a removal of legacy docker version, used for clusters less then v1.17

**Special notes for your reviewer**:
Kubernetes clusters version 1.17 or less are long ago out of support.

**Does this PR introduce a user-facing change?**:
```release-note
Remove legacy docker support (kubernetes < 1.17)
```
