### PR TITLE
AWS: install csi driver if k8s >1.23 even if cloud.external=false

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -28,6 +28,7 @@ import (
 
 	"k8c.io/kubeone/pkg/addons"
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
+	"k8c.io/kubeone/pkg/semverutil"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -41,8 +42,8 @@ const (
 )
 
 var (
-	lowerConstraint = mustParseConstraint(lowerVersionConstraint)
-	upperConstraint = mustParseConstraint(upperVersionConstraint)
+	lowerConstraint = semverutil.MustParseConstraint(lowerVersionConstraint)
+	upperConstraint = semverutil.MustParseConstraint(upperVersionConstraint)
 )
 
 // ValidateKubeOneCluster validates the KubeOneCluster object
@@ -639,13 +640,4 @@ func ValidateAssetConfiguration(a *kubeoneapi.AssetConfiguration, fldPath *field
 	}
 
 	return allErrs
-}
-
-func mustParseConstraint(constraint string) *semver.Constraints {
-	result, err := semver.NewConstraint(constraint)
-	if err != nil {
-		panic(err)
-	}
-
-	return result
 }

--- a/pkg/semverutil/helper.go
+++ b/pkg/semverutil/helper.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package semverutil
+
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
+func MustParseConstraint(constraint string) *semver.Constraints {
+	result, err := semver.NewConstraint(constraint)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
since k8s 1.23 `CSIMigrationAWS`  flag is turned on by default and require installation of AWS EBS CSI driver even if we don't use external ccm (kubernetes/kubernetes#106098)

This pr install CSI driver for AWS if `k8S >= 1.23` even if `cloud.external=false`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1814 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
