### PR TITLE
Fix pre-pull images

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -123,6 +123,7 @@ func WithFullInstall(t Tasks) Tasks {
 	}...).
 		append(kubernetesConfigFiles()...).
 		append(Tasks{
+			{Fn: prePullImages, Operation: "pre-pull images"},
 			{
 				Fn: func(s *state.State) error {
 					s.Logger.Infoln("Configuring certs and etcd on control plane node...")
@@ -357,7 +358,6 @@ func kubernetesConfigFiles() Tasks {
 		{Fn: generateKubeadm, Operation: "generating kubeadm config files"},
 		{Fn: generateConfigurationFiles, Operation: "generating config files"},
 		{Fn: uploadConfigurationFiles, Operation: "uploading config files"},
-		{Fn: prePullImages, Operation: "pre-pull images"},
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Because we tried to pre-pull images before upgrading kubeadm it failed
during the upgrade process for kubernetes v1.21 (prior v1beta3 kubeadm).

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix pre-pull images
```
