### PR TITLE
Mount /usr/share/ca-certificates to the OpenStack CCM pod

### DIFF
--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -206,6 +206,9 @@ spec:
             - mountPath: /etc/ssl/certs
               name: ca-certs
               readOnly: true
+            - mountPath: /usr/share/ca-certificates
+              name: usr-ca-certs
+              readOnly: true
             - mountPath: /etc/config
               name: cloud-config-volume
               readOnly: true
@@ -225,6 +228,10 @@ spec:
         hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-ca-certs
       - name: cloud-config-volume
         secret:
           secretName: cloud-config

--- a/examples/terraform/openstack/gobetween.sh
+++ b/examples/terraform/openstack/gobetween.sh
@@ -21,14 +21,14 @@ set -euf -o pipefail
 
 GOBETWEEN_VERSION=0.7.0
 
-noop() { : "didn't detected package manager, noop"; }
-
 PKG_MANAGER="noop"
 
 [ "$(command -v yum)" ] && PKG_MANAGER=yum
 [ "$(command -v apt-get)" ] && PKG_MANAGER=apt-get
 
-sudo ${PKG_MANAGER} install tar -y
+if [ "$PKG_MANAGER" != "noop" ]; then
+  sudo ${PKG_MANAGER} install tar -y
+fi
 
 mkdir -p /tmp/gobetween
 cd /tmp/gobetween


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Some operating systems (e.g. Flatcar Linux), use symlinks in the `/etc/ssl/certs` directory. Those symlinks are often pointing to the `/usr/share/ca-certificates` directory. In this case, the OpenStack CCM pod will fail to start because it can't resolve the symlinks, due to `/usr/share/ca-certificates` not being mounted. This issue is fixed by mounting the `/usr/share/ca-certificates` to the OpenStack CCM pod.

Additionally, this PR fixes the issue with the `gobetween.sh` script failing on Flatcar Linux instances. It's failing because the `noop` function is not passed to `sudo`, therefore, the function is not usable at all.

**Does this PR introduce a user-facing change?**:
```release-note
Mount /usr/share/ca-certificates to the OpenStack CCM pod to fix the OpenStack CCM pod CrashLooping on Flatcar Linux
Fix the GoBetween script failing to install the zip package on Flatcar Linux
```

/assign @kron4eg 