### PR TITLE
Add a script for generating the changelog

### DIFF
--- a/hack/changelog.tpl
+++ b/hack/changelog.tpl
@@ -1,0 +1,23 @@
+{{- $CurrentRevision := .CurrentRevision -}}
+{{- $PreviousRevision := .PreviousRevision -}}
+
+# v1.x.y
+
+## Changelog since {{ $PreviousRevision }}
+
+{{with .NotesWithActionRequired -}}
+## Urgent Upgrade Notes 
+
+### (No, really, you MUST read this before you upgrade)
+
+{{range .}}{{println "-" .}} {{end}}
+{{end}}
+
+{{- if .Notes -}}
+## Changes by Kind
+{{ range .Notes}}
+### {{.Kind | prettyKind}}
+
+{{range $note := .NoteEntries }}{{println "-" $note}}{{end}}
+{{- end -}}
+{{- end -}}

--- a/hack/generate-changelog.sh
+++ b/hack/generate-changelog.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This script is used to generate the changelog. It uses the Kubernetes
+### release-notes tool (https://github.com/kubernetes/release) under the hood.
+###
+### Prerequisites:
+###   1) GitHub token set as GITHUB_TOKEN environment variable
+###   2) the release-notes tool installed
+###
+### Currently, there are no release-notes binaries, so you have to build it
+### manually. This can be done by cloning https://github.com/kubernetes/release
+### and running make compile-release-tools (note: this will include other
+### Kubernetes tools as well, e.g. krel, cip-mm...).
+###
+### Usage:
+###  The script can be used in the following way:
+###    CHANGELOG_START_REV="v1.4.0-rc.1" \
+###    CHANGELOG_END_SHA="315fd8a12d3452620fcd76e90f0a0bf9e1f4beba" \
+###    ./hack/generate-changelog.sh
+###
+###  The changelog will be saved to the /tmp directory with the random
+###  generated filename. You can a custom path/filename by using the
+###  CHANGELOG_OUTPUT variable.
+###
+###  CHANGELOG_START_REV and CHANGELOG_END_SHA are required variables.
+###  There are additional environment variables that can control the changelog
+###  generation, but those are optional. You can check the script contents for
+###  more details.
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+source $(dirname $0)/lib.sh
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echodate "env var GITHUB_TOKEN unset, cannot generate changelog"
+  exit 0
+fi
+
+if [ -z "${CHANGELOG_START_REV:-}" ]; then
+  echodate "env var CHANGELOG_START_REV unset, cannot generate changelog"
+  exit 0
+fi
+
+if [ -z "${CHANGELOG_END_SHA:-}" ]; then
+  echodate "env var CHANGELOG_END_SHA unset, cannot generate changelog"
+  exit 0
+fi
+
+org=${CHANGELOG_ORG:-"kubermatic"}
+repo=${CHANGELOG_REPO:-"kubeone"}
+output=${CHANGELOG_OUTPUT:-""}
+tpl=${CHANGELOG_TPL:-"$(dirname "$0")/changelog.tpl"}
+
+git_branch="$(git rev-parse --abbrev-ref HEAD)"
+branch=${CHANGELOG_BRANCH:-"$git_branch"}
+
+release-notes \
+    --org="$org" \
+    --repo="$repo" \
+    --start-rev="$CHANGELOG_START_REV" \
+    --end-sha="$CHANGELOG_END_SHA" \
+    --branch="$branch" \
+    --go-template="go-template:$tpl" \
+    --output="$output" \
+    --required-author "" \
+    --markdown-links


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds:

* a template changelog that will be used by the `release-notes` tool to generate the changelog
* a wrapper script for the `release-notes` tool used to generate the changelog

The [`release-notes` tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes) is maintained by the Kubernetes SIG Release/Release Engineering team and is used by Kubernetes and some other projects in the community.

Currently, there are no `release-notes` binaries available, so before using the script, you have to compile the tool yourself. That can be done by cloning [the `kubernetes/release` repository](https://github.com/kubernetes/release) and running `make compile-release-tools` (Go is required).

The `release-notes` tool takes the release note from the release note block (which we already have). Depending on the `kind/` label, `release-notes` will put the PR in the appropriate category (API change, Feature, Bug or Regression, Other).

To use the script, you need the GitHub token exposed via the `GITHUB_TOKEN` environment variable. Additionally, you need to set `CHANGELOG_START_REV` and `CHANGELOG_END_SHA` variables (see the example usage below).

The changelog will be saved in the `/tmp` directory with a random filename. The path and the filename can be overridden by using the `CHANGELOG_OUTPUT` variable.

There are additional environment variables that can control the changelog generation, but those are optional. You can check the script contents for more details.

Example usage:

```
CHANGELOG_START_REV="v1.4.0-rc.1" \
CHANGELOG_END_SHA="315fd8a12d3452620fcd76e90f0a0bf9e1f4beba" \
./hack/generate-changelog.sh
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #369

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg @ahmedwaleedmalik 