### PR TITLE
Improve CCM/CSI migration warning for OpenStack

### DIFF
--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -23,6 +23,10 @@ output "kubeone_api" {
   }
 }
 
+output "ssh_commands" {
+  value = formatlist("ssh -J ${var.bastion_user}@${openstack_networking_floatingip_v2.lb.address} ${var.ssh_username}@%s", openstack_compute_instance_v2.control_plane.*.access_ip_v4)
+}
+
 output "kubeone_hosts" {
   description = "Control plane endpoints to SSH to"
 

--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -193,6 +193,7 @@ func runMigrateToCCMCSI(opts *migrateCCMOptions) error {
 	if s.Cluster.CloudProvider.Openstack != nil {
 		s.Logger.Warnln("The OpenStack external CCM uses Octavia Load Balancers by default.")
 		s.Logger.Warnln("If you currently use Neutron Load Balancers, migrating to the external CCM/CSI will cause *ALL* Load Balancers to be recreated!")
+		s.Logger.Warnln("The existing Neutron Load Balancers will **NOT** be removed automatically. Instead, those Load Balancers must be removed manually!")
 		s.Logger.Warnln("Make sure to check documentation for more details.")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve CCM/CSI migration warning for OpenStack.

This PR also adds SSH commands to the Terraform output to make it easier to SSH to nodes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
