### PR TITLE
Update machine-controller to v1.46.0

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -179,8 +179,6 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
-            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
-              value: "0.138"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.20.13"
             - name: KUBEONE_TEST_RUN
@@ -243,8 +241,6 @@ presubmits:
           env:
             - name: PROVIDER
               value: "aws"
-            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
-              value: "0.138"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.20.13"
             - name: KUBEONE_TEST_RUN
@@ -926,8 +922,6 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
-            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
-              value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -954,8 +948,6 @@ presubmits:
           env:
             - name: PROVIDER
               value: "aws"
-            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
-              value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.20.13"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -984,8 +976,6 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
-            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
-              value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -1014,8 +1004,6 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
-            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
-              value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.22.4"
             - name: TEST_CLUSTER_TARGET_VERSION

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -181,6 +181,8 @@ presubmits:
               value: containerd
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
+            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
+              value: "0.138"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.20.13"
             - name: KUBEONE_TEST_RUN
@@ -245,6 +247,8 @@ presubmits:
               value: "aws"
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
+            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
+              value: "0.138"
             - name: TEST_CLUSTER_TARGET_VERSION
               value: "1.20.13"
             - name: KUBEONE_TEST_RUN
@@ -928,6 +932,8 @@ presubmits:
               value: containerd
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
+            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
+              value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -956,6 +962,8 @@ presubmits:
               value: "aws"
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
+            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
+              value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.20.13"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -986,6 +994,8 @@ presubmits:
               value: containerd
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
+            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
+              value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.21.7"
             - name: TEST_CLUSTER_TARGET_VERSION

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -179,8 +179,6 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
             - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
               value: "0.138"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -245,8 +243,6 @@ presubmits:
           env:
             - name: PROVIDER
               value: "aws"
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
             - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
               value: "0.138"
             - name: TEST_CLUSTER_TARGET_VERSION
@@ -930,8 +926,6 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
             - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
               value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
@@ -960,8 +954,6 @@ presubmits:
           env:
             - name: PROVIDER
               value: "aws"
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
             - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
               value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
@@ -992,8 +984,6 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
             - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
               value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
@@ -1024,8 +1014,8 @@ presubmits:
               value: "aws"
             - name: CONTAINER_RUNTIME
               value: containerd
-            - name: TF_VAR_initial_machinedeployment_spotinstances
-              value: "true"
+            - name: TF_VAR_initial_machinedeployment_spotinstances_max_price
+              value: "0.138"
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.22.4"
             - name: TEST_CLUSTER_TARGET_VERSION

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -67,7 +67,7 @@ No modules.
 | <a name="input_control_plane_vm_count"></a> [control\_plane\_vm\_count](#input\_control\_plane\_vm\_count) | Number of control plane instances | `number` | `3` | no |
 | <a name="input_control_plane_volume_size"></a> [control\_plane\_volume\_size](#input\_control\_plane\_volume\_size) | Size of the EBS volume, in Gb | `number` | `100` | no |
 | <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | number of replicas per MachineDeployment | `number` | `1` | no |
-| <a name="input_initial_machinedeployment_spotinstances"></a> [initial\_machinedeployment\_spotinstances](#input\_initial\_machinedeployment\_spotinstances) | use spot instances for initial machine-deployment | `bool` | `false` | no |
+| <a name="input_initial_machinedeployment_spotinstances_max_price"></a> [initial\_machinedeployment\_spotinstances\_max\_price](#input\_initial\_machinedeployment\_spotinstances\_max\_price) | Max price for spot instances, when specified spot instances will be used for initial machine-deployment | `number` | `0` | no |
 | <a name="input_internal_api_lb"></a> [internal\_api\_lb](#input\_internal\_api\_lb) | make kubernetes API loadbalancer internal (reachible only from inside the VPC) | `bool` | `false` | no |
 | <a name="input_os"></a> [os](#input\_os) | Operating System to use in AMI filtering and MachineDeployment | `string` | `"ubuntu"` | no |
 | <a name="input_ssh_agent_socket"></a> [ssh\_agent\_socket](#input\_ssh\_agent\_socket) | SSH Agent socket, default to grab from $SSH\_AUTH\_SOCK | `string` | `"env:SSH_AUTH_SOCK"` | no |

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -31,6 +31,7 @@ locals {
   worker_deploy_ssh_key = var.worker_deploy_ssh_key ? [aws_key_pair.deployer.public_key] : []
   ssh_username          = var.ssh_username == "" ? var.ami_filters[var.os].ssh_username : var.ssh_username
   bastion_user          = var.bastion_user == "" ? var.ami_filters[var.os].ssh_username : var.bastion_user
+  initial_machinedeployment_spotinstances = var.initial_machinedeployment_spotinstances_max_price > 0
 
   subnets = {
     (local.zoneA) = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[0].id : ""

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -86,7 +86,7 @@ output "kubeone_workers" {
           provisioningUtility = "cloud-init"
         }
         labels = {
-          isSpotInstance = format("%t", var.initial_machinedeployment_spotinstances)
+          isSpotInstance = format("%t", local.initial_machinedeployment_spotinstances)
         }
         # uncomment to following to set those kubelet parameters. More into at:
         # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
@@ -112,10 +112,10 @@ output "kubeone_workers" {
           diskType         = "gp2"
           ## Only applicable if diskType = io1
           diskIops           = 500
-          isSpotInstance     = var.initial_machinedeployment_spotinstances
+          isSpotInstance     = local.initial_machinedeployment_spotinstances
           ## Only applicable if isSpotInstance is true
           spotInstanceConfig = {
-            maxPrice = var.initial_machinedeployment_spotinstances_max_price
+            maxPrice = "var.initial_machinedeployment_spotinstances_max_price"
           }
           ebsVolumeEncrypted = false
           tags = {
@@ -138,7 +138,7 @@ output "kubeone_workers" {
           provisioningUtility = "cloud-init"
         }
         labels = {
-          isSpotInstance = format("%t", var.initial_machinedeployment_spotinstances)
+          isSpotInstance = format("%t", local.initial_machinedeployment_spotinstances)
         }
         cloudProviderSpec = {
           # provider specific fields:
@@ -157,10 +157,10 @@ output "kubeone_workers" {
           diskType         = "gp2"
           ## Only applicable if diskType = io1
           diskIops           = 500
-          isSpotInstance     = var.initial_machinedeployment_spotinstances
+          isSpotInstance     = local.initial_machinedeployment_spotinstances
           ## Only applicable if isSpotInstance is true
           spotInstanceConfig = {
-            maxPrice = var.initial_machinedeployment_spotinstances_max_price
+            maxPrice = "var.initial_machinedeployment_spotinstances_max_price"
           }
           ebsVolumeEncrypted = false
           tags = {
@@ -183,7 +183,7 @@ output "kubeone_workers" {
           provisioningUtility = "cloud-init"
         }
         labels = {
-          isSpotInstance = format("%t", var.initial_machinedeployment_spotinstances)
+          isSpotInstance = format("%t", local.initial_machinedeployment_spotinstances)
         }
         cloudProviderSpec = {
           # provider specific fields:
@@ -202,10 +202,10 @@ output "kubeone_workers" {
           diskType         = "gp2"
           ## Only applicable if diskType = io1
           diskIops           = 500
-          isSpotInstance     = var.initial_machinedeployment_spotinstances
+          isSpotInstance     = local.initial_machinedeployment_spotinstances
           ## Only applicable if isSpotInstance is true
           spotInstanceConfig = {
-            maxPrice = var.initial_machinedeployment_spotinstances_max_price
+            maxPrice = "var.initial_machinedeployment_spotinstances_max_price"
           }
           ebsVolumeEncrypted = false
           tags = {

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -115,7 +115,7 @@ output "kubeone_workers" {
           isSpotInstance     = local.initial_machinedeployment_spotinstances
           ## Only applicable if isSpotInstance is true
           spotInstanceConfig = {
-            maxPrice = "var.initial_machinedeployment_spotinstances_max_price"
+            maxPrice = format("%f", var.initial_machinedeployment_spotinstances_max_price)
           }
           ebsVolumeEncrypted = false
           tags = {
@@ -160,7 +160,7 @@ output "kubeone_workers" {
           isSpotInstance     = local.initial_machinedeployment_spotinstances
           ## Only applicable if isSpotInstance is true
           spotInstanceConfig = {
-            maxPrice = "var.initial_machinedeployment_spotinstances_max_price"
+            maxPrice = format("%f", var.initial_machinedeployment_spotinstances_max_price)
           }
           ebsVolumeEncrypted = false
           tags = {
@@ -205,7 +205,7 @@ output "kubeone_workers" {
           isSpotInstance     = local.initial_machinedeployment_spotinstances
           ## Only applicable if isSpotInstance is true
           spotInstanceConfig = {
-            maxPrice = "var.initial_machinedeployment_spotinstances_max_price"
+            maxPrice = format("%f", var.initial_machinedeployment_spotinstances_max_price)
           }
           ebsVolumeEncrypted = false
           tags = {

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -113,6 +113,10 @@ output "kubeone_workers" {
           ## Only applicable if diskType = io1
           diskIops           = 500
           isSpotInstance     = var.initial_machinedeployment_spotinstances
+          ## Only applicable if isSpotInstance is true
+          spotInstanceConfig = {
+            maxPrice = var.initial_machinedeployment_spotinstances_max_price
+          }
           ebsVolumeEncrypted = false
           tags = {
             "${var.cluster_name}-workers" = ""
@@ -154,6 +158,10 @@ output "kubeone_workers" {
           ## Only applicable if diskType = io1
           diskIops           = 500
           isSpotInstance     = var.initial_machinedeployment_spotinstances
+          ## Only applicable if isSpotInstance is true
+          spotInstanceConfig = {
+            maxPrice = var.initial_machinedeployment_spotinstances_max_price
+          }
           ebsVolumeEncrypted = false
           tags = {
             "${var.cluster_name}-workers" = ""
@@ -195,6 +203,10 @@ output "kubeone_workers" {
           ## Only applicable if diskType = io1
           diskIops           = 500
           isSpotInstance     = var.initial_machinedeployment_spotinstances
+          ## Only applicable if isSpotInstance is true
+          spotInstanceConfig = {
+            maxPrice = var.initial_machinedeployment_spotinstances_max_price
+          }
           ebsVolumeEncrypted = false
           tags = {
             "${var.cluster_name}-workers" = ""

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -219,17 +219,11 @@ variable "static_workers_count" {
   type        = number
 }
 
-variable "initial_machinedeployment_spotinstances" {
-  description = "use spot instances for initial machine-deployment"
-  default     = false
-  type        = bool
-}
-
 variable "initial_machinedeployment_spotinstances_max_price" {
   description = "used to specify max spot instance price for initial machine-deployment"
-# we intentionally set minimum max price to ensure that user specifies it explicitly
-  default     = "0.01"
-  type        = string
+  # we intentionally set minimum max price to ensure that user specifies it explicitly
+  default     = 0
+  type        = number
 }
 
 variable "worker_deploy_ssh_key" {

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -225,6 +225,13 @@ variable "initial_machinedeployment_spotinstances" {
   type        = bool
 }
 
+variable "initial_machinedeployment_spotinstances_max_price" {
+  description = "used to specify max spot instance price for initial machine-deployment"
+# we intentionally set minimum max price to ensure that user specifies it explicitly
+  default     = "0.01"
+  type        = string
+}
+
 variable "worker_deploy_ssh_key" {
   description = "add provided ssh public key to MachineDeployments"
   default     = true
@@ -232,7 +239,7 @@ variable "worker_deploy_ssh_key" {
 }
 
 variable "control_plane_vm_count" {
-  description = "Number of control plane instances"
+  description = "number of control plane instances"
   default     = 3
   type        = number
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/iancoleman/orderedmap v0.2.0
 	github.com/imdario/mergo v0.3.12
 	github.com/koron-go/prefixw v0.0.0-20181013140428-271b207a7572
-	github.com/kubermatic/machine-controller v1.43.0
+	github.com/kubermatic/machine-controller v1.46.0
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,7 @@ github.com/Azure/azure-sdk-for-go v38.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-sdk-for-go v46.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v49.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v56.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v62.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-storage-blob-go v0.0.0-20190123011202-457680cc0804/go.mod h1:oGfmITT1V6x//CswqY2gtAHND+xIP64/qL7a5QJix0Y=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -179,6 +180,7 @@ github.com/aliyun/alibaba-cloud-sdk-go v1.61.751/go.mod h1:pUKYbK5JQ+1Dfxk80P0qx
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andygrunwald/go-gerrit v0.0.0-20190120104749-174420ebee6c/go.mod h1:0iuRQp6WJ44ts+iihy5E/WlPqfg5RNeQxOmzRkxCdtk=
 github.com/anexia-it/go-anxcloud v0.3.8/go.mod h1:cevqezsbOJ4GBlAWaztfLKl9w4VzxJBt4ipgHORi3gw=
+github.com/anexia-it/go-anxcloud v0.3.26/go.mod h1:fiEBxEtBXx78/OWBJvL7+2o4TESrnEcrDYjLeonGkDw=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -920,8 +922,8 @@ github.com/kubermatic/machine-controller v1.26.0/go.mod h1:dcJ+GdDSCxCwM0poxwOK8
 github.com/kubermatic/machine-controller v1.36.1/go.mod h1:6BFZEvEMZi8OT8aHOsS7DXYsF6ZSpmsNxsci7OLTTn8=
 github.com/kubermatic/machine-controller v1.40.1/go.mod h1:5LVcN4tCybGg+55hIHcVzCjNsBJy2PlnXG0xIzKmXGY=
 github.com/kubermatic/machine-controller v1.42.2/go.mod h1:vr6i5XWfd5FIq2yodXcgdlKvOhMnM5uzn2XEZ2wcoFM=
-github.com/kubermatic/machine-controller v1.43.0 h1:L0WtATmY0sgyRLV9CE5NcYs7A/ZJrOyOGf1hm221/JM=
-github.com/kubermatic/machine-controller v1.43.0/go.mod h1:Ct66z/Ae/ctS0VnbA2N4eZp+MmyTKB5h6nlwNgKtdfc=
+github.com/kubermatic/machine-controller v1.46.0 h1:vW7DLrUEFzRxlOATQAGMUk0xl1+I97p/oFXCVwKCzfU=
+github.com/kubermatic/machine-controller v1.46.0/go.mod h1:uDJuaS0TrLkJ4YL0HsixlLhfPTs9eGaYvMThYNqhTfA=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1087,6 +1089,7 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
+github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -170,7 +170,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:        {"*": "docker.io/calico/node:v3.22.0"},
 		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
 		Flannel:           {"*": "quay.io/coreos/flannel:v0.13.0"},
-		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.44.0"},
+		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.46.0"},
 		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
 	}
 }

--- a/pkg/templates/machinecontroller/cloudprovider_specs.go
+++ b/pkg/templates/machinecontroller/cloudprovider_specs.go
@@ -18,21 +18,28 @@ package machinecontroller
 
 // AWSSpec holds cloudprovider spec for AWS
 type AWSSpec struct {
-	AMI                string            `json:"ami"`
-	AssignPublicIP     *bool             `json:"assignPublicIP"`
-	AvailabilityZone   string            `json:"availabilityZone"`
-	DiskIops           *int              `json:"diskIops,omitempty"`
-	DiskSize           *int              `json:"diskSize"`
-	DiskType           string            `json:"diskType"`
-	EBSVolumeEncrypted bool              `json:"ebsVolumeEncrypted"`
-	InstanceProfile    string            `json:"instanceProfile"`
-	InstanceType       *string           `json:"instanceType"`
-	IsSpotInstance     *bool             `json:"isSpotInstance,omitempty"`
-	Region             string            `json:"region"`
-	SecurityGroupIDs   []string          `json:"securityGroupIDs"`
-	SubnetID           string            `json:"subnetId"`
-	Tags               map[string]string `json:"tags"`
-	VPCID              string            `json:"vpcId"`
+	AMI                string                 `json:"ami"`
+	AssignPublicIP     *bool                  `json:"assignPublicIP"`
+	AvailabilityZone   string                 `json:"availabilityZone"`
+	DiskIops           *int                   `json:"diskIops,omitempty"`
+	DiskSize           *int                   `json:"diskSize"`
+	DiskType           string                 `json:"diskType"`
+	EBSVolumeEncrypted bool                   `json:"ebsVolumeEncrypted"`
+	InstanceProfile    string                 `json:"instanceProfile"`
+	InstanceType       *string                `json:"instanceType"`
+	IsSpotInstance     *bool                  `json:"isSpotInstance,omitempty"`
+	SpotInstanceConfig *AWSSpotInstanceConfig `json:"spotInstanceConfig,omitempty"`
+	Region             string                 `json:"region"`
+	SecurityGroupIDs   []string               `json:"securityGroupIDs"`
+	SubnetID           string                 `json:"subnetId"`
+	Tags               map[string]string      `json:"tags"`
+	VPCID              string                 `json:"vpcId"`
+}
+
+type AWSSpotInstanceConfig struct {
+	MaxPrice             string `json:"maxPrice,omitempty"`
+	PersistentRequest    bool   `json:"persistentRequest,omitempty"`
+	InterruptionBehavior string `json:"interruptionBehavior,omitempty"`
 }
 
 // DigitalOceanSpec holds cloudprovider spec for DigitalOcean


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind question
-->
/kind feature

**What this PR does / why we need it**:

1. machine-controller updated to v1.46.0
2. `initial_machinedeployment_spotinstances` removed in favor of `initial_machinedeployment_spotinstances_max_price`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
* machine-controller updated to v1.46.0
* For AWS, variable 'initial_machinedeployment_spotinstances_max_price' is introduced. When set, spot instances will be used for initial machine deployments
```
