### PR TITLE
Include darwin/arm64 builds in release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
   - darwin
   goarch:
   - amd64
+  - arm64
 archives:
   - id: kubeone
     format: zip


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adding support for generating release artifacts for darwin/arm64 and linux/arm64.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Include darwin/arm64 and linux/arm64 builds in release artifacts
```
