### PR TITLE
Provide correct path to the vSphere CSI webhook certs

### DIFF
--- a/pkg/addons/manifest.go
+++ b/pkg/addons/manifest.go
@@ -314,8 +314,8 @@ func txtFuncMap(overwriteRegistry string) template.FuncMap {
 		cfg := vsphereCSIWebhookConfigWrapper{
 			WebHookConfig: vsphereCSIWebhookConfig{
 				Port:     "8443",
-				CertFile: "/etc/webhook/cert.pem",
-				KeyFile:  "/etc/webhook/key.pem",
+				CertFile: "/run/secrets/tls/cert.pem",
+				KeyFile:  "/run/secrets/tls/key.pem",
 			},
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Provide the correct path to the vSphere CSI webhook certs.

**Does this PR introduce a user-facing change?**:
```release-note
Provide the correct path to the vSphere CSI webhook certs.
```

/assign @kron4eg 