### PR TITLE
[release/v1.4] Add (re-)rendering container runtime config to flatcar upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This patch release enables the etcd corruption checks on every etcd member that 
 
 ### Bug or Regression
 
+- Regenerate container runtime configurations based on kubeone.yaml during control-plane upgrades on Flatcar Linux nodes, not only on the initial installation. ([#1918](https://github.com/kubermatic/kubeone/pull/1918))
 - Approve pending CSRs when upgrading control plane and static worker nodes ([#1888](https://github.com/kubermatic/kubeone/pull/1888))
 - Enable the etcd integrity checks (on startup and every 4 hours) for Kubernetes 1.22+ clusters. See [the official etcd announcement for more details](https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ). ([#1909](https://github.com/kubermatic/kubeone/pull/1909))
 - Fix CSR approving issue for existing nodes with already approved and GCed CSRs ([#1897](https://github.com/kubermatic/kubeone/pull/1897))

--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -572,7 +572,8 @@ func TestUpgradeKubeadmAndCNIAmazonLinux(t *testing.T) {
 func TestUpgradeKubeadmAndCNIFlatcar(t *testing.T) {
 	t.Parallel()
 
-	got, err := UpgradeKubeadmAndCNIFlatcar("v1.17.4")
+	cls := genCluster(withDocker)
+	got, err := UpgradeKubeadmAndCNIFlatcar(&cls)
 	if err != nil {
 		t.Errorf("UpgradeKubeadmAndCNIFlatcar() error = %v", err)
 
@@ -627,7 +628,8 @@ func TestUpgradeKubeletAndKubectlAmazonLinux(t *testing.T) {
 func TestUpgradeKubeletAndKubectlFlatcar(t *testing.T) {
 	t.Parallel()
 
-	got, err := UpgradeKubeletAndKubectlFlatcar("v1.17.4")
+	cls := genCluster(withDocker)
+	got, err := UpgradeKubeletAndKubectlFlatcar(&cls)
 	if err != nil {
 		t.Errorf("UpgradeKubeletAndKubectlFlatcar() error = %v", err)
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -19,11 +19,41 @@ esac
 
 source /etc/kubeone/proxy-env
 
+
+
+sudo mkdir -p $(dirname /etc/docker/daemon.json)
+sudo touch /etc/docker/daemon.json
+sudo chmod 600 /etc/docker/daemon.json
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-file": "5",
+		"max-size": "100m"
+	}
+}
+EOF
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl restart docker
+
+
+
+
+
 sudo mkdir -p /opt/cni/bin
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
-RELEASE="vv1.17.4"
+RELEASE="v1.17.4"
 
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlFlatcar.golden
@@ -19,7 +19,37 @@ aarch64)
 esac
 
 
-RELEASE="vv1.17.4"
+
+
+sudo mkdir -p $(dirname /etc/docker/daemon.json)
+sudo touch /etc/docker/daemon.json
+sudo chmod 600 /etc/docker/daemon.json
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+	"exec-opts": [
+		"native.cgroupdriver=systemd"
+	],
+	"storage-driver": "overlay2",
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-file": "5",
+		"max-size": "100m"
+	}
+}
+EOF
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/dockershim.sock
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker
+sudo systemctl restart docker
+
+
+
+
+
+RELEASE="v1.17.4"
 sudo mkdir -p /var/tmp/kube-binaries
 cd /var/tmp/kube-binaries
 sudo curl -L --remote-name-all \

--- a/pkg/tasks/kubernetes_binaries.go
+++ b/pkg/tasks/kubernetes_binaries.go
@@ -58,7 +58,7 @@ func upgradeKubeletAndKubectlBinariesDebian(s *state.State) error {
 }
 
 func upgradeKubeletAndKubectlBinariesFlatcar(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeletAndKubectlFlatcar(s.Cluster.Versions.Kubernetes)
+	cmd, err := scripts.UpgradeKubeletAndKubectlFlatcar(s.Cluster)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func upgradeKubeadmAndCNIBinariesAmazonLinux(s *state.State) error {
 }
 
 func upgradeKubeadmAndCNIBinariesFlatcar(s *state.State) error {
-	cmd, err := scripts.UpgradeKubeadmAndCNIFlatcar(s.Cluster.Versions.Kubernetes)
+	cmd, err := scripts.UpgradeKubeadmAndCNIFlatcar(s.Cluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR is a manual cherry-pick of #1910 to the `release/v1.4` branch. The PR has been tested and it works as expected.

**Does this PR introduce a user-facing change?**:
```release-note
Regenerate container runtime configurations based on kubeone.yaml during control-plane upgrades on Flatcar Linux nodes, not only on the initial installation.
```