### PR TITLE
PDB Objects for all addons Deployments

### DIFF
--- a/addons/ccm-azure/poddisruptionbudget.yaml
+++ b/addons/ccm-azure/poddisruptionbudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: azure-cloud-controller-manager
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       component: azure-cloud-controller-manager

--- a/addons/ccm-azure/poddisruptionbudget.yaml
+++ b/addons/ccm-azure/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: azure-cloud-controller-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      component: azure-cloud-controller-manager

--- a/addons/ccm-digitalocean/poddisruptionbudget.yaml
+++ b/addons/ccm-digitalocean/poddisruptionbudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: digitalocean-cloud-controller-manager
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: digitalocean-cloud-controller-manager

--- a/addons/ccm-digitalocean/poddisruptionbudget.yaml
+++ b/addons/ccm-digitalocean/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: digitalocean-cloud-controller-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: digitalocean-cloud-controller-manager

--- a/addons/ccm-equinixmetal/poddisruptionbudget.yaml
+++ b/addons/ccm-equinixmetal/poddisruptionbudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: equinixmetal-cloud-controller-manager
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: equinixmetal-cloud-controller-manager

--- a/addons/ccm-equinixmetal/poddisruptionbudget.yaml
+++ b/addons/ccm-equinixmetal/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: equinixmetal-cloud-controller-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: equinixmetal-cloud-controller-manager

--- a/addons/ccm-hetzner/poddisruptionbudget.yaml
+++ b/addons/ccm-hetzner/poddisruptionbudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: hcloud-cloud-controller-manager
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: hcloud-cloud-controller-manager

--- a/addons/ccm-hetzner/poddisruptionbudget.yaml
+++ b/addons/ccm-hetzner/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: hcloud-cloud-controller-manager

--- a/addons/cluster-autoscaler/poddisruptionbudget.yaml
+++ b/addons/cluster-autoscaler/poddisruptionbudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: cluster-autoscaler
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: cluster-autoscaler

--- a/addons/cluster-autoscaler/poddisruptionbudget.yaml
+++ b/addons/cluster-autoscaler/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler

--- a/addons/cni-cilium/poddisruptionbudgets.yaml
+++ b/addons/cni-cilium/poddisruptionbudgets.yaml
@@ -1,0 +1,45 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      name: cilium-operator
+---
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: hubble-relay
+---
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: hubble-ui

--- a/addons/cni-cilium/poddisruptionbudgets.yaml
+++ b/addons/cni-cilium/poddisruptionbudgets.yaml
@@ -14,6 +14,8 @@ spec:
     matchLabels:
       name: cilium-operator
 ---
+
+{{ if .Config.ClusterNetwork.CNI.Cilium.EnableHubble }}
 {{- if ge $version.Minor 21 }}
 apiVersion: policy/v1
 {{- else }}
@@ -43,3 +45,4 @@ spec:
   selector:
     matchLabels:
       k8s-app: hubble-ui
+{{ end }}

--- a/addons/cni-cilium/poddisruptionbudgets.yaml
+++ b/addons/cni-cilium/poddisruptionbudgets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: cilium-operator
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       name: cilium-operator
@@ -26,7 +26,7 @@ metadata:
   name: hubble-relay
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: hubble-relay
@@ -41,7 +41,7 @@ metadata:
   name: hubble-ui
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: hubble-ui

--- a/addons/csi-azuredisk/csi-azuredisk-controller.yaml
+++ b/addons/csi-azuredisk/csi-azuredisk-controller.yaml
@@ -4,6 +4,8 @@ apiVersion: apps/v1
 metadata:
   name: csi-azuredisk-controller
   namespace: kube-system
+  labels:
+    app: csi-azuredisk-controller
 spec:
   replicas: 2
   selector:

--- a/addons/csi-azuredisk/csi-snapshot-controller.yaml
+++ b/addons/csi-azuredisk/csi-snapshot-controller.yaml
@@ -4,6 +4,8 @@ apiVersion: apps/v1
 metadata:
   name: csi-snapshot-controller
   namespace: kube-system
