### PR TITLE
[release/v1.3] Use semver constraints on Kubernetes version for upper and lower bounds (#1808)

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"bytes"
 	"crypto/x509"
+	"fmt"
 	"net"
 	"reflect"
 	"strings"
@@ -34,7 +35,7 @@ const (
 	// lowerVersionConstraint defines a semver constraint that validates Kubernetes versions against a lower bound
 	lowerVersionConstraint = ">= 1.19"
 	// upperVersionConstraint defines a semver constraint that validates Kubernetes versions against an upper bound
-	upperVersionConstraint = "<= 1.23"
+	upperVersionConstraint = "<= 1.22"
 )
 
 var (

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -30,6 +30,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+const (
+	// lowerVersionConstraint defines a semver constraint that validates Kubernetes versions against a lower bound
+	lowerVersionConstraint = ">= 1.19"
+	// upperVersionConstraint defines a semver constraint that validates Kubernetes versions against an upper bound
+	upperVersionConstraint = "<= 1.23"
+)
+
+var (
+	lowerConstraint = mustParseConstraint(lowerVersionConstraint)
+	upperConstraint = mustParseConstraint(upperVersionConstraint)
+)
+
 // ValidateKubeOneCluster validates the KubeOneCluster object
 func ValidateKubeOneCluster(c kubeone.KubeOneCluster) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -183,11 +195,21 @@ func ValidateVersionConfig(version kubeone.VersionConfig, fldPath *field.Path) f
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, ".versions.kubernetes is not a semver string"))
 		return allErrs
 	}
-	if v.Major() != 1 || v.Minor() < 19 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, "kubernetes versions lower than 1.19 are not supported. You need to use an older KubeOne version to upgrade your cluster to v1.19. Please refer to the Compatibility section of docs for more details."))
-	}
+
 	if strings.HasPrefix(version.Kubernetes, "v") {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, ".versions.kubernetes can't start with a leading 'v'"))
+	}
+
+	if valid, errs := lowerConstraint.Validate(v); !valid {
+		for _, err := range errs {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, fmt.Sprintf("kubernetes version does not satisfy version constraint '%s': %s. You need to use an older KubeOne version to upgrade your cluster to a supported version. Please refer to the Compatibility section of docs for more details.", lowerVersionConstraint, err.Error())))
+		}
+	}
+
+	if valid, errs := upperConstraint.Validate(v); !valid {
+		for _, err := range errs {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes"), version, fmt.Sprintf("kubernetes version does not satisfy version constraint '%s': %s. This version is not yet supported. Please refer to the Compatibility section of docs for more details.", upperVersionConstraint, err.Error())))
+		}
 	}
 
 	return allErrs
@@ -515,4 +537,13 @@ func ValidateAssetConfiguration(a *kubeone.AssetConfiguration, fldPath *field.Pa
 	}
 
 	return allErrs
+}
+
+func mustParseConstraint(constraint string) *semver.Constraints {
+	result, err := semver.NewConstraint(constraint)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
 }

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -630,6 +630,13 @@ func TestValidateVersionConfig(t *testing.T) {
 		expectedError bool
 	}{
 		{
+			name: "valid version config (1.23.1)",
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.23.1",
+			},
+			expectedError: false,
+		},
+		{
 			name: "valid version config (1.22.1)",
 			versionConfig: kubeone.VersionConfig{
 				Kubernetes: "1.22.1",
@@ -677,6 +684,13 @@ func TestValidateVersionConfig(t *testing.T) {
 				Kubernetes: "1.19.0",
 			},
 			expectedError: false,
+		},
+		{
+			name: "not supported kubernetes version (1.24.0)",
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.24.0",
+			},
+			expectedError: true,
 		},
 		{
 			name: "not supported kubernetes version (1.18.19)",

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -630,13 +630,6 @@ func TestValidateVersionConfig(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name: "valid version config (1.23.1)",
-			versionConfig: kubeoneapi.VersionConfig{
-				Kubernetes: "1.23.1",
-			},
-			expectedError: false,
-		},
-		{
 			name: "valid version config (1.22.1)",
 			versionConfig: kubeone.VersionConfig{
 				Kubernetes: "1.22.1",
@@ -687,22 +680,15 @@ func TestValidateVersionConfig(t *testing.T) {
 		},
 		{
 			name: "not supported kubernetes version (1.24.0)",
-			versionConfig: kubeoneapi.VersionConfig{
+			versionConfig: kubeone.VersionConfig{
 				Kubernetes: "1.24.0",
 			},
 			expectedError: true,
 		},
 		{
-			name: "not supported kubernetes version (1.18.19)",
+			name: "not supported kubernetes version (1.23.3)",
 			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.18.19",
-			},
-			expectedError: true,
-		},
-		{
-			name: "not supported kubernetes version (1.18.0)",
-			versionConfig: kubeone.VersionConfig{
-				Kubernetes: "1.18.0",
+				Kubernetes: "1.23.3",
 			},
 			expectedError: true,
 		},
@@ -710,6 +696,13 @@ func TestValidateVersionConfig(t *testing.T) {
 			name: "not supported kubernetes version (1.17.0)",
 			versionConfig: kubeone.VersionConfig{
 				Kubernetes: "1.17.0",
+			},
+			expectedError: true,
+		},
+		{
+			name: "not supported kubernetes version (1.18.19)",
+			versionConfig: kubeone.VersionConfig{
+				Kubernetes: "1.18.19",
 			},
 			expectedError: true,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This is a cherry-pick of #1808 to `release/v1.3`, adjusted to the supported Kubernetes versions as per https://docs.kubermatic.com/kubeone/v1.3/architecture/compatibility/#supported-kubernetes-versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Validate Kubernetes version against supported versions constraints
```
