### PR TITLE
add node affinity for cluster-autoscaler

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -197,3 +197,10 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed in https://github.com/kubermatic/kubeone/pull/1713, it adds node affinity to the `cluster-autoscaler` addon.

**Which issue(s) this PR fixes**: None

**Special notes for your reviewer**: -

**Does this PR introduce a user-facing change?**: No.

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
