### PR TITLE
Remove --network-plugin Kubelet flag for Kubernetes 1.24 clusters

### DIFF
--- a/pkg/tasks/containerd.go
+++ b/pkg/tasks/containerd.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	kubeadmCRISocket = "kubeadm.alpha.kubernetes.io/cri-socket"
+	kubeadmCRISocket  = "kubeadm.alpha.kubernetes.io/cri-socket"
+	networkPluginFlag = "--network-plugin"
 )
 
 var (
@@ -89,6 +90,10 @@ func migrateToContainerdTask(s *state.State, node *kubeoneapi.HostConfig, conn s
 		if err != nil {
 			return nil, err
 		}
+
+		// --network-plugin flag is not used with containerd and has been
+		// removed in Kubernetes 1.24
+		delete(kubeletFlags, networkPluginFlag)
 
 		for k, v := range containerdKubeletFlags {
 			kubeletFlags[k] = v

--- a/pkg/tasks/fix_network_plugin.go
+++ b/pkg/tasks/fix_network_plugin.go
@@ -17,10 +17,14 @@ limitations under the License.
 package tasks
 
 import (
-	"github.com/Masterminds/semver/v3"
-
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
+	"k8c.io/kubeone/pkg/semverutil"
 	"k8c.io/kubeone/pkg/state"
+)
+
+var (
+	version124 = semverutil.MustParseConstraint("1.24.*")
+	version123 = semverutil.MustParseConstraint("1.23.*")
 )
 
 // removeNetworkPluginFlagKubelet removes --network-plugin flag from Kubelet
@@ -28,10 +32,6 @@ import (
 // This function is executed only when upgrading cluster from 1.23 to 1.24.
 // TODO: Remove this function after dropping support for Kubernetes 1.23.
 func removeNetworkPluginFlagKubelet(s *state.State, node kubeoneapi.HostConfig) error {
-	version124, _ := semver.NewConstraint("1.24.*")
-	version123, _ := semver.NewConstraint("1.23.*")
-
-	// Migrate Kubelet config only when upgrading the cluster to 1.24
 	needed := false
 	if !version124.Check(s.LiveCluster.ExpectedVersion) {
 		return nil

--- a/pkg/tasks/fix_network_plugin.go
+++ b/pkg/tasks/fix_network_plugin.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"github.com/Masterminds/semver/v3"
+
+	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
+	"k8c.io/kubeone/pkg/state"
+)
+
+// removeNetworkPluginFlagKubelet removes --network-plugin flag from Kubelet
+// config because it has been removed in Kubernetes 1.24.
+// This function is executed only when upgrading cluster from 1.23 to 1.24.
+// TODO: Remove this function after dropping support for Kubernetes 1.23.
+func removeNetworkPluginFlagKubelet(s *state.State, node kubeoneapi.HostConfig) error {
+	version124, _ := semver.NewConstraint("1.24.*")
+	version123, _ := semver.NewConstraint("1.23.*")
+
+	// Migrate Kubelet config only when upgrading the cluster to 1.24
+	needed := false
+	if !version124.Check(s.LiveCluster.ExpectedVersion) {
+		return nil
+	}
+	for _, cp := range s.LiveCluster.ControlPlane {
+		if cp.Config.Hostname == node.Hostname && version123.Check(cp.Kubelet.Version) {
+			needed = true
+
+			break
+		}
+	}
+	if !needed {
+		return nil
+	}
+
+	s.Logger.Info("Removing --network-plugin flag from Kubelet config")
+
+	return updateRemoteFile(s, kubeadmEnvFlagsFile, func(content []byte) ([]byte, error) {
+		kubeletFlags, err := unmarshalKubeletFlags(content)
+		if err != nil {
+			return nil, err
+		}
+
+		// --network-plugin flag is not used with containerd and has been
+		// removed in Kubernetes 1.24
+		delete(kubeletFlags, networkPluginFlag)
+
+		buf := marshalKubeletFlags(kubeletFlags)
+
+		return buf, nil
+	})
+}

--- a/pkg/tasks/upgrade_follower.go
+++ b/pkg/tasks/upgrade_follower.go
@@ -53,6 +53,10 @@ func upgradeFollowerExecutor(s *state.State, node *kubeoneapi.HostConfig, conn s
 		return err
 	}
 
+	if err := removeNetworkPluginFlagKubelet(s, *node); err != nil {
+		return err
+	}
+
 	logger.Infoln("Upgrading Kubernetes binaries on follower control plane...")
 	if err := upgradeKubeadmAndCNIBinaries(s, *node); err != nil {
 		return err

--- a/pkg/tasks/upgrade_leader.go
+++ b/pkg/tasks/upgrade_leader.go
@@ -53,6 +53,10 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 		return err
 	}
 
+	if err := removeNetworkPluginFlagKubelet(s, *node); err != nil {
+		return err
+	}
+
 	logger.Infoln("Upgrading kubeadm binary on the leader control plane...")
 	if err := upgradeKubeadmAndCNIBinaries(s, *node); err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

* Remove `--network-plugin` Kubelet flag when migrating from Docker to containerd
  * New containerd clusters don't have this flag out of the box
* Remove `--network-plugin` Kubelet flag when upgrading from Kubernetes 1.23.x to 1.24.x
  * This is required because in earlier KubeOne versions we didn't remove the `--network-plugin` flag when migrating to containerd. Therefore, the flag is still present in the Kubelet config. Upgrading such a cluster to 1.24 causes Kubelet to crash.

This is required since `--network-plugin` and some other flags got removed in Kubernetes 1.24 (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#feature).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2010 

**Special notes for your reviewer**:

This is still not tested.

**Does this PR introduce a user-facing change?**:
```release-note
Remove the `--network-plugin` Kubelet flag when migrating from Docker to containerd
Remove the `--network-plugin` Kubelet flag when upgrading from Kubernetes 1.23.x to 1.24.x
```

/assign @kron4eg 