### PR TITLE
Update OpenStack CCM and Cinder CSI

### DIFF
--- a/addons/csi-openstack-cinder/controllerplugin-rbac.yaml
+++ b/addons/csi-openstack-cinder/controllerplugin-rbac.yaml
@@ -26,7 +26,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: ClusterRoleBinding
@@ -76,7 +78,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -109,10 +113,13 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -150,11 +157,13 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
-    verbs: ["patch", "update"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -167,30 +176,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: csi-resizer-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: kube-system
-  name: external-resizer-cfg
-rules:
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-resizer-role-cfg
-  namespace: kube-system
-subjects:
-  - kind: ServiceAccount
-    name: csi-cinder-controller-sa
-    namespace: kube-system
-roleRef:
-  kind: Role
-  name: external-resizer-cfg
   apiGroup: rbac.authorization.k8s.io

--- a/addons/csi-openstack-cinder/controllerplugin.yaml
+++ b/addons/csi-openstack-cinder/controllerplugin.yaml
@@ -2,30 +2,19 @@
 # external-attacher, external-provisioner, external-snapshotter
 # external-resize, liveness-probe
 {{ $version := semver .Config.Versions.Kubernetes }}
-
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-cinder-controller-service
-  namespace: kube-system
-  labels:
-    app: csi-cinder-controllerplugin
-spec:
-  selector:
-    app: csi-cinder-controllerplugin
-  ports:
-    - name: dummy
-      port: 12345
-
 ---
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-cinder-controllerplugin
   namespace: kube-system
 spec:
-  serviceName: "csi-cinder-controller-service"
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: csi-cinder-controllerplugin
@@ -42,10 +31,11 @@ spec:
           effect: NoSchedule
       containers:
         - name: csi-attacher
-          image: {{ .InternalImages.Get "CSIAttacher" }}
+          image: {{ .InternalImages.Get "OpenstackCSIAttacher" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -54,19 +44,14 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: {{ .InternalImages.Get "CSIProvisioner" }}
+          image: {{ .InternalImages.Get "OpenstackCSIProvisioner" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
-{{ if ge $version.Minor 21 }}
-            # --default-fstype and --feature-gates is only used since CSI v1.21.0
             - "--default-fstype=ext4"
             - "--feature-gates=Topology=true"
-{{ end }}
-{{ if ge $version.Minor 20 }}
-            # --extra-create-metadata is only used since CSI v1.20.0
             - "--extra-create-metadata"
-{{ end }}
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -75,14 +60,12 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: {{ .InternalImages.Get "CSISnapshotter" }}
+          image: {{ .InternalImages.Get "OpenstackCSISnapshotter" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
-{{ if ge $version.Minor 20 }}
-            # --extra-create-metadata is only used since CSI v1.20.0
             - "--extra-create-metadata"
-{{ end }}
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -91,11 +74,12 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: {{ .InternalImages.Get "CSIResizer" }}
+          image: {{ .InternalImages.Get "OpenstackCSIResizer" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--handle-volume-inuse-error=false"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -104,7 +88,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: {{ .InternalImages.Get "CSILivenessProbe" }}
+          image: {{ .InternalImages.Get "OpenstackCSILivenessProbe" }}
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/addons/csi-openstack-cinder/nodeplugin.yaml
+++ b/addons/csi-openstack-cinder/nodeplugin.yaml
@@ -1,7 +1,7 @@
 # This YAML file contains driver-registrar & csi driver nodeplugin API objects,
 # which are necessary to run csi nodeplugin for cinder.
 {{ $version := semver .Config.Versions.Kubernetes }}
-
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -22,7 +22,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: {{ .InternalImages.Get "CSINodeDriverRegistar" }}
+          image: {{ .InternalImages.Get "OpenstackCSINodeDriverRegistar" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -49,7 +49,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: {{ .InternalImages.Get "CSILivenessProbe" }}
+          image: {{ .InternalImages.Get "OpenstackCSILivenessProbe" }}
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/addons/csi-openstack-cinder/snapshot-crds.yaml
+++ b/addons/csi-openstack-cinder/snapshot-crds.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Sourced from
-# https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.2/client/config/crd
+# https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -30,6 +30,8 @@ spec:
     kind: VolumeSnapshot
     listKind: VolumeSnapshotList
     plural: volumesnapshots
+    shortNames:
+    - vs
     singular: volumesnapshot
   scope: Namespaced
   versions:
@@ -109,7 +111,7 @@ spec:
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
                     description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
@@ -213,7 +215,7 @@ spec:
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
                     description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
@@ -262,6 +264,9 @@ spec:
     kind: VolumeSnapshotContent
     listKind: VolumeSnapshotContentList
     plural: volumesnapshotcontents
+    shortNames:
+    - vsc
+    - vscs
     singular: volumesnapshotcontent
   scope: Cluster
   versions:
@@ -568,6 +573,9 @@ spec:
     kind: VolumeSnapshotClass
     listKind: VolumeSnapshotClassList
     plural: volumesnapshotclasses
+    shortNames:
+    - vsclass
+    - vsclasses
     singular: volumesnapshotclass
   scope: Cluster
   versions:
@@ -668,3 +676,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -268,11 +268,11 @@ func optionalResources() map[Resource]map[string]string {
 
 		// OpenStack CCM
 		OpenstackCCM: {
-			"1.19.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.19.2",
 			"1.20.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2",
 			"1.21.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0",
 			"1.22.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0",
-			">= 1.23.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.0",
+			"1.23.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.1",
+			">= 1.24.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.0",
 		},
 
 		// OpenStack CSI

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -140,12 +140,20 @@ const (
 	DigitalOceanCSISnapshotValidationWebhook
 	DigitalOceanCSISnapshotter
 
+	// OpenStack CSI
+	OpenstackCSI
+	OpenstackCSINodeDriverRegistar
+	OpenstackCSILivenessProbe
+	OpenstackCSIAttacher
+	OpenstackCSIProvisioner
+	OpenstackCSIResizer
+	OpenstackCSISnapshotter
+
 	// CCMs and CSI plugins
 	DigitaloceanCCM
 	HetznerCCM
 	HetznerCSI
 	OpenstackCCM
-	OpenstackCSI
 	EquinixMetalCCM
 	VsphereCCM
 	VsphereCSIDriver
@@ -277,12 +285,18 @@ func optionalResources() map[Resource]map[string]string {
 
 		// OpenStack CSI
 		OpenstackCSI: {
-			"1.19.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.19.0",
 			"1.20.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.3",
 			"1.21.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.21.0",
 			"1.22.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
-			">= 1.23.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.0",
+			"1.23.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.0",
+			">= 1.24.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.24.0",
 		},
+		OpenstackCSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
+		OpenstackCSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.6.0"},
+		OpenstackCSIAttacher:           {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
+		OpenstackCSIProvisioner:        {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"},
+		OpenstackCSIResizer:            {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},
+		OpenstackCSISnapshotter:        {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1"},
 
 		// Equinix Metal CCM
 		EquinixMetalCCM: {"*": "docker.io/equinix/cloud-provider-equinix-metal:v3.4.2"},

--- a/pkg/templates/images/resource_string.go
+++ b/pkg/templates/images/resource_string.go
@@ -76,24 +76,30 @@ func _() {
 	_ = x[DigitalOceanCSISnapshotController-66]
 	_ = x[DigitalOceanCSISnapshotValidationWebhook-67]
 	_ = x[DigitalOceanCSISnapshotter-68]
-	_ = x[DigitaloceanCCM-69]
-	_ = x[HetznerCCM-70]
-	_ = x[HetznerCSI-71]
-	_ = x[OpenstackCCM-72]
-	_ = x[OpenstackCSI-73]
-	_ = x[EquinixMetalCCM-74]
-	_ = x[VsphereCCM-75]
-	_ = x[VsphereCSIDriver-76]
-	_ = x[VsphereCSISyncer-77]
-	_ = x[VsphereCSIProvisioner-78]
-	_ = x[CalicoVXLANCNI-79]
-	_ = x[CalicoVXLANController-80]
-	_ = x[CalicoVXLANNode-81]
+	_ = x[OpenstackCSI-69]
+	_ = x[OpenstackCSINodeDriverRegistar-70]
+	_ = x[OpenstackCSILivenessProbe-71]
+	_ = x[OpenstackCSIAttacher-72]
+	_ = x[OpenstackCSIProvisioner-73]
+	_ = x[OpenstackCSIResizer-74]
+	_ = x[OpenstackCSISnapshotter-75]
+	_ = x[DigitaloceanCCM-76]
+	_ = x[HetznerCCM-77]
+	_ = x[HetznerCSI-78]
+	_ = x[OpenstackCCM-79]
+	_ = x[EquinixMetalCCM-80]
+	_ = x[VsphereCCM-81]
+	_ = x[VsphereCSIDriver-82]
+	_ = x[VsphereCSISyncer-83]
+	_ = x[VsphereCSIProvisioner-84]
+	_ = x[CalicoVXLANCNI-85]
+	_ = x[CalicoVXLANController-86]
+	_ = x[CalicoVXLANNode-87]
 }
 
-const _Resource_name = "CalicoCNICalicoControllerCalicoNodeFlannelCiliumCiliumOperatorHubbleRelayHubbleUIHubbleUIBackendHubbleProxyCiliumCertGenWeaveNetCNIKubeWeaveNetCNINPCDNSNodeCacheMachineControllerMetricsServerOperatingSystemManagerClusterAutoscalerCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeAwsCCMAzureCCMAzureCNMAwsEbsCSIAwsEbsCSIAttacherAwsEbsCSILivenessProbeAwsEbsCSINodeDriverRegistrarAwsEbsCSIProvisionerAwsEbsCSIResizerAwsEbsCSISnapshotterAwsEbsCSISnapshotControllerAzureFileCSIAzureFileCSIAttacherAzureFileCSILivenessProbeAzureFileCSINodeDriverRegistarAzureFileCSIProvisionerAzureFileCSIResizerAzureFileCSISnapshotterAzureFileCSISnapshotterControllerAzureDiskCSIAzureDiskCSIAttacherAzureDiskCSILivenessProbeAzureDiskCSINodeDriverRegistarAzureDiskCSIProvisionerAzureDiskCSIResizerAzureDiskCSISnapshotterAzureDiskCSISnapshotterControllerNutanixCSILivenessProbeNutanixCSINutanixCSIProvisionerNutanixCSIRegistrarNutanixCSIResizerNutanixCSISnapshotterNutanixCSISnapshotControllerNutanixCSISnapshotValidationWebhookDigitalOceanCSIDigitalOceanCSIAlpineDigitalOceanCSIAttacherDigitalOceanCSINodeDriverRegistarDigitalOceanCSIProvisionerDigitalOceanCSIResizerDigitalOceanCSISnapshotControllerDigitalOceanCSISnapshotValidationWebhookDigitalOceanCSISnapshotterDigitaloceanCCMHetznerCCMHetznerCSIOpenstackCCMOpenstackCSIEquinixMetalCCMVsphereCCMVsphereCSIDriverVsphereCSISyncerVsphereCSIProvisionerCalicoVXLANCNICalicoVXLANControllerCalicoVXLANNode"
+const _Resource_name = "CalicoCNICalicoControllerCalicoNodeFlannelCiliumCiliumOperatorHubbleRelayHubbleUIHubbleUIBackendHubbleProxyCiliumCertGenWeaveNetCNIKubeWeaveNetCNINPCDNSNodeCacheMachineControllerMetricsServerOperatingSystemManagerClusterAutoscalerCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeAwsCCMAzureCCMAzureCNMAwsEbsCSIAwsEbsCSIAttacherAwsEbsCSILivenessProbeAwsEbsCSINodeDriverRegistrarAwsEbsCSIProvisionerAwsEbsCSIResizerAwsEbsCSISnapshotterAwsEbsCSISnapshotControllerAzureFileCSIAzureFileCSIAttacherAzureFileCSILivenessProbeAzureFileCSINodeDriverRegistarAzureFileCSIProvisionerAzureFileCSIResizerAzureFileCSISnapshotterAzureFileCSISnapshotterControllerAzureDiskCSIAzureDiskCSIAttacherAzureDiskCSILivenessProbeAzureDiskCSINodeDriverRegistarAzureDiskCSIProvisionerAzureDiskCSIResizerAzureDiskCSISnapshotterAzureDiskCSISnapshotterControllerNutanixCSILivenessProbeNutanixCSINutanixCSIProvisionerNutanixCSIRegistrarNutanixCSIResizerNutanixCSISnapshotterNutanixCSISnapshotControllerNutanixCSISnapshotValidationWebhookDigitalOceanCSIDigitalOceanCSIAlpineDigitalOceanCSIAttacherDigitalOceanCSINodeDriverRegistarDigitalOceanCSIProvisionerDigitalOceanCSIResizerDigitalOceanCSISnapshotControllerDigitalOceanCSISnapshotValidationWebhookDigitalOceanCSISnapshotterOpenstackCSIOpenstackCSINodeDriverRegistarOpenstackCSILivenessProbeOpenstackCSIAttacherOpenstackCSIProvisionerOpenstackCSIResizerOpenstackCSISnapshotterDigitaloceanCCMHetznerCCMHetznerCSIOpenstackCCMEquinixMetalCCMVsphereCCMVsphereCSIDriverVsphereCSISyncerVsphereCSIProvisionerCalicoVXLANCNICalicoVXLANControllerCalicoVXLANNode"
 
-var _Resource_index = [...]uint16{0, 9, 25, 35, 42, 48, 62, 73, 81, 96, 107, 120, 135, 149, 161, 178, 191, 213, 230, 241, 262, 276, 290, 300, 316, 322, 330, 338, 347, 364, 386, 414, 434, 450, 470, 497, 509, 529, 554, 584, 607, 626, 649, 682, 694, 714, 739, 769, 792, 811, 834, 867, 890, 900, 921, 940, 957, 978, 1006, 1041, 1056, 1077, 1100, 1133, 1159, 1181, 1214, 1254, 1280, 1295, 1305, 1315, 1327, 1339, 1354, 1364, 1380, 1396, 1417, 1431, 1452, 1467}
+var _Resource_index = [...]uint16{0, 9, 25, 35, 42, 48, 62, 73, 81, 96, 107, 120, 135, 149, 161, 178, 191, 213, 230, 241, 262, 276, 290, 300, 316, 322, 330, 338, 347, 364, 386, 414, 434, 450, 470, 497, 509, 529, 554, 584, 607, 626, 649, 682, 694, 714, 739, 769, 792, 811, 834, 867, 890, 900, 921, 940, 957, 978, 1006, 1041, 1056, 1077, 1100, 1133, 1159, 1181, 1214, 1254, 1280, 1292, 1322, 1347, 1367, 1390, 1409, 1432, 1447, 1457, 1467, 1479, 1494, 1504, 1520, 1536, 1557, 1571, 1592, 1607}
 
 func (i Resource) String() string {
 	i -= 1


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

* Add support for OpenStack CCM v1.24.0 (for Kubernetes 1.24 clusters)
* Add support for OpenStack Cinder CSI driver v1.24.0 (for Kubernetes 1.24 clusters)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2011

**Does this PR introduce a user-facing change?**:
```release-note
Add support for OpenStack CCM v1.24.0 (for Kubernetes 1.24 clusters)
Add support for OpenStack Cinder CSI driver v1.24.0 (for Kubernetes 1.24 clusters)
```

/assign @kron4eg 