### PR TITLE
Add (re-)rendering container runtime config to flatcar upgrades

### DIFF
--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -457,6 +457,15 @@ func TestKubeadmFlatcar(t *testing.T) {
 				cluster: genCluster(withContainerd),
 			},
 		},
+		{
+			name: "with containerd with insecure registry",
+			args: args{
+				cluster: genCluster(
+					withContainerd,
+					withInsecureRegistry("127.0.0.1:5000"),
+				),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -572,7 +581,12 @@ func TestUpgradeKubeadmAndCNIAmazonLinux(t *testing.T) {
 func TestUpgradeKubeadmAndCNIFlatcar(t *testing.T) {
 	t.Parallel()
 
-	got, err := UpgradeKubeadmAndCNIFlatcar("v1.17.4")
+	c := genCluster(
+		withKubeVersion("v1.17.4"),
+		withContainerd,
+		withInsecureRegistry("127.0.0.1:5000"),
+	)
+	got, err := UpgradeKubeadmAndCNIFlatcar(&c)
 	if err != nil {
 		t.Errorf("UpgradeKubeadmAndCNIFlatcar() error = %v", err)
 
@@ -627,7 +641,12 @@ func TestUpgradeKubeletAndKubectlAmazonLinux(t *testing.T) {
 func TestUpgradeKubeletAndKubectlFlatcar(t *testing.T) {
 	t.Parallel()
 
-	got, err := UpgradeKubeletAndKubectlFlatcar("v1.17.4")
+	c := genCluster(
+		withKubeVersion("v1.17.4"),
+		withContainerd,
+		withInsecureRegistry("127.0.0.1:5000"),
+	)
+	got, err := UpgradeKubeletAndKubectlFlatcar(&c)
 	if err != nil {
 		t.Errorf("UpgradeKubeletAndKubectlFlatcar() error = %v", err)
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -18,6 +18,51 @@ aarch64)
 	;;
 esac
 
+
+cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+ip_tables
+EOF
+sudo modprobe overlay
+sudo modprobe br_netfilter
+sudo modprobe ip_tables
+sudo mkdir -p /etc/sysctl.d
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+fs.inotify.max_user_watches         = 1048576
+kernel.panic                        = 10
+kernel.panic_on_oops                = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.netfilter.nf_conntrack_max      = 1000000
+vm.overcommit_memory                = 1
+EOF
+sudo sysctl --system
+
+
+sudo mkdir -p /etc/systemd/journald.conf.d
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/max_disk_use.conf
+[Journal]
+SystemMaxUse=5G
+EOF
+sudo systemctl force-reload systemd-journald
+
+
+sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+	sudo tar -C /opt/cni/bin -xz
+
+RELEASE="v1.17.4"
+CRI_TOOLS_RELEASE="v1.21.0"
+
+curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
+	sudo tar -C /opt/bin -xz
+
+
+
+
+
 sudo mkdir -p $(dirname /etc/containerd/config.toml)
 sudo touch /etc/containerd/config.toml
 sudo chmod 600 /etc/containerd/config.toml
@@ -63,16 +108,15 @@ sudo systemctl restart containerd
 
 
 
-RELEASE="vv1.17.4"
-sudo mkdir -p /var/tmp/kube-binaries
-cd /var/tmp/kube-binaries
-sudo curl -L --remote-name-all \
-	https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${HOST_ARCH}/{kubelet,kubectl}
 sudo mkdir -p /opt/bin
 cd /opt/bin
-sudo systemctl stop kubelet
-sudo mv /var/tmp/kube-binaries/{kubelet,kubectl} .
-sudo chmod +x {kubelet,kubectl}
+k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
+for binary in kubeadm kubelet kubectl; do
+	curl -L --output /tmp/$binary \
+		$k8s_rel_baseurl/${RELEASE}/bin/linux/${HOST_ARCH}/$binary
+	sudo install --owner=0 --group=0 --mode=0755 /tmp/$binary /opt/bin/$binary
+	rm /tmp/$binary
+done
 
 cat <<EOF | sudo tee /etc/systemd/system/kubelet.service
 [Unit]
@@ -106,4 +150,4 @@ ExecStart=/opt/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUB
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl start kubelet
+sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -16,6 +16,50 @@ aarch64)
 	;;
 esac
 
+sudo mkdir -p $(dirname /etc/containerd/config.toml)
+sudo touch /etc/containerd/config.toml
+sudo chmod 600 /etc/containerd/config.toml
+cat <<EOF | sudo tee /etc/containerd/config.toml
+version = 2
+
+[metrics]
+address = "127.0.0.1:1338"
+
+[plugins]
+[plugins."io.containerd.grpc.v1.cri"]
+[plugins."io.containerd.grpc.v1.cri".containerd]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+SystemdCgroup = true
+[plugins."io.containerd.grpc.v1.cri".registry]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."127.0.0.1:5000"]
+endpoint = ["http://127.0.0.1:5000"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+endpoint = ["https://registry-1.docker.io"]
+
+EOF
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///run/containerd/containerd.sock
+EOF
+
+sudo mkdir -p /etc/systemd/system/containerd.service.d
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/10-kubeone.conf
+[Service]
+Restart=always
+Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
+ExecStart=
+ExecStart=/usr/bin/env PATH=\${TORCX_BINDIR}:\${PATH} \${TORCX_BINDIR}/containerd --config \${CONTAINERD_CONFIG}
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable containerd
+sudo systemctl restart containerd
+
+
+
 
 source /etc/kubeone/proxy-env
 

--- a/pkg/tasks/kubernetes_binaries.go
+++ b/pkg/tasks/kubernetes_binaries.go
@@ -57,7 +57,7 @@ func upgradeKubeletAndKubectlBinariesDebian(s *state.State) error {
 }
 
 func upgradeKubeletAndKubectlBinariesFlatcar(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeletAndKubectlFlatcar(s.Cluster.Versions.Kubernetes)
+	cmd, err := scripts.UpgradeKubeletAndKubectlFlatcar(s.Cluster)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func upgradeKubeadmAndCNIBinariesAmazonLinux(s *state.State) error {
 }
 
 func upgradeKubeadmAndCNIBinariesFlatcar(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeadmAndCNIFlatcar(s.Cluster.Versions.Kubernetes)
+	cmd, err := scripts.UpgradeKubeadmAndCNIFlatcar(s.Cluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind question
-->
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug where it's only possible to render the containerd-config on control-plane nodes during the initial kubeone installation, but not re-render it during (forced) cluster upgrades using kubeone.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1901 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Regenerate container runtime configurations based on kubeone.yaml during control-plane upgrades on Flatcar Linux nodes, not only on the initial installation.
```
