### PR TITLE
Update DigitalOcean and Hetzner CCMs

### DIFF
--- a/addons/ccm-digitalocean/ccm-digitalocean.yaml
+++ b/addons/ccm-digitalocean/ccm-digitalocean.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       dnsPolicy: Default
+      hostNetwork: true
       serviceAccountName: cloud-controller-manager
       tolerations:
         # this taint is set by all kubelets running `--cloud-provider=external`

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -233,10 +233,10 @@ func optionalResources() map[Resource]map[string]string {
 		AzureDiskCSISnapshotterController: {"*": "mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v3.0.3"},
 
 		// DigitalOcean CCM
-		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.33"},
+		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.36"},
 
 		// Hetzner CCM
-		HetznerCCM: {"*": "docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.12.0"},
+		HetznerCCM: {"*": "docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.12.1"},
 
 		// Hetzner CSI
 		HetznerCSI: {"*": "docker.io/hetznercloud/hcloud-csi-driver:1.6.0"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Update DigitalOcean and Hetzner CCMs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1685

**Does this PR introduce a user-facing change?**:
```release-note
Update the DigitalOcean External Cloud Controller Manager (CCM) to v0.1.36
Update the Hetzner External Cloud Controller Manager (CCM) to v1.12.1
```
