### PR TITLE
Let kubeadm manage cri-tools on Amazon Linux 2

### DIFF
--- a/docs/api_reference/v1beta1.en.md
+++ b/docs/api_reference/v1beta1.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta1 API Reference"
-date = 2021-12-21T13:30:12+01:00
+date = 2021-12-23T12:22:34+01:00
 weight = 11
 +++
 ## v1beta1

--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2021-12-21T21:30:20+02:00
+date = 2021-12-23T12:22:34+01:00
 weight = 11
 +++
 ## v1beta2
@@ -451,7 +451,7 @@ KubeProxyConfig defines configured kube-proxy mode, default is iptables mode
 
 ### KubeletConfig
 
-KubeletConfig provides some kubelet configration options
+KubeletConfig provides some kubelet configuration options
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -171,7 +171,7 @@ type StaticWorkersConfig struct {
 	Hosts []HostConfig `json:"hosts,omitempty"`
 }
 
-// KubeletConfig provides some kubelet configration options
+// KubeletConfig provides some kubelet configuration options
 type KubeletConfig struct {
 	// SystemReserved configure --system-reserved command-line flag of the kubelet.
 	// See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -169,7 +169,7 @@ type StaticWorkersConfig struct {
 	Hosts []HostConfig `json:"hosts,omitempty"`
 }
 
-// KubeletConfig provides some kubelet configration options
+// KubeletConfig provides some kubelet configuration options
 type KubeletConfig struct {
 	// SystemReserved configure --system-reserved command-line flag of the kubelet.
 	// See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/

--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -77,5 +77,4 @@ const (
 	latestDockerVersion            = "20.10.*"
 	defaultContainerdVersion       = "1.4.*"
 	defaultAmazonContainerdVersion = "1.4.*"
-	defaultAmazonCrictlVersion     = "1.13.0"
 )

--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -129,6 +129,7 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
+sudo yum install -y cri-tools
 {{- end }}
 
 {{- if and .KUBECTL .KUBECTL_URL }}

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -98,25 +98,21 @@ var (
 		),
 
 		"yum-docker-ce-amzn": heredoc.Docf(`
-			sudo yum versionlock delete docker cri-tools containerd || true
+			sudo yum versionlock delete docker containerd || true
 
-			{{- $CRICTL_VERSION_TO_INSTALL := "%s" }}
 			{{- $DOCKER_VERSION_TO_INSTALL := "%s" }}
-			
 			{{- if semverCompare ">= 1.21" .KUBERNETES_VERSION }}
 			{{ $DOCKER_VERSION_TO_INSTALL = "%s" }}
 			{{- end }}
 
 			sudo yum install -y \
 				docker-{{ $DOCKER_VERSION_TO_INSTALL }} \
-				containerd.io-%s \
-				cri-tools-{{ $CRICTL_VERSION_TO_INSTALL }}
-			sudo yum versionlock add docker cri-tools containerd
+				containerd.io-%s
+			sudo yum versionlock add docker containerd
 			{{ template "container-runtime-daemon-config" . }}
 			{{ template "containerd-systemd-setup" . -}}
 			sudo systemctl enable --now docker
 		`,
-			defaultAmazonCrictlVersion,
 			defaultDockerVersion,
 			latestDockerVersion,
 			defaultContainerdVersion,
@@ -191,15 +187,14 @@ var (
 		),
 
 		"yum-containerd-amzn": heredoc.Docf(`
-			sudo yum versionlock delete containerd cri-tools || true
-			sudo yum install -y containerd-%s cri-tools-%s
-			sudo yum versionlock add containerd cri-tools
+			sudo yum versionlock delete containerd || true
+			sudo yum install -y containerd-%s
+			sudo yum versionlock add containerd
 
 			{{ template "container-runtime-daemon-config" . }}
 			{{ template "containerd-systemd-setup" . -}}
 			`,
 			defaultAmazonContainerdVersion,
-			defaultAmazonCrictlVersion,
 		),
 
 		"flatcar-containerd": heredoc.Doc(`

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -70,13 +70,12 @@ sudo yum install -y \
 	rsync
 
 
-sudo yum versionlock delete docker cri-tools containerd || true
+sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
+	containerd.io-1.4.*
+sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -157,6 +156,7 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
+sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -70,13 +70,12 @@ sudo yum install -y \
 	rsync
 
 
-sudo yum versionlock delete docker cri-tools containerd || true
+sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
+	containerd.io-1.4.*
+sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -157,6 +156,7 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
+sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -70,13 +70,12 @@ sudo yum install -y \
 	rsync
 
 
-sudo yum versionlock delete docker cri-tools containerd || true
+sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
+	containerd.io-1.4.*
+sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -160,6 +159,7 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
+sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -70,13 +70,12 @@ sudo yum install -y \
 	rsync
 
 
-sudo yum versionlock delete docker cri-tools containerd || true
+sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
+	containerd.io-1.4.*
+sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -157,6 +156,7 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
+sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -70,13 +70,12 @@ sudo yum install -y \
 	rsync
 
 
-sudo yum versionlock delete docker cri-tools containerd || true
+sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
+	containerd.io-1.4.*
+sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -157,6 +156,7 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
+sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -70,13 +70,12 @@ sudo yum install -y \
 	rsync
 
 
-sudo yum versionlock delete docker cri-tools containerd || true
+sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
+	containerd.io-1.4.*
+sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -157,6 +156,7 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
+sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -72,9 +72,9 @@ sudo yum install -y \
 
 
 
-sudo yum versionlock delete containerd cri-tools || true
-sudo yum install -y containerd-1.4.* cri-tools-1.13.0
-sudo yum versionlock add containerd cri-tools
+sudo yum versionlock delete containerd || true
+sudo yum install -y containerd-1.4.*
+sudo yum versionlock add containerd
 
 
 sudo mkdir -p $(dirname /etc/containerd/config.toml)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -72,9 +72,9 @@ sudo yum install -y \
 
 
 
-sudo yum versionlock delete containerd cri-tools || true
-sudo yum install -y containerd-1.4.* cri-tools-1.13.0
-sudo yum versionlock add containerd cri-tools
+sudo yum versionlock delete containerd || true
+sudo yum install -y containerd-1.4.*
+sudo yum versionlock add containerd
 
 
 sudo mkdir -p $(dirname /etc/containerd/config.toml)

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -70,13 +70,12 @@ sudo yum install -y \
 	rsync
 
 
-sudo yum versionlock delete docker cri-tools containerd || true
+sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
+	containerd.io-1.4.*
+sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json
@@ -123,6 +122,7 @@ tar xvf node.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
+sudo yum install -y cri-tools
 
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -70,13 +70,12 @@ sudo yum install -y \
 	rsync
 
 
-sudo yum versionlock delete docker cri-tools containerd || true
+sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-19.03.* \
-	containerd.io-1.4.* \
-	cri-tools-1.13.0
-sudo yum versionlock add docker cri-tools containerd
+	containerd.io-1.4.*
+sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)
 cat <<EOF | sudo tee /etc/docker/daemon.json


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this PR, we were manually installing cri-tools 1.13.0 on Amazon Linux 2. Newer Kubernetes (kubeadm) versions are requiring cri-tools 1.19.0 which is conflicting with cri-tools 1.13.0. This is causing the cluster reconciliation/provisioning to fail.

With this PR, cri-tools is now installed automatically as a dependency of kubeadm. This way the package manager (`yum`) will choose the proper version.

If users are using the AssetConfiguration API (i.e. when they're not using packages to install kubeadm), we install the latest available cri-tools package using `yum`.

**Does this PR introduce a user-facing change?**:
```release-note
cri-tools is now installed automatically as a dependency of kubeadm on Amazon Linux 2. This fixes provisioning issues on Amazon Linux 2 with newer Kubernetes versions.
```

/assign @moadqassem 