### PR TITLE
Use etcd v3.5.3 for Kubernetes 1.22+

### DIFF
--- a/pkg/templates/kubeadm/v1beta3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm.go
@@ -64,12 +64,16 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		return nil, fail.Config(err, "parsing kubernetes semver")
 	}
 
+	etcdImageTag := cluster.AssetConfiguration.Etcd.ImageTag
 	etcdExtraArgs := map[string]string{}
 	if etcdIntegrityCheckConstraint.Check(kubeSemVer) {
-		// This is required because etcd v3.5 (used for Kubernetes 1.22+)
+		// This is required because etcd v3.5-[0-2] (used for Kubernetes 1.22+)
 		// has an issue with the data integrity.
 		// See https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ
 		// for more details.
+		if etcdImageTag == "" {
+			etcdImageTag = "3.5.3-0"
+		}
 		etcdExtraArgs["experimental-initial-corrupt-check"] = "true"
 		etcdExtraArgs["experimental-corrupt-check-time"] = "240m"
 	}
@@ -168,7 +172,7 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			Local: &kubeadmv1beta3.LocalEtcd{
 				ImageMeta: kubeadmv1beta3.ImageMeta{
 					ImageRepository: cluster.AssetConfiguration.Etcd.ImageRepository,
-					ImageTag:        cluster.AssetConfiguration.Etcd.ImageTag,
+					ImageTag:        etcdImageTag,
 				},
 				ExtraArgs: etcdExtraArgs,
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Deploy etcd v3.5.3 for clusters running Kubernetes 1.22 or newer. etcd v3.5.3 includes a fix for [the data inconsistency issues announced by the etcd maintainers](https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ).

To upgrade etcd for an existing cluster, you need to [force upgrade the cluster as described here](https://docs.kubermatic.com/kubeone/v1.4/guides/etcd_corruption/#enabling-etcd-corruption-checks).

More information about this etcd release can be found here:

* https://github.com/etcd-io/etcd/issues/13894
* https://github.com/etcd-io/etcd/releases/tag/v3.5.3

**Does this PR introduce a user-facing change?**:
```release-note
Deploy etcd v3.5.3 for clusters running Kubernetes 1.22 or newer. etcd v3.5.3 includes a fix for the data inconsistency issues announced by the etcd maintainers: https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ
To upgrade etcd for an existing cluster, you need to force upgrade the cluster as described here: https://docs.kubermatic.com/kubeone/v1.4/guides/etcd_corruption/#enabling-etcd-corruption-checks
```

/assign @kron4eg 