### PR TITLE
Remove kubetest from the kubeone-e2e image

### DIFF
--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -23,14 +23,6 @@ ENV TERRAFORM_VERSION "1.1.0"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform
 RUN chmod +x /usr/local/bin/terraform
 
-ENV KUBETEST_COMMIT "eb1a87c9083a31f9a9dda7822cb674f9f8d99439"
-ENV KUBETESTS_ROOT "/opt/kube-test"
-ENV GO111MODULE=on
-
-# Install the kubetest binary
-RUN go get -v k8s.io/test-infra/kubetest@${KUBETEST_COMMIT} && \
-    go clean -modcache -cache
-
 COPY install-kube-tests-binaries.sh /opt/install-kube-tests-binaries.sh
 RUN /opt/install-kube-tests-binaries.sh
 
@@ -47,9 +39,7 @@ LABEL description="Set of kubernetes binaries to conduct kubeone E2E tests"
 LABEL maintainer="https://github.com/kubermatic/kubeone/blob/master/OWNERS"
 
 ENV KUBETESTS_ROOT "/opt/kube-test"
-ENV GO111MODULE on
 ENV USER root
 
 COPY --from=builder /usr/local/bin/terraform /usr/local/bin/terraform
-COPY --from=builder /go/bin/kubetest /usr/local/bin/kubetest
 COPY --from=builder ${KUBETESTS_ROOT} ${KUBETESTS_ROOT}

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -20,6 +20,7 @@ declare -A full_versions
 full_versions["1.21"]="v1.21.12"
 full_versions["1.22"]="v1.22.9"
 full_versions["1.23"]="v1.23.6"
+full_versions["1.24"]="v1.24.0"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.21
+TAG=v0.1.22
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}

--- a/test/e2e/testutil/testutil.go
+++ b/test/e2e/testutil/testutil.go
@@ -69,9 +69,5 @@ func ValidateCommon() error {
 		return errors.New("the terraform client is not available, please install")
 	}
 
-	if ok := IsCommandAvailable("kubetest"); !ok {
-		return errors.New("the kubetest is not available, please install: 'go get -u k8s.io/test-infra/kubetest'")
-	}
-
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Kubetest has been replaced with Ginkgo a long time ago by #729. This PR removes the kubetest binary from the kubeone-e2e image. Additionally, we're having issues pulling `kubernetes/test-infra` and building kubetest with Go 1.18, which is an additional reason for removing it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2008 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
