### PR TITLE
Allow docker as container-runtime up to k8s v1.24

### DIFF
--- a/addons/cni-cilium/cilium.yaml
+++ b/addons/cni-cilium/cilium.yaml
@@ -847,10 +847,10 @@ data:
   config.yaml: |
     peer-service: unix:///var/run/cilium/hubble.sock
     listen-address: :4245
-    dial-timeout: 
-    retry-timeout: 
-    sort-buffer-len-max: 
-    sort-buffer-drain-timeout: 
+    dial-timeout:
+    retry-timeout:
+    sort-buffer-len-max:
+    sort-buffer-drain-timeout:
     tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-client-key-file: /var/lib/hubble-relay/tls/client.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt

--- a/pkg/apis/kubeone/config/config.go
+++ b/pkg/apis/kubeone/config/config.go
@@ -314,4 +314,8 @@ func checkClusterFeatures(c kubeoneapi.KubeOneCluster, logger logrus.FieldLogger
 		logger.Warnf("Nutanix support is considered as alpha, so the implementation might be changed in the future")
 		logger.Warnf("Nutanix support is planned to graduate to beta/stable in KubeOne 1.5+")
 	}
+
+	if c.ContainerRuntime.Docker != nil {
+		logger.Warnf("Support for docker will be removed with Kubernetes 1.24 release. It is recommended to switch to containerd as container runtime using `kubeone migrate to-containerd`")
+	}
 }

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -337,9 +337,9 @@ func ValidateContainerRuntimeConfig(cr kubeoneapi.ContainerRuntimeConfig, versio
 
 	if cr.Docker != nil {
 		kubeVer, _ := semver.NewVersion(versions.Kubernetes)
-		gteKube122Condition, _ := semver.NewConstraint(">= 1.22")
-		if gteKube122Condition.Check(kubeVer) {
-			allErrs = append(allErrs, field.Invalid(fldPath, cr.Docker, "kubernetes v1.22+ require containerd container runtime"))
+		gteKube124Condition, _ := semver.NewConstraint(">= 1.24")
+		if gteKube124Condition.Check(kubeVer) {
+			allErrs = append(allErrs, field.Invalid(fldPath, cr.Docker, "kubernetes v1.24+ requires containerd container runtime"))
 		}
 	}
 

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -1008,9 +1008,9 @@ func TestValidateContainerRuntimeConfig(t *testing.T) {
 			expectedError:    false,
 		},
 		{
-			name:             "docker with kubernetes 1.22+",
+			name:             "docker with kubernetes 1.24+",
 			containerRuntime: kubeoneapi.ContainerRuntimeConfig{Docker: &kubeoneapi.ContainerRuntimeDocker{}},
-			versions:         kubeoneapi.VersionConfig{Kubernetes: "1.22"},
+			versions:         kubeoneapi.VersionConfig{Kubernetes: "1.24"},
 			expectedError:    true,
 		},
 		{

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -617,7 +617,7 @@ cloudProvider:
 # Only one container runtime can be present at the time.
 #
 # Note: Kubernetes has announced deprecation of Docker (dockershim) support.
-# It's expected that the Docker support will be removed in Kubernetes 1.22.
+# It's expected that the Docker support will be removed in Kubernetes 1.24.
 # It's highly advised to use containerd for all newly created clusters.
 containerRuntime:
   # Installs containerd container runtime.
@@ -643,7 +643,7 @@ containerRuntime:
   #       - https://secure.tld
   # Installs Docker container runtime.
   # Default for Kubernetes clusters up to 1.20.
-  # This option will be removed once Kubernetes 1.21 reaches EOL.
+  # This option will be removed once Kubernetes 1.23 reaches EOL.
   # docker: {}
 
 features:

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -90,7 +90,9 @@ func safeguard(s *state.State) error {
 
 		if nodesContainerRuntime != configuredClusterContainerRuntime {
 			errMsg := "Migration is not supported yet"
-			if cr.Containerd != nil {
+			if nodesContainerRuntime == "docker" {
+				errMsg = "Support for docker will be removed with Kubernetes 1.24 release. It is recommended to switch to containerd as container runtime using `kubeone migrate to-containerd`. To continue using Docker please specify ContainerRuntime explicitly in KubeOneCluster manifest"
+			} else if cr.Containerd != nil {
 				errMsg = "Use `kubeone migrate to-containerd`"
 			}
 
@@ -174,10 +176,10 @@ func runProbes(s *state.State) error {
 		return nil
 	}
 
-	gteKube121Condition, _ := semver.NewConstraint(">= 1.21")
+	gteKube124Condition, _ := semver.NewConstraint(">= 1.24")
 
 	switch {
-	case gteKube121Condition.Check(s.LiveCluster.ExpectedVersion):
+	case gteKube124Condition.Check(s.LiveCluster.ExpectedVersion):
 		s.Cluster.ContainerRuntime.Containerd = &kubeoneapi.ContainerRuntimeContainerd{}
 
 		if s.LiveCluster.IsProvisioned() {


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Allow docker as container-runtime up to k8s v1.24

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow docker as container-runtime up to k8s v1.24
```
