### PR TITLE
Bump flannel image to v0.15.1

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -169,7 +169,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoController:  {"*": "docker.io/calico/kube-controllers:v3.22.0"},
 		CalicoNode:        {"*": "docker.io/calico/node:v3.22.0"},
 		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
-		Flannel:           {"*": "quay.io/coreos/flannel:v0.13.0"},
+		Flannel:           {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.47.0"},
 		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind question
-->

**What this PR does / why we need it**:
Our customers facing https://github.com/flannel-io/flannel/issues/1408
> Kubeone installs a kube-flannel container version (0.13.0) in the canal-cni pod causing iptables segfaults in Centos8/Rocky8 hosts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix problem with flannel causing iptables segfaults
```
