### PR TITLE
Force static manifests render on upgrade

### DIFF
--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -57,8 +57,8 @@ var (
 		sudo rm -rf /etc/kubeone
 	`)
 
-	kubeadmUpgradeLeaderScriptTemplate = heredoc.Doc(`
-		sudo {{ .KUBEADM_UPGRADE }} --config={{ .WORK_DIR }}/cfg/master_0.yaml
+	kubeadmUpgradeScriptTemplate = heredoc.Doc(`
+		sudo {{ .KUBEADM_UPGRADE }}{{ if .LEADER }} --config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml{{ end }}
 	`)
 
 	kubeadmPauseImageVersionScriptTemplate = heredoc.Doc(`
@@ -110,10 +110,12 @@ func KubeadmReset(verboseFlag, workdir string) (string, error) {
 	})
 }
 
-func KubeadmUpgradeLeader(kubeadmCmd, workdir string) (string, error) {
-	return Render(kubeadmUpgradeLeaderScriptTemplate, map[string]interface{}{
+func KubeadmUpgrade(kubeadmCmd, workdir string, leader bool, nodeID int) (string, error) {
+	return Render(kubeadmUpgradeScriptTemplate, map[string]interface{}{
 		"KUBEADM_UPGRADE": kubeadmCmd,
 		"WORK_DIR":        workdir,
+		"NODE_ID":         nodeID,
+		"LEADER":          leader,
 	})
 }
 

--- a/pkg/scripts/kubeadm_test.go
+++ b/pkg/scripts/kubeadm_test.go
@@ -245,12 +245,13 @@ func TestKubeadmReset(t *testing.T) {
 	}
 }
 
-func TestKubeadmUpgradeLeader(t *testing.T) {
+func TestKubeadmUpgrade(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
 		kubeadmCmd string
 		workdir    string
+		leader     bool
 	}
 	tests := []struct {
 		name string
@@ -261,7 +262,15 @@ func TestKubeadmUpgradeLeader(t *testing.T) {
 			name: "v1beta2",
 			args: args{
 				workdir:    "test-wd",
-				kubeadmCmd: "kubeadm upgrade node --certificate-renewal=true",
+				kubeadmCmd: "kubeadm upgrade node",
+			},
+		},
+		{
+			name: "leader",
+			args: args{
+				workdir:    "some",
+				kubeadmCmd: "kubeadm upgrade apply -y --certificate-renewal=true v1.1.1",
+				leader:     true,
 			},
 		},
 	}
@@ -269,7 +278,7 @@ func TestKubeadmUpgradeLeader(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := KubeadmUpgradeLeader(tt.args.kubeadmCmd, tt.args.workdir)
+			got, err := KubeadmUpgrade(tt.args.kubeadmCmd, tt.args.workdir, tt.args.leader, 0)
 			if err != tt.err {
 				t.Errorf("KubeadmUpgradeLeader() error = %v, wantErr %v", err, tt.err)
 				return

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -34,7 +34,6 @@ var migrateToContainerdScriptTemplate = heredoc.Doc(`
 	sudo docker ps -qa | xargs sudo docker rm || true
 
 	{{ template "container-runtime-daemon-config" . }}
-	{{ template "containerd-systemd-environment" . }}
 	{{ if .IS_FLATCAR -}}
 	{{ template "flatcar-systemd-drop-in" . }}
 	{{ end -}}

--- a/pkg/scripts/proxy_test.go
+++ b/pkg/scripts/proxy_test.go
@@ -81,10 +81,10 @@ func TestEnvironmentFile(t *testing.T) {
 	}
 }
 
-func TestDaemonsProxy(t *testing.T) {
+func TestTestDaemonsProxy(t *testing.T) {
 	t.Parallel()
 
-	got, err := DaemonsProxy()
+	got, err := DaemonsEnvironmentDropIn("docker", "containerd", "kubelet")
 	if err != nil {
 		t.Errorf("DaemonsProxy() error = %v", err)
 		return

--- a/pkg/scripts/render.go
+++ b/pkg/scripts/render.go
@@ -44,17 +44,7 @@ var (
 			{{- end }}
 		`),
 
-		"containerd-systemd-environment": heredoc.Doc(`
-			sudo mkdir -p /etc/systemd/system/containerd.service.d
-			cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-			[Service]
-			Restart=always
-			EnvironmentFile=-/etc/environment
-			EOF
-		`),
-
 		"containerd-systemd-setup": heredoc.Doc(`
-			{{ template "containerd-systemd-environment" . }}
 			sudo systemctl daemon-reload
 			sudo systemctl enable containerd
 			sudo systemctl restart containerd
@@ -207,7 +197,6 @@ var (
 
 		"flatcar-docker": heredoc.Doc(`
 			{{ template "container-runtime-daemon-config" . }}
-			{{ template "containerd-systemd-environment" . }}
 			sudo systemctl daemon-reload
 			sudo systemctl enable --now docker
 			sudo systemctl restart docker

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -96,13 +96,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -96,13 +96,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -99,13 +99,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -96,13 +96,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -96,13 +96,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -96,13 +96,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -104,13 +104,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -106,13 +106,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -102,13 +102,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -102,13 +102,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -105,13 +105,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -102,13 +102,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -102,13 +102,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -102,13 +102,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -110,13 +110,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -112,13 +112,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -104,13 +104,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -107,13 +107,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -104,13 +104,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -106,13 +106,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -108,13 +108,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -80,13 +80,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl restart docker

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -80,13 +80,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl restart docker

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -83,13 +83,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl restart docker

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -80,13 +80,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable --now docker
 sudo systemctl restart docker

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -99,13 +99,6 @@ ExecStart=
 ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestKubeadmUpgrade-leader.golden
+++ b/pkg/scripts/testdata/TestKubeadmUpgrade-leader.golden
@@ -1,0 +1,3 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+sudo kubeadm upgrade apply -y --certificate-renewal=true v1.1.1 --config=some/cfg/master_0.yaml

--- a/pkg/scripts/testdata/TestKubeadmUpgrade-v1beta2.golden
+++ b/pkg/scripts/testdata/TestKubeadmUpgrade-v1beta2.golden
@@ -1,0 +1,3 @@
+set -xeu pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+sudo kubeadm upgrade node

--- a/pkg/scripts/testdata/TestKubeadmUpgradeLeader-v1beta2.golden
+++ b/pkg/scripts/testdata/TestKubeadmUpgradeLeader-v1beta2.golden
@@ -1,3 +1,0 @@
-set -xeu pipefail
-export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
-sudo kubeadm upgrade node --certificate-renewal=true --config=test-wd/cfg/master_0.yaml

--- a/pkg/scripts/testdata/TestMigrateToContainerd-flatcar.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-flatcar.golden
@@ -33,26 +33,12 @@ runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
 sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
-sudo mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
 [Service]
 Restart=always
 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
 ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
-EOF
-
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
 EOF
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestMigrateToContainerd-insecureRegistry.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-insecureRegistry.golden
@@ -34,20 +34,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestMigrateToContainerd-simple.golden
+++ b/pkg/scripts/testdata/TestMigrateToContainerd-simple.golden
@@ -32,20 +32,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestTestDaemonsProxy.golden
+++ b/pkg/scripts/testdata/TestTestDaemonsProxy.golden
@@ -19,3 +19,7 @@ cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/http-proxy.conf
 EnvironmentFile=/etc/environment
 EOF
 
+sudo systemctl daemon-reload
+if sudo systemctl status docker &>/dev/null; then sudo systemctl restart docker; fi
+if sudo systemctl status containerd &>/dev/null; then sudo systemctl restart containerd; fi
+if sudo systemctl status kubelet &>/dev/null; then sudo systemctl restart kubelet; fi

--- a/pkg/scripts/testdata/TestTestDaemonsProxy.golden
+++ b/pkg/scripts/testdata/TestTestDaemonsProxy.golden
@@ -4,15 +4,18 @@ export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 sudo mkdir -p /etc/systemd/system/docker.service.d
 cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/http-proxy.conf
 [Service]
-EnvironmentFile=/etc/kubeone/proxy-env
+EnvironmentFile=/etc/environment
+EOF
+
+sudo mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/http-proxy.conf
+[Service]
+EnvironmentFile=/etc/environment
 EOF
 
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/http-proxy.conf
 [Service]
-EnvironmentFile=/etc/kubeone/proxy-env
+EnvironmentFile=/etc/environment
 EOF
 
-sudo systemctl daemon-reload
-if sudo systemctl status docker &>/dev/null; then sudo systemctl restart docker; fi
-if sudo systemctl status kubelet &>/dev/null; then sudo systemctl restart kubelet; fi

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -96,13 +96,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -102,13 +102,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -105,13 +105,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -96,13 +96,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -102,13 +102,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -105,13 +105,6 @@ cat <<EOF | sudo tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 EOF
 
-sudo mkdir -p /etc/systemd/system/containerd.service.d
-cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/environment.conf
-[Service]
-Restart=always
-EnvironmentFile=-/etc/environment
-EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable containerd
 sudo systemctl restart containerd

--- a/pkg/tasks/kubeadm_upgrade.go
+++ b/pkg/tasks/kubeadm_upgrade.go
@@ -24,13 +24,13 @@ import (
 	"k8c.io/kubeone/pkg/templates/kubeadm"
 )
 
-func upgradeLeaderControlPlane(s *state.State) error {
+func upgradeLeaderControlPlane(s *state.State, nodeID int) error {
 	kadm, err := kubeadm.New(s.Cluster.Versions.Kubernetes)
 	if err != nil {
 		return errors.Wrap(err, "failed to init kubeadm")
 	}
 
-	cmd, err := scripts.KubeadmUpgradeLeader(kadm.UpgradeLeaderCommand(), s.WorkDir)
+	cmd, err := scripts.KubeadmUpgrade(kadm.UpgradeLeaderCommand(), s.WorkDir, true, nodeID)
 	if err != nil {
 		return err
 	}
@@ -40,13 +40,18 @@ func upgradeLeaderControlPlane(s *state.State) error {
 	return err
 }
 
-func upgradeFollowerControlPlane(s *state.State) error {
+func upgradeFollowerControlPlane(s *state.State, nodeID int) error {
 	kadm, err := kubeadm.New(s.Cluster.Versions.Kubernetes)
 	if err != nil {
 		return errors.Wrap(err, "failed to init kubadm")
 	}
 
-	_, _, err = s.Runner.Run(`sudo `+kadm.UpgradeFollowerCommand(), nil)
+	cmd, err := scripts.KubeadmUpgrade(kadm.UpgradeFollowerCommand(), s.WorkDir, false, nodeID)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = s.Runner.RunRaw(cmd)
 	return err
 }
 

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/scripts"
@@ -85,18 +86,27 @@ func generateConfigurationFiles(s *state.State) error {
 func installPrerequisitesOnNode(s *state.State, node *kubeoneapi.HostConfig, _ ssh.Connection) error {
 	logger := s.Logger.WithField("os", node.OperatingSystem)
 
+	err := setupProxy(logger, s)
+	if err != nil {
+		return err
+	}
+
+	logger.Infoln("Installing kubeadm...")
+	return errors.Wrap(installKubeadm(s, *node), "failed to install kubeadm")
+}
+
+func setupProxy(logger *logrus.Entry, s *state.State) error {
 	logger.Infoln("Creating environment file...")
 	if err := createEnvironmentFile(s); err != nil {
 		return errors.Wrap(err, "failed to create environment file")
 	}
 
 	logger.Infoln("Configuring proxy...")
-	if err := configureProxy(s); err != nil {
+	if err := containerRuntimeEnvironment(s); err != nil {
 		return errors.Wrap(err, "failed to configure proxy for docker daemon")
 	}
 
-	logger.Infoln("Installing kubeadm...")
-	return errors.Wrap(installKubeadm(s, *node), "failed to install kubeadm")
+	return nil
 }
 
 func createEnvironmentFile(s *state.State) error {
@@ -250,13 +260,13 @@ func uploadConfigurationFilesToNode(s *state.State, _ *kubeoneapi.HostConfig, co
 	return nil
 }
 
-func configureProxy(s *state.State) error {
+func containerRuntimeEnvironment(s *state.State) error {
 	if s.Cluster.Proxy.HTTP == "" && s.Cluster.Proxy.HTTPS == "" && s.Cluster.Proxy.NoProxy == "" {
 		return nil
 	}
 
-	s.Logger.Infoln("Configuring docker/kubelet proxy...")
-	cmd, err := scripts.DaemonsProxy()
+	s.Logger.Infoln("Configuring docker/containerd/kubelet environment...")
+	cmd, err := scripts.DaemonsEnvironmentDropIn("docker", "containerd", "kubelet")
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/upgrade_follower.go
+++ b/pkg/tasks/upgrade_follower.go
@@ -51,13 +51,17 @@ func upgradeFollowerExecutor(s *state.State, node *kubeoneapi.HostConfig, conn s
 		return errors.Wrap(err, "failed to drain follower control plane node")
 	}
 
+	if err := setupProxy(logger, s); err != nil {
+		return err
+	}
+
 	logger.Infoln("Upgrading Kubernetes binaries on follower control plane...")
 	if err := upgradeKubeadmAndCNIBinaries(s, *node); err != nil {
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on follower control plane")
 	}
 
 	logger.Infoln("Running 'kubeadm upgrade' on the follower control plane node...")
-	if err := upgradeFollowerControlPlane(s); err != nil {
+	if err := upgradeFollowerControlPlane(s, node.ID); err != nil {
 		return errors.Wrap(err, "failed to upgrade follower control plane")
 	}
 

--- a/pkg/tasks/upgrade_leader.go
+++ b/pkg/tasks/upgrade_leader.go
@@ -51,13 +51,17 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 		return errors.Wrap(err, "failed to drain follower control plane node")
 	}
 
+	if err := setupProxy(logger, s); err != nil {
+		return err
+	}
+
 	logger.Infoln("Upgrading kubeadm binary on the leader control plane...")
 	if err := upgradeKubeadmAndCNIBinaries(s, *node); err != nil {
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on leader control plane")
 	}
 
 	logger.Infoln("Running 'kubeadm upgrade' on leader control plane node...")
-	if err := upgradeLeaderControlPlane(s); err != nil {
+	if err := upgradeLeaderControlPlane(s, node.ID); err != nil {
 		return errors.Wrap(err, "failed to run 'kubeadm upgrade' on leader control plane")
 	}
 

--- a/pkg/tasks/upgrade_static_workers.go
+++ b/pkg/tasks/upgrade_static_workers.go
@@ -53,6 +53,10 @@ func upgradeStaticWorkersExecutor(s *state.State, node *kubeoneapi.HostConfig, c
 		return errors.Wrap(err, "failed to drain follower control plane node")
 	}
 
+	if err := setupProxy(logger, s); err != nil {
+		return err
+	}
+
 	logger.Infoln("Upgrading Kubernetes binaries on static worker node...")
 	if err := upgradeKubeadmAndCNIBinaries(s, *node); err != nil {
 		return errors.Wrap(err, "failed to upgrade kubernetes binaries on static worker node")


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix proxy settings rendering when running kubeone upgrade --force (or apply --force-upgrade).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1749 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Force static manifests render on upgrade
```