+  labels:
+    app: csi-snapshot-controller
 spec:
   replicas: 1
   selector:

--- a/addons/csi-azuredisk/poddisruptionbudgets.yaml
+++ b/addons/csi-azuredisk/poddisruptionbudgets.yaml
@@ -1,0 +1,30 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: csi-azuredisk-controller
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: csi-azuredisk-controller
+---
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: csi-snapshot-controller
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: csi-snapshot-controller

--- a/addons/csi-azuredisk/poddisruptionbudgets.yaml
+++ b/addons/csi-azuredisk/poddisruptionbudgets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: csi-azuredisk-controller
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: csi-azuredisk-controller
@@ -24,7 +24,7 @@ metadata:
   name: csi-snapshot-controller
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: csi-snapshot-controller

--- a/addons/csi-azurefile/csi-azurefile-controller.yaml
+++ b/addons/csi-azurefile/csi-azurefile-controller.yaml
@@ -4,6 +4,8 @@ apiVersion: apps/v1
 metadata:
   name: csi-azurefile-controller
   namespace: kube-system
+  labels:
+    app: csi-azurefile-controller
 spec:
   replicas: 2
   selector:

--- a/addons/csi-azurefile/csi-snapshot-controller.yaml
+++ b/addons/csi-azurefile/csi-snapshot-controller.yaml
@@ -4,6 +4,8 @@ apiVersion: apps/v1
 metadata:
   name: csi-snapshot-controller
   namespace: kube-system
+  labels:
+    app: csi-snapshot-controller
 spec:
   replicas: 1
   selector:

--- a/addons/csi-azurefile/poddisruptionbudgets.yaml
+++ b/addons/csi-azurefile/poddisruptionbudgets.yaml
@@ -1,0 +1,30 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: csi-azurefile-controller
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: csi-azurefile-controller
+---
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: csi-snapshot-controller
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: csi-snapshot-controller

--- a/addons/csi-azurefile/poddisruptionbudgets.yaml
+++ b/addons/csi-azurefile/poddisruptionbudgets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: csi-azurefile-controller
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: csi-azurefile-controller
@@ -24,7 +24,7 @@ metadata:
   name: csi-snapshot-controller
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: csi-snapshot-controller

--- a/addons/csi-digitalocean/poddisruptionbudgets.yaml
+++ b/addons/csi-digitalocean/poddisruptionbudgets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: snapshot-validation
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: snapshot-validation

--- a/addons/csi-digitalocean/poddisruptionbudgets.yaml
+++ b/addons/csi-digitalocean/poddisruptionbudgets.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: snapshot-validation
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: snapshot-validation

--- a/addons/csi-nutanix/poddisruptionbudget.yaml
+++ b/addons/csi-nutanix/poddisruptionbudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: snapshot-validation
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: snapshot-validation

--- a/addons/csi-nutanix/poddisruptionbudget.yaml
+++ b/addons/csi-nutanix/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: snapshot-validation
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: snapshot-validation

--- a/addons/csi-vsphere/poddisruptionbudgets.yaml
+++ b/addons/csi-vsphere/poddisruptionbudgets.yaml
@@ -1,0 +1,30 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: vsphere-csi-webhook
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-webhook
+---
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller

--- a/addons/csi-vsphere/poddisruptionbudgets.yaml
+++ b/addons/csi-vsphere/poddisruptionbudgets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: vsphere-csi-webhook
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: vsphere-csi-webhook
@@ -24,7 +24,7 @@ metadata:
   name: vsphere-csi-controller
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: vsphere-csi-controller

--- a/addons/csi-vsphere/validatingwebhook.yaml
+++ b/addons/csi-vsphere/validatingwebhook.yaml
@@ -86,6 +86,8 @@ apiVersion: apps/v1
 metadata:
   name: vsphere-csi-webhook
   namespace: kube-system
+  labels:
+    app: vsphere-csi-webhook
 spec:
   replicas: 1
   selector:

