### PR TITLE
Add the Nutanix CSI driver

### DIFF
--- a/addons/ccm-azure/ccm-azure.yaml
+++ b/addons/ccm-azure/ccm-azure.yaml
@@ -286,8 +286,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
         - key: node-role.kubernetes.io/master
-          operator: Equal
-          value: "true"
+          operator: Exists
           effect: NoSchedule
         - operator: "Exists"
           effect: NoExecute

--- a/addons/csi-azuredisk/csi-snapshot-controller.yaml
+++ b/addons/csi-azuredisk/csi-snapshot-controller.yaml
@@ -20,12 +20,10 @@ spec:
       priorityClassName: system-cluster-critical
       tolerations:
         - key: "node-role.kubernetes.io/master"
-          operator: "Equal"
-          value: "true"
+          operator: "Exists"
           effect: "NoSchedule"
         - key: "node-role.kubernetes.io/controlplane"
-          operator: "Equal"
-          value: "true"
+          operator: "Exists"
           effect: "NoSchedule"
       containers:
         - name: csi-snapshot-controller

--- a/addons/csi-azurefile/csi-snapshot-controller.yaml
+++ b/addons/csi-azurefile/csi-snapshot-controller.yaml
@@ -20,12 +20,10 @@ spec:
       priorityClassName: system-cluster-critical
       tolerations:
         - key: "node-role.kubernetes.io/master"
-          operator: "Equal"
-          value: "true"
+          operator: "Exists"
           effect: "NoSchedule"
         - key: "node-role.kubernetes.io/controlplane"
-          operator: "Equal"
-          value: "true"
+          operator: "Exists"
           effect: "NoSchedule"
       containers:
         - name: csi-snapshot-controller

--- a/addons/csi-nutanix/csi-driver.yaml
+++ b/addons/csi-nutanix/csi-driver.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.nutanix.com
+spec:
+  attachRequired: false
+  podInfoOnMount: true

--- a/addons/csi-nutanix/ntnx-csi-node-ds.yaml
+++ b/addons/csi-nutanix/ntnx-csi-node-ds.yaml
@@ -1,0 +1,150 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-node-ntnx-plugin
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-node-ntnx-plugin
+  template:
+    metadata:
+      labels:
+        app: csi-node-ntnx-plugin
+      annotations:
+        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+    spec:
+      serviceAccount: csi-node-ntnx-plugin
+      hostNetwork: true
+      containers:
+        - name: driver-registrar
+          image: {{ .InternalImages.Get "NutanixCSIRegistrar" }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.nutanix.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi/
+            - name: registration-dir
+              mountPath: /registration
+        - name: csi-node-ntnx-plugin
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+          image: {{ .InternalImages.Get "NutanixCSI" }}
+          imagePullPolicy: IfNotPresent
+          args :
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(NODE_ID)"
+            - "--drivername=csi.nutanix.com"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - mountPath: /dev
+              name: device-dir
+            - mountPath: /etc/iscsi
+              name: iscsi-dir
+            - mountPath: /host
+              name: root-dir
+              # This is needed because mount is run from host using chroot.
+              mountPropagation: "Bidirectional"
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}
+          ports:
+            - containerPort: 9808
+              name: http-endpoint
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-endpoint
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 3
+        - name: liveness-probe
+          volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+          image: {{ .InternalImages.Get "NutanixCSILivenessProbe" }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --http-endpoint=:9808
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      tolerations:
+        - operator: "Exists"
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.nutanix.com/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+        - name: iscsi-dir
+          hostPath:
+            path: /etc/iscsi
+            type: Directory
+        - name: root-dir
+          hostPath:
+            path: /
+            type: Directory
+{{ if .Config.CABundle }}
+{{ caBundleVolume | indent 8 }}
+{{ end }}

--- a/addons/csi-nutanix/ntnx-csi-provisioner-sts.yaml
+++ b/addons/csi-nutanix/ntnx-csi-provisioner-sts.yaml
@@ -1,0 +1,155 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-provisioner-ntnx-plugin
+  namespace: kube-system
+spec:
+  serviceName: csi-provisioner-ntnx-plugin
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-provisioner-ntnx-plugin
+  template:
+    metadata:
+      labels:
+        app: csi-provisioner-ntnx-plugin
+      annotations:
+        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+    spec:
+      serviceAccount: csi-provisioner
+      hostNetwork: true
+      containers:
+        - name: csi-provisioner
+          image: {{ .InternalImages.Get "NutanixCSIProvisioner" }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=$(ADDRESS)
+            - --timeout=60s
+            - --worker-threads=16
+            # This adds PV/PVC metadata to create volume requests
+            - --extra-create-metadata=true
+            - --default-fstype=ext4
+            # This is used to collect CSI operation metrics
+            - --http-endpoint=:9809
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: {{ .InternalImages.Get "NutanixCSIResizer" }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --timeout=60s
+            - --leader-election=false
+            # NTNX CSI dirver supports online volume expansion.
+            - --handle-volume-inuse-error=false
+            - --http-endpoint=:9810
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-snapshotter
+          image: {{ .InternalImages.Get "NutanixCSISnapshotter" }}
+          imagePullPolicy: IfNotPresent
+          args:
+          - --csi-address=$(ADDRESS)
+          - --leader-election=false
+          - --logtostderr=true
+          - --timeout=300s
+          env:
+          - name: ADDRESS
+            value: /csi/csi.sock
+          volumeMounts:
+          - name: socket-dir
+            mountPath: /csi
+        - name: ntnx-csi-plugin
+          image: {{ .InternalImages.Get "NutanixCSI" }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --nodeid=$(NODE_ID)
+            - --drivername=csi.nutanix.com
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+            # This is needed for static NFS volume feature.
+            - mountPath: /host
+              name: root-dir
+{{ if .Config.CABundle }}
+{{ caBundleVolumeMount | indent 12 }}
+{{ end }}
+          ports:
+            - containerPort: 9807
+              name: http-endpoint
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-endpoint
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 3
+        - name: liveness-probe
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          image: {{ .InternalImages.Get "NutanixCSILivenessProbe" }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --http-endpoint=:9807
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/controlplane"
+          operator: "Exists"
+          effect: "NoSchedule"
+      volumes:
+        - emptyDir: {}
+          name: socket-dir
+        - hostPath:
+            path: /
+            type: Directory
+          name: root-dir
+{{ if .Config.CABundle }}
+{{ caBundleVolume | indent 8 }}
+{{ end }}

--- a/addons/csi-nutanix/ntnx-csi-rbac.yaml
+++ b/addons/csi-nutanix/ntnx-csi-rbac.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-provisioner
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-provisioner-runner
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+# needed for StatefulSet
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-provisioner-ntnx-plugin
+  namespace: kube-system
+  labels:
+    app: csi-provisioner-ntnx-plugin
+spec:
+  selector:
+    app: csi-provisioner-ntnx-plugin
+  ports:
+    - name: dummy
+      port: 12345
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-node-ntnx-plugin
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-node-runner
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-node-role
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: csi-node-ntnx-plugin
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-node-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/addons/csi-nutanix/ntnx-secret.yaml
+++ b/addons/csi-nutanix/ntnx-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ntnx-secret
+  namespace: kube-system
+data:
+  # base64 encoded prism-ip:prism-port:admin:password. 
+  # E.g.: echo -n "10.83.0.91:9440:admin:mypassword" | base64
+  key: {{ printf "%s:%s:%s:%s" .Credentials.NUTANIX_PE_ENDPOINT .Credentials.NUTANIX_PORT .Credentials.NUTANIX_PE_USERNAME .Credentials.NUTANIX_PE_PASSWORD | b64enc }}

--- a/addons/csi-nutanix/service-prometheus-csi.yaml
+++ b/addons/csi-nutanix/service-prometheus-csi.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-metrics-service
+  namespace: kube-system
+  labels:
+    app: csi-provisioner-ntnx-plugin
+spec:
+  type: ClusterIP
+  selector:
+    app: csi-provisioner-ntnx-plugin
+  ports:
+    - name: provisioner
+      port: 9809
+      targetPort: 9809
+      protocol: TCP
+    - name: resizer
+      port: 9810
+      targetPort: 9810
+      protocol: TCP

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -141,7 +141,7 @@ parameters:
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: default
+  name: ntnx-csi
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: csi.nutanix.com

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -137,6 +137,29 @@ parameters:
   type: pd-ssd
 {{ end }}
 
+{{ if eq .Config.CloudProvider.CloudProviderName "nutanix" }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: default
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.nutanix.com
+parameters:
+  storageType: NutanixVolumes
+  csi.storage.k8s.io/provisioner-secret-name: ntnx-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/node-publish-secret-name: ntnx-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: kube-system
+  csi.storage.k8s.io/controller-expand-secret-name: ntnx-secret
+  csi.storage.k8s.io/controller-expand-secret-namespace: kube-system
+  storageContainer: {{ default "Default" .Params.storageContainer | quote }}
+  csi.storage.k8s.io/fstype: {{ default "xfs" .Params.fsType | quote }}
+  isSegmentedIscsiNetwork: {{ default "false" .Params.isSegmentedIscsiNetwork | quote }}
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+{{ end }}
+
 {{ if eq .Config.CloudProvider.CloudProviderName "hetzner" }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/examples/terraform/nutanix/main.tf
+++ b/examples/terraform/nutanix/main.tf
@@ -14,9 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-provider "nutanix" {
-  insecure = var.allow_insecure
-}
+provider "nutanix" {}
 
 data "nutanix_cluster" "cluster" {
   name = var.nutanix_cluster_name

--- a/examples/terraform/nutanix/variables.tf
+++ b/examples/terraform/nutanix/variables.tf
@@ -84,12 +84,6 @@ variable "bastion_user" {
 
 # Provider specific settings
 
-variable "allow_insecure" {
-  default     = false
-  description = "Allow insecure access to the Nutanix API"
-  type        = bool
-}
-
 variable "nutanix_cluster_name" {
   description = "Name of the Nutanix Cluster which will be used for this Kubernetes cluster"
   type        = string

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -81,7 +81,7 @@ type registryCredentialsContainer struct {
 func newAddonsApplier(s *state.State) (*applier, error) {
 	var localFS fs.FS
 
-	if s.Cluster.Addons.Enabled() {
+	if s.Cluster.Addons.Enabled() && s.Cluster.Addons.Path != "" {
 		addonsPath, err := s.Cluster.Addons.RelativePath(s.ManifestFilePath)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get addons path")

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -191,6 +191,9 @@ func ValidateCloudProviderSpec(p kubeone.CloudProviderSpec, fldPath *field.Path)
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("nutanix"), "only one provider can be used at the same time"))
 		}
 		providerFound = true
+		if p.External {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("external"), "external is not supported on nutanix clusters"))
+		}
 	}
 	if p.Openstack != nil {
 		if providerFound {

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -625,6 +625,14 @@ func TestValidateCloudProviderSpec(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			name: "Nutanix provider config with external enabled",
+			providerConfig: kubeone.CloudProviderSpec{
+				Nutanix:  &kubeone.NutanixSpec{},
+				External: true,
+			},
+			expectedError: true,
+		},
+		{
 			name: "OpenStack provider config without cloudConfig",
 			providerConfig: kubeone.CloudProviderSpec{
 				Openstack: &kubeone.OpenstackSpec{},

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -53,9 +53,12 @@ const (
 	NutanixPort                          = "NUTANIX_PORT"
 	NutanixUsername                      = "NUTANIX_USERNAME"
 	NutanixPassword                      = "NUTANIX_PASSWORD"
-	NutanixAllowInsecure                 = "NUTANIX_ALLOW_INSECURE"
+	NutanixInsecure                      = "NUTANIX_INSECURE"
 	NutanixProxyURL                      = "NUTANIX_PROXY_URL"
 	NutanixClusterName                   = "NUTANIX_CLUSTER_NAME"
+	NutanixPEEndpoint                    = "NUTANIX_PE_ENDPOINT"
+	NutanixPEUsername                    = "NUTANIX_PE_USERNAME"
+	NutanixPEPassword                    = "NUTANIX_PE_PASSWORD" //nolint:gosec
 	OpenStackAuthURL                     = "OS_AUTH_URL"
 	OpenStackDomainName                  = "OS_DOMAIN_NAME"
 	OpenStackPassword                    = "OS_PASSWORD"
@@ -102,9 +105,12 @@ var (
 		NutanixPort,
 		NutanixUsername,
 		NutanixPassword,
-		NutanixAllowInsecure,
+		NutanixInsecure,
 		NutanixProxyURL,
 		NutanixClusterName,
+		NutanixPEEndpoint,
+		NutanixPEUsername,
+		NutanixPEPassword,
 		OpenStackAuthURL,
 		OpenStackDomainName,
 		OpenStackPassword,
@@ -197,9 +203,12 @@ func ProviderCredentials(cloudProvider kubeone.CloudProviderSpec, credentialsFil
 			{Name: NutanixPort},
 			{Name: NutanixUsername},
 			{Name: NutanixPassword},
-			{Name: NutanixAllowInsecure},
+			{Name: NutanixInsecure},
 			{Name: NutanixProxyURL},
 			{Name: NutanixClusterName},
+			{Name: NutanixPEEndpoint},
+			{Name: NutanixPEUsername},
+			{Name: NutanixPEPassword},
 		}, nutanixValidationFunc)
 	case cloudProvider.Openstack != nil:
 		return credentialsFinder.parseCredentialVariables([]ProviderEnvironmentVariable{
@@ -373,7 +382,15 @@ func defaultValidationFunc(creds map[string]string) error {
 }
 
 func nutanixValidationFunc(creds map[string]string) error {
-	alwaysRequired := []string{NutanixEndpoint, NutanixPort, NutanixUsername, NutanixPassword}
+	alwaysRequired := []string{
+		NutanixEndpoint,
+		NutanixPort,
+		NutanixUsername,
+		NutanixPassword,
+		NutanixPEEndpoint,
+		NutanixPEUsername,
+		NutanixPEPassword,
+	}
 
 	for _, key := range alwaysRequired {
 		if v, ok := creds[key]; !ok || len(v) == 0 {

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -54,3 +54,7 @@ func MigrateToContainerd(cluster *kubeone.KubeOneCluster) (string, error) {
 
 	return Render(migrateToContainerdScriptTemplate, data)
 }
+
+func installISCSIAndNFS(cluster *kubeone.KubeOneCluster) bool {
+	return cluster.CloudProvider.Nutanix != nil
+}

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -62,7 +62,15 @@ sudo yum install -y \
 	ebtables \
 	socat \
 	iproute-tc \
+	{{- if .INSTALL_ISCSI_AND_NFS }}
+	iscsi-initiator-utils \
+	nfs-utils \
+	{{- end }}
 	rsync
+
+{{- if .INSTALL_ISCSI_AND_NFS }}
+sudo systemctl enable --now iscsid
+{{- end }}
 
 {{ if .INSTALL_DOCKER }}
 {{ template "yum-docker-ce" . }}
@@ -130,6 +138,7 @@ func KubeadmCentOS(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 		"FORCE":                  force,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
 	}
 
 	if err := containerruntime.UpdateDataMap(cluster, data); err != nil {
@@ -158,6 +167,7 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeone.KubeOneCluster) (string, error)
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
 	}
 
 	if err := containerruntime.UpdateDataMap(cluster, data); err != nil {
@@ -183,6 +193,7 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeone.KubeOneCluster) (string, er
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
 	}
 
 	if err := containerruntime.UpdateDataMap(cluster, data); err != nil {

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -49,7 +49,15 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--
 	curl \
 	gnupg \
 	lsb-release \
+	{{- if .INSTALL_ISCSI_AND_NFS }}
+	open-iscsi \
+	nfs-common \
+	{{- end }}
 	rsync
+
+{{- if .INSTALL_ISCSI_AND_NFS }}
+sudo systemctl enable --now iscsid
+{{- end }}
 
 {{- if .CONFIGURE_REPOSITORIES }}
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
@@ -127,6 +135,7 @@ func KubeadmDebian(cluster *kubeone.KubeOneCluster, force bool) (string, error) 
 		"FORCE":                  force,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
 	}
 
 	if err := containerruntime.UpdateDataMap(cluster, data); err != nil {
@@ -151,6 +160,7 @@ func UpgradeKubeadmAndCNIDebian(cluster *kubeone.KubeOneCluster) (string, error)
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
 	}
 
 	if err := containerruntime.UpdateDataMap(cluster, data); err != nil {
@@ -172,6 +182,7 @@ func UpgradeKubeletAndKubectlDebian(cluster *kubeone.KubeOneCluster) (string, er
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
 		"INSTALL_CONTAINERD":     cluster.ContainerRuntime.Containerd,
+		"INSTALL_ISCSI_AND_NFS":  installISCSIAndNFS(cluster),
 	}
 
 	if err := containerruntime.UpdateDataMap(cluster, data); err != nil {

--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -41,6 +41,12 @@ func withKubeVersion(ver string) genClusterOpts {
 	}
 }
 
+func withNutanixCloudProvider(cls *kubeone.KubeOneCluster) {
+	cls.CloudProvider = kubeone.CloudProviderSpec{
+		Nutanix: &kubeone.NutanixSpec{},
+	}
+}
+
 func withProxy(proxy string) genClusterOpts {
 	return func(cls *kubeone.KubeOneCluster) {
 		cls.Proxy.HTTPS = proxy
@@ -143,6 +149,12 @@ func TestKubeadmDebian(t *testing.T) {
 			name: "with containerd with insecure registry",
 			args: args{
 				cluster: genCluster(withContainerd, withInsecureRegistry("127.0.0.1:5000")),
+			},
+		},
+		{
+			name: "nutanix cluster",
+			args: args{
+				cluster: genCluster(withNutanixCloudProvider),
 			},
 		},
 	}
@@ -260,6 +272,12 @@ func TestKubeadmCentOS(t *testing.T) {
 			name: "with containerd with insecure registry",
 			args: args{
 				cluster: genCluster(withContainerd, withInsecureRegistry("127.0.0.1:5000")),
+			},
+		},
+		{
+			name: "nutanix cluster",
+			args: args{
+				cluster: genCluster(withNutanixCloudProvider),
 			},
 		},
 	}

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -1,0 +1,89 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+sudo swapoff -a
+sudo sed -i '/.*swap.*/d' /etc/fstab
+sudo setenforce 0 || true
+[ -f /etc/selinux/config ] && sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
+sudo systemctl disable --now firewalld || true
+
+source /etc/kubeone/proxy-env
+
+
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+ip_tables
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
+sudo modprobe ip_tables
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+yum_proxy=""
+yum_proxy="proxy=http://https.proxy #kubeone"
+
+grep -v '#kubeone' /etc/yum.conf > /tmp/yum.conf || true
+echo -n "${yum_proxy}" >> /tmp/yum.conf
+sudo mv /tmp/yum.conf /etc/yum.conf
+
+
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+
+
+sudo yum install -y \
+	yum-plugin-versionlock \
+	device-mapper-persistent-data \
+	lvm2 \
+	conntrack-tools \
+	ebtables \
+	socat \
+	iproute-tc \
+	iscsi-initiator-utils \
+	nfs-utils \
+	rsync
+sudo systemctl enable --now iscsid
+
+
+
+
+
+sudo yum install -y \
+	kubelet-1.17.4 \
+	kubeadm-1.17.4 \
+	kubectl-1.17.4 \
+	kubernetes-cni-0.8.7
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet
+

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -1,0 +1,86 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+
+sudo swapoff -a
+sudo sed -i '/.*swap.*/d' /etc/fstab
+sudo systemctl disable --now ufw || true
+
+source /etc/kubeone/proxy-env
+
+
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+ip_tables
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
+sudo modprobe ip_tables
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+sudo mkdir -p /etc/apt/apt.conf.d
+cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf
+Acquire::https::Proxy "http://https.proxy";
+Acquire::http::Proxy "http://http.proxy";
+EOF
+
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --option "Dpkg::Options::=--force-confold" -y --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	gnupg \
+	lsb-release \
+	open-iscsi \
+	nfs-common \
+	rsync
+sudo systemctl enable --now iscsid
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+
+# You'd think that kubernetes-$(lsb_release -sc) belongs there instead, but the debian repo
+# contains neither kubeadm nor kubelet, and the docs themselves suggest using xenial repo.
+echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+sudo apt-get update
+
+kube_ver="1.17.4*"
+cni_ver="0.8.7*"
+
+
+
+
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+	--option "Dpkg::Options::=--force-confold" \
+	--no-install-recommends \
+	-y \
+	kubelet=${kube_ver} \
+	kubeadm=${kube_ver} \
+	kubectl=${kube_ver} \
+	kubernetes-cni=${cni_ver}
+
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now kubelet
+sudo systemctl restart kubelet

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -152,7 +152,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:        {"*": "docker.io/calico/node:v3.19.1"},
 		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
 		Flannel:           {"*": "quay.io/coreos/flannel:v0.13.0"},
-		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.41.1"},
+		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.42.0"},
 		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
 	}
 }

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -114,6 +114,14 @@ const (
 	AzureDiskCSISnapshotter
 	AzureDiskCSISnapshotterController
 
+	// Nutanix CSI
+	NutanixCSILivenessProbe
+	NutanixCSI
+	NutanixCSIProvisioner
+	NutanixCSIRegistrar
+	NutanixCSIResizer
+	NutanixCSISnapshotter
+
 	// CCMs and CSI plugins
 	DigitaloceanCCM
 	HetznerCCM
@@ -259,6 +267,14 @@ func optionalResources() map[Resource]map[string]string {
 		VsphereCSIDriver:      {"*": "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.0"},
 		VsphereCSISyncer:      {"*": "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.0"},
 		VsphereCSIProvisioner: {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0"},
+
+		// Nutanix CSI
+		NutanixCSI:              {"*": "quay.io/karbon/ntnx-csi:v2.5.0"},
+		NutanixCSILivenessProbe: {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.3.0"},
+		NutanixCSIProvisioner:   {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"},
+		NutanixCSIRegistrar:     {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"},
+		NutanixCSIResizer:       {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.2.0"},
+		NutanixCSISnapshotter:   {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1"},
 
 		// WeaveNet CNI plugin
 		WeaveNetCNIKube: {"*": "docker.io/weaveworks/weave-kube:2.8.1"},

--- a/pkg/templates/images/resource_string.go
+++ b/pkg/templates/images/resource_string.go
@@ -57,21 +57,27 @@ func _() {
 	_ = x[AzureDiskCSIResizer-47]
 	_ = x[AzureDiskCSISnapshotter-48]
 	_ = x[AzureDiskCSISnapshotterController-49]
-	_ = x[DigitaloceanCCM-50]
-	_ = x[HetznerCCM-51]
-	_ = x[HetznerCSI-52]
-	_ = x[OpenstackCCM-53]
-	_ = x[OpenstackCSI-54]
-	_ = x[EquinixMetalCCM-55]
-	_ = x[VsphereCCM-56]
-	_ = x[VsphereCSIDriver-57]
-	_ = x[VsphereCSISyncer-58]
-	_ = x[VsphereCSIProvisioner-59]
+	_ = x[NutanixCSILivenessProbe-50]
+	_ = x[NutanixCSI-51]
+	_ = x[NutanixCSIProvisioner-52]
+	_ = x[NutanixCSIRegistrar-53]
+	_ = x[NutanixCSIResizer-54]
+	_ = x[NutanixCSISnapshotter-55]
+	_ = x[DigitaloceanCCM-56]
+	_ = x[HetznerCCM-57]
+	_ = x[HetznerCSI-58]
+	_ = x[OpenstackCCM-59]
+	_ = x[OpenstackCSI-60]
+	_ = x[EquinixMetalCCM-61]
+	_ = x[VsphereCCM-62]
+	_ = x[VsphereCSIDriver-63]
+	_ = x[VsphereCSISyncer-64]
+	_ = x[VsphereCSIProvisioner-65]
 }
 
-const _Resource_name = "CalicoCNICalicoControllerCalicoNodeFlannelCiliumCiliumOperatorHubbleRelayHubbleUIHubbleUIBackendHubbleProxyWeaveNetCNIKubeWeaveNetCNINPCDNSNodeCacheMachineControllerMetricsServerClusterAutoscalerCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeAwsCCMAzureCCMAzureCNMAwsEbsCSIAwsEbsCSIAttacherAwsEbsCSILivenessProbeAwsEbsCSINodeDriverRegistrarAwsEbsCSIProvisionerAwsEbsCSIResizerAwsEbsCSISnapshotterAwsEbsCSISnapshotControllerAzureFileCSIAzureFileCSIAttacherAzureFileCSILivenessProbeAzureFileCSINodeDriverRegistarAzureFileCSIProvisionerAzureFileCSIResizerAzureFileCSISnapshotterAzureFileCSISnapshotterControllerAzureDiskCSIAzureDiskCSIAttacherAzureDiskCSILivenessProbeAzureDiskCSINodeDriverRegistarAzureDiskCSIProvisionerAzureDiskCSIResizerAzureDiskCSISnapshotterAzureDiskCSISnapshotterControllerDigitaloceanCCMHetznerCCMHetznerCSIOpenstackCCMOpenstackCSIEquinixMetalCCMVsphereCCMVsphereCSIDriverVsphereCSISyncerVsphereCSIProvisioner"
+const _Resource_name = "CalicoCNICalicoControllerCalicoNodeFlannelCiliumCiliumOperatorHubbleRelayHubbleUIHubbleUIBackendHubbleProxyWeaveNetCNIKubeWeaveNetCNINPCDNSNodeCacheMachineControllerMetricsServerClusterAutoscalerCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeAwsCCMAzureCCMAzureCNMAwsEbsCSIAwsEbsCSIAttacherAwsEbsCSILivenessProbeAwsEbsCSINodeDriverRegistrarAwsEbsCSIProvisionerAwsEbsCSIResizerAwsEbsCSISnapshotterAwsEbsCSISnapshotControllerAzureFileCSIAzureFileCSIAttacherAzureFileCSILivenessProbeAzureFileCSINodeDriverRegistarAzureFileCSIProvisionerAzureFileCSIResizerAzureFileCSISnapshotterAzureFileCSISnapshotterControllerAzureDiskCSIAzureDiskCSIAttacherAzureDiskCSILivenessProbeAzureDiskCSINodeDriverRegistarAzureDiskCSIProvisionerAzureDiskCSIResizerAzureDiskCSISnapshotterAzureDiskCSISnapshotterControllerNutanixCSILivenessProbeNutanixCSINutanixCSIProvisionerNutanixCSIRegistrarNutanixCSIResizerNutanixCSISnapshotterDigitaloceanCCMHetznerCCMHetznerCSIOpenstackCCMOpenstackCSIEquinixMetalCCMVsphereCCMVsphereCSIDriverVsphereCSISyncerVsphereCSIProvisioner"
 
-var _Resource_index = [...]uint16{0, 9, 25, 35, 42, 48, 62, 73, 81, 96, 107, 122, 136, 148, 165, 178, 195, 206, 227, 241, 255, 265, 281, 287, 295, 303, 312, 329, 351, 379, 399, 415, 435, 462, 474, 494, 519, 549, 572, 591, 614, 647, 659, 679, 704, 734, 757, 776, 799, 832, 847, 857, 867, 879, 891, 906, 916, 932, 948, 969}
+var _Resource_index = [...]uint16{0, 9, 25, 35, 42, 48, 62, 73, 81, 96, 107, 122, 136, 148, 165, 178, 195, 206, 227, 241, 255, 265, 281, 287, 295, 303, 312, 329, 351, 379, 399, 415, 435, 462, 474, 494, 519, 549, 572, 591, 614, 647, 659, 679, 704, 734, 757, 776, 799, 832, 855, 865, 886, 905, 922, 943, 958, 968, 978, 990, 1002, 1017, 1027, 1043, 1059, 1080}
 
 func (i Resource) String() string {
 	i -= 1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:

* Add the Nutanix CSI driver addon. The addon is deployed manually, on-demand, by enabling the `csi-nutanix` embedded addon
  * The reason for not using `.cloudProvider.external` (like for other providers) is that Nutanix doesn't have an external CCM, so enabling `external` renders the cluster useless (there's no CCM to initialize nodes, so nodes remain tainted)
* Add the default StorageClass for the Nutanix CSI driver. The StorageClass can be deployed by enabling the `default-storage-class` embedded addon
  * Note: this StorageClass might get changed before the final release to support additional features
  * This addon can take the following parameters in order to customize the StorageClass: `storageContainer` (default is `Default`), `fsType` (default is `xfs`), `isSegmentedIscsiNetwork` (default is `false`)
* Add new environment variables used to provide endpoint and credentials for Prism Element: `NUTANIX_PE_ENDPOINT`, `NUTANIX_PE_USERNAME`, `NUTANIX_PE_PASSWORD`. Prism Element access is required by the Nutanix CSI driver
* Rename the `NUTANIX_ALLOW_INSECURE` environment variable to `NUTANIX_INSECURE`
* Remove the `allow_insecure` variable from Terraform configs for Nutanix in favor of the `NUTANIX_INSECURE` environment variable
* Forbid enabling `.cloudProvider.external` for Nutanix clusters because Nutanix doesn't have an external CCM that would initialize nodes
* Install and enable iscsid and NFS on Nutanix machines (required by the CSI driver)
* Update machine-controller to v1.42.0
* Fix a bug with the addons applier applying all files when addons path is not provided
* Fixes control plane tolerations in Azure CCM and CSI addons (`node-role.kubernetes.io/master` doesn't have a value)

However, this PR doesn't implement the snapshot controller and functionalities. This will be tackled in a follow-up. It's also yet to test this on newer Kubernetes versions.

The following KubeOneCluster manifest can be used on Nutanix clusters (params are optional and can be omitted if you want to use default values):

```yaml
apiVersion: kubeone.k8c.io/v1beta2
kind: KubeOneCluster
versions:
  kubernetes: 1.21.8
cloudProvider:
  nutanix: {}
addons:
  enable: true
  addons:
  - name: "csi-nutanix"
  - name: "default-storage-class"
    params:
      storageContainer: "Default"
      fsType: "xfs"
      isSegmentedIscsiNetwork: "false"
```

The following manifest has been used for testing:

```yaml
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: csi-pvc-ntnx
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: ntnx-csi
---
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - image: nginx
    imagePullPolicy: IfNotPresent
    name: nginx
    ports:
    - containerPort: 80
      protocol: TCP
    volumeMounts:
      - mountPath: /var/lib/www/html
        name: csi-data-ntnx
  volumes:
  - name: csi-data-ntnx
    persistentVolumeClaim:
      claimName: csi-pvc-ntnx
      readOnly: false
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1726

**Does this PR introduce a user-facing change?**:
```release-note
* Add the Nutanix CSI driver addon. The addon is deployed manually, on-demand, by enabling the `csi-nutanix` embedded addon (see the PR description for more details and examples)
* Add the default StorageClass for the Nutanix CSI driver. The StorageClass can be deployed by enabling the `default-storage-class` embedded addon (see the PR description for more details and examples)
* Add new environment variables used to provide endpoint and credentials for Prism Element: `NUTANIX_PE_ENDPOINT`, `NUTANIX_PE_USERNAME`, `NUTANIX_PE_PASSWORD`. Prism Element access is required by the Nutanix CSI driver
* Rename the `NUTANIX_ALLOW_INSECURE` environment variable to `NUTANIX_INSECURE`
* Remove the `allow_insecure` variable from Terraform configs for Nutanix in favor of the `NUTANIX_INSECURE` environment variable
* Forbid enabling `.cloudProvider.external` for Nutanix clusters because Nutanix doesn't have an external CCM that would initialize nodes
* Install and enable iscsid and NFS on Nutanix machines (required by the CSI driver)
* Update machine-controller to v1.42.0
* Fix a bug with the addons applier applying all files when addons path is not provided
* Fixes control plane tolerations in Azure CCM and CSI addons (`node-role.kubernetes.io/master` doesn't have a value)
```
