### PR TITLE
Upgrade machine-controller to v1.49.0

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -170,7 +170,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:        {"*": "docker.io/calico/node:v3.22.0"},
 		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
 		Flannel:           {"*": "quay.io/coreos/flannel:v0.15.1"},
-		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.47.0"},
+		MachineController: {"*": "quay.io/kubermatic/machine-controller:v1.49.0"},
 		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Upgrade machine-controller to v1.49.0. This release includes proper support for Kubernetes 1.24. machine-controller images are also now hosted on Quay instead of Docker Hub.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2010 

**Does this PR introduce a user-facing change?**:
```release-note
Upgrade machine-controller to v1.49.0. machine-controller images are now hosted on Quay instead of Docker Hub.
```
