### PR TITLE
Deprecate kubeone install and upgrade commands in favor of kubeone apply, and use kubeone apply in E2E tests

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -134,6 +134,8 @@ func runInstall(opts *installOpts) error {
 		return errors.Wrap(err, "failed to initialize State")
 	}
 
+	s.Logger.Warn("The \"kubeone install\" command is deprecated and will be removed in KubeOne 1.6. Please use \"kubeone apply\" instead.")
+
 	// Validate credentials
 	_, err = credentials.ProviderCredentials(s.Cluster.CloudProvider, opts.CredentialsFile)
 	if err != nil {

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -90,6 +90,8 @@ func runUpgrade(opts *upgradeOpts) error {
 		return errors.Wrap(err, "failed to initialize State")
 	}
 
+	s.Logger.Warn("The \"kubeone upgrade\" command is deprecated and will be removed in KubeOne 1.6. Please use \"kubeone apply\" instead.")
+
 	// Validate credentials
 	_, err = credentials.ProviderCredentials(s.Cluster.CloudProvider, opts.CredentialsFile)
 	if err != nil {

--- a/test/e2e/kubeone.go
+++ b/test/e2e/kubeone.go
@@ -201,7 +201,8 @@ func (k1 *Kubeone) Install(tfJSON string, installFlags []string) error {
 		return err
 	}
 
-	flags := []string{"install",
+	flags := []string{"apply",
+		"--auto-approve",
 		"--tfjson", "tf.json",
 		"--manifest", k1.ConfigurationFilePath}
 	if len(installFlags) != 0 {
@@ -218,7 +219,8 @@ func (k1 *Kubeone) Install(tfJSON string, installFlags []string) error {
 
 // Upgrade runs 'kubeone upgrade' command to upgrade the cluster
 func (k1 *Kubeone) Upgrade(upgradeFlags []string) error {
-	flags := []string{"upgrade",
+	flags := []string{"apply",
+		"--auto-approve",
 		"--tfjson", "tf.json",
 		"--upgrade-machine-deployments",
 		"--manifest", k1.ConfigurationFilePath}


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubeone install` and `kubeone upgrade` commands are deprecated in favor of kubeone apply. Those commands will be removed in KubeOne 1.6+

KubeOne E2E tests are now using `kubeone apply` instead of `install`/`upgrade`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1694 
Fixes #1056 

**Does this PR introduce a user-facing change?**:
```release-note
[ATTENTION NEEDED] kubeone install and kubeone upgrade commands are deprecated in favor of kubeone apply. Those commands will be removed in KubeOne 1.6+
```

/assign @kron4eg 