### PR TITLE
AWS: add kubeone prefix for role, policy and instance profile

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -234,7 +234,7 @@ resource "aws_key_pair" "deployer" {
 
 ##################################### IAM ######################################
 resource "aws_iam_role" "role" {
-  name = "${var.cluster_name}-host"
+  name = "kubeone-${var.cluster_name}-host"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -251,12 +251,12 @@ resource "aws_iam_role" "role" {
 }
 
 resource "aws_iam_instance_profile" "profile" {
-  name = "${var.cluster_name}-host"
+  name = "kubeone-${var.cluster_name}-host"
   role = aws_iam_role.role.name
 }
 
 resource "aws_iam_role_policy" "policy" {
-  name = "${var.cluster_name}-host"
+  name = "kubeone-${var.cluster_name}-host"
   role = aws_iam_role.role.id
 
   policy = jsonencode({


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind question
-->
/kind feature

**What this PR does / why we need it**:
Add `kubeone` prefix for the role, policy, and instance profile names for AWS.

Currently, we prefix these resources with the cluster-name which is always unique for each cluster. Adding a prefix makes it easier to isolate resources created/managed by kubeone. 

In our documentation for using machine-controller with kubeone, we create policies that target the resources at:
- "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:instance-profile/kubernetes-*"
- "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/kubernetes-*"

Although in our terraform config for AWS we don't use the prefix `kubernetes-`. This will be updated accordingly as well.

https://github.com/kubermatic/docs/blob/master/content/kubeone/v1.4/architecture/requirements/machine_controller/aws/aws.en.md

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `kubeone` prefix for the role, policy, and instance profile names for AWS.
```
