### PR TITLE
Add jobs for Kubernetes 1.23 and update other jobs as needed

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -125,7 +125,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.42.1
+        - image: golangci/golangci-lint:v1.43.0
           command:
             - make
           args:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -137,7 +137,7 @@ presubmits:
             limits:
               memory: 2Gi
   #########################################################
-  # E2E/Conformance tests (AWS, 1.19-1.22)
+  # E2E/Conformance tests (AWS, 1.20-1.23)
   #########################################################
   - name: pull-kubeone-e2e-aws-containerd-conformance-1.20
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
@@ -284,7 +284,7 @@ presubmits:
           resources:
             requests:
               cpu: 1
-  - name: pull-kubeone-e2e-aws-conformance-1.22-v1beta1
+  - name: pull-kubeone-e2e-aws-conformance-1.23
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
@@ -305,7 +305,34 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.23.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
+  - name: pull-kubeone-e2e-aws-conformance-1.23-v1beta1
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-aws: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "aws"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
             - name: TEST_CONFIG_API_VERSION
               value: "v1beta1"
             - name: KUBEONE_TEST_RUN
@@ -314,7 +341,7 @@ presubmits:
             requests:
               cpu: 1
   #########################################################
-  # E2E/Conformance tests (DigitalOcean, 1.19-1.22)
+  # E2E/Conformance tests (DigitalOcean, 1.20-1.23)
   #########################################################
   - name: pull-kubeone-e2e-digitalocean-conformance-1.20
     always_run: false
@@ -393,8 +420,35 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-digitalocean-conformance-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-digitalocean: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
   #########################################################
-  # E2E/Conformance tests (Hetzner, 1.19-1.22)
+  # E2E/Conformance tests (Hetzner, 1.20-1.23)
   #########################################################
   - name: pull-kubeone-e2e-hetzner-conformance-1.20
     always_run: false
@@ -473,8 +527,35 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-hetzner-conformance-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-hetzner: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "hetzner"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
   #########################################################
-  # E2E/Conformance tests (GCE, 1.19-1.22)
+  # E2E/Conformance tests (GCE, 1.20-1.23)
   #########################################################
   - name: pull-kubeone-e2e-gce-conformance-1.20
     always_run: false
@@ -559,8 +640,37 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-gce-conformance-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-gce: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "gce"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+            - name: TF_VAR_project
+              value: "kubeone-terraform-test"
+          resources:
+            requests:
+              cpu: 1
   #########################################################
-  # E2E/Conformance tests (Packet, 1.19-1.22)
+  # E2E/Conformance tests (Packet, 1.20-1.23)
   #########################################################
   - name: pull-kubeone-e2e-packet-conformance-1.20
     always_run: false
@@ -639,8 +749,35 @@ presubmits:
           resources:
             requests:
               cpu: 1
+  - name: pull-kubeone-e2e-packet-conformance-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-packet: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "packet"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
   #########################################################
-  # E2E/Conformance tests (OpenStack, 1.19-1.22)
+  # E2E/Conformance tests (OpenStack, 1.20-1.23)
   #########################################################
   - name: pull-kubeone-e2e-openstack-conformance-1.20
     always_run: false
@@ -714,6 +851,33 @@ presubmits:
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.4"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterConformance"
+          resources:
+            requests:
+              cpu: 1
+  - name: pull-kubeone-e2e-openstack-conformance-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -836,6 +1000,36 @@ presubmits:
               valut: "120m"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-aws-upgrade-1.22-1.23
+    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-aws: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "aws"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TF_VAR_initial_machinedeployment_spotinstances
+              value: "true"
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.22.4"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
   #########################################################
   # E2E/Upgrade tests (DigitalOcean)
   #########################################################
@@ -919,6 +1113,34 @@ presubmits:
               valut: "120m"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-digitalocean-upgrade-1.22-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-digitalocean: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.22.4"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
   #########################################################
   # E2E/Upgrade tests (Hetzner)
   #########################################################
