### PR TITLE
e2e: allow amzn2 for worker nodes

### DIFF
--- a/test/e2e/os.go
+++ b/test/e2e/os.go
@@ -26,13 +26,14 @@ import (
 type OperatingSystem string
 
 const (
-	OperatingSystemUbuntu  OperatingSystem = "ubuntu"
-	OperatingSystemCentOS7 OperatingSystem = "centos7"
-	OperatingSystemCentOS8 OperatingSystem = "centos"
-	OperatingSystemFlatcar OperatingSystem = "flatcar"
-	OperatingSystemAmazon  OperatingSystem = "amzn2"
-	OperatingSystemRHEL    OperatingSystem = "rhel"
-	OperatingSystemDefault OperatingSystem = ""
+	OperatingSystemUbuntu   OperatingSystem = "ubuntu"
+	OperatingSystemCentOS7  OperatingSystem = "centos7"
+	OperatingSystemCentOS8  OperatingSystem = "centos"
+	OperatingSystemFlatcar  OperatingSystem = "flatcar"
+	OperatingSystemAmazon   OperatingSystem = "amzn"
+	OperatingSystemAmazonMC OperatingSystem = "amzn2"
+	OperatingSystemRHEL     OperatingSystem = "rhel"
+	OperatingSystemDefault  OperatingSystem = ""
 )
 
 const (
@@ -46,6 +47,7 @@ func ValidateOperatingSystem(osName string) error {
 		OperatingSystemCentOS7,
 		OperatingSystemCentOS8,
 		OperatingSystemAmazon,
+		OperatingSystemAmazonMC,
 		OperatingSystemRHEL,
 		OperatingSystemDefault:
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Terraform configs for AWS use `amzn`, while machine-controller uses `amzn2`. We need to make sure both are considered valid by our E2E tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