--- a/addons/csi-vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi-vsphere/vsphere-csi-driver.yaml
@@ -188,6 +188,8 @@ apiVersion: apps/v1
 metadata:
   name: vsphere-csi-controller
   namespace: kube-system
+  labels:
+    app: vsphere-csi-controller
 spec:
   replicas: 1
   selector:

--- a/addons/machinecontroller/deployment-controller.yaml
+++ b/addons/machinecontroller/deployment-controller.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: machine-controller
   namespace: kube-system
+  labels:
+    app: machine-controller
 spec:
   replicas: 1
   selector:

--- a/addons/machinecontroller/poddisruptionbudgets.yaml
+++ b/addons/machinecontroller/poddisruptionbudgets.yaml
@@ -1,0 +1,30 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: machine-controller
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: machine-controller
+---
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: machine-controller-webhook
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: machine-controller-webhook

--- a/addons/machinecontroller/poddisruptionbudgets.yaml
+++ b/addons/machinecontroller/poddisruptionbudgets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: machine-controller
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: machine-controller
@@ -24,7 +24,7 @@ metadata:
   name: machine-controller-webhook
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: machine-controller-webhook

--- a/addons/machinecontroller/webhook.yaml
+++ b/addons/machinecontroller/webhook.yaml
@@ -46,6 +46,8 @@ kind: Deployment
 metadata:
   name: machine-controller-webhook
   namespace: kube-system
+  labels:
+    app: machine-controller-webhook
 spec:
   replicas: 1
   selector:

--- a/addons/metrics-server/poddisruptionbudget.yaml
+++ b/addons/metrics-server/poddisruptionbudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: metrics-server

--- a/addons/metrics-server/poddisruptionbudget.yaml
+++ b/addons/metrics-server/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: metrics-server

--- a/addons/operating-system-manager/deployment-controller.yaml
+++ b/addons/operating-system-manager/deployment-controller.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: operating-system-manager
   namespace: kube-system
+  labels:
+    app: operating-system-manager
 spec:
   replicas: 1
   selector:

--- a/addons/operating-system-manager/poddisruptionbudgets.yaml
+++ b/addons/operating-system-manager/poddisruptionbudgets.yaml
@@ -1,0 +1,30 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: operating-system-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager
+---
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: operating-system-manager-webhook
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook

--- a/addons/operating-system-manager/poddisruptionbudgets.yaml
+++ b/addons/operating-system-manager/poddisruptionbudgets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: operating-system-manager
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: operating-system-manager
@@ -24,7 +24,7 @@ metadata:
   name: operating-system-manager-webhook
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: operating-system-manager-webhook

--- a/addons/operating-system-manager/webhook.yaml
+++ b/addons/operating-system-manager/webhook.yaml
@@ -34,6 +34,8 @@ kind: Deployment
 metadata:
   name: operating-system-manager-webhook
   namespace: kube-system
+  labels:
+    app: operating-system-manager-webhook
 spec:
   replicas: 1
   selector:

--- a/addons/unattended-upgrades/fluo.yaml
+++ b/addons/unattended-upgrades/fluo.yaml
@@ -310,6 +310,8 @@ kind: Deployment
 metadata:
   name: flatcar-linux-update-operator
   namespace: reboot-coordinator
+  labels:
+    app: flatcar-linux-update-operator
 spec:
   replicas: 1
   selector:

--- a/addons/unattended-upgrades/poddisruptionbudget.yaml
+++ b/addons/unattended-upgrades/poddisruptionbudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: flatcar-linux-update-operator
   namespace: kube-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: flatcar-linux-update-operator

--- a/addons/unattended-upgrades/poddisruptionbudget.yaml
+++ b/addons/unattended-upgrades/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{ $version := semver .Config.Versions.Kubernetes }}
+{{- if ge $version.Minor 21 }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: flatcar-linux-update-operator
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: flatcar-linux-update-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
Introducing PodDisruptionBudget object for all addons Deployments, in order to let cluster-autoscaler to drain worker nodes with pods running in kube-system namespace.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1891

/kind bug

```release-note
PDB Objects for all addons Deployments 
```
