### PR TITLE
Update Equinix Metal CCM to v3.4.2

### DIFF
--- a/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
+++ b/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
@@ -48,7 +48,7 @@ spec:
             - "--cloud-provider=equinixmetal"
             - "--leader-elect=false"
             - "--authentication-skip-lookup=true"
-            - "--provider-config=/etc/cloud-sa/cloud-sa.json"
+            - "--cloud-config=/etc/cloud-sa/cloud-sa.json"
           resources:
             requests:
               cpu: 100m

--- a/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
+++ b/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
@@ -35,6 +35,10 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
           operator: Exists
+        # Needed to let CCM come up and assign the EIP
+        - key: "node.kubernetes.io/not-ready"
+          effect: NoSchedule
+          operator: Exists
       containers:
         - image: {{ .InternalImages.Get "EquinixMetalCCM" }}
           name: cloud-provider-equinix-metal
@@ -71,84 +75,85 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   name: system:cloud-controller-manager
 rules:
-  - apiGroups:
-      # reason: so ccm can read the information about the kube-system namespace
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-  - apiGroups:
-      # reason: so ccm can monitor and update endpoints, used for control plane loadbalancer
-      - ""
-    resources:
-      - endpoints
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      # reason: so ccm can read and update nodes and annotations
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - "*"
-  - apiGroups:
-      # reason: so ccm can update the status of nodes
-      - ""
-    resources:
-      - nodes/status
-    verbs:
-      - patch
-  - apiGroups:
-      # reason: so ccm can manage services for loadbalancer
-      - ""
-    resources:
-      - services
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-      - create
-  - apiGroups:
-      # reason: so ccm can update the status of services for loadbalancer
-      - ""
-    resources:
-      - services/status
-    verbs:
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      # reason: so ccm can read and update configmap/metallb-system:config
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      # reason: so ccm can read and update events
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-      - patch
+- apiGroups:
+  # reason: so ccm can read the information about the kube-system namespace
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  # reason: so ccm can monitor and update endpoints, used for control plane loadbalancer
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  # reason: so ccm can read and update nodes and annotations
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  # reason: so ccm can update the status of nodes
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  # reason: so ccm can manage services for loadbalancer
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - create
+- apiGroups:
+  # reason: so ccm can update the status of services for loadbalancer
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  # reason: so ccm can read and update configmap/metallb-system:config
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  # reason: so ccm can read and update events
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/terraform/equinixmetal/main.tf
+++ b/examples/terraform/equinixmetal/main.tf
@@ -43,7 +43,7 @@ resource "metal_device" "lb" {
   depends_on = [metal_ssh_key.deployer]
 
   hostname         = "${var.cluster_name}-lb"
-  plan             = "t1.small.x86"
+  plan             = var.lb_device_type
   facilities       = [var.facility]
   operating_system = var.lb_operating_system
   billing_cycle    = "hourly"

--- a/examples/terraform/equinixmetal/variables.tf
+++ b/examples/terraform/equinixmetal/variables.tf
@@ -92,8 +92,14 @@ variable "lb_operating_system" {
 }
 
 variable "device_type" {
-  default     = "t1.small.x86"
+  default     = "c3.small.x86"
   description = "type (size) of the device"
+  type        = string
+}
+
+variable "lb_device_type" {
+  default     = "c3.small.x86"
+  description = "type (size) of the load balancer device"
   type        = string
 }
 

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -291,7 +291,7 @@ func optionalResources() map[Resource]map[string]string {
 		},
 
 		// Equinix Metal CCM
-		EquinixMetalCCM: {"*": "docker.io/equinix/cloud-provider-equinix-metal:v3.3.0"},
+		EquinixMetalCCM: {"*": "docker.io/equinix/cloud-provider-equinix-metal:v3.4.2"},
 
 		// vSphere CCM
 		VsphereCCM: {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Update Equinix Metal CCM to v3.4.2.

The default instance size is changed to `c3.small.x86` because `t1.small.x86` is not available any longer. If you're using the latest Terraform configs for Equinix Metal with an existing cluster, make sure to explicitly set the instance size (`device_type` and `lb_device_type`) in terraform.tfvars or otherwise your instances might get recreated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2011 

**Does this PR introduce a user-facing change?**:
```release-note
Update Equinix Metal CCM to v3.4.2
[ACTION REQUIRED] Change default instance size in example Terraform configs for Equinix Metal to `c3.small.x86` because `t1.small.x86` is not available any longer. If you're using the latest Terraform configs for Equinix Metal with an existing cluster, make sure to explicitly set the instance size (device_type and lb_device_type) in terraform.tfvars or otherwise your instances might get recreated
```

/assign @kron4eg 