### PR TITLE
Update the PR template with kinds

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,25 @@
 3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
 -->
 
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+/kind question
+-->
+
 **What this PR does / why we need it**:
 
 **Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to automate the changelog generation in KubeOne. To have automated changelog generation, we need to categorize PRs (what's a bug fix, a new feature, dependency update). This PR proposes that we use the `kind` label for that (e.g. `kind/feature`, `kind/bug`...). The PR author will have to set the label via GitHub or by using the `/kind` Prow command.

Prow will set the `do-not-merge/needs-kind` label if there's no kind label, which is going to block merging. The label is automatically removed by Prow once the kind label is set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #369

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg @ahmedwaleedmalik 
/hold
for discussion