### PR TITLE
fix: centos periodic

### DIFF
--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -11,14 +11,15 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.10 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.45.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.45.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
@@ -55,18 +56,19 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ami"></a> [ami](#input\_ami) | AMI ID, use it to fixate control-plane AMI in order to avoid force-recreation it at later times | `string` | `""` | no |
-| <a name="input_ami_filters"></a> [ami\_filters](#input\_ami\_filters) | map with AMI filters | `map` | <pre>{<br>  "amazon_linux2": {<br>    "image_name": [<br>      "amzn2-ami-hvm-2.0.*-x86_64-gp2"<br>    ],<br>    "owners": [<br>      "137112412989"<br>    ]<br>  },<br>  "centos": {<br>    "image_name": [<br>      "CentOS 8.2.* x86_64"<br>    ],<br>    "owners": [<br>      "125523088429"<br>    ]<br>  },<br>  "flatcar": {<br>    "image_name": [<br>      "Flatcar-stable-*-hvm"<br>    ],<br>    "owners": [<br>      "075585003325"<br>    ]<br>  },<br>  "rhel": {<br>    "image_name": [<br>      "RHEL-8*_HVM-*-x86_64-*"<br>    ],<br>    "owners": [<br>      "309956199498"<br>    ]<br>  },<br>  "ubuntu": {<br>    "image_name": [<br>      "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"<br>    ],<br>    "owners": [<br>      "099720109477"<br>    ]<br>  }<br>}</pre> | no |
+| <a name="input_ami_filters"></a> [ami\_filters](#input\_ami\_filters) | map with AMI filters | <pre>map(object({<br>    owners     = list(string)<br>    image_name = list(string)<br>    osp_name   = string<br>  }))</pre> | <pre>{<br>  "amzn2": {<br>    "image_name": [<br>      "amzn2-ami-hvm-2.0.*-x86_64-gp2"<br>    ],<br>    "osp_name": "osp-amzn2",<br>    "owners": [<br>      "137112412989"<br>    ]<br>  },<br>  "centos": {<br>    "image_name": [<br>      "Rocky-8-ec2-*.x86_64"<br>    ],<br>    "osp_name": "osp-centos",<br>    "owners": [<br>      "792107900819"<br>    ]<br>  },<br>  "flatcar": {<br>    "image_name": [<br>      "Flatcar-stable-*-hvm"<br>    ],<br>    "osp_name": "osp-flatcar",<br>    "owners": [<br>      "075585003325"<br>    ]<br>  },<br>  "rhel": {<br>    "image_name": [<br>      "RHEL-8*_HVM-*-x86_64-*"<br>    ],<br>    "osp_name": "osp-rhel",<br>    "owners": [<br>      "309956199498"<br>    ]<br>  },<br>  "ubuntu": {<br>    "image_name": [<br>      "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"<br>    ],<br>    "osp_name": "osp-ubuntu",<br>    "owners": [<br>      "099720109477"<br>    ]<br>  }<br>}</pre> | no |
+| <a name="input_apiserver_alternative_names"></a> [apiserver\_alternative\_names](#input\_apiserver\_alternative\_names) | subject alternative names for the API Server signing cert. | `list(string)` | `[]` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region to speak to | `string` | `"eu-west-3"` | no |
 | <a name="input_bastion_port"></a> [bastion\_port](#input\_bastion\_port) | Bastion SSH port | `number` | `22` | no |
 | <a name="input_bastion_type"></a> [bastion\_type](#input\_bastion\_type) | instance type for bastion | `string` | `"t3.nano"` | no |
 | <a name="input_bastion_user"></a> [bastion\_user](#input\_bastion\_user) | Bastion SSH username | `string` | `"ubuntu"` | no |
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `any` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
 | <a name="input_control_plane_type"></a> [control\_plane\_type](#input\_control\_plane\_type) | AWS instance type | `string` | `"t3.medium"` | no |
+| <a name="input_control_plane_vm_count"></a> [control\_plane\_vm\_count](#input\_control\_plane\_vm\_count) | Number of control plane instances | `number` | `3` | no |
 | <a name="input_control_plane_volume_size"></a> [control\_plane\_volume\_size](#input\_control\_plane\_volume\_size) | Size of the EBS volume, in Gb | `number` | `100` | no |
 | <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | number of replicas per MachineDeployment | `number` | `1` | no |
 | <a name="input_initial_machinedeployment_spotinstances"></a> [initial\_machinedeployment\_spotinstances](#input\_initial\_machinedeployment\_spotinstances) | use spot instances for initial machine-deployment | `bool` | `false` | no |
 | <a name="input_internal_api_lb"></a> [internal\_api\_lb](#input\_internal\_api\_lb) | make kubernetes API loadbalancer internal (reachible only from inside the VPC) | `bool` | `false` | no |
-| <a name="input_open_nodeports"></a> [open\_nodeports](#input\_open\_nodeports) | open NodePorts flag | `bool` | `false` | no |
 | <a name="input_os"></a> [os](#input\_os) | Operating System to use in AMI filtering and MachineDeployment | `string` | `"ubuntu"` | no |
 | <a name="input_ssh_agent_socket"></a> [ssh\_agent\_socket](#input\_ssh\_agent\_socket) | SSH Agent socket, default to grab from $SSH\_AUTH\_SOCK | `string` | `"env:SSH_AUTH_SOCK"` | no |
 | <a name="input_ssh_port"></a> [ssh\_port](#input\_ssh\_port) | SSH port to be used to provision instances | `number` | `22` | no |
@@ -76,6 +78,7 @@ No modules.
 | <a name="input_static_workers_count"></a> [static\_workers\_count](#input\_static\_workers\_count) | number of static workers | `number` | `0` | no |
 | <a name="input_subnets_cidr"></a> [subnets\_cidr](#input\_subnets\_cidr) | CIDR mask bits per subnet | `number` | `24` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC to use ('default' for default VPC) | `string` | `"default"` | no |
+| <a name="input_worker_deploy_ssh_key"></a> [worker\_deploy\_ssh\_key](#input\_worker\_deploy\_ssh\_key) | add provided ssh public key to MachineDeployments | `bool` | `true` | no |
 | <a name="input_worker_os"></a> [worker\_os](#input\_worker\_os) | OS to run on worker machines, default to var.os | `string` | `""` | no |
 | <a name="input_worker_type"></a> [worker\_type](#input\_worker\_type) | instance type for workers | `string` | `"t3.medium"` | no |
 

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -29,6 +29,8 @@ locals {
   subnet_newbits        = var.subnets_cidr - (32 - local.vpc_mask)
   worker_os             = var.worker_os == "" ? var.os : var.worker_os
   worker_deploy_ssh_key = var.worker_deploy_ssh_key ? [aws_key_pair.deployer.public_key] : []
+  ssh_username          = var.ssh_username == "" ? var.ami_filters[var.os].ssh_username : var.ssh_username
+  bastion_user          = var.bastion_user == "" ? var.ami_filters[var.os].ssh_username : var.bastion_user
 
   subnets = {
     (local.zoneA) = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[0].id : ""

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -40,10 +40,10 @@ output "kubeone_hosts" {
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file
-      ssh_user             = var.ssh_username
+      ssh_user             = local.ssh_username
       bastion              = aws_instance.bastion.public_ip
       bastion_port         = var.bastion_port
-      bastion_user         = var.bastion_user
+      bastion_user         = local.bastion_user
     }
   }
 }
@@ -59,10 +59,10 @@ output "kubeone_static_workers" {
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file
-      ssh_user             = var.ssh_username
+      ssh_user             = local.ssh_username
       bastion              = aws_instance.bastion.public_ip
       bastion_port         = var.bastion_port
-      bastion_user         = var.bastion_user
+      bastion_user         = local.bastion_user
     }
   }
 }

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -145,39 +145,45 @@ variable "ami" {
 variable "ami_filters" {
   description = "map with AMI filters"
   type = map(object({
-    owners     = list(string)
-    image_name = list(string)
-    osp_name   = string
+    owners       = list(string)
+    image_name   = list(string)
+    osp_name     = string
+    ssh_username = string
   }))
   default = {
     ubuntu = {
-      owners     = ["099720109477"] # Canonical
-      image_name = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
-      osp_name   = "osp-ubuntu"
+      owners       = ["099720109477"] # Canonical
+      image_name   = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+      osp_name     = "osp-ubuntu"
+      ssh_username = "ubuntu"
     }
 
     centos = {
-      owners     = ["792107900819"] # RockyLinux
-      image_name = ["Rocky-8-ec2-*.x86_64"]
-      osp_name   = "osp-centos"
+      owners       = ["792107900819"] # RockyLinux
+      image_name   = ["Rocky-8-ec2-*.x86_64"]
+      osp_name     = "osp-centos"
+      ssh_username = "rocky"
     }
 
     flatcar = {
-      owners     = ["075585003325"] # Kinvolk
-      image_name = ["Flatcar-stable-*-hvm"]
-      osp_name   = "osp-flatcar"
+      owners       = ["075585003325"] # Kinvolk
+      image_name   = ["Flatcar-stable-*-hvm"]
+      osp_name     = "osp-flatcar"
+      ssh_username = "core"
     }
 
     rhel = {
-      owners     = ["309956199498"] # Red Hat
-      image_name = ["RHEL-8*_HVM-*-x86_64-*"]
-      osp_name   = "osp-rhel"
+      owners       = ["309956199498"] # Red Hat
+      image_name   = ["RHEL-8*_HVM-*-x86_64-*"]
+      osp_name     = "osp-rhel"
+      ssh_username = "ec2-user"
     }
 
     amzn = {
-      owners     = ["137112412989"] # Amazon
-      image_name = ["amzn2-ami-hvm-2.0.*-x86_64-gp2"]
-      osp_name   = "osp-amzn2"
+      owners       = ["137112412989"] # Amazon
+      image_name   = ["amzn2-ami-hvm-2.0.*-x86_64-gp2"]
+      osp_name     = "osp-amzn2"
+      ssh_username = "ec2-user"
     }
   }
 }

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -131,7 +131,7 @@ variable "os" {
   # * centos
   # * rhel
   # * flatcar
-  # * amzn2
+  # * amzn
   default = "ubuntu"
   type    = string
 }
@@ -174,7 +174,7 @@ variable "ami_filters" {
       osp_name   = "osp-rhel"
     }
 
-    amzn2 = {
+    amzn = {
       owners     = ["137112412989"] # Amazon
       image_name = ["amzn2-ami-hvm-2.0.*-x86_64-gp2"]
       osp_name   = "osp-amzn2"

--- a/test/e2e/os.go
+++ b/test/e2e/os.go
@@ -57,43 +57,20 @@ func ValidateOperatingSystem(osName string) error {
 // ControlPlaneImageFlags returns Terraform flags for control plane image and SSH username
 func ControlPlaneImageFlags(provider string, osName OperatingSystem) ([]string, error) {
 	if provider == provisioner.AWS {
-		user, err := sshUsername(osName)
-		if err != nil {
-			return nil, err
-		}
-
 		switch {
 		case osName == OperatingSystemCentOS7:
 			return []string{
 				"-var", fmt.Sprintf("ami=%s", AWSCentOS7AMI),
 				"-var", "os=centos",
-				"-var", fmt.Sprintf("ssh_username=%s", user),
-				"-var", fmt.Sprintf("bastion_user=%s", user),
+				"-var", "ssh_username=centos",
+				"-var", "bastion_user=centos",
 			}, nil
 		default:
 			return []string{
 				"-var", fmt.Sprintf("os=%s", osName),
-				"-var", fmt.Sprintf("ssh_username=%s", user),
-				"-var", fmt.Sprintf("bastion_user=%s", user),
 			}, nil
 		}
 	}
 
 	return nil, errors.New("custom operating system is not supported for selected provider")
-}
-
-func sshUsername(osName OperatingSystem) (string, error) {
-	switch osName {
-	case OperatingSystemUbuntu:
-		return "ubuntu", nil
-	case OperatingSystemCentOS7, OperatingSystemCentOS8:
-		return "centos", nil
-	case OperatingSystemFlatcar:
-		return "core", nil
-	case OperatingSystemRHEL, OperatingSystemAmazon:
-		return "ec2-user", nil
-	case OperatingSystemDefault:
-	}
-
-	return "", errors.New("operating system not matched")
 }

--- a/test/e2e/os.go
+++ b/test/e2e/os.go
@@ -66,6 +66,7 @@ func ControlPlaneImageFlags(provider string, osName OperatingSystem) ([]string, 
 		case osName == OperatingSystemCentOS7:
 			return []string{
 				"-var", fmt.Sprintf("ami=%s", AWSCentOS7AMI),
+				"-var", "os=centos",
 				"-var", fmt.Sprintf("ssh_username=%s", user),
 				"-var", fmt.Sprintf("bastion_user=%s", user),
 			}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the problem with defaulting to ubuntu, which in turn prevents OS
autodetection (works only if the config variable is empty).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
A bunch of centos periodic jobs has failed.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Introduce dedicated terraform statis_os
```