@@ -998,6 +1220,34 @@ presubmits:
               value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.4"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-hetzner-upgrade-1.22-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-hetzner: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "hetzner"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.22.4"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1091,6 +1341,36 @@ presubmits:
               value: "TestClusterUpgrade"
             - name: TF_VAR_project
               value: "kubeone-terraform-test"
+  - name: pull-kubeone-e2e-gce-upgrade-1.22-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-gce: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "gce"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.22.4"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
+            - name: TF_VAR_project
+              value: "kubeone-terraform-test"
   #########################################################
   # E2E/Upgrade tests (Packet)
   #########################################################
@@ -1174,6 +1454,34 @@ presubmits:
               valut: "120m"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-packet-upgrade-1.22-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-packet: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "packet"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.22.4"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
   #########################################################
   # E2E/Upgrade tests (OpenStack)
   #########################################################
@@ -1253,6 +1561,34 @@ presubmits:
               value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.22.4"
+            - name: TEST_TIMEOUT
+              valut: "120m"
+            - name: KUBEONE_TEST_RUN
+              value: "TestClusterUpgrade"
+  - name: pull-kubeone-e2e-openstack-upgrade-1.22-1.23
+    always_run: false
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-openstack: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubeone-e2e:v0.1.19
+          imagePullPolicy: Always
+          command:
+            - make
+          args:
+            - e2e-test
+          env:
+            - name: PROVIDER
+              value: "openstack"
+            - name: CONTAINER_RUNTIME
+              value: containerd
+            - name: TEST_CLUSTER_INITIAL_VERSION
+              value: "1.22.4"
+            - name: TEST_CLUSTER_TARGET_VERSION
+              value: "1.23.0"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.17.1
+        - image: golang:1.17.4
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.17.1
+        - image: golang:1.17.4
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.17.1
+        - image: golang:1.17.4
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.17.1
+        - image: golang:1.17.4
           command:
             - make
           args:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1607,7 +1607,7 @@ postsubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-0
+        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-2
           command:
             - /bin/bash
             - -c
@@ -1633,7 +1633,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-1
+        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-2
           command:
             - ./hack/ci/upload-gocache.sh
           resources:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -148,7 +148,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -177,7 +177,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -214,7 +214,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -241,7 +241,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -268,7 +268,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -293,7 +293,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -320,7 +320,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -352,7 +352,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -377,7 +377,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -402,7 +402,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -427,7 +427,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -457,7 +457,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -482,7 +482,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -507,7 +507,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -532,7 +532,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -562,7 +562,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -589,7 +589,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -616,7 +616,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -643,7 +643,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -675,7 +675,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -700,7 +700,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -725,7 +725,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -750,7 +750,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -780,7 +780,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -805,7 +805,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -830,7 +830,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -855,7 +855,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -885,7 +885,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -915,7 +915,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -941,7 +941,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -969,7 +969,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1002,7 +1002,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1028,7 +1028,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1054,7 +1054,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1085,7 +1085,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1111,7 +1111,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1137,7 +1137,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1168,7 +1168,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1196,7 +1196,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1224,7 +1224,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1257,7 +1257,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1283,7 +1283,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1309,7 +1309,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1340,7 +1340,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1366,7 +1366,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make
@@ -1392,7 +1392,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.18
+        - image: kubermatic/kubeone-e2e:v0.1.19
           imagePullPolicy: Always
           command:
             - make

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -139,7 +139,7 @@ presubmits:
   #########################################################
   # E2E/Conformance tests (AWS, 1.19-1.22)
   #########################################################
-  - name: pull-kubeone-e2e-aws-containerd-conformance-1.19
+  - name: pull-kubeone-e2e-aws-containerd-conformance-1.20
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
@@ -162,13 +162,13 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
+              value: "1.20.13"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
             requests:
               cpu: 1
-  - name: pull-kubeone-e2e-aws-flatcar-containerd-conformance-1.19
+  - name: pull-kubeone-e2e-aws-flatcar-containerd-conformance-1.20
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
@@ -199,34 +199,7 @@ presubmits:
             - name: TF_VAR_bastion_user
               value: "core"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
