### PR TITLE
Add node-role.kubernetes.io/control-plane taint to nodes running Kubernetes 1.24

### DIFF
--- a/docs/api_reference/v1beta1.en.md
+++ b/docs/api_reference/v1beta1.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta1 API Reference"
-date = 2022-01-28T02:22:19+04:00
+date = 2022-05-05T10:18:47+02:00
 weight = 11
 +++
 ## v1beta1
@@ -370,7 +370,7 @@ HostConfig describes a single control plane node.
 | bastionUser | BastionUser is system login name to use when connecting to bastion host. Default value is \"root\". | string | false |
 | hostname | Hostname is the hostname(1) of the host. Default value is populated at the runtime via running `hostname -f` command over ssh. | string | false |
 | isLeader | IsLeader indicates this host as a session leader. Default value is populated at the runtime. | bool | false |
-| taints | Taints if not provided (i.e. nil) defaults to TaintEffectNoSchedule, with key node-role.kubernetes.io/master for control plane nodes. Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes). | [][corev1.Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#taint-v1-core) | false |
+| taints | Taints are taints applied to nodes. If not provided (i.e. nil) for control plane nodes, it defaults to:\n  * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master\n  * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys\n    node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master\nExplicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes). | [][corev1.Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#taint-v1-core) | false |
 
 [Back to Group](#v1beta1)
 

--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2022-04-12T14:49:46+03:00
+date = 2022-05-05T10:18:47+02:00
 weight = 11
 +++
 ## v1beta2
@@ -399,7 +399,7 @@ HostConfig describes a single control plane node.
 | bastionUser | BastionUser is system login name to use when connecting to bastion host. Default value is \"root\". | string | false |
 | hostname | Hostname is the hostname(1) of the host. Default value is populated at the runtime via running `hostname -f` command over ssh. | string | false |
 | isLeader | IsLeader indicates this host as a session leader. Default value is populated at the runtime. | bool | false |
-| taints | Taints if not provided (i.e. nil) defaults to TaintEffectNoSchedule, with key node-role.kubernetes.io/master for control plane nodes. Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes). | [][corev1.Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#taint-v1-core) | false |
+| taints | Taints are taints applied to nodes. If not provided (i.e. nil) for control plane nodes, it defaults to:\n  * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master\n  * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys\n    node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master\nExplicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes). | [][corev1.Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#taint-v1-core) | false |
 | kubelet | Kubelet | [KubeletConfig](#kubeletconfig) | false |
 | operatingSystem | OperatingSystem information, can be populated at the runtime. | OperatingSystemName | false |
 

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -172,8 +172,11 @@ type HostConfig struct {
 	// IsLeader indicates this host as a session leader.
 	// Default value is populated at the runtime.
 	IsLeader bool `json:"isLeader,omitempty"`
-	// Taints if not provided (i.e. nil) defaults to TaintEffectNoSchedule, with key node-role.kubernetes.io/master for
-	// control plane nodes.
+	// Taints are taints applied to nodes. Those taints are only applied when the node is being provisioned.
+	// If not provided (i.e. nil) for control plane nodes, it defaults to:
+	//   * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master
+	//   * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys
+	//     node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master
 	// Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes).
 	Taints []corev1.Taint `json:"taints,omitempty"`
 	// Kubelet

--- a/pkg/apis/kubeone/v1beta1/defaults.go
+++ b/pkg/apis/kubeone/v1beta1/defaults.go
@@ -65,6 +65,12 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 
 	setDefaultLeader := true
 
+	gteKube124Condition, _ := semver.NewConstraint(">= 1.24")
+	actualVer, err := semver.NewVersion(obj.Versions.Kubernetes)
+	if err != nil {
+		return
+	}
+
 	// Define a unique ID for each host
 	for idx := range obj.ControlPlane.Hosts {
 		if setDefaultLeader && obj.ControlPlane.Hosts[idx].IsLeader {
@@ -80,6 +86,12 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 					Effect: corev1.TaintEffectNoSchedule,
 					Key:    "node-role.kubernetes.io/master",
 				},
+			}
+			if gteKube124Condition.Check(actualVer) {
+				obj.ControlPlane.Hosts[idx].Taints = append(obj.ControlPlane.Hosts[idx].Taints, corev1.Taint{
+					Effect: corev1.TaintEffectNoSchedule,
+					Key:    "node-role.kubernetes.io/control-plane",
+				})
 			}
 		}
 	}

--- a/pkg/apis/kubeone/v1beta1/types.go
+++ b/pkg/apis/kubeone/v1beta1/types.go
@@ -125,8 +125,11 @@ type HostConfig struct {
 	// IsLeader indicates this host as a session leader.
 	// Default value is populated at the runtime.
 	IsLeader bool `json:"isLeader,omitempty"`
-	// Taints if not provided (i.e. nil) defaults to TaintEffectNoSchedule, with key node-role.kubernetes.io/master for
-	// control plane nodes.
+	// Taints are taints applied to nodes. If not provided (i.e. nil) for control plane nodes,
+	// it defaults to:
+	//   * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master
+	//   * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys
+	//     node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master
 	// Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes).
 	Taints []corev1.Taint `json:"taints,omitempty"`
 	// OperatingSystem information populated at the runtime.

--- a/pkg/apis/kubeone/v1beta2/defaults.go
+++ b/pkg/apis/kubeone/v1beta2/defaults.go
@@ -64,6 +64,12 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 
 	setDefaultLeader := true
 
+	gteKube124Condition, _ := semver.NewConstraint(">= 1.24")
+	actualVer, err := semver.NewVersion(obj.Versions.Kubernetes)
+	if err != nil {
+		return
+	}
+
 	// Define a unique ID for each host
 	for idx := range obj.ControlPlane.Hosts {
 		if setDefaultLeader && obj.ControlPlane.Hosts[idx].IsLeader {
@@ -79,6 +85,12 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 					Effect: corev1.TaintEffectNoSchedule,
 					Key:    "node-role.kubernetes.io/master",
 				},
+			}
+			if gteKube124Condition.Check(actualVer) {
+				obj.ControlPlane.Hosts[idx].Taints = append(obj.ControlPlane.Hosts[idx].Taints, corev1.Taint{
+					Effect: corev1.TaintEffectNoSchedule,
+					Key:    "node-role.kubernetes.io/control-plane",
+				})
 			}
 		}
 	}

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -170,8 +170,11 @@ type HostConfig struct {
 	// IsLeader indicates this host as a session leader.
 	// Default value is populated at the runtime.
 	IsLeader bool `json:"isLeader,omitempty"`
-	// Taints if not provided (i.e. nil) defaults to TaintEffectNoSchedule, with key node-role.kubernetes.io/master for
-	// control plane nodes.
+	// Taints are taints applied to nodes. If not provided (i.e. nil) for control plane nodes,
+	// it defaults to:
+	//   * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master
+	//   * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys
+	//     node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master
 	// Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes).
 	Taints []corev1.Taint `json:"taints,omitempty"`
 	// Kubelet

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -38,7 +38,7 @@ const (
 	// lowerVersionConstraint defines a semver constraint that validates Kubernetes versions against a lower bound
 	lowerVersionConstraint = ">= 1.20"
 	// upperVersionConstraint defines a semver constraint that validates Kubernetes versions against an upper bound
-	upperVersionConstraint = "<= 1.23"
+	upperVersionConstraint = "<= 1.24"
 )
 
 var (

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -764,9 +764,9 @@ func TestValidateVersionConfig(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "not supported kubernetes version (1.24.0)",
+			name: "not supported kubernetes version (1.99.0)",
 			versionConfig: kubeoneapi.VersionConfig{
-				Kubernetes: "1.24.0",
+				Kubernetes: "1.99.0",
 			},
 			expectedError: true,
 		},

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -807,10 +807,12 @@ addons:
 #     # prefixed with "env:" to refer to an environment variable.
 #     sshPrivateKeyFile: '/home/me/.ssh/id_rsa'
 #     sshAgentSocket: 'env:SSH_AUTH_SOCK'
-#     # Taints is used to apply taints to the node.
-#     # If not provided defaults to TaintEffectNoSchedule, with key
-#     # node-role.kubernetes.io/master for control plane nodes.
-#     # Explicitly empty (i.e. taints: {}) means no taints will be applied.
+#     # Taints are taints applied to nodes. If not provided (i.e. nil) for control plane nodes,
+#     # it defaults to:
+#     #   * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master
+#     #   * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys
+#     #     node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master
+#     # Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes).
 #     taints:
 #     - key: "node-role.kubernetes.io/master"
 #       effect: "NoSchedule"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Automatically apply the `node-role.kubernetes.io/control-plane` taint to nodes running Kubernetes 1.24. The taint is also supposed to be applied when nodes are upgraded from 1.23 to 1.24. This might require customers to adjust their workloads to tolerate the new taint before upgrading. This is now matching the behavior of kubeadm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2010

**Does this PR introduce a user-facing change?**:
```release-note
[ACTION REQUIRED] Automatically apply the `node-role.kubernetes.io/control-plane` taint to nodes running Kubernetes 1.24. The taint is also applied when upgrading nodes from Kubernetes 1.23 to 1.24. You might need to adjust your workloads to tolerate the `node-role.kubernetes.io/control-plane` taint (in addition to the `node-role.kubernetes.io/master` taint)
```

/assign @kron4eg 