### PR TITLE
Fixed missing reading of the static workers defined in terraform

### DIFF
--- a/pkg/terraform/v1beta2/config.go
+++ b/pkg/terraform/v1beta2/config.go
@@ -175,9 +175,10 @@ type cloudProviderFlags struct {
 // NewConfigFromJSON creates a new config object from json
 func NewConfigFromJSON(buf []byte) (*Config, error) {
 	wholeTFOutput := struct {
-		KubeoneAPI     interface{} `json:"kubeone_api"`
-		KubeoneHosts   interface{} `json:"kubeone_hosts"`
-		KubeoneWorkers interface{} `json:"kubeone_workers"`
+		KubeoneAPI           interface{} `json:"kubeone_api"`
+		KubeoneHosts         interface{} `json:"kubeone_hosts"`
+		KubeoneWorkers       interface{} `json:"kubeone_workers"`
+		KubeoneStaticWorkers interface{} `json:"kubeone_static_workers"`
 	}{}
 
 	// cat off all the excessive fields from the terraform output JSON that will prevent otherwise strict unmarshalling


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
While migrating to strict terraform output reading we've missed static workers.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed missing reading of the static workers defined in terraform
```
