### PR TITLE
Update terraform provider version for openstack to 1.47.0

### DIFF
--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -111,7 +111,7 @@ variable "image" {
 variable "image_properties_query" {
   default = {
     os_distro  = "ubuntu"
-    os_version = "18.04"
+    os_version = "20.04"
   }
   description = "in absense of var.image, this will be used to query API for the image"
   type        = map(any)

--- a/examples/terraform/openstack/versions.tf
+++ b/examples/terraform/openstack/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "~> 1.35.0"
+      version = "~> 1.47.0"
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Update terraform provider for OpenStack to 1.47.0. The current version `v1.35.0` doesn't have a package available for  `darwin/arm64` which can be a nuisance for our end users.

This PR also updates the default image for OpenStack to `Ubuntu 20.04` as I don't see any reason to still use 18.04. Worker nodes provisioned using machine-controller also use 20.04 as default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Update terraform provider for OpenStack to version 1.47.0
* Set Ubuntu 20.04 as the default image for OpenStack
```

Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>