-  - name: pull-kubeone-e2e-aws-conformance-1.19
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-aws: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.19
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "aws"
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
+              value: "1.20.13"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -253,7 +226,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -278,7 +251,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -305,7 +278,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -332,7 +305,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: TEST_CONFIG_API_VERSION
               value: "v1beta1"
             - name: KUBEONE_TEST_RUN
@@ -343,31 +316,6 @@ presubmits:
   #########################################################
   # E2E/Conformance tests (DigitalOcean, 1.19-1.22)
   #########################################################
-  - name: pull-kubeone-e2e-digitalocean-conformance-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-digitalocean: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.19
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "digitalocean"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-digitalocean-conformance-1.20
     always_run: false
     decorate: true
@@ -387,7 +335,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -412,7 +360,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -439,7 +387,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -448,31 +396,6 @@ presubmits:
   #########################################################
   # E2E/Conformance tests (Hetzner, 1.19-1.22)
   #########################################################
-  - name: pull-kubeone-e2e-hetzner-conformance-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-hetzner: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.19
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "hetzner"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-hetzner-conformance-1.20
     always_run: false
     decorate: true
@@ -492,7 +415,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -517,7 +440,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -544,7 +467,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -553,33 +476,6 @@ presubmits:
   #########################################################
   # E2E/Conformance tests (GCE, 1.19-1.22)
   #########################################################
-  - name: pull-kubeone-e2e-gce-conformance-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-gce: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.19
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "gce"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-            - name: TF_VAR_project
-              value: "kubeone-terraform-test"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-gce-conformance-1.20
     always_run: false
     decorate: true
@@ -599,7 +495,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -626,7 +522,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -655,7 +551,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -666,31 +562,6 @@ presubmits:
   #########################################################
   # E2E/Conformance tests (Packet, 1.19-1.22)
   #########################################################
-  - name: pull-kubeone-e2e-packet-conformance-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-packet: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.19
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "packet"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-packet-conformance-1.20
     always_run: false
     decorate: true
@@ -710,7 +581,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -735,7 +606,7 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -762,7 +633,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -771,31 +642,6 @@ presubmits:
   #########################################################
   # E2E/Conformance tests (OpenStack, 1.19-1.22)
   #########################################################
-  - name: pull-kubeone-e2e-openstack-conformance-1.19
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-openstack: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.19
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "openstack"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.19.14"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterConformance"
-          resources:
-            requests:
-              cpu: 1
   - name: pull-kubeone-e2e-openstack-conformance-1.20
     always_run: false
     decorate: true
@@ -815,7 +661,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -840,7 +686,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -867,7 +713,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -899,9 +745,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.14"
+              value: "1.19.16"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -925,9 +771,9 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.14"
+              value: "1.19.16"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -953,9 +799,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -983,9 +829,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1012,9 +858,9 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.14"
+              value: "1.19.16"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1038,9 +884,9 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1066,9 +912,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1095,9 +941,9 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.14"
+              value: "1.19.16"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1121,9 +967,9 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1149,9 +995,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1178,9 +1024,9 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.14"
+              value: "1.19.16"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1206,9 +1052,9 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1236,9 +1082,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1267,9 +1113,9 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.14"
+              value: "1.19.16"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1293,9 +1139,9 @@ presubmits:
             - name: PROVIDER
               value: "packet"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1321,9 +1167,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1350,9 +1196,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.14"
+              value: "1.19.16"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1376,9 +1222,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.10"
+              value: "1.20.13"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1404,9 +1250,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.4"
+              value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.0"
+              value: "1.22.4"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update jobs using golang image to 1.17.4
* Update golangci-lint to 1.43.0
* Update kubeone-e2e to 0.1.19
* Remove 1.19 conformance jobs and update k8s versions
* Add 1.23 conformance and upgrade tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1670

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 