### PR TITLE
Allow seccomp profiles in privileged PSP

### DIFF
--- a/pkg/features/psp.go
+++ b/pkg/features/psp.go
@@ -73,6 +73,13 @@ func privilegedPSP() *policyv1beta1.PodSecurityPolicy {
 	return &policyv1beta1.PodSecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "privileged",
+			Annotations: map[string]string{
+				// This annotation is required, as control plane components
+				// such as API server use the RuntimeDefault seccomp profile.
+				// Without this annotation, components specifying seccomp
+				// profile cannot get scheduled.
+				"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "*",
+			},
 		},
 		Spec: policyv1beta1.PodSecurityPolicySpec{
 			Privileged:               true,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the `privileged` PSP to allow all seccomp profiles to be used. Without this change, the control plane components are failing to get scheduled when PSP is enabled. That's because the control plane components, such as the API server, are using the RuntimeDefault seccomp profile.

**Does this PR introduce a user-facing change?**:
```release-note
Allow seccomp profiles in privileged PSP
```

/assign @kron4eg 