### PR TITLE
Use Infof instead of Info for correct logging format

### DIFF
--- a/pkg/tasks/certs.go
+++ b/pkg/tasks/certs.go
@@ -245,7 +245,7 @@ func approvePendingCSR(s *state.State, node *kubeoneapi.HostConfig, conn ssh.Con
 	}
 
 	if !csrFound {
-		s.Logger.Info("No CSR found for node %q, assuming it was garbage-collected", node.Hostname)
+		s.Logger.Infof("No CSR found for node %q, assuming it was garbage-collected", node.Hostname)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

The logging was using `Info` instead of `Infof`within a single place which resulted in a bad formatted loginline like this:

```
time="10:06:56 UTC" level=info msg="No CSR found for node %q, assuming it was garbage-collectedworker-01" node=XXX.XXX.XXX.XXX
```

instead of the expected result:


```
time="10:06:56 UTC" level=info msg="No CSR found for node \"worker-01\", assuming it was garbage-collected" node=XXX.XXX.XXX.XXX
```

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

It just fixes the logging format

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
