### PR TITLE
Make upgrade tests optional

### DIFF
--- a/.prow/1.20.yaml
+++ b/.prow/1.20.yaml
@@ -216,7 +216,7 @@ presubmits:
             requests:
               cpu: 1
   - name: pull-kubeone-e2e-aws-upgrade-containerd-1.20-1.21
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
+    always_run: false
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:
@@ -244,7 +244,7 @@ presubmits:
             - name: KUBEONE_TEST_RUN
               value: "TestClusterUpgrade"
   - name: pull-kubeone-e2e-aws-upgrade-1.20-1.21
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
+    always_run: false
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:

--- a/.prow/1.21.yaml
+++ b/.prow/1.21.yaml
@@ -152,7 +152,7 @@ presubmits:
             requests:
               cpu: 1
   - name: pull-kubeone-e2e-aws-upgrade-1.21-1.22
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
+    always_run: false
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:

--- a/.prow/1.22.yaml
+++ b/.prow/1.22.yaml
@@ -164,7 +164,7 @@ presubmits:
             requests:
               cpu: 1
   - name: pull-kubeone-e2e-aws-upgrade-1.22-1.23
-    run_if_changed: "(pkg/|examples/terraform/aws|hack/|test/|addons/)"
+    always_run: false
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubeone.git"
     labels:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR makes upgrade tests optional. The upgrade tests can still be manually triggered by using the appropriate `/test <test-name>` command.

I'll create daily periodics for upgrade tests in a follow up.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #1959

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 