### PR TITLE
Show the "Ensure MachineDeployments" message only when provisioning a cluster for the first time

### DIFF
--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -317,8 +317,10 @@ func runApplyInstall(s *state.State, opts *applyOpts) error { // Print the expec
 		fmt.Println("\t! force-install option provided: force install new binary versions (!dangerous!)")
 	}
 
-	for _, node := range s.Cluster.DynamicWorkers {
-		fmt.Printf("\t+ ensure machinedeployment %q with %d replica(s) exists\n", node.Name, resolveInt(node.Replicas))
+	if !s.LiveCluster.IsProvisioned() {
+		for _, node := range s.Cluster.DynamicWorkers {
+			fmt.Printf("\t+ ensure machinedeployment %q with %d replica(s) exists\n", node.Name, resolveInt(node.Replicas))
+		}
 	}
 
 	if s.Cluster.Addons.Enabled() && s.Cluster.Addons.Path != "" {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

KubeOne is ensuring MachineDeployments only when provisioning a cluster for the first time. However, we're also showing the `Ensure MachineDeployments` message when repairing the cluster (e.g. when only one node is being initialized), and in that case, MachineDeployments are not actually ensured.

**Does this PR introduce a user-facing change?**:
```release-note
Show "Ensure MachineDeployments" as an action to be taken only when provisioning a cluster for the first time
```

/assign @kron4eg 