### PR TITLE
fix: use yaml.UnmarshalStrict for registriesAuth from credentials file

### DIFF
--- a/pkg/apis/kubeone/config/config_test.go
+++ b/pkg/apis/kubeone/config/config_test.go
@@ -90,6 +90,30 @@ func Test_setRegistriesAuth(t *testing.T) {
 			wantErr:        true,
 		},
 		{
+			name: "borked fields (strict)",
+			args: args{
+				cluster: &kubeoneapi.KubeOneCluster{
+					ContainerRuntime: kubeoneapi.ContainerRuntimeConfig{
+						Containerd: &kubeoneapi.ContainerRuntimeContainerd{},
+					},
+				},
+				buf: heredoc.Doc(`
+					apiVersion: kubeone.k8c.io/v1beta2
+					kind: ContainerRuntimeContainerd
+					registries:
+					  auth:
+					    some.tld:
+					      username: root
+				`),
+			},
+			exampleCluster: &kubeoneapi.KubeOneCluster{
+				ContainerRuntime: kubeoneapi.ContainerRuntimeConfig{
+					Containerd: &kubeoneapi.ContainerRuntimeContainerd{},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "simple",
 			args: args{
 				cluster: &kubeoneapi.KubeOneCluster{


### PR DESCRIPTION
**What this PR does / why we need it**:
Add strict unmarshalling of the registriesAuth from credentials file to avoid confusion like in #1827 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1827

**Special notes for your reviewer**:

```release-note
NONE
```
