### PR TITLE
Increase version lower bound to Kubernetes 1.20

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -886,7 +886,7 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (AWS)
   #########################################################
-  - name: pull-kubeone-e2e-aws-upgrade-containerd-1.19-1.20
+  - name: pull-kubeone-e2e-aws-upgrade-containerd-1.20-1.21
     run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
@@ -909,35 +909,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.16"
+              value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
-  - name: pull-kubeone-e2e-aws-upgrade-1.19-1.20
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-aws: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "aws"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.16"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
+              value: "1.21.9"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1033,32 +1007,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (DigitalOcean)
   #########################################################
-  - name: pull-kubeone-e2e-digitalocean-upgrade-1.19-1.20
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-digitalocean: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "digitalocean"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.16"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-digitalocean-upgrade-1.20-1.21
     always_run: false
     decorate: true
@@ -1144,32 +1092,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (Hetzner)
   #########################################################
-  - name: pull-kubeone-e2e-hetzner-upgrade-1.19-1.20
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-hetzner: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "hetzner"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.16"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-hetzner-upgrade-1.20-1.21
     always_run: false
     decorate: true
@@ -1255,34 +1177,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (GCE)
   #########################################################
-  - name: pull-kubeone-e2e-gce-upgrade-1.19-1.20
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-gce: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "gce"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.16"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
-            - name: TF_VAR_project
-              value: "kubeone-terraform-test"
   - name: pull-kubeone-e2e-gce-upgrade-1.20-1.21
     always_run: false
     decorate: true
@@ -1374,32 +1268,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (Equinix Metal)
   #########################################################
-  - name: pull-kubeone-e2e-equinix-metal-upgrade-1.19-1.20
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-equinix-metal: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "equinixmetal"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.16"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-equinix-metal-upgrade-1.20-1.21
     always_run: false
     decorate: true
@@ -1485,32 +1353,6 @@ presubmits:
   #########################################################
   # E2E/Upgrade tests (OpenStack)
   #########################################################
-  - name: pull-kubeone-e2e-openstack-upgrade-1.19-1.20
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
-    labels:
-      preset-goproxy: "true"
-      preset-openstack: "true"
-    spec:
-      containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
-          imagePullPolicy: Always
-          command:
-            - make
-          args:
-            - e2e-test
-          env:
-            - name: PROVIDER
-              value: "openstack"
-            - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.19.16"
-            - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
-            - name: TEST_TIMEOUT
-              valut: "120m"
-            - name: KUBEONE_TEST_RUN
-              value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-openstack-upgrade-1.20-1.21
     always_run: false
     decorate: true

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	// lowerVersionConstraint defines a semver constraint that validates Kubernetes versions against a lower bound
-	lowerVersionConstraint = ">= 1.19"
+	lowerVersionConstraint = ">= 1.20"
 	// upperVersionConstraint defines a semver constraint that validates Kubernetes versions against an upper bound
 	upperVersionConstraint = "<= 1.23"
 )

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -764,16 +764,16 @@ func TestValidateVersionConfig(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "valid version config (1.19.0)",
-			versionConfig: kubeoneapi.VersionConfig{
-				Kubernetes: "1.19.0",
-			},
-			expectedError: false,
-		},
-		{
 			name: "not supported kubernetes version (1.24.0)",
 			versionConfig: kubeoneapi.VersionConfig{
 				Kubernetes: "1.24.0",
+			},
+			expectedError: true,
+		},
+		{
+			name: "not supported kubernetes version (1.19.0)",
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.19.0",
 			},
 			expectedError: true,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
After working on #1817, I realised I was too lenient in the initial PR, allowing Kubernetes 1.19 which will not be supported by kubeone 1.4 according to the docs. This PR raises the bar to minimum Kubernetes 1.20, and removes the e2e tests that were still running with 1.19. Not sure you want this, but I thought I raise it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Minimum Kubernetes version is set to v1.20
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>