### PR TITLE
Run push-image postsubmit in the nomock mode

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1513,6 +1513,9 @@ postsubmits:
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
+          env:
+            - name: NOMOCK
+              value: "true"
   - name: post-kubeone-upload-gocache-amd64
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The push-image postsubmit is currently running in the mock mode, i.e. images are not pushed to the registry. This PR changes the postsubmit to run the script in the nomock mode, so images are pushed to the registry.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1868

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 