### PR TITLE
Use semver constraints on Kubernetes version for upper and lower bounds

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -40,6 +40,11 @@ const (
 	upperVersionConstraint = "<= 1.23"
 )
 
+var (
+	lowerConstraint = mustParseConstraint(lowerVersionConstraint)
+	upperConstraint = mustParseConstraint(upperVersionConstraint)
+)
+
 // ValidateKubeOneCluster validates the KubeOneCluster object
 func ValidateKubeOneCluster(c kubeoneapi.KubeOneCluster) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -263,20 +268,6 @@ func ValidateVersionConfig(version kubeoneapi.VersionConfig, fldPath *field.Path
 
 	if strings.HasPrefix(version.Kubernetes, "v") {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, ".versions.kubernetes can't start with a leading 'v'"))
-	}
-
-	lowerConstraint, err := semver.NewConstraint(lowerVersionConstraint)
-	if err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath.Child("kubernetes"), fmt.Errorf("failed to parse constraint: %w", err)))
-
-		return allErrs
-	}
-
-	upperConstraint, err := semver.NewConstraint(upperVersionConstraint)
-	if err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath.Child("kubernetes"), fmt.Errorf("failed to parse constraint: %w", err)))
-
-		return allErrs
 	}
 
 	if valid, errs := lowerConstraint.Validate(v); !valid {
@@ -648,4 +639,12 @@ func ValidateAssetConfiguration(a *kubeoneapi.AssetConfiguration, fldPath *field
 	}
 
 	return allErrs
+}
+
+func mustParseConstraint(constraint string) *semver.Constraints {
+	result, err := semver.NewConstraint(constraint)
+	if err != nil {
+		panic(err)
+	}
+	return result
 }

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -268,6 +268,7 @@ func ValidateVersionConfig(version kubeoneapi.VersionConfig, fldPath *field.Path
 	lowerConstraint, err := semver.NewConstraint(lowerVersionConstraint)
 	if err != nil {
 		allErrs = append(allErrs, field.InternalError(fldPath.Child("kubernetes"), fmt.Errorf("failed to parse constraint: %w", err)))
+
 		return allErrs
 	}
 
@@ -277,16 +278,24 @@ func ValidateVersionConfig(version kubeoneapi.VersionConfig, fldPath *field.Path
 		for _, err := range errs {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("kubernetes"), fmt.Errorf("failed to validate version against constraint: %w", err)))
 		}
+
 		return allErrs
 	}
 
 	upperConstraint, err := semver.NewConstraint(upperVersionConstraint)
+	if err != nil {
+		allErrs = append(allErrs, field.InternalError(fldPath.Child("kubernetes"), fmt.Errorf("failed to parse constraint: %w", err)))
+
+		return allErrs
+	}
+
 	if ok, errs := upperConstraint.Validate(v); len(errs) == 0 && !ok {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, fmt.Sprintf("kubernetes version does not satisfy version constraint '%s'. This version is not yet supported. Please refer to the Compatibility section of docs for more details.", upperVersionConstraint)))
 	} else if len(errs) > 0 {
 		for _, err := range errs {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("kubernetes"), fmt.Errorf("failed to validate version against constraint: %w", err)))
 		}
+
 		return allErrs
 	}
 

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -646,5 +646,6 @@ func mustParseConstraint(constraint string) *semver.Constraints {
 	if err != nil {
 		panic(err)
 	}
+
 	return result
 }

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -715,6 +715,13 @@ func TestValidateVersionConfig(t *testing.T) {
 		expectedError bool
 	}{
 		{
+			name: "valid version config (1.23.1)",
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.23.1",
+			},
+			expectedError: false,
+		},
+		{
 			name: "valid version config (1.22.1)",
 			versionConfig: kubeoneapi.VersionConfig{
 				Kubernetes: "1.22.1",
@@ -757,11 +764,18 @@ func TestValidateVersionConfig(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "valid version config (1.19.0)",
+			name: "not supported kubernetes version (1.24.0)",
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.24.0",
+			},
+			expectedError: true,
+		},
+		{
+			name: "not supported kubernetes version (1.19.0)",
 			versionConfig: kubeoneapi.VersionConfig{
 				Kubernetes: "1.19.0",
 			},
-			expectedError: false,
+			expectedError: true,
 		},
 		{
 			name: "not supported kubernetes version (1.18.19)",

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -764,16 +764,16 @@ func TestValidateVersionConfig(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "valid version config (1.19.0)",
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.19.0",
+			},
+			expectedError: false,
+		},
+		{
 			name: "not supported kubernetes version (1.24.0)",
 			versionConfig: kubeoneapi.VersionConfig{
 				Kubernetes: "1.24.0",
-			},
-			expectedError: true,
-		},
-		{
-			name: "not supported kubernetes version (1.19.0)",
-			versionConfig: kubeoneapi.VersionConfig{
-				Kubernetes: "1.19.0",
 			},
 			expectedError: true,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This adds validation against two semver constraints that can easily be bumped from the top of the file when adding new Kubernetes versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1807

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Validate Kubernetes version against supported versions constraints
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>