### PR TITLE
Add support for different credentials for machine-controller and CCM

### DIFF
--- a/addons/ccm-digitalocean/ccm-digitalocean.yaml
+++ b/addons/ccm-digitalocean/ccm-digitalocean.yaml
@@ -47,7 +47,7 @@ spec:
           - name: DO_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
-                name: cloud-provider-credentials
+                name: ccm-credentials
                 key: DO_TOKEN
 
 ---

--- a/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
+++ b/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
@@ -170,4 +170,4 @@ metadata:
   namespace: kube-system
 data:
   cloud-sa.json:
-    {{ EquinixMetalSecret .Credentials.METAL_AUTH_TOKEN .Credentials.METAL_PROJECT_ID | b64enc }}
+    {{ EquinixMetalSecret .CredentialsCCM.METAL_AUTH_TOKEN .CredentialsCCM.METAL_PROJECT_ID | b64enc }}

--- a/addons/ccm-hetzner/ccm-hetzner.yaml
+++ b/addons/ccm-hetzner/ccm-hetzner.yaml
@@ -77,7 +77,7 @@ spec:
             - name: HCLOUD_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: cloud-provider-credentials
+                  name: ccm-credentials
                   key: HZ_TOKEN
             {{ if .Config.CloudProvider.Hetzner.NetworkID -}}
             - name: HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP

--- a/addons/csi-hetzner/hcloud-csi.yml
+++ b/addons/csi-hetzner/hcloud-csi.yml
@@ -170,7 +170,7 @@ spec:
             - name: HCLOUD_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: cloud-provider-credentials
+                  name: ccm-credentials
                   key: HZ_TOKEN
           volumeMounts:
             - name: socket-dir
@@ -259,7 +259,7 @@ spec:
             - name: HCLOUD_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: cloud-provider-credentials
+                  name: ccm-credentials
                   key: HZ_TOKEN
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -88,12 +88,12 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 		return nil, errors.Wrap(err, "unable to fetch credentials")
 	}
 
-	credsCCM, err := credentials.ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, credentials.CredentialsTypeCCM)
+	credsCCM, err := credentials.ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, credentials.TypeCCM)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch cloud provider credentials")
 	}
 
-	envVarsMC, err := credentials.EnvVarBindings(s.Cluster.CloudProvider, s.CredentialsFilePath, credentials.SecretNameMC, credentials.CredentialsTypeMC)
+	envVarsMC, err := credentials.EnvVarBindings(s.Cluster.CloudProvider, s.CredentialsFilePath, credentials.SecretNameMC, credentials.TypeMC)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch env var bindings for credentials")
 	}

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
 
@@ -173,9 +172,8 @@ func runApply(opts *applyOpts) error {
 	}
 
 	// Validate credentials
-	_, err = credentials.ProviderCredentials(s.Cluster.CloudProvider, opts.CredentialsFile)
-	if err != nil {
-		return errors.Wrap(err, "failed to validate credentials")
+	if vErr := validateCredentials(s, opts.CredentialsFile); vErr != nil {
+		return vErr
 	}
 
 	// Probe the cluster for the actual state and the needed tasks.

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
 )
@@ -137,9 +136,8 @@ func runInstall(opts *installOpts) error {
 	s.Logger.Warn("The \"kubeone install\" command is deprecated and will be removed in KubeOne 1.6. Please use \"kubeone apply\" instead.")
 
 	// Validate credentials
-	_, err = credentials.ProviderCredentials(s.Cluster.CloudProvider, opts.CredentialsFile)
-	if err != nil {
-		return errors.Wrap(err, "failed to validate credentials")
+	if vErr := validateCredentials(s, opts.CredentialsFile); vErr != nil {
+		return vErr
 	}
 
 	if opts.NoInit {

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
 )
@@ -169,9 +168,8 @@ func runMigrateToCCMCSI(opts *migrateCCMOptions) error {
 	}
 
 	// Validate credentials
-	_, err = credentials.ProviderCredentials(s.Cluster.CloudProvider, opts.CredentialsFile)
-	if err != nil {
-		return errors.Wrap(err, "failed to validate credentials")
+	if vErr := validateCredentials(s, opts.CredentialsFile); vErr != nil {
+		return vErr
 	}
 
 	// Probe the cluster for the actual state and the needed tasks.

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -179,9 +179,9 @@ func confirmCommand(autoApprove bool) (bool, error) {
 }
 
 func validateCredentials(s *state.State, credentialsFile string) error {
-	_, universalErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.CredentialsTypeUniversal)
-	_, mcErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.CredentialsTypeMC)
-	_, ccmErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.CredentialsTypeCCM)
+	_, universalErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.TypeUniversal)
+	_, mcErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.TypeMC)
+	_, ccmErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.TypeCCM)
 
 	switch {
 	case universalErr != nil && mcErr != nil && ccmErr != nil:

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -32,6 +32,7 @@ import (
 	"k8c.io/kubeone/pkg/addons"
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/apis/kubeone/config"
+	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/state"
 )
 
@@ -175,4 +176,23 @@ func confirmCommand(autoApprove bool) (bool, error) {
 	fmt.Println()
 
 	return strings.Trim(confirmation, "\n") == yes, nil
+}
+
+func validateCredentials(s *state.State, credentialsFile string) error {
+	_, universalErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.CredentialsTypeUniversal)
+	_, mcErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.CredentialsTypeMC)
+	_, ccmErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.CredentialsTypeCCM)
+
+	switch {
+	case universalErr != nil && mcErr != nil && ccmErr != nil:
+		// No credentials found
+		fallthrough
+	case mcErr == nil && ccmErr != nil && universalErr != nil:
+		// MC credentials found, but no CCM or universal credentials
+		fallthrough
+	case ccmErr == nil && mcErr != nil && universalErr != nil: // CCM credentials found, but no MC or universal credentials
+		return errors.Wrap(universalErr, "failed to validate credentials")
+	default:
+		return nil
+	}
 }

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/tasks"
 )
@@ -93,9 +92,8 @@ func runUpgrade(opts *upgradeOpts) error {
 	s.Logger.Warn("The \"kubeone upgrade\" command is deprecated and will be removed in KubeOne 1.6. Please use \"kubeone apply\" instead.")
 
 	// Validate credentials
-	_, err = credentials.ProviderCredentials(s.Cluster.CloudProvider, opts.CredentialsFile)
-	if err != nil {
-		return errors.Wrap(err, "failed to validate credentials")
+	if vErr := validateCredentials(s, opts.CredentialsFile); vErr != nil {
+		return vErr
 	}
 
 	// Probe the cluster for the actual state and the needed tasks.

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -28,6 +28,15 @@ import (
 	"k8c.io/kubeone/pkg/apis/kubeone"
 )
 
+// CredentialsType is a type of credentials that should be fetched
+type CredentialsType string //nolint:revive
+
+const (
+	CredentialsTypeUniversal CredentialsType = ""
+	CredentialsTypeCCM       CredentialsType = "CCM"
+	CredentialsTypeMC        CredentialsType = "MC"
+)
+
 // The environment variable names with credential in them
 const (
 	// Variables that KubeOne (and Terraform) expect to see
@@ -107,7 +116,7 @@ type ProviderEnvironmentVariable struct {
 }
 
 func Any(credentialsFilePath string) (map[string]string, error) {
-	credentialsFinder, err := newCredsFinder(credentialsFilePath)
+	credentialsFinder, err := newCredsFinder(credentialsFilePath, CredentialsTypeUniversal)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +142,8 @@ func Any(credentialsFilePath string) (map[string]string, error) {
 }
 
 // ProviderCredentials implements fetching credentials for each supported provider
-func ProviderCredentials(cloudProvider kubeone.CloudProviderSpec, credentialsFilePath string) (map[string]string, error) {
-	credentialsFinder, err := newCredsFinder(credentialsFilePath)
+func ProviderCredentials(cloudProvider kubeone.CloudProviderSpec, credentialsFilePath string, credentialsType CredentialsType) (map[string]string, error) {
+	credentialsFinder, err := newCredsFinder(credentialsFilePath, credentialsType)
 	if err != nil {
 		return nil, err
 	}
@@ -201,13 +210,25 @@ func ProviderCredentials(cloudProvider kubeone.CloudProviderSpec, credentialsFil
 	return nil, errors.New("no provider matched")
 }
 
-func newCredsFinder(credentialsFilePath string) (lookupFunc, error) {
+func newCredsFinder(credentialsFilePath string, credentialsType CredentialsType) (lookupFunc, error) {
 	staticMap := map[string]string{}
 	finder := func(name string) string {
-		if val := os.Getenv(name); val != "" {
-			return val
+		switch {
+		case credentialsType != CredentialsTypeUniversal:
+			typedName := string(credentialsType) + "_" + name
+			if val := os.Getenv(typedName); val != "" {
+				return val
+			}
+			if val, ok := staticMap[typedName]; ok && val != "" {
+				return val
+			}
+			fallthrough
+		default:
+			if val := os.Getenv(name); val != "" {
+				return val
+			}
+			return staticMap[name]
 		}
-		return staticMap[name]
 	}
 
 	if credentialsFilePath == "" {

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -28,13 +28,13 @@ import (
 	"k8c.io/kubeone/pkg/apis/kubeone"
 )
 
-// CredentialsType is a type of credentials that should be fetched
-type CredentialsType string //nolint:revive
+// Type is a type of credentials that should be fetched
+type Type string
 
 const (
-	CredentialsTypeUniversal CredentialsType = ""
-	CredentialsTypeCCM       CredentialsType = "CCM"
-	CredentialsTypeMC        CredentialsType = "MC"
+	TypeUniversal Type = ""
+	TypeCCM       Type = "CCM"
+	TypeMC        Type = "MC"
 )
 
 // The environment variable names with credential in them
@@ -116,7 +116,7 @@ type ProviderEnvironmentVariable struct {
 }
 
 func Any(credentialsFilePath string) (map[string]string, error) {
-	credentialsFinder, err := newCredsFinder(credentialsFilePath, CredentialsTypeUniversal)
+	credentialsFinder, err := newCredsFinder(credentialsFilePath, TypeUniversal)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func Any(credentialsFilePath string) (map[string]string, error) {
 }
 
 // ProviderCredentials implements fetching credentials for each supported provider
-func ProviderCredentials(cloudProvider kubeone.CloudProviderSpec, credentialsFilePath string, credentialsType CredentialsType) (map[string]string, error) {
+func ProviderCredentials(cloudProvider kubeone.CloudProviderSpec, credentialsFilePath string, credentialsType Type) (map[string]string, error) {
 	credentialsFinder, err := newCredsFinder(credentialsFilePath, credentialsType)
 	if err != nil {
 		return nil, err
@@ -210,11 +210,11 @@ func ProviderCredentials(cloudProvider kubeone.CloudProviderSpec, credentialsFil
 	return nil, errors.New("no provider matched")
 }
 
-func newCredsFinder(credentialsFilePath string, credentialsType CredentialsType) (lookupFunc, error) {
+func newCredsFinder(credentialsFilePath string, credentialsType Type) (lookupFunc, error) {
 	staticMap := map[string]string{}
 	finder := func(name string) string {
 		switch {
-		case credentialsType != CredentialsTypeUniversal:
+		case credentialsType != TypeUniversal:
 			typedName := string(credentialsType) + "_" + name
 			if val := os.Getenv(typedName); val != "" {
 				return val

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -62,7 +62,7 @@ func Ensure(s *state.State) error {
 
 	s.Logger.Infoln("Creating machine-controller credentials secret...")
 
-	mcCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, CredentialsTypeMC)
+	mcCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, TypeMC)
 	if err != nil {
 		return errors.Wrap(err, "unable to fetch cloud provider credentials")
 	}
@@ -82,7 +82,7 @@ func Ensure(s *state.State) error {
 	if s.Cluster.CloudProvider.External && s.Cluster.CloudProvider.Vsphere == nil {
 		s.Logger.Infoln("Creating CCM credentials secret...")
 
-		ccmCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, CredentialsTypeCCM)
+		ccmCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, TypeCCM)
 		if err != nil {
 			return errors.Wrap(err, "unable to fetch cloud provider credentials")
 		}
@@ -94,7 +94,7 @@ func Ensure(s *state.State) error {
 	} else if s.Cluster.CloudProvider.Vsphere != nil {
 		s.Logger.Infoln("Creating vSphere CCM credentials secret...")
 
-		ccmCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, CredentialsTypeCCM)
+		ccmCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, TypeCCM)
 		if err != nil {
 			return errors.Wrap(err, "unable to fetch cloud provider credentials")
 		}
@@ -108,7 +108,7 @@ func Ensure(s *state.State) error {
 	return nil
 }
 
-func EnvVarBindings(cloudProviderSpec kubeoneapi.CloudProviderSpec, credentialsFilePath, secretName string, credentialsType CredentialsType) ([]corev1.EnvVar, error) {
+func EnvVarBindings(cloudProviderSpec kubeoneapi.CloudProviderSpec, credentialsFilePath, secretName string, credentialsType Type) ([]corev1.EnvVar, error) {
 	creds, err := ProviderCredentials(cloudProviderSpec, credentialsFilePath, credentialsType)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch cloud provider credentials")

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -32,8 +32,10 @@ import (
 )
 
 const (
-	// SecretName is name of the secret which contains the cloud provider credentials
-	SecretName = "cloud-provider-credentials"
+	// SecretNameMC is name of the secret which contains the cloud provider credentials for machine-controller
+	SecretNameMC = "machine-controller-credentials"
+	// SecretNameCCM is name of the secret which contains the cloud provider credentials for CCM
+	SecretNameCCM = "ccm-credentials"
 	// SecretNamespace is namespace of the credentials secret
 	SecretNamespace = "kube-system"
 	// VsphereSecretName is name of the secret which contains the vSphere credentials
@@ -58,16 +60,16 @@ func Ensure(s *state.State) error {
 		return nil
 	}
 
-	s.Logger.Infoln("Creating credentials secret...")
+	s.Logger.Infoln("Creating machine-controller credentials secret...")
 
-	creds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath)
+	mcCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, CredentialsTypeMC)
 	if err != nil {
 		return errors.Wrap(err, "unable to fetch cloud provider credentials")
 	}
 
-	secret := credentialsSecret(creds)
-	if err := clientutil.CreateOrReplace(context.Background(), s.DynamicClient, secret); err != nil {
-		return errors.Wrap(err, "failed to ensure credentials secret")
+	mcSecret := credentialsSecret(SecretNameMC, mcCreds)
+	if createErr := clientutil.CreateOrReplace(context.Background(), s.DynamicClient, mcSecret); createErr != nil {
+		return errors.Wrap(createErr, "failed to ensure credentials secret")
 	}
 
 	if s.Cluster.CloudProvider.CloudConfig != "" {
@@ -77,8 +79,27 @@ func Ensure(s *state.State) error {
 		}
 	}
 
-	if s.Cluster.CloudProvider.Vsphere != nil {
-		vsecret := vsphereSecret(creds)
+	if s.Cluster.CloudProvider.External && s.Cluster.CloudProvider.Vsphere == nil {
+		s.Logger.Infoln("Creating CCM credentials secret...")
+
+		ccmCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, CredentialsTypeCCM)
+		if err != nil {
+			return errors.Wrap(err, "unable to fetch cloud provider credentials")
+		}
+
+		ccmSecret := credentialsSecret(SecretNameCCM, ccmCreds)
+		if createErr := clientutil.CreateOrReplace(context.Background(), s.DynamicClient, ccmSecret); createErr != nil {
+			return errors.Wrap(createErr, "failed to ensure credentials secret")
+		}
+	} else if s.Cluster.CloudProvider.Vsphere != nil {
+		s.Logger.Infoln("Creating vSphere CCM credentials secret...")
+
+		ccmCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, CredentialsTypeCCM)
+		if err != nil {
+			return errors.Wrap(err, "unable to fetch cloud provider credentials")
+		}
+
+		vsecret := vsphereSecret(ccmCreds)
 		if err := clientutil.CreateOrReplace(context.Background(), s.DynamicClient, vsecret); err != nil {
 			return errors.Wrap(err, "failed to ensure vsphere credentials secret")
 		}
@@ -87,8 +108,8 @@ func Ensure(s *state.State) error {
 	return nil
 }
 
-func EnvVarBindings(cloudProviderSpec kubeoneapi.CloudProviderSpec, credentialsFilePath string) ([]corev1.EnvVar, error) {
-	creds, err := ProviderCredentials(cloudProviderSpec, credentialsFilePath)
+func EnvVarBindings(cloudProviderSpec kubeoneapi.CloudProviderSpec, credentialsFilePath, secretName string, credentialsType CredentialsType) ([]corev1.EnvVar, error) {
+	creds, err := ProviderCredentials(cloudProviderSpec, credentialsFilePath, credentialsType)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch cloud provider credentials")
 	}
@@ -101,7 +122,7 @@ func EnvVarBindings(cloudProviderSpec kubeoneapi.CloudProviderSpec, credentialsF
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: SecretName,
+						Name: secretName,
 					},
 					Key: k,
 				},
@@ -112,10 +133,10 @@ func EnvVarBindings(cloudProviderSpec kubeoneapi.CloudProviderSpec, credentialsF
 	return env, nil
 }
 
-func credentialsSecret(credentials map[string]string) *corev1.Secret {
+func credentialsSecret(secretName string, credentials map[string]string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      SecretName,
+			Name:      secretName,
 			Namespace: SecretNamespace,
 		},
 		Type:       corev1.SecretTypeOpaque,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for using different credentials for machine-controller and external CCMs. This is implemented in the following way:

* We now create `machine-controller-credentials` and `ccm-credentials` secrets instead of `cloud-provider-credentials` secret
* Typed credentials are prefixed with `MC_` for machine-controller credentials and `CCM_` from CCM credentials
* KubeOne will first try to fetch prefixed credentials and then fallback to non-prefixed (default) credentials

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1262

**Does this PR introduce a user-facing change?**:
```release-note
Add support for different credentials for machine-controller and CCM. Environment variables can be prefixed with `MC_` for machine-controller credentials and `CCM_` for CCM credentials.
[BREAKING] `cloud-provider-credentials` secret is not created and maintained by KubeOne any longer
```

/assign @kron4eg 