### PR TITLE
Use a pointer to KubeOneCluster in AssetConfig defaulting

### DIFF
--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -426,7 +426,7 @@ func (ads *Addons) RelativePath(manifestFilePath string) (string, error) {
 // highest priority, then comes the RegistryConfiguration.
 // This function is needed because the AssetsConfiguration API has been removed
 // in the v1beta2 API, so we can't use defaulting
-func (c KubeOneCluster) DefaultAssetConfiguration() {
+func (c *KubeOneCluster) DefaultAssetConfiguration() {
 	if c.RegistryConfiguration == nil || c.RegistryConfiguration.OverwriteRegistry == "" {
 		// We default AssetConfiguration only if RegistryConfiguration.OverwriteRegistry
 		// is used


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The function used to default the AssetConfiguration object didn't use a pointer to the KubeOneCluster object, so changes were not reflected at all. This broke the overwriteRegistry functionality for some images.

**Does this PR introduce a user-facing change?**:
```release-note
Fix overwriteRegistry not overwriting the Kubernetes control plane images
```

/assign @kron4eg @ahmedwaleedmalik 