### PR TITLE
Migrate AzureDisk CSIDriver to set fsGroupPolicy

### DIFF
--- a/addons/csi-azuredisk/csi-azuredisk-driver.yaml
+++ b/addons/csi-azuredisk/csi-azuredisk-driver.yaml
@@ -9,3 +9,4 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  fsGroupPolicy: File

--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -339,6 +339,9 @@ func ensureCSIAddons(s *state.State, addonsToDeploy []addonAction) []addonAction
 		addonsToDeploy = append(addonsToDeploy,
 			addonAction{
 				name: resources.AddonCSIAzureDisk,
+				supportFn: func() error {
+					return migrateAzureDiskCSIDriver(s)
+				},
 			},
 			addonAction{
 				name: resources.AddonCSIAzureFile,

--- a/pkg/addons/helpers.go
+++ b/pkg/addons/helpers.go
@@ -27,12 +27,26 @@ import (
 	"k8c.io/kubeone/pkg/templates/resources"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	vSphereDeploymentName = "vsphere-cloud-controller-manager"
+	azureDiskCSIDriverName = "disk.csi.azure.com"
+	vSphereDeploymentName  = "vsphere-cloud-controller-manager"
 )
+
+func migrateAzureDiskCSIDriver(s *state.State) error {
+	return clientutil.DeleteIfExists(s.Context, s.DynamicClient, azureDiskCSIDriver())
+}
+
+func azureDiskCSIDriver() *storagev1.CSIDriver {
+	return &storagev1.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: azureDiskCSIDriverName,
+		},
+	}
+}
 
 func migrateVsphereAddon(s *state.State) error {
 	return clientutil.DeleteIfExists(s.Context, s.DynamicClient, vSphereService())


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR sets fsGroupPolicy to File for the AzureDisk CSIDriver. Initially, this wasn't set in the upstream manifests, but recently, they added it to the upstream manifests as well. Because CSIDriver objects are immutable, we have to migrate by removing the old CSIDriver object and creating a new one.

Without the fsGroupPolicy set, some workloads might fail to write to the mounted volume. See #2073 for more details on how to reproduce the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2073 

**Does this PR introduce a user-facing change?**:
```release-note
Migrate AzureDisk CSIDriver to set fsGroupPolicy to File
```