### PR TITLE
Automatically determine GCE zone for the initial MachineDeployment

### DIFF
--- a/examples/terraform/gce/main.tf
+++ b/examples/terraform/gce/main.tf
@@ -21,6 +21,7 @@ provider "google" {
 
 locals {
   zones_count = length(data.google_compute_zones.available.names)
+  zone_first  = data.google_compute_zones.available.names[0]
 }
 
 data "google_compute_zones" "available" {

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -64,7 +64,7 @@ output "kubeone_workers" {
           machineType           = var.workers_type
           network               = google_compute_network.network.self_link
           subnetwork            = google_compute_subnetwork.subnet.self_link
-          zone                  = "${var.region}-a"
+          zone                  = "${local.zone_first}"
           preemptible           = false
           assignPublicIPAddress = true
           # Enable support for multizone clusters


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, our example Terraform configs for GCE are always deploying the initial MachineDeployment in the `-a` zone. However, the `-a` zone doesn't exist in all regions. For example, `us-east1` has only `-b` to `-d` zones. In such cases, KubeOne will fail to create the initial MachineDeployment.

This PR modifies our Terraform configs to automatically determine the first zone. We use that zone to deploy the initial MachineDeployment there.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1263

**Does this PR introduce a user-facing change?**:
```release-note
Automatically determine GCE zone for the initial MachineDeployment
```

/assign @moadqassem 