### PR TITLE
Remove cloud-provider-credentials Secret and prefix credentials Secret created by KubeOne

### DIFF
--- a/addons/ccm-digitalocean/ccm-digitalocean.yaml
+++ b/addons/ccm-digitalocean/ccm-digitalocean.yaml
@@ -47,7 +47,7 @@ spec:
           - name: DO_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
-                name: ccm-credentials
+                name: kubeone-ccm-credentials
                 key: DO_TOKEN
 
 ---

--- a/addons/ccm-hetzner/ccm-hetzner.yaml
+++ b/addons/ccm-hetzner/ccm-hetzner.yaml
@@ -77,7 +77,7 @@ spec:
             - name: HCLOUD_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: ccm-credentials
+                  name: kubeone-ccm-credentials
                   key: HZ_TOKEN
             {{ if .Config.CloudProvider.Hetzner.NetworkID -}}
             - name: HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP

--- a/addons/csi-hetzner/hcloud-csi.yml
+++ b/addons/csi-hetzner/hcloud-csi.yml
@@ -170,7 +170,7 @@ spec:
             - name: HCLOUD_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: ccm-credentials
+                  name: kubeone-ccm-credentials
                   key: HZ_TOKEN
           volumeMounts:
             - name: socket-dir
@@ -259,7 +259,7 @@ spec:
             - name: HCLOUD_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: ccm-credentials
+                  name: kubeone-ccm-credentials
                   key: HZ_TOKEN
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -33,9 +33,9 @@ import (
 
 const (
 	// SecretNameMC is name of the secret which contains the cloud provider credentials for machine-controller
-	SecretNameMC = "machine-controller-credentials"
+	SecretNameMC = "kubeone-machine-controller-credentials"
 	// SecretNameCCM is name of the secret which contains the cloud provider credentials for CCM
-	SecretNameCCM = "ccm-credentials"
+	SecretNameCCM = "kubeone-ccm-credentials"
 	// SecretNameLegacy is name of the secret created by earlier KubeOne versions, but not used anymore
 	// This secret will be removed for all clusters when running kubeone apply the next time
 	SecretNameLegacy = "cloud-provider-credentials"

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -36,6 +36,9 @@ const (
 	SecretNameMC = "machine-controller-credentials"
 	// SecretNameCCM is name of the secret which contains the cloud provider credentials for CCM
 	SecretNameCCM = "ccm-credentials"
+	// SecretNameLegacy is name of the secret created by earlier KubeOne versions, but not used anymore
+	// This secret will be removed for all clusters when running kubeone apply the next time
+	SecretNameLegacy = "cloud-provider-credentials"
 	// SecretNamespace is namespace of the credentials secret
 	SecretNamespace = "kube-system"
 	// VsphereSecretName is name of the secret which contains the vSphere credentials
@@ -58,6 +61,16 @@ func Ensure(s *state.State) error {
 	if !s.Cluster.MachineController.Deploy && !s.Cluster.CloudProvider.External {
 		s.Logger.Info("Skipping creating credentials secret because both machine-controller and external CCM are disabled.")
 		return nil
+	}
+
+	oldSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SecretNameLegacy,
+			Namespace: SecretNamespace,
+		},
+	}
+	if err := clientutil.DeleteIfExists(s.Context, s.DynamicClient, oldSecret); err != nil {
+		return errors.Wrap(err, "unable to remove cloud-provider-credentials secret")
 	}
 
 	s.Logger.Infoln("Creating machine-controller credentials secret...")

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -35,7 +35,7 @@ const (
 	// SecretNameMC is name of the secret which contains the cloud provider credentials for machine-controller
 	SecretNameMC = "kubeone-machine-controller-credentials"
 	// SecretNameCCM is name of the secret which contains the cloud provider credentials for CCM
-	SecretNameCCM = "kubeone-ccm-credentials"
+	SecretNameCCM = "kubeone-ccm-credentials" //nolint:gosec
 	// SecretNameLegacy is name of the secret created by earlier KubeOne versions, but not used anymore
 	// This secret will be removed for all clusters when running kubeone apply the next time
 	SecretNameLegacy = "cloud-provider-credentials"


### PR DESCRIPTION
**What this PR does / why we need it**:

* `cloud-provider-credentials` Secret is not used anymore, so KubeOne will attempt to remove it if it exists
* Credentials Secrets created by KubeOne are now prefixed with `kubeone-` to highlight that those Secrets are managed by KubeOne

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1262 #1717

**Does this PR introduce a user-facing change?**:
```release-note
[BREAKING] cloud-provider-credentials Secret will be removed by KubeOne because it is not used any longer. If you have any workloads NOT created by KubeOne that use this Secret, please migrate before upgrading KubeOne
```

/assign @kron4eg 