### PR TITLE
Fix the flaky TestFillTwoNewRootKeys unit test

### DIFF
--- a/pkg/yamled/document_test.go
+++ b/pkg/yamled/document_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package yamled
 
 import (
+	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
@@ -410,6 +412,11 @@ func TestFillTwoNewRootKeys(t *testing.T) {
 		t.Fatal("should have been able to fill in stuff")
 	}
 
+	// as Fill is iterating over a map we don't have ordering guarantees, we
+	// sort the document to have a predictable output
+	sort.Slice(doc.root, func(i, j int) bool {
+		return fmt.Sprintf("%s", doc.root[i].Key) < fmt.Sprintf("%s", doc.root[j].Key)
+	})
 	assertEqualYAML(t, doc, expected)
 }
 

--- a/pkg/yamled/testcases/fill-two-new-root-keys.yaml
+++ b/pkg/yamled/testcases/fill-two-new-root-keys.yaml
@@ -1,6 +1,6 @@
 foo: bar
 ###
-foo: bar
-newKey: new value
 anotherKey:
   subKey: 42
+foo: bar
+newKey: new value


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

Fix the flaky `TestFillTwoNewRootKeys` unit test. The fix is based on https://github.com/kubermatic/kubermatic/commit/95689974d71c9f5325d508c8881722fcc704e422

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 