### PR TITLE
Remove centos from GCE Terraform example

### DIFF
--- a/examples/terraform/gce/variables.tf
+++ b/examples/terraform/gce/variables.tf
@@ -35,7 +35,6 @@ variable "worker_os" {
 
   # valid choices are:
   # * ubuntu
-  # * centos
   default = "ubuntu"
   type    = string
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
There was some confusion on the Kubermatic community Slack about supported OSes in GCP/GCE (https://kubermatic-community.slack.com/archives/C0PGCH99P/p1641219410010900). I was looking into the GCE Terraform example, which listed `centos` as valid worker OS choice, but `machine-controller` does not support it. So, this PR removes `centos` from the list (which makes it a list of one, but anyway ...) to avoid more people running into this problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove 'centos' choice from GCE Terraform example as it's unsupported
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
