### PR TITLE
Enable the etcd corruption checks for etcd v3.5

### DIFF
--- a/pkg/templates/kubeadm/v1beta3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm.go
@@ -30,6 +30,7 @@ import (
 	"k8c.io/kubeone/pkg/fail"
 	"k8c.io/kubeone/pkg/features"
 	"k8c.io/kubeone/pkg/kubeflags"
+	"k8c.io/kubeone/pkg/semverutil"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/templates/kubeadm/kubeadmargs"
 	"k8c.io/kubeone/pkg/templates/resources"
@@ -46,12 +47,31 @@ const (
 	bootstrapTokenTTL = 60 * time.Minute
 )
 
+const (
+	// greaterOrEqualThan122 defines a version constraint for the Kubernetes 1.22+ clusters
+	greaterOrEqualThan122 = ">= 1.22.0"
+)
+
+var (
+	etcdIntegrityCheckConstraint = semverutil.MustParseConstraint(greaterOrEqualThan122)
+)
+
 // NewConfig returns all required configs to init a cluster via a set of v1beta3 configs
 func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, error) {
 	cluster := s.Cluster
 	kubeSemVer, err := semver.NewVersion(cluster.Versions.Kubernetes)
 	if err != nil {
 		return nil, fail.Config(err, "parsing kubernetes semver")
+	}
+
+	etcdExtraArgs := map[string]string{}
+	if etcdIntegrityCheckConstraint.Check(kubeSemVer) {
+		// This is required because etcd v3.5 (used for Kubernetes 1.22+)
+		// has an issue with the data integrity.
+		// See https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ
+		// for more details.
+		etcdExtraArgs["experimental-initial-corrupt-check"] = "true"
+		etcdExtraArgs["experimental-corrupt-check-time"] = "240m"
 	}
 
 	nodeRegistration := newNodeRegistration(s, host)
@@ -150,6 +170,7 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 					ImageRepository: cluster.AssetConfiguration.Etcd.ImageRepository,
 					ImageTag:        cluster.AssetConfiguration.Etcd.ImageTag,
 				},
+				ExtraArgs: etcdExtraArgs,
 			},
 		},
 		DNS: kubeadmv1beta3.DNS{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Yesterday, the etcd team announced [that they do not recommend usage of etcd 3.5 in production anymore](https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ) due to data consistency issues that can occur when etcd is terminated under high load. They expect that an upcoming etcd 3.5.3 release will fix this problem, but no ETA has been communicated so far.

This PR enables two flags, as per the etcd production recommendations:

* `experimental-initial-corrupt-check` -- used to check the data integrity when etcd is starting. This will prevent a member with corrupted data to join the cluster and potentially affect other members
* `experimental-corrupt-check-time` -- periodically check the etcd members for corruption. This is done every 4 hours

Those flags are enabled for all Kubernetes 1.22+ clusters since those clusters are using etcd v3.5. This can't repair broken etcd members, but it can at least prevent broken members from affecting other members.

**Does this PR introduce a user-facing change?**:
```release-note
Enable the etcd integrity checks (on startup and every 4 hours) for Kubernetes 1.22+ clusters. See the official etcd announcement for more details (https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ).
```

/assign @kron4eg 