### PR TITLE
[release/v1.4] Update vSphere CCM to v1.23.0

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -293,15 +293,6 @@ func ValidateKubernetesSupport(c kubeoneapi.KubeOneCluster, fldPath *field.Path)
 		return append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, "Amazon EKS-D clusters are not supported by KubeOne 1.4+"))
 	}
 
-	v, err := semver.NewVersion(c.Versions.Kubernetes)
-	if err != nil {
-		return append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, ".versions.kubernetes is not a semver string"))
-	}
-
-	if v.Minor() >= 23 && c.CloudProvider.Vsphere != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, "kubernetes versions 1.23.0 and newer are currently not supported for vsphere clusters"))
-	}
-
 	return allErrs
 }
 

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -867,26 +867,6 @@ func TestValidateKubernetesSupport(t *testing.T) {
 			},
 			expectedError: false,
 		},
-		{
-			name: "vSphere 1.22.4 cluster",
-			providerConfig: kubeoneapi.CloudProviderSpec{
-				Vsphere: &kubeoneapi.VsphereSpec{},
-			},
-			versionConfig: kubeoneapi.VersionConfig{
-				Kubernetes: "1.22.4",
-			},
-			expectedError: false,
-		},
-		{
-			name: "vSphere 1.23.0 cluster",
-			providerConfig: kubeoneapi.CloudProviderSpec{
-				Vsphere: &kubeoneapi.VsphereSpec{},
-			},
-			versionConfig: kubeoneapi.VersionConfig{
-				Kubernetes: "1.23.0",
-			},
-			expectedError: true,
-		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -291,7 +291,8 @@ func optionalResources() map[Resource]map[string]string {
 			"1.19.x":    "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.19.1",
 			"1.20.x":    "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.20.0",
 			"1.21.x":    "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.21.1",
-			">= 1.22.0": "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.22.4",
+			"1.22.x":    "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.22.4",
+			">= 1.23.0": "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.23.0",
 		},
 
 		// vSphere CSI


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

* Update vSphere CCM to v1.23.0 for Kubernetes 1.23 clusters
* Add support for Kubernetes 1.23 on vSphere

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1685 

**Does this PR introduce a user-facing change?**:
```release-note
Update vSphere CCM to v1.23.0 for Kubernetes 1.23 clusters. Add support for Kubernetes 1.23 on vSphere
```

/assign @kron4eg 