### PR TITLE
Replace node-role.kubernetes.io/master with control-plane label and add control-plane toleration

### DIFF
--- a/addons/backups-restic/backups-restic.yaml
+++ b/addons/backups-restic/backups-restic.yaml
@@ -35,8 +35,11 @@ spec:
           hostNetwork: true
           dnsPolicy: ClusterFirstWithHostNet
           nodeSelector:
-            node-role.kubernetes.io/master: ""
+            node-role.kubernetes.io/control-plane: ""
           tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+            operator: Exists
           - key: node-role.kubernetes.io/master
             effect: NoSchedule
             operator: Exists

--- a/addons/calico-vxlan/calico-vxlan.yaml
+++ b/addons/calico-vxlan/calico-vxlan.yaml
@@ -4382,6 +4382,8 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/addons/ccm-aws/ccm-aws.yaml
+++ b/addons/ccm-aws/ccm-aws.yaml
@@ -145,12 +145,14 @@ spec:
               cpu: 200m
       hostNetwork: true
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       serviceAccountName: cloud-controller-manager
       tolerations:
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
   updateStrategy:

--- a/addons/ccm-azure/ccm-azure.yaml
+++ b/addons/ccm-azure/ccm-azure.yaml
@@ -156,13 +156,15 @@ spec:
       hostNetwork: true
       serviceAccountName: cloud-controller-manager
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
         - key: "node.cloudprovider.kubernetes.io/uninitialized"
           value: "true"
           effect: "NoSchedule"
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       containers:
         - name: cloud-controller-manager
           image: "{{ .InternalImages.Get "AzureCCM" }}"
@@ -285,6 +287,9 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule

--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -170,7 +170,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       securityContext:
         runAsUser: 1001
       tolerations:

--- a/addons/ccm-vsphere/ccm-vsphere.yaml
+++ b/addons/ccm-vsphere/ccm-vsphere.yaml
@@ -165,13 +165,16 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       securityContext:
         runAsUser: 1001
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+          operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
           operator: Exists

--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -196,11 +196,15 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
               - key: node-role.kubernetes.io/master
                 operator: Exists

--- a/addons/cni-canal/canal.yaml
+++ b/addons/cni-canal/canal.yaml
@@ -4378,6 +4378,8 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/addons/csi-aws-ebs/controller.yaml
+++ b/addons/csi-aws-ebs/controller.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
       tolerations:
@@ -31,7 +31,7 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/controlplane"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
         - operator: Exists

--- a/addons/csi-aws-ebs/csi-snapshot-controller.yaml
+++ b/addons/csi-aws-ebs/csi-snapshot-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/controlplane"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
       containers:

--- a/addons/csi-azuredisk/csi-azuredisk-controller.yaml
+++ b/addons/csi-azuredisk/csi-azuredisk-controller.yaml
@@ -25,7 +25,7 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/controlplane"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
       containers:

--- a/addons/csi-azuredisk/csi-snapshot-controller.yaml
+++ b/addons/csi-azuredisk/csi-snapshot-controller.yaml
@@ -24,7 +24,7 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/controlplane"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
       containers:

--- a/addons/csi-azurefile/csi-azurefile-controller.yaml
+++ b/addons/csi-azurefile/csi-azurefile-controller.yaml
@@ -25,7 +25,7 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/controlplane"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
       containers:

--- a/addons/csi-azurefile/csi-snapshot-controller.yaml
+++ b/addons/csi-azurefile/csi-snapshot-controller.yaml
@@ -24,7 +24,7 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/controlplane"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
       containers:

--- a/addons/csi-nutanix/ntnx-csi-provisioner-sts.yaml
+++ b/addons/csi-nutanix/ntnx-csi-provisioner-sts.yaml
@@ -134,13 +134,13 @@ spec:
             - --csi-address=/csi/csi.sock
             - --http-endpoint=:9807
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/controlplane"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
       volumes:

--- a/addons/csi-nutanix/snapshot-controller-sts.yaml
+++ b/addons/csi-nutanix/snapshot-controller-sts.yaml
@@ -30,12 +30,12 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/controlplane"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"

--- a/addons/csi-nutanix/validating-deployment.yaml
+++ b/addons/csi-nutanix/validating-deployment.yaml
@@ -42,13 +42,13 @@ spec:
           secret:
             secretName: nutanix-webhook-certs
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/controlplane"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
 ---

--- a/addons/csi-vsphere/validatingwebhook.yaml
+++ b/addons/csi-vsphere/validatingwebhook.yaml
@@ -104,8 +104,11 @@ spec:
     spec:
       serviceAccountName: vsphere-csi-webhook
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule

--- a/addons/csi-vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi-vsphere/vsphere-csi-driver.yaml
@@ -206,8 +206,11 @@ spec:
     spec:
       serviceAccountName: vsphere-csi-controller
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule

--- a/addons/machinecontroller/deployment-controller.yaml
+++ b/addons/machinecontroller/deployment-controller.yaml
@@ -21,8 +21,11 @@ spec:
         app: machine-controller
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: Exists
+          effect: NoSchedule
         - key: "node-role.kubernetes.io/master"
           operator: Exists
           effect: NoSchedule

--- a/addons/machinecontroller/webhook.yaml
+++ b/addons/machinecontroller/webhook.yaml
@@ -59,8 +59,11 @@ spec:
         app: machine-controller-webhook
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: Exists
+          effect: NoSchedule
         - key: "node-role.kubernetes.io/master"
           operator: Exists
           effect: NoSchedule

--- a/addons/operating-system-manager/deployment-controller.yaml
+++ b/addons/operating-system-manager/deployment-controller.yaml
@@ -20,7 +20,7 @@ spec:
         app: operating-system-manager
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: Exists

--- a/addons/operating-system-manager/webhook.yaml
+++ b/addons/operating-system-manager/webhook.yaml
@@ -48,7 +48,7 @@ spec:
         app: operating-system-manager-webhook
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: Exists

--- a/addons/unattended-upgrades/apt.yaml
+++ b/addons/unattended-upgrades/apt.yaml
@@ -31,6 +31,8 @@ spec:
                 - ubuntu
                 - debian
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       hostPID: true

--- a/addons/unattended-upgrades/fluo.yaml
+++ b/addons/unattended-upgrades/fluo.yaml
@@ -282,6 +282,9 @@ spec:
         securityContext:
           runAsUser: 0
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
@@ -348,6 +351,9 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
@@ -390,6 +396,8 @@ spec:
                 values:
                 - flatcar
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       hostPID: true

--- a/addons/unattended-upgrades/kured.yaml
+++ b/addons/unattended-upgrades/kured.yaml
@@ -107,6 +107,8 @@ spec:
                 - ubuntu
       serviceAccountName: kured
       tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       hostPID: true # Facilitate entering the host mount namespace via init

--- a/addons/unattended-upgrades/yum.yaml
+++ b/addons/unattended-upgrades/yum.yaml
@@ -34,6 +34,8 @@ spec:
                 - centos
                 - rhel
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       hostPID: true

--- a/pkg/clusterstatus/preflightstatus/preflightstatus.go
+++ b/pkg/clusterstatus/preflightstatus/preflightstatus.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	LabelControlPlaneNode = "node-role.kubernetes.io/master"
+	LabelControlPlaneNode = "node-role.kubernetes.io/control-plane"
 	LabelUpgradeLock      = "kubeone.io/upgrade-in-progress"
 )
 

--- a/pkg/tasks/util.go
+++ b/pkg/tasks/util.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	labelUpgradeLock      = "kubeone.io/upgrade-in-progress"
-	labelControlPlaneNode = "node-role.kubernetes.io/master"
+	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
 	// timeoutNodeUpgrade is time for how long kubeone will wait after finishing the upgrade
 	// process on the node
 	timeoutNodeUpgrade = 30 * time.Second

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	labelControlPlaneNode = "node-role.kubernetes.io/master"
+	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
 	delayUpgrade          = 2 * time.Minute
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

* Replace `node-role.kubernetes.io/master` label selector with `node-role.kubernetes.io/control-plane`
  * Nodes running Kubernetes 1.24 are no longer having the `node-role.kubernetes.io/master` label
  * Nodes running Kubernetes 1.20 and newer have the `node-role.kubernetes.io/control-plane` label, and since KubeOne 1.4 only supports Kubernetes 1.20 and newer, it's safe to do this migration
* Add `node-role.kubernetes.io/control-plane` toleration in addition to `node-role.kubernetes.io/master` toleration
  * The `node-role.kubernetes.io/master` toleration will be removed with Kubernetes 1.25

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2010 

**Does this PR introduce a user-facing change?**:
```release-note
[ACTION REQUIRED] Kubeadm is not applying the `node-role.kubernetes.io/control-plane` label for Kubernetes 1.24 nodes. The old label (`node-role.kubernetes.io/master`) will be removed when upgrading the cluster to Kubernetes 1.24. All addons are updated to use the `node-role.kubernetes.io/control-plane` label selector instead. All addons now have toleration for `node-role.kubernetes.io/control-plane` taint in addition to toleration for `node-role.kubernetes.io/master` taint. If you are overriding addons, make sure to apply those changes before upgrading to Kubernetes 1.24.
```

/assign @kron4eg 