### PR TITLE
config: Unmarshal to versioned KubeOneCluster

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -30,8 +30,8 @@ import (
 	"github.com/spf13/pflag"
 	yaml "gopkg.in/yaml.v2"
 
-	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/apis/kubeone/config"
+	kubeonev1beta2 "k8c.io/kubeone/pkg/apis/kubeone/v1beta2"
 	"k8c.io/kubeone/pkg/containerruntime"
 	"k8c.io/kubeone/pkg/templates/machinecontroller"
 	"k8c.io/kubeone/pkg/yamled"
@@ -272,7 +272,7 @@ func runPrint(printOptions *printOpts) error {
 			return errors.Wrap(err, "unable to run the example manifest template")
 		}
 
-		cfg := &kubeoneapi.KubeOneCluster{}
+		cfg := &kubeonev1beta2.KubeOneCluster{}
 		err = kyaml.UnmarshalStrict(buffer.Bytes(), &cfg)
 		if err != nil {
 			return errors.Wrap(err, "failed to decode new config")
@@ -502,7 +502,7 @@ func validateAndPrintConfig(cfgYaml interface{}) error {
 		return errors.Wrap(err, "failed to encode new config as YAML")
 	}
 
-	cfg := &kubeoneapi.KubeOneCluster{}
+	cfg := &kubeonev1beta2.KubeOneCluster{}
 	err = kyaml.UnmarshalStrict(buffer.Bytes(), &cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode new config")
@@ -748,78 +748,6 @@ caBundle: ""
 systemPackages:
   # will add Docker and Kubernetes repositories to OS package manager
   configureRepositories: true # it's true by default
-
-# assetConfiguration controls how assets (e.g. CNI, Kubelet, kube-apiserver, and more) are pulled.
-# The AssetConfiguration API is an alpha API currently working only on Amazon Linux 2.
-assetConfiguration:
-  # kubernetes configures the image registry and repository for the core Kubernetes
-  # images (kube-apiserver, kube-controller-manager, kube-scheduler, and kube-proxy).
-  # kubernetes respects only ImageRepository (ImageTag is ignored).
-  # Default image repository and tag: defaulted dynamically by Kubeadm.
-  # Defaults to RegistryConfiguration.OverwriteRegistry if left empty
-  # and RegistryConfiguration.OverwriteRegistry is specified.
-  kubernetes:
-    # imageRepository customizes the registry/repository
-    imageRepository: ""
-  # pause configures the sandbox (pause) image to be used by Kubelet.
-  # Default image repository and tag: defaulted dynamically by Kubeadm.
-  # Defaults to RegistryConfiguration.OverwriteRegistry if left empty
-  # and RegistryConfiguration.OverwriteRegistry is specified.
-  pause:
-    # imageRepository customizes the registry/repository
-    imageRepository: ""
-    # imageTag customizes the image tag
-    imageTag: ""
-  # coreDNS configures the image registry and tag to be used for deploying
-  # the CoreDNS component.
-  # Default image repository and tag: defaulted dynamically by Kubeadm.
-  # Defaults to RegistryConfiguration.OverwriteRegistry if left empty
-  # and RegistryConfiguration.OverwriteRegistry is specified.
-  coreDNS:
-    # imageRepository customizes the registry/repository
-    imageRepository: ""
-    # imageTag customizes the image tag
-    imageTag: ""
-  # etcd configures the image registry and tag to be used for deploying
-  # the Etcd component.
-  # Default image repository and tag: defaulted dynamically by Kubeadm.
-  # Defaults to RegistryConfiguration.OverwriteRegistry if left empty
-  # and RegistryConfiguration.OverwriteRegistry is specified.
-  etcd:
-    # imageRepository customizes the registry/repository
-    imageRepository: ""
-    # imageTag customizes the image tag
-    imageTag: ""
-  # metricsServer configures the image registry and tag to be used for deploying
-  # the metrics-server component.
-  # Default image repository and tag: defaulted dynamically by Kubeadm.
-  # Defaults to RegistryConfiguration.OverwriteRegistry if left empty
-  # and RegistryConfiguration.OverwriteRegistry is specified.
-  metricsServer:
-    # imageRepository customizes the registry/repository
-    imageRepository: ""
-    # imageTag customizes the image tag
-    imageTag: ""
-  # cni configures the source for downloading the CNI binaries.
-  # If not specified, kubernetes-cni package will be installed.
-  # Default: none
-  cni:
-    url: ""
-  # nodeBinaries configures the source for downloading the
-  # Kubernetes Node Binaries tarball (e.g. kubernetes-node-linux-amd64.tar.gz).
-  # The tarball must have .tar.gz as the extension and must contain the
-  # following files:
-  # - kubernetes/node/bin/kubelet
-  # - kubernetes/node/bin/kubeadm
-  # If not specified, kubelet and kubeadm packages will be installed.
-  # Default: none
-  nodeBinaries:
-    url: ""
-  # kubectl configures the source for downloading the Kubectl binary.
-  # If not specified, kubelet package will be installed.
-  # Default: none
-  kubectl:
-    url: ""
 
 # registryConfiguration controls how images used for components deployed by
 # KubeOne and kubeadm are pulled from an image registry


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the config package is unmarshaling the KubeOneCluster YAML to the internal struct. That's not correct because the config package always produces the v1beta2 YAML. The internal and the v1beta2 APIs can be different, which can cause issues.

Also, for some reason, `kubeone config migrate` is failing to migrate configs with the `containerRuntime` block. This is also fixed by using the v1beta2 API instead of the internal API. I tried to investigate this because the ContainerRuntime API is the same across two API versions, but I wasn't able to find the root cause.

Finally, the AssetConfiguration is removed from the example config because it has been removed in the v1beta2 API.

**Does this PR introduce a user-facing change?**:
```release-note
Fix an issue with `kubeone config migrate` failing to migrate configs with the `containerRuntime` block
```

/assign @kron4eg @ahmedwaleedmalik 