### PR TITLE
Add .Params.RequestsCPU reading to cni-canal addon

### DIFF
--- a/addons/cni-canal/canal.yaml
+++ b/addons/cni-canal/canal.yaml
@@ -4212,7 +4212,7 @@ spec:
             privileged: true
           resources:
             requests:
-              cpu: 250m
+              cpu: {{ default .Params.RequestsCPU "250m" }}
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
**What this PR does / why we need it**:
To allow configuring resources.requests.cpu.

/kind feature

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1883

```release-note
Add .Params.RequestsCPU reading to cni-canal addon
```
