### PR TITLE
Add placement_group to Hetzner terraform

### DIFF
--- a/examples/terraform/hetzner/main.tf
+++ b/examples/terraform/hetzner/main.tf
@@ -98,12 +98,22 @@ resource "hcloud_server_network" "control_plane" {
   subnet_id = hcloud_network_subnet.kubeone.id
 }
 
+resource "hcloud_placement_group" "control_plane" {
+  name = var.cluster_name
+  type = "spread"
+
+  labels = {
+    "kubeone_cluster_name" = var.cluster_name
+  }
+}
+
 resource "hcloud_server" "control_plane" {
   count       = var.control_plane_replicas
   name        = "${var.cluster_name}-control-plane-${count.index + 1}"
   server_type = var.control_plane_type
   image       = var.image
   location    = var.datacenter
+  placement_group_id = hcloud_placement_group.control_plane.id
 
   ssh_keys = [
     hcloud_ssh_key.kubeone.id,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Hetzner API supports a [placement group](https://docs.hetzner.com/cloud/placement-groups/overview/) feature which could be used to ensure that certain VMs are not running on the same virtual machine.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
If you think that this setting is useful please tell me. I could open a PR to implement this for worker nodes in machine-controller too.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
