### PR TITLE
Don't upgrade MachineDeployments when refreshing resources

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -270,12 +270,6 @@ func WithResources(t Tasks) Tasks {
 				ErrMsg:    "failed to wait for operating-system-manager",
 				Predicate: func(s *state.State) bool { return s.Cluster.OperatingSystemManagerEnabled() },
 			},
-			{
-				Fn:          upgradeMachineDeployments,
-				ErrMsg:      "failed to upgrade MachineDeployments",
-				Description: "upgrade MachineDeployments",
-				Predicate:   func(s *state.State) bool { return s.UpgradeMachineDeployments },
-			},
 		}...,
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`WithResources` task list is supposed to refresh resources (e.g. Deployments, addons, etc), but it currently also tries to upgrade MachineDeployments. MachineDeployments should be upgraded only when running `kubeone upgrade`, otherwise we will violate the version skew policy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref https://github.com/kubermatic/kubeone/issues/1775#issuecomment-1036670606

**Does this PR introduce a user-facing change?**:
```release-note
Don't upgrade MachineDeployments when refreshing resources
```

/assign @kron4eg @ahmedwaleedmalik 
h/t @dermorz for noticing and reporting the issue