### PR TITLE
Approve pending CSRs when upgrading nodes

### DIFF
--- a/pkg/tasks/upgrade_follower.go
+++ b/pkg/tasks/upgrade_follower.go
@@ -83,5 +83,5 @@ func upgradeFollowerExecutor(s *state.State, node *kubeoneapi.HostConfig, conn s
 		return errors.Wrap(err, "failed to unlabel follower control plane node")
 	}
 
-	return nil
+	return approvePendingCSR(s, node, conn)
 }

--- a/pkg/tasks/upgrade_leader.go
+++ b/pkg/tasks/upgrade_leader.go
@@ -83,5 +83,5 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 		return errors.Wrap(err, "failed to unlabel leader control plane node")
 	}
 
-	return nil
+	return approvePendingCSR(s, node, conn)
 }

--- a/pkg/tasks/upgrade_static_workers.go
+++ b/pkg/tasks/upgrade_static_workers.go
@@ -85,5 +85,5 @@ func upgradeStaticWorkersExecutor(s *state.State, node *kubeoneapi.HostConfig, c
 		return errors.Wrap(err, "failed to unlabel static worker node node")
 	}
 
-	return nil
+	return approvePendingCSR(s, node, conn)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Approve pending CSRs when upgrading control plane and static worker nodes. It seems that upgrading the cluster causes new CSRs to be created. If we don't approve those CSRs, the certificates will not work. This will cause errors such as:

```
Error from server: Get "https://10.0.42.12:10250/containerLogs/kube-system/machine-controller-7b647fdc45-tfskm/machine-controller?follow=true": remote error: tls: internal error
```

**Does this PR introduce a user-facing change?**:
```release-note
Approve pending CSRs when upgrading control plane and static worker nodes
```

/assign @kron4eg 