### PR TITLE
Build KubeOne container image

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -136,6 +136,27 @@ presubmits:
               cpu: 4
             limits:
               memory: 2Gi
+  - name: pull-kubeone-build-image
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    labels:
+      preset-goproxy: "true"
+      preset-docker-push-kubermatic: "true"
+      preset-docker-mirror: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-4
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              start-docker.sh
+              ./hack/ci/push-image.sh
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
   #########################################################
   # E2E/Conformance tests (AWS, 1.20-1.23)
   #########################################################
@@ -1466,6 +1487,32 @@ postsubmits:
             requests:
               cpu: 100m
               memory: 1Gi
+  - name: post-kubeone-push-image
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    decorate: true
+    reporter_config:
+      slack:
+        channel: dev-kubeone
+    branches:
+      - ^master$
+      - ^v\d+\.\d+\.\d+.*
+    labels:
+      preset-goproxy: "true"
+      preset-docker-push-kubermatic: "true"
+      preset-docker-mirror: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-4
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              start-docker.sh
+              TAGS="latest $(git tag --points-at HEAD)" ./hack/ci/push-image.sh
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
   - name: post-kubeone-upload-gocache-amd64
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN make build
 FROM docker.io/alpine:3.15
 LABEL maintainer="support@kubermatic.com"
 
-RUN apk add --update openssh-client
+# openssh-client is required for the ssh binary and for ssh-agent
+RUN apk add --no-cache openssh-client
 
 COPY --from=builder /go/src/k8c.io/kubeone/dist/kubeone /usr/local/bin/kubeone
 ENTRYPOINT ["/usr/local/bin/kubeone"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker.io/golang:1.17.5 as builder
+
+ARG GOPROXY=
+ENV GOPROXY=$GOPROXY
+
+ARG GOCACHE=
+ENV GOCACHE=$GOCACHE
+
+WORKDIR /go/src/k8c.io/kubeone
+COPY . .
+RUN make build
+
+FROM docker.io/alpine:3.15
+LABEL maintainer="support@kubermatic.com"
+
+RUN apk add --update openssh-client
+
+COPY --from=builder /go/src/k8c.io/kubeone/dist/kubeone /usr/local/bin/kubeone
+ENTRYPOINT ["/usr/local/bin/kubeone"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2022 The KubeOne Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/ci/download-gocache.sh
+++ b/hack/ci/download-gocache.sh
@@ -51,8 +51,9 @@ if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
 fi
 
 GOCACHE="$(go env GOCACHE)"
+TARGET_DIRECTORY="${TARGET_DIRECTORY:-$GOCACHE}"
 # Make sure it actually exists
-mkdir -p "${GOCACHE}"
+mkdir -p "${TARGET_DIRECTORY}"
 
 # PULL_BASE_REF is the name of the current branch in case of a post-submit
 # or the name of the base branch in case of a PR.
@@ -100,6 +101,6 @@ TEST_NAME="Download and extract gocache"
 # Passing the Headers as space-separated literals doesn't seem to work
 # in conjunction with the retry func, so we just put them in a file instead
 echo 'Content-Type: application/octet-stream' > /tmp/headers
-retry 5 curl --fail -H @/tmp/headers "${URL}" | tar -C $GOCACHE -xf -
+retry 5 curl --fail -H @/tmp/headers "${URL}" | tar -C $TARGET_DIRECTORY -xf -
 
-echodate "Successfully fetched gocache into $GOCACHE"
+echodate "Successfully fetched gocache into $TARGET_DIRECTORY"

--- a/hack/ci/push-image.sh
+++ b/hack/ci/push-image.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This script is used to build the KubeOne Docker image.
+### The KubeOne image is currently experimental and NOT supposed to be used
+### in production.
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+source $(dirname $0)/../lib.sh
+
+DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
+ARCHITECTURES=${ARCHITECTURES:-amd64 arm64}
+NOMOCK=${NOMOCK:-false}
+
+PRIMARY_TAG="$(git rev-parse HEAD | tr -d '\n')"
+TAGS=${TAGS:-}
+
+gocaches="$(mktemp -d)"
+for ARCH in ${ARCHITECTURES}; do
+  cacheDir="$gocaches/$ARCH"
+  mkdir -p "$cacheDir"
+ 
+  # try to get a gocache for this arch; this can "fail" but still exit with 0
+  echodate "Attempting to fetch gocache for $ARCH..."
+  TARGET_DIRECTORY="$cacheDir" GOARCH="$ARCH" ./hack/ci/download-gocache.sh
+done
+
+echodate "Building ${DOCKER_REPO}/kubeone:${PRIMARY_TAG}"
+
+# build multi-arch images
+buildah manifest create "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}"
+for ARCH in ${ARCHITECTURES}; do
+  echodate "Building a KubeOne image for $ARCH..."
+
+  # Building via buildah does not use the gocache, but that's okay, because we
+  # wouldn't want to cache arm64 stuff anyway, as it would just blow up the
+  # cache size and force every e2e test to download gigabytes worth of unneeded
+  # arm64 stuff. We might need to change this once we run e2e tests on arm64.
+  buildah bud \
+    --tag="${DOCKER_REPO}/kubeone-${ARCH}:${PRIMARY_TAG}" \
+    --build-arg="GOPROXY=${GOPROXY:-}" \
+    --build-arg="GOCACHE=/gocache" \
+    --arch="$ARCH" \
+    --override-arch="$ARCH" \
+    --format=docker \
+    --file Dockerfile \
+    --volume "$gocaches/$ARCH:/gocache" \
+    .
+  buildah manifest add "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}" "${DOCKER_REPO}/kubeone-${ARCH}:${PRIMARY_TAG}"
+done
+
+if [ "$NOMOCK" = true ]; then
+  echodate "Pushing ${DOCKER_REPO}/kubeone:${PRIMARY_TAG}..."
+  buildah manifest push --all "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}" "docker://${DOCKER_REPO}/kubeone:${PRIMARY_TAG}"
+
+  for TAG in ${TAGS}; do
+    echodate "Pushing ${DOCKER_REPO}/kubeone:${TAG}..."
+    buildah tag "${DOCKER_REPO}/kubeone:${PRIMARY_TAG}" "${DOCKER_REPO}/kubeone:${TAG}"
+    buildah manifest push --all "${DOCKER_REPO}/kubeone:${TAG}" "docker://${DOCKER_REPO}/kubeone:${TAG}"
+  done
+fi
+
+echodate "Done. :-)"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR introduces an experimental KubeOne container image. The image is:

* built using `buildah` for `amd64` and `arm64`
* available in the `quay.io/kubermatic/kubeone` repository, which is already created.
* based on `alpine:3.15` with the `openssh-client` package installed (so we can use SSH and ssh-agent).

This PR also adds the `pull-kubeone-build-image` job, which tests building the image on each PR. This is very fast (around 2 minutes) because of the recent introduction of `arm64` GOCACHE (#1876).

The image is pushed on each commit to master and on each release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1868

**Does this PR introduce a user-facing change?**:
```release-note
[EXPERIMENTAL] Add the KubeOne container image. This image should NOT be used in the production.
```
