### PR TITLE
Build and upload GOCACHE for arm64

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1466,7 +1466,7 @@ postsubmits:
             requests:
               cpu: 100m
               memory: 1Gi
-  - name: post-kubeone-upload-gocache
+  - name: post-kubeone-upload-gocache-amd64
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     branches:
@@ -1478,6 +1478,28 @@ postsubmits:
         - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-4
           command:
             - ./hack/ci/upload-gocache.sh
+          resources:
+            requests:
+              # Make sure we get a node exclusively so this is fast and we do not disturb others
+              cpu: 3500m
+              memory: 6Gi
+            limits:
+              cpu: 4
+  - name: post-kubeone-upload-gocache-arm64
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
+    branches:
+      - ^master$
+    spec:
+      containers:
+        # This must match the go version used for building, else go will rightfully
+        # not use the cache
+        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-4
+          command:
+            - ./hack/ci/upload-gocache.sh
+          env:
+            - name: GOARCH
+              value: arm64
           resources:
             requests:
               # Make sure we get a node exclusively so this is fast and we do not disturb others


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds a new job, `post-kubeone-upload-gocache-arm64`, used to build and upload GOCACHE for arm64 architectures. We need GOCACHE for arm64 to speed up the multiarch image builds (see #1875).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1868

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
