### PR TITLE
Run docker login when pushing images

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -142,7 +142,6 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
       preset-goproxy: "true"
-      preset-docker-push-kubermatic: "true"
       preset-docker-mirror: "true"
     spec:
       containers:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1509,6 +1509,7 @@ postsubmits:
             - |
               set -euo pipefail
               start-docker.sh
+              docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io
               TAGS="latest $(git tag --points-at HEAD)" ./hack/ci/push-image.sh
           # docker-in-docker needs privileged mode
           securityContext:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Run `docker login` when pushing images. This should, hopefully, fix the image pushing postsubmit.

Also, the credentials preset is removed from the presubmit because we don't push images via that job.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1868

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg @ahmedwaleedmalik 