### PR TITLE
Fix issues when disabling nm-cloud-setup on RHEL

### DIFF
--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -104,11 +104,11 @@ sudo yum remove -y \
 sudo yum remove -y kubernetes-cni || true
 `
 	disableNMCloudSetup = `
-if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
-systemctl stop nm-cloud-setup.timer
-systemctl disable nm-cloud-setup.service
-systemctl disable nm-cloud-setup.timer
-reboot
+if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active: active"; then
+sudo systemctl stop nm-cloud-setup.timer
+sudo systemctl disable nm-cloud-setup.service
+sudo systemctl disable nm-cloud-setup.timer
+sudo reboot
 fi
 `
 )

--- a/test/e2e/os.go
+++ b/test/e2e/os.go
@@ -31,6 +31,7 @@ const (
 	OperatingSystemCentOS8 OperatingSystem = "centos"
 	OperatingSystemFlatcar OperatingSystem = "flatcar"
 	OperatingSystemAmazon  OperatingSystem = "amzn2"
+	OperatingSystemRHEL    OperatingSystem = "rhel"
 	OperatingSystemDefault OperatingSystem = ""
 )
 
@@ -45,6 +46,7 @@ func ValidateOperatingSystem(osName string) error {
 		OperatingSystemCentOS7,
 		OperatingSystemCentOS8,
 		OperatingSystemAmazon,
+		OperatingSystemRHEL,
 		OperatingSystemDefault:
 		return nil
 	}
@@ -85,7 +87,7 @@ func sshUsername(osName OperatingSystem) (string, error) {
 		return "centos", nil
 	case OperatingSystemFlatcar:
 		return "core", nil
-	case OperatingSystemAmazon:
+	case OperatingSystemRHEL, OperatingSystemAmazon:
 		return "ec2-user", nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes several issues related to disabling `nm-cloud-setup` on RHEL:

* Run `systemctl` commands with `sudo` to prevent authorization errors
* Ignore errors returned from the `reboot` command
* Close all SSH connections after restarting the machine because in some cases KubeOne is not able to reuse them

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1705

**Does this PR introduce a user-facing change?**:
```release-note
Fix issues when disabling nm-cloud-setup on RHEL
```

/assign @moadqassem 