### PR TITLE
Fix the default-storage-class addon

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -1,5 +1,8 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{ $csi := or .Config.CloudProvider.External (ge $version.Minor 23) }}
+
 {{ if eq .Config.CloudProvider.CloudProviderName "azure" }}
-{{ if .Config.CloudProvider.External }}
+{{ if $csi }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -26,12 +29,15 @@ parameters:
   skuName: Standard_LRS
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
-{{ else }}
+---
+{{ end }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+{{ if not $csi }}
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
+{{ end }}
   labels:
     kubernetes.io/cluster-service: "true"
   name: standard
@@ -40,10 +46,9 @@ parameters:
   kind: Managed
   storageaccounttype: Standard_LRS
 {{ end }}
-{{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "aws" }}
-{{ if .Config.CloudProvider.External }}
+{{ if $csi }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -56,12 +61,15 @@ provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
 volumeBindingMode: WaitForFirstConsumer
-{{ else }}
+---
+{{ end }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+{{ if not $csi }}
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
+{{ end }}
   labels:
     kubernetes.io/cluster-service: "true"
   name: standard-v2
@@ -70,10 +78,9 @@ parameters:
   type: gp2
 volumeBindingMode: WaitForFirstConsumer
 {{ end }}
-{{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "vsphere" }}
-{{ if .Config.CloudProvider.External }}
+{{ if $csi }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -83,12 +90,15 @@ metadata:
     kubernetes.io/cluster-service: "true"
   name: vsphere-csi
 provisioner: csi.vsphere.vmware.com
-{{ else }}
+---
+{{ end }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
+{{ if not $csi }}
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
+{{ end }}
   labels:
     kubernetes.io/cluster-service: "true"
   name: standard
@@ -96,10 +106,8 @@ provisioner: kubernetes.io/vsphere-volume
 parameters:
   diskformat: thin
 {{ end }}
-{{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "openstack" }}
-{{ if .Config.CloudProvider.External }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -110,17 +118,14 @@ metadata:
   name: cinder-csi
 provisioner: cinder.csi.openstack.org
 volumeBindingMode: WaitForFirstConsumer
-{{ else }}
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
   name: standard
 provisioner: kubernetes.io/cinder
-{{ end }}
 {{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "gce" }}
@@ -174,7 +179,6 @@ allowVolumeExpansion: true
 {{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "digitalocean" }}
-{{ if .Config.CloudProvider.External }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -192,5 +196,4 @@ metadata:
     snapshot.storage.kubernetes.io/is-default-class: "true"
 driver: dobs.csi.digitalocean.com
 deletionPolicy: Delete
-{{ end }}
 {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

We started unconditionally deploying the CSI driver in some cases with #1831. This was needed because Kubernetes 1.23 enabled CSIMigration for some providers by default, requiring the CSI driver to be deployed. Namely:

* Deploy CSI driver on Azure, AWS, and vSphere clusters if the external CCM is enabled or if the Kubernetes version is >= 1.23
* Deploy CSI driver on DigitalOcean, Hetzner, Nutanix, and OpenStack unconditionally
  * OpenStack has the CSIMigration enabled by default since Kubernetes 1.18
  * Other providers don't have the in-tree provider, so the CSI driver is required to use volumes

However, we haven't adjusted the `default-storage-class` addon used to deploy StorageClasses, so it might happen that the StorageClass is not deployed even if it should be deployed.

On top of that, if a cluster is migrated from the in-tree provider to the external CCM, there will be two StorageClasses, and both SCs will be default. This is breaking some workflows, as Kubernetes will fail to create a PV.

The first issue is solved by adjusting the criteria when we deploy the StorageClass.

The second issue (two default StorageClasses) is a more complicated one. We don't want to remove a StorageClass because we don't know is it going to break existing PVCs/PVs. We need to somehow reconcile the old StorageClass (the one that uses the in-tree provider) to remove the default annotation. Right now, we are reconciling only one StorageClass, depending on if the CSI driver is deployed or not.

To solve the issue, we now deploy both StorageClasses unconditionally if the CSI driver is deployed. We are checking if the CSI driver is deployed, and based on that set the default annotation. With this approach, we will have one StorageClass that's not needed, but both StorageClasses are effectively doing the same thing since the CSIMigration will translate all calls from the in-tree provider to the CSI driver.

**Does this PR introduce a user-facing change?**:
```release-note
Deploy the StorageClass based on the CSI driver if the CSI driver is deployed
Always deploy the StorageClass based on the in-tree provider. This StorageClass will use the CSI driver if the CSI migration is enabled (default for all providers if the Kubernetes version is >= 1.23 or if the external CCM is used)
```
