### PR TITLE
Add Terraform configs for Nutanix

### DIFF
--- a/examples/terraform/equinixmetal/README.md
+++ b/examples/terraform/equinixmetal/README.md
@@ -10,7 +10,7 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
 [docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/guides/using_terraform_configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/examples/ha_load_balancing/
 
 ## Inputs
 

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -10,7 +10,7 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
 [docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/guides/using_terraform_configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/examples/ha_load_balancing/
 
 ## Inputs
 

--- a/examples/terraform/nutanix/README.md
+++ b/examples/terraform/nutanix/README.md
@@ -1,0 +1,77 @@
+# Nutanix Quickstart Terraform configs
+
+The Nutanix Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the following
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
+
+## Kubernetes API Server Load Balancing
+
+See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
+
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/guides/using_terraform_configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/examples/ha_load_balancing/
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_nutanix"></a> [nutanix](#requirement\_nutanix) | 1.2.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
+| <a name="provider_nutanix"></a> [nutanix](#provider\_nutanix) | 1.2.2 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.lb_config](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [nutanix_category_key.category_key](https://registry.terraform.io/providers/nutanix/nutanix/1.2.2/docs/resources/category_key) | resource |
+| [nutanix_category_value.category_value](https://registry.terraform.io/providers/nutanix/nutanix/1.2.2/docs/resources/category_value) | resource |
+| [nutanix_virtual_machine.control_plane](https://registry.terraform.io/providers/nutanix/nutanix/1.2.2/docs/resources/virtual_machine) | resource |
+| [nutanix_virtual_machine.lb](https://registry.terraform.io/providers/nutanix/nutanix/1.2.2/docs/resources/virtual_machine) | resource |
+| [nutanix_cluster.cluster](https://registry.terraform.io/providers/nutanix/nutanix/1.2.2/docs/data-sources/cluster) | data source |
+| [nutanix_image.image](https://registry.terraform.io/providers/nutanix/nutanix/1.2.2/docs/data-sources/image) | data source |
+| [nutanix_project.project](https://registry.terraform.io/providers/nutanix/nutanix/1.2.2/docs/data-sources/project) | data source |
+| [nutanix_subnet.subnet](https://registry.terraform.io/providers/nutanix/nutanix/1.2.2/docs/data-sources/subnet) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_apiserver_alternative_names"></a> [apiserver\_alternative\_names](#input\_apiserver\_alternative\_names) | subject alternative names for the API Server signing cert. | `list(string)` | `[]` | no |
+| <a name="input_bastion_disk_size"></a> [bastion\_disk\_size](#input\_bastion\_disk\_size) | Disk size size, in Mib, for bastion/LB node | `number` | `102400` | no |
+| <a name="input_bastion_memory_size"></a> [bastion\_memory\_size](#input\_bastion\_memory\_size) | Memory size, in Mib, for bastion/LB node | `number` | `4096` | no |
+| <a name="input_bastion_port"></a> [bastion\_port](#input\_bastion\_port) | Bastion SSH port | `number` | `22` | no |
+| <a name="input_bastion_sockets"></a> [bastion\_sockets](#input\_bastion\_sockets) | Number of sockets for bastion/LB node | `number` | `1` | no |
+| <a name="input_bastion_user"></a> [bastion\_user](#input\_bastion\_user) | Bastion SSH username | `string` | `"ubuntu"` | no |
+| <a name="input_bastion_vcpus"></a> [bastion\_vcpus](#input\_bastion\_vcpus) | Number of vCPUs per socket for bastion/LB node | `number` | `1` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
+| <a name="input_control_plane_disk_size"></a> [control\_plane\_disk\_size](#input\_control\_plane\_disk\_size) | Disk size size, in Mib, for control plane nodes | `number` | `102400` | no |
+| <a name="input_control_plane_memory_size"></a> [control\_plane\_memory\_size](#input\_control\_plane\_memory\_size) | Memory size, in Mib, for control plane nodes | `number` | `4096` | no |
+| <a name="input_control_plane_sockets"></a> [control\_plane\_sockets](#input\_control\_plane\_sockets) | Number of sockets for control plane nodes | `number` | `1` | no |
+| <a name="input_control_plane_vcpus"></a> [control\_plane\_vcpus](#input\_control\_plane\_vcpus) | Number of vCPUs per socket for control plane nodes | `number` | `2` | no |
+| <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Image to be used for instances (control plane, bastion/LB, workers) | `string` | n/a | yes |
+| <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | number of replicas per MachineDeployment | `number` | `1` | no |
+| <a name="input_nutanix_cluster_name"></a> [nutanix\_cluster\_name](#input\_nutanix\_cluster\_name) | Name of the Nutanix Cluster which will be used for this Kubernetes cluster | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the Nutanix Project | `string` | n/a | yes |
+| <a name="input_ssh_agent_socket"></a> [ssh\_agent\_socket](#input\_ssh\_agent\_socket) | SSH Agent socket, default to grab from $SSH\_AUTH\_SOCK | `string` | `"env:SSH_AUTH_SOCK"` | no |
+| <a name="input_ssh_port"></a> [ssh\_port](#input\_ssh\_port) | SSH port to be used to provision instances | `number` | `22` | no |
+| <a name="input_ssh_private_key_file"></a> [ssh\_private\_key\_file](#input\_ssh\_private\_key\_file) | SSH private key file used to access instances | `string` | `""` | no |
+| <a name="input_ssh_public_key_file"></a> [ssh\_public\_key\_file](#input\_ssh\_public\_key\_file) | SSH public key file | `string` | `"~/.ssh/id_rsa.pub"` | no |
+| <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | SSH user, used only in output | `string` | `"ubuntu"` | no |
+| <a name="input_subnet_name"></a> [subnet\_name](#input\_subnet\_name) | Name of the subnet | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_kubeone_api"></a> [kubeone\_api](#output\_kubeone\_api) | kube-apiserver LB endpoint |
+| <a name="output_kubeone_hosts"></a> [kubeone\_hosts](#output\_kubeone\_hosts) | Control plane endpoints to SSH to |
+| <a name="output_kubeone_workers"></a> [kubeone\_workers](#output\_kubeone\_workers) | Workers definitions, that will be transformed into MachineDeployment object |
+| <a name="output_ssh_commands"></a> [ssh\_commands](#output\_ssh\_commands) | n/a |

--- a/examples/terraform/nutanix/cloud-config.tftpl
+++ b/examples/terraform/nutanix/cloud-config.tftpl
@@ -1,0 +1,5 @@
+#cloud-config
+hostname: ${machine_name}
+ssh_pwauth: false
+ssh_authorized_keys:
+  - "${ssh_key}"

--- a/examples/terraform/nutanix/etc_gobetween.tpl
+++ b/examples/terraform/nutanix/etc_gobetween.tpl
@@ -1,0 +1,26 @@
+[api]
+enabled = false
+
+[servers.default]
+protocol = "tcp"
+bind = "0.0.0.0:6443"
+balance = "roundrobin"
+max_connections = 10000
+client_idle_timeout = "10m"
+backend_idle_timeout = "10m"
+backend_connection_timeout = "2s"
+
+[servers.default.discovery]
+kind = "static"
+static_list = [
+    %{ for target in lb_targets ~}
+    "${target}:6443",
+    %{ endfor ~}
+]
+
+[servers.default.healthcheck]
+kind = "ping"
+interval = "10s"
+timeout = "2s"
+fails = 2
+passes = 1

--- a/examples/terraform/nutanix/gobetween.sh
+++ b/examples/terraform/nutanix/gobetween.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is mostly used in CI
+# It installs dependencies and starts the tests
+
+set -euf -o pipefail
+
+GOBETWEEN_VERSION=0.7.0
+
+noop() { : "didn't detected package manager, noop"; }
+
+PKG_MANAGER="noop"
+
+[ "$(command -v yum)" ] && PKG_MANAGER=yum
+[ "$(command -v apt-get)" ] && PKG_MANAGER=apt-get
+
+sudo ${PKG_MANAGER} install tar -y
+
+mkdir -p /tmp/gobetween
+cd /tmp/gobetween
+curl -L -o gobetween_${GOBETWEEN_VERSION}_linux_amd64.tar.gz \
+    https://github.com/yyyar/gobetween/releases/download/${GOBETWEEN_VERSION}/gobetween_${GOBETWEEN_VERSION}_linux_amd64.tar.gz
+tar xvf gobetween_${GOBETWEEN_VERSION}_linux_amd64.tar.gz
+sudo mkdir -p /opt/bin
+sudo mv gobetween /opt/bin/gobetween
+sudo chown root:root /opt/bin/gobetween
+
+cat <<EOF | sudo tee /etc/systemd/system/gobetween.service
+[Unit]
+Description=Gobetween - modern LB for cloud era
+Documentation=https://github.com/yyyar/gobetween/wiki
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=simple
+ExecStart=/opt/bin/gobetween -c /etc/gobetween.toml
+PrivateTmp=true
+User=nobody
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable gobetween.service
+sudo systemctl start gobetween.service

--- a/examples/terraform/nutanix/main.tf
+++ b/examples/terraform/nutanix/main.tf
@@ -1,0 +1,163 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+provider "nutanix" {
+  insecure = var.allow_insecure
+}
+
+data "nutanix_cluster" "cluster" {
+  name = var.nutanix_cluster_name
+}
+
+data "nutanix_project" "project" {
+  project_name = var.project_name
+}
+
+data "nutanix_subnet" "subnet" {
+  subnet_name = var.subnet_name
+}
+
+data "nutanix_image" "image" {
+  image_name = var.image_name
+}
+
+resource "nutanix_category_key" "category_key" {
+  name        = "KubeOneCluster"
+  description = "KubeOne Cluster category key"
+}
+
+resource "nutanix_category_value" "category_value" {
+  name        = nutanix_category_key.category_key.id
+  description = "KubeOne Cluster category value"
+  value       = var.cluster_name
+}
+
+resource "nutanix_virtual_machine" "control_plane" {
+  count        = 3
+  name         = "${var.cluster_name}-cp-${count.index}"
+  cluster_uuid = data.nutanix_cluster.cluster.metadata.uuid
+  project_reference = {
+    kind = "project"
+    uuid = data.nutanix_project.project.metadata.uuid
+  }
+
+  num_vcpus_per_socket = var.control_plane_vcpus
+  num_sockets          = var.control_plane_sockets
+  memory_size_mib      = var.control_plane_memory_size
+
+  nic_list {
+    subnet_uuid = data.nutanix_subnet.subnet.metadata.uuid
+  }
+
+  disk_list {
+    disk_size_mib = var.control_plane_disk_size
+    
+    data_source_reference = {
+      kind = "image"
+      uuid = data.nutanix_image.image.metadata.uuid
+    }
+  }
+
+  guest_customization_cloud_init_user_data = base64encode(templatefile("./cloud-config.tftpl", {
+    machine_name = "${var.cluster_name}-cp-${count.index}"
+    ssh_key = file(var.ssh_public_key_file)
+  }))
+
+  categories {
+    name   = nutanix_category_key.category_key.name
+    value  = nutanix_category_value.category_value.value
+  }
+}
+
+resource "nutanix_virtual_machine" "lb" {
+  name         = "${var.cluster_name}-lb"
+  cluster_uuid = data.nutanix_cluster.cluster.metadata.uuid
+  project_reference = {
+    kind = "project"
+    uuid = data.nutanix_project.project.metadata.uuid
+  }
+
+  num_vcpus_per_socket = var.bastion_vcpus
+  num_sockets          = var.bastion_sockets
+  memory_size_mib      = var.bastion_memory_size
+
+  nic_list {
+    subnet_uuid = data.nutanix_subnet.subnet.metadata.uuid
+  }
+
+  disk_list {
+    disk_size_mib = var.bastion_disk_size
+    
+    data_source_reference = {
+      kind = "image"
+      uuid = data.nutanix_image.image.metadata.uuid
+    }
+  }
+
+  guest_customization_cloud_init_user_data = base64encode(templatefile("./cloud-config.tftpl", {
+    machine_name = "${var.cluster_name}-lb"
+    ssh_key = file(var.ssh_public_key_file)
+  }))
+
+  categories {
+    name   = nutanix_category_key.category_key.name
+    value  = nutanix_category_value.category_value.value
+  }
+
+  connection {
+    type = "ssh"
+    host = nutanix_virtual_machine.lb.nic_list.0.ip_endpoint_list.0.ip
+    user = var.ssh_username
+  }
+
+  provisioner "remote-exec" {
+    script = "gobetween.sh"
+  }
+}
+
+locals {
+  rendered_lb_config = templatefile("./etc_gobetween.tpl", {
+    lb_targets = nutanix_virtual_machine.control_plane.*.nic_list.0.ip_endpoint_list.0.ip,
+  })
+}
+
+resource "null_resource" "lb_config" {
+  triggers = {
+    cluster_instance_ids = join(",", nutanix_virtual_machine.control_plane.*.metadata.uuid)
+    config               = local.rendered_lb_config
+  }
+
+  depends_on = [
+    nutanix_virtual_machine.lb
+  ]
+
+  connection {
+    host = nutanix_virtual_machine.lb.nic_list.0.ip_endpoint_list.0.ip
+    user = var.ssh_username
+  }
+
+  provisioner "file" {
+    content     = local.rendered_lb_config
+    destination = "/tmp/gobetween.toml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/gobetween.toml /etc/gobetween.toml",
+      "sudo systemctl restart gobetween",
+    ]
+  }
+}

--- a/examples/terraform/nutanix/output.tf
+++ b/examples/terraform/nutanix/output.tf
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "kubeone_api" {
+  description = "kube-apiserver LB endpoint"
+
+  value = {
+    endpoint = nutanix_virtual_machine.lb.nic_list.0.ip_endpoint_list.0.ip
+    apiserver_alternative_names = var.apiserver_alternative_names
+  }
+}
+
+output "ssh_commands" {
+  value = formatlist("ssh -J ${var.bastion_user}@${nutanix_virtual_machine.lb.nic_list.0.ip_endpoint_list.0.ip} ${var.ssh_username}@%s", nutanix_virtual_machine.control_plane.*.nic_list.0.ip_endpoint_list.0.ip)
+}
+
+output "kubeone_hosts" {
+  description = "Control plane endpoints to SSH to"
+
+  value = {
+    control_plane = {
+      cluster_name         = var.cluster_name
+      cloud_provider       = "none"
+      private_address      = nutanix_virtual_machine.control_plane.*.nic_list.0.ip_endpoint_list.0.ip
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
+      bastion              = nutanix_virtual_machine.lb.nic_list.0.ip_endpoint_list.0.ip
+      bastion_port         = var.bastion_port
+      bastion_user         = var.bastion_user
+    }
+  }
+}
+
+output "kubeone_workers" {
+  description = "Workers definitions, that will be transformed into MachineDeployment object"
+
+  value = {}
+}
+

--- a/examples/terraform/nutanix/variables.tf
+++ b/examples/terraform/nutanix/variables.tf
@@ -1,0 +1,156 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "cluster_name" {
+  description = "Name of the cluster"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
+    error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
+  }
+}
+
+variable "apiserver_alternative_names" {
+  description = "subject alternative names for the API Server signing cert."
+  default     = []
+  type        = list(string)
+}
+
+variable "ssh_public_key_file" {
+  description = "SSH public key file"
+  default     = "~/.ssh/id_rsa.pub"
+  type        = string
+}
+
+variable "ssh_port" {
+  description = "SSH port to be used to provision instances"
+  default     = 22
+  type        = number
+}
+
+variable "ssh_username" {
+  description = "SSH user, used only in output"
+  default     = "ubuntu"
+  type        = string
+}
+
+variable "ssh_private_key_file" {
+  description = "SSH private key file used to access instances"
+  default     = ""
+  type        = string
+}
+
+variable "ssh_agent_socket" {
+  description = "SSH Agent socket, default to grab from $SSH_AUTH_SOCK"
+  default     = "env:SSH_AUTH_SOCK"
+  type        = string
+}
+
+variable "bastion_port" {
+  description = "Bastion SSH port"
+  default     = 22
+  type        = number
+}
+
+variable "bastion_user" {
+  description = "Bastion SSH username"
+  default     = "ubuntu"
+  type        = string
+}
+
+# Provider specific settings
+
+variable "allow_insecure" {
+  default     = false
+  description = "Allow insecure access to the Nutanix API"
+  type        = bool
+}
+
+variable "nutanix_cluster_name" {
+  description = "Name of the Nutanix Cluster which will be used for this Kubernetes cluster"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Name of the Nutanix Project"
+  type        = string
+}
+
+variable "subnet_name" {
+  description = "Name of the subnet"
+  type        = string
+}
+
+variable "image_name" {
+  description = "Image to be used for instances (control plane, bastion/LB, workers)"
+  type        = string
+}
+
+variable "control_plane_vcpus" {
+  default     = 2
+  description = "Number of vCPUs per socket for control plane nodes"
+  type        = number
+}
+
+variable "control_plane_sockets" {
+  default     = 1
+  description = "Number of sockets for control plane nodes"
+  type        = number
+}
+
+variable "control_plane_memory_size" {
+  default     = 4096
+  description = "Memory size, in Mib, for control plane nodes"
+  type        = number
+}
+
+variable "control_plane_disk_size" {
+  default     = 102400
+  description = "Disk size size, in Mib, for control plane nodes"
+  type        = number
+}
+
+variable "bastion_vcpus" {
+  default     = 1
+  description = "Number of vCPUs per socket for bastion/LB node"
+  type        = number
+}
+
+variable "bastion_sockets" {
+  default     = 1
+  description = "Number of sockets for bastion/LB node"
+  type        = number
+}
+
+variable "bastion_memory_size" {
+  default     = 4096
+  description = "Memory size, in Mib, for bastion/LB node"
+  type        = number
+}
+
+variable "bastion_disk_size" {
+  default     = 102400
+  description = "Disk size size, in Mib, for bastion/LB node"
+  type        = number
+}
+
+variable "initial_machinedeployment_replicas" {
+  default     = 1
+  description = "number of replicas per MachineDeployment"
+  type        = number
+
+}

--- a/examples/terraform/nutanix/versions.tf
+++ b/examples/terraform/nutanix/versions.tf
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    nutanix = {
+      source = "nutanix/nutanix"
+      version = "1.2.2"
+    }
+  }
+}

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -10,7 +10,7 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
 [docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/guides/using_terraform_configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/examples/ha_load_balancing/
 
 ## Inputs
 

--- a/examples/terraform/vsphere/README.md
+++ b/examples/terraform/vsphere/README.md
@@ -21,7 +21,7 @@ See https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md
 See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 
 [docs-infrastructure]: https://docs.kubermatic.com/kubeone/master/guides/using_terraform_configs/
-[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/advanced/example_loadbalancer/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/master/examples/ha_load_balancing/
 
 ## Inputs
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds example Terraform configs for Nutanix.

The example configs have the following assumptions:

* Project is supposed to be created and provided by the user because Projects are sort-of-like accounts, and you also need to figure out various settings and permissions, which is complicated to do on our own
* Subnet is supposed to be created and provided by the user as well because creating subnets might require additional network configuration
* We don't manage Network Security Rules because they require an additional license from Nutanix. Users can extend their Terraform configs on their own if they want to use Network Security Rules
* We don't manage Access Control Policies as we also don't manage Projects

The user needs to provide the following information via Terraform variables:

* Kubernetes Cluster name (`cluster_name`) - name to be used as a prefix for Nutanix resources and Kubernetes cluster
* Nutanix Cluster name (`nutanix_cluster_name`) - can be obtained via Prism Central
* Project Name (`project_name`) - can be obtained via Prism Central
* Subnet Name (`subnet_name`) - can be obtained via Prism Central
* Image Name (`image_name`) - the image must be uploaded by the user manually

The following resources are created by Terraform configs:

* KubeOne-Cluster category - the value is the cluster name
* 3 virtual machines for the Control Plane (by default each has 2 vCPUs, 1 CPU socket, 4 GB RAM, 100 GB disk)
* 1 virtual machine as a bastion and for GoBetween Load Balancer (by default machine has 1 vCPUs, 1 CPU socket, 4 GB RAM, 100 GB disk)
  * GoBetween is used to provide Load Balancing for the Kubernetes API servers
  * It uses the same GoBetween config as other providers

Notes:

* There's no way to provide an SSH key to the instance, and the default hostname is `ubuntu`. To fix this, a simple cloud-config is generated to set the hostname and the SSH public key

TODO:

* Terraform integration for Nutanix is not yet implemented, therefore there's no template for MachineDeployments, and cloud provider is set to `none`. This is going to be fixed in a follow up.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1720

**Does this PR introduce a user-facing change?**:
```release-note
Add example Terraform configs for Nutanix
```

/assign @embik @kron4eg 