### PR TITLE
Resolve environment variables in addon parameters

### DIFF
--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -43,7 +44,7 @@ import (
 )
 
 const (
-	paramsEnvPrefix = "env:"
+	ParamsEnvPrefix = "env:"
 )
 
 func (a *applier) getManifestsFromDirectory(s *state.State, fsys fs.FS, addonName string) (string, error) {
@@ -135,13 +136,14 @@ func (a *applier) loadAddonsManifests(
 
 		// Resolve environment variables in Params
 		for k, v := range tplDataParams {
-			if strings.HasPrefix(v, paramsEnvPrefix) {
-				envName := strings.TrimPrefix(v, paramsEnvPrefix)
-				if env := os.Getenv(envName); len(env) > 0 {
+			if strings.HasPrefix(v, ParamsEnvPrefix) {
+				envName := strings.TrimPrefix(v, ParamsEnvPrefix)
+				if env, ok := os.LookupEnv(envName); ok {
 					tplDataParams[k] = env
+				} else {
+					return nil, fmt.Errorf("failed to get environment variable '%s'", envName)
 				}
 			}
-
 		}
 
 		tplData := a.TemplateData


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Parameters for addons can potentially include sensitive information / secrets. Since the kubeone config file could be checked into version control, this PR adds the capability to prefix a parameter string with `env:` to make kubeone load the environment variable. It supports both addon-specific and global parameters.

The config file could then look like this:

```yaml
addons:
  enable: true
  path: "./addons"
  globalParams:
    globalTest: "env:SUPER_SECRET_VALUE2"
  addons:
    - name: "default-storage-class"
    - name: "testaddon"
      params:
        test: "env:SUPER_SECRET_VALUE"
```

`SUPER_SECRET_VALUE2` and `SUPER_SECRET_VALUE` need to be set as environment variables then.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1498

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Addon parameters can be resolved into environment variable contents if the "env:" prefix is set in the parameter value
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
