### PR TITLE
Fix flatcar AMI filter

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -56,6 +56,11 @@ data "aws_ami" "ami" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
 }
 
 data "aws_vpc" "selected" {

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = aws_elb.control_plane.dns_name
+    endpoint                    = aws_elb.control_plane.dns_name
     apiserver_alternative_names = var.apiserver_alternative_names
   }
 }
@@ -77,7 +77,7 @@ output "kubeone_workers" {
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
         operatingSystemSpec = {
-          distUpgradeOnBoot = false
+          distUpgradeOnBoot   = false
           provisioningUtility = "cloud-init"
         }
         labels = {
@@ -115,7 +115,7 @@ output "kubeone_workers" {
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
         operatingSystemSpec = {
-          distUpgradeOnBoot = false
+          distUpgradeOnBoot   = false
           provisioningUtility = "cloud-init"
         }
         labels = {
@@ -153,7 +153,7 @@ output "kubeone_workers" {
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
         operatingSystemSpec = {
-          distUpgradeOnBoot = false
+          distUpgradeOnBoot   = false
           provisioningUtility = "cloud-init"
         }
         labels = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like recently flatcar got new arm64 images, and THEY starter to return from search query, which leads to incompatible architecture errors between AMI and instance.

This PR fixes that problem

```release-note
Fix flatcar AMI filter
```
