### PR TITLE
Fix CSR approving issue for existing nodes with already approved and GCed CSRs

### DIFF
--- a/pkg/tasks/certs.go
+++ b/pkg/tasks/certs.go
@@ -244,7 +244,7 @@ func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Con
 	}
 
 	if !csrFound {
-		s.Logger.Info("no CSR found for node %q, assuming it was garbage-collected", node.Hostname)
+		s.Logger.Info("No CSR found for node %q, assuming it was garbage-collected", node.Hostname)
 	}
 
 	return nil

--- a/pkg/tasks/certs.go
+++ b/pkg/tasks/certs.go
@@ -185,8 +185,7 @@ func saveCABundleOnControlPlane(s *state.State, _ *kubeoneapi.HostConfig, conn s
 }
 
 func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Connection) error {
-	approveErr := errors.Errorf("no CSR found for node %q", node.Hostname)
-
+	var csrFound bool
 	sleepTime := 20 * time.Second
 	s.Logger.Infof("Waiting %s for CSRs to approve...", sleepTime)
 	time.Sleep(sleepTime)
@@ -219,8 +218,8 @@ func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Con
 			}
 		}
 		if approved {
-			// CSR matched but it's already approved, no need to raise an error
-			approveErr = nil
+			// CSR matched but it's already approved
+			csrFound = true
 
 			continue
 		}
@@ -228,7 +227,7 @@ func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Con
 		if err := validateCSR(csr.Spec); err != nil {
 			return fmt.Errorf("failed to validate CSR: %w", err)
 		}
-		approveErr = nil
+		csrFound = true
 
 		csr := csr.DeepCopy()
 		csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
@@ -244,7 +243,11 @@ func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Con
 		}
 	}
 
-	return approveErr
+	if !csrFound {
+		s.Logger.Info("no CSR found for node %q, assuming it was garbage-collected", node.Hostname)
+	}
+
+	return nil
 }
 
 func validateCSR(spec certificatesv1.CertificateSigningRequestSpec) error {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Successfully approved CSR is GC-ed after 1 hour, effectively leading to the situation where perfectly good Kubelet cert doesn't need any new CSRs will make kubeone to throw out with misleading error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1893

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix CSR approving issue for existing nodes with already approved and GCed CSRs
```