### PR TITLE
Fix containerd migration on non-flatcar OS

### DIFF
--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -180,13 +180,15 @@ func TestMigrateToContainerd(t *testing.T) {
 		name             string
 		insecureRegistry string
 		mirrors          []string
+		osName           kubeone.OperatingSystemName
 		err              error
 	}{
 		{
 			name: "simple",
 		},
 		{
-			name: "flatcat",
+			name:   "flatcar",
+			osName: kubeone.OperatingSystemNameFlatcar,
 		},
 		{
 			name:             "insecureRegistry",
@@ -202,7 +204,7 @@ func TestMigrateToContainerd(t *testing.T) {
 				withContainerd,
 			)
 
-			got, err := MigrateToContainerd(&cls)
+			got, err := MigrateToContainerd(&cls, &kubeone.HostConfig{OperatingSystem: tt.osName})
 			if err != tt.err {
 				t.Errorf("MigrateToContainerd() error = %v, wantErr %v", err, tt.err)
 				return

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -200,14 +200,7 @@ var (
 
 		"flatcar-containerd": heredoc.Doc(`
 			{{ template "container-runtime-daemon-config" . }}
-			sudo mkdir -p /etc/systemd/system/containerd.service.d
-			cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
-			[Service]
-			Restart=always
-			Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
-			ExecStart=
-			ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
-			EOF
+			{{ template "flatcar-systemd-drop-in" . }}
 			{{ template "containerd-systemd-setup" . }}
 			`,
 		),
@@ -220,6 +213,17 @@ var (
 			sudo systemctl restart docker
 			`,
 		),
+
+		"flatcar-systemd-drop-in": heredoc.Doc(`
+			sudo mkdir -p /etc/systemd/system/containerd.service.d
+			cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
+			[Service]
+			Restart=always
+			Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
+			ExecStart=
+			ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+			EOF
+		`),
 	}
 )
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -98,6 +98,7 @@ Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
 ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
 EOF
+
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]

--- a/pkg/scripts/testdata/TestMigrateToContainerd-flatcar.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-flatcar.golden
@@ -33,6 +33,13 @@ runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
+[Service]
+Restart=always
+EnvironmentFile=-/etc/environment
+EOF
+
+sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 [Service]
 Restart=always
@@ -40,6 +47,7 @@ Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
 ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
 EOF
+
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]
@@ -50,5 +58,4 @@ EOF
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd
-
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestMigrateToContainerd-insecureRegistry.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-insecureRegistry.golden
@@ -35,13 +35,12 @@ runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]
 Restart=always
-Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
-ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+EnvironmentFile=-/etc/environment
 EOF
+
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]
@@ -52,5 +51,4 @@ EOF
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd
-
 sudo systemctl restart kubelet

--- a/pkg/scripts/testdata/TestMigrateToContainerd-simple.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-simple.golden
@@ -33,13 +33,12 @@ runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]
 Restart=always
-Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
-ExecStart=
-ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+EnvironmentFile=-/etc/environment
 EOF
+
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
 [Service]
@@ -50,5 +49,4 @@ EOF
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd
-
 sudo systemctl restart kubelet

--- a/pkg/tasks/containerd.go
+++ b/pkg/tasks/containerd.go
@@ -100,7 +100,7 @@ func migrateToContainerdTask(s *state.State, node *kubeone.HostConfig, conn ssh.
 		return err
 	}
 
-	migrateScript, err := scripts.MigrateToContainerd(s.Cluster)
+	migrateScript, err := scripts.MigrateToContainerd(s.Cluster, node)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
After refactoring the bug was introduced such that flatcar specific binaries been used on non-flatcar OSes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1742

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix containerd migration on non-flatcar OS
```
