### PR TITLE
Fix Terraform configs for AWS

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -27,7 +27,7 @@ locals {
   vpc_mask              = parseint(split("/", data.aws_vpc.selected.cidr_block)[1], 10)
   subnet_total          = pow(2, var.subnets_cidr - local.vpc_mask)
   subnet_newbits        = var.subnets_cidr - (32 - local.vpc_mask)
-  worker_os             = var.worker_os == "" ? var.os : var.worker_os
+  worker_os             = var.worker_os == "" ? var.ami_filters[var.os].worker_os : var.worker_os
   worker_deploy_ssh_key = var.worker_deploy_ssh_key ? [aws_key_pair.deployer.public_key] : []
   ssh_username          = var.ssh_username == "" ? var.ami_filters[var.os].ssh_username : var.ssh_username
   bastion_user          = var.bastion_user == "" ? var.ami_filters[var.os].ssh_username : var.bastion_user

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -24,7 +24,7 @@ output "kubeone_api" {
 }
 
 output "ssh_commands" {
-  value = formatlist("ssh -J ${var.bastion_user}@${aws_instance.bastion.public_ip} ${var.ssh_username}@%s", aws_instance.control_plane.*.private_ip)
+  value = formatlist("ssh -J ${local.bastion_user}@${aws_instance.bastion.public_ip} ${local.ssh_username}@%s", aws_instance.control_plane.*.private_ip)
 }
 
 output "kubeone_hosts" {

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -57,7 +57,7 @@ variable "ssh_port" {
 
 variable "ssh_username" {
   description = "SSH user, used only in output"
-  default     = "ubuntu"
+  default     = ""
   type        = string
 }
 
@@ -81,7 +81,7 @@ variable "bastion_port" {
 
 variable "bastion_user" {
   description = "Bastion SSH username"
-  default     = "ubuntu"
+  default     = ""
   type        = string
 }
 

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -149,6 +149,7 @@ variable "ami_filters" {
     image_name   = list(string)
     osp_name     = string
     ssh_username = string
+    worker_os    = string
   }))
   default = {
     ubuntu = {
@@ -156,6 +157,7 @@ variable "ami_filters" {
       image_name   = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
       osp_name     = "osp-ubuntu"
       ssh_username = "ubuntu"
+      worker_os    = "ubuntu"
     }
 
     centos = {
@@ -163,6 +165,7 @@ variable "ami_filters" {
       image_name   = ["Rocky-8-ec2-*.x86_64"]
       osp_name     = "osp-centos"
       ssh_username = "rocky"
+      worker_os    = "centos"
     }
 
     flatcar = {
@@ -170,6 +173,7 @@ variable "ami_filters" {
       image_name   = ["Flatcar-stable-*-hvm"]
       osp_name     = "osp-flatcar"
       ssh_username = "core"
+      worker_os    = "flatcar"
     }
 
     rhel = {
@@ -177,6 +181,7 @@ variable "ami_filters" {
       image_name   = ["RHEL-8*_HVM-*-x86_64-*"]
       osp_name     = "osp-rhel"
       ssh_username = "ec2-user"
+      worker_os    = "rhel"
     }
 
     amzn = {
@@ -184,6 +189,7 @@ variable "ami_filters" {
       image_name   = ["amzn2-ami-hvm-2.0.*-x86_64-gp2"]
       osp_name     = "osp-amzn2"
       ssh_username = "ec2-user"
+      worker_os    = "amzn2"
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix Terraform configs for AWS:

* Don't default the SSH username because it's supposed to be determined automatically
* Properly default the `worker_os` variable if Amazon Linux 2 is used
  * Terraform configs expect `amzn` to be provided as the operating system, while machine-controller expects `amzn2`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
