### PR TITLE
Update the build image to include the Go 1.17.5 update

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1607,7 +1607,7 @@ postsubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-2
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-3
           command:
             - /bin/bash
             - -c
@@ -1633,7 +1633,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.17-node-14-kind-0.11-2
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-3
           command:
             - ./hack/ci/upload-gocache.sh
           resources:

--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -36,6 +36,7 @@ RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
+
 FROM golang:1.17.5
 
 ARG version


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the build image to include the Go 1.17.5 update.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 