### PR TITLE
Domain is not required when using application credentials

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,7 @@ issues:
     text: "`registry` always receives `\"127.0.0.1:5000\"`"
 
   - path: pkg/credentials
-    text: "cyclomatic complexity 32 of func `openstackValidationFunc` is high"
+    text: "cyclomatic complexity 34 of func `openstackValidationFunc` is high"
 
   - path: pkg/addons
     text: "cyclomatic complexity 34 of func `newAddonsApplier` is high"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Domain is not required when using application credentials.

**Does this PR close any issues?**:<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #1872

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!-- Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Domain is not required when using application credentials
```