### PR TITLE
Control Plan Count Variable `control_plane_vm_count` addition to variables.tf for AWS

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -276,7 +276,7 @@ resource "aws_iam_role_policy" "policy" {
 ############################ CONTROL PLANE INSTANCES ###########################
 
 resource "aws_instance" "control_plane" {
-  count                  = 3
+  count                  = var.control_plane_vm_count
   instance_type          = var.control_plane_type
   iam_instance_profile   = aws_iam_instance_profile.profile.name
   ami                    = local.ami

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -218,3 +218,9 @@ variable "worker_deploy_ssh_key" {
   default     = true
   type        = bool
 }
+
+variable "control_plane_vm_count" {
+  description = "Number of control plane instances"
+  default     = 3
+  type        = number
+}


### PR DESCRIPTION
Signed-off-by: archups <archupsawant@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
```
To handle Control Plane count via terraform variables for AWS and refer to this variable value instead of the hardcoded count = 3 in the main.tf
```


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
