### PR TITLE
Add template function "required" for addons

### DIFF
--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -261,6 +261,19 @@ func txtFuncMap(overwriteRegistry string) template.FuncMap {
 		return registry
 	}
 
+	funcs["required"] = func(warn string, input interface{}) (interface{}, error) {
+		switch val := input.(type) {
+		case nil:
+			return val, fmt.Errorf(warn)
+		case string:
+			if val == "" {
+				return val, fmt.Errorf(warn)
+			}
+		}
+
+		return input, nil
+	}
+
 	funcs["caBundleEnvVar"] = func() (string, error) {
 		buf, err := yaml.Marshal([]corev1.EnvVar{cabundle.EnvVar()})
 		return string(buf), err

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scripts
 
 import (
-	"fmt"
 	"strings"
 	"text/template"
 
@@ -230,9 +229,6 @@ type Data map[string]interface{}
 func Render(cmd string, variables map[string]interface{}) (string, error) {
 	tpl := template.New("base").
 		Funcs(sprig.TxtFuncMap()).
-		Funcs(template.FuncMap{
-			"required": requiredTemplateFunc,
-		}).
 		Funcs(sprig.TxtFuncMap())
 
 	_, err := tpl.New("library").Parse(libraryTemplate)
@@ -262,17 +258,4 @@ func Render(cmd string, variables map[string]interface{}) (string, error) {
 	}
 
 	return buf.String(), nil
-}
-
-func requiredTemplateFunc(warn string, input interface{}) (interface{}, error) {
-	switch val := input.(type) {
-	case nil:
-		return val, fmt.Errorf(warn)
-	case string:
-		if val == "" {
-			return val, fmt.Errorf(warn)
-		}
-	}
-
-	return input, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Previously the template function "required" was only available for OS
template scripts, but not for addon manifest templates, which caused the
rendering of the built-in addon "backups-restic" to fail. Therefore the
"required" template function was moved into package "addons" and made
available to the addons manifest templates.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make template function "required" available to addon manifest templates
```
