### PR TITLE
Make goreleaser generate SBOM using kubernetes-sigs/bom

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,7 @@
 project_name: kubeone
+before:
+  hooks:
+    - "bom generate -n https://kubeone.io/kubeone-v{{.Version}}.spdx -o ./kubeone-v{{.Version}}.spdx --dirs=."
 builds:
 - ldflags:
   - "-s -w"
@@ -26,3 +29,6 @@ archives:
       - examples/**/*
       - hack/image-loader.sh
       - addons/**/*
+release:
+  extra_files:
+    - glob: kubeone-v{{.Version}}.spdx


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the GoReleaser script to generate SBOM on release time using [`kubernetes-sigs/bom` tool](https://github.com/kubernetes-sigs/bom). This PR:

* is an RFC to get the discussion started on how should we structure our SBOM files
* adds a way to generate initial SBOMs, so we can test and exercise the tooling

For now, there are some key questions:

* Which tool do we want to use for generating SBOMs?
    * There are many tools and formats out there, but I'm in favor of [`kubernetes-sigs/bom`](https://github.com/kubernetes-sigs/bom) because it's a Go tool created by Kubernetes, so it's probably the closest to us
    * Possible alternative is to use [Syft](https://github.com/anchore/syft) which also integrates with GoReleaser
* What do we want to include in our SBOM files?
  * Right now, this would only include source files and information about dependencies (including their LICENSEs). Ideally, we should include a few more things.
  * We should include information about the generated release archive, but we can't use GoReleaser for that. We would have to do generate SBOMs on our own in this case.
  * Should we include images that we use and deploy in clusters? Are those images our dependencies? Should we have them analyzed? Is it just enough to have YAML manifests listed in the SBOM?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevants to #1669

**Does this PR introduce a user-facing change?**:
```release-note
KubeOne releases now include Software Bill of Materials (SBOM)
```

/assign @scheeles 
/hold
for discussion