### PR TITLE
Introduce new variable for specifying custom operating system profile

### DIFF
--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -68,6 +68,7 @@ No modules.
 | <a name="input_control_plane_volume_size"></a> [control\_plane\_volume\_size](#input\_control\_plane\_volume\_size) | Size of the EBS volume, in Gb | `number` | `100` | no |
 | <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | number of replicas per MachineDeployment | `number` | `1` | no |
 | <a name="input_initial_machinedeployment_spotinstances_max_price"></a> [initial\_machinedeployment\_spotinstances\_max\_price](#input\_initial\_machinedeployment\_spotinstances\_max\_price) | Max price for spot instances, when specified spot instances will be used for initial machine-deployment | `number` | `0` | no |
+| <a name="initial_machinedeployment_operating_system_profile"></a> [initial\_machinedeployment\_operating\_system\_profile](#input\_initial\_machinedeployment\_operating\_system\_profile) | Name of operating system profile for MachineDeployment, only applicable if operatng-system-manager addon is enabled | `string` | `""` | no |
 | <a name="input_internal_api_lb"></a> [internal\_api\_lb](#input\_internal\_api\_lb) | make kubernetes API loadbalancer internal (reachible only from inside the VPC) | `bool` | `false` | no |
 | <a name="input_os"></a> [os](#input\_os) | Operating System to use in AMI filtering and MachineDeployment | `string` | `"ubuntu"` | no |
 | <a name="input_ssh_agent_socket"></a> [ssh\_agent\_socket](#input\_ssh\_agent\_socket) | SSH Agent socket, default to grab from $SSH\_AUTH\_SOCK | `string` | `"env:SSH_AUTH_SOCK"` | no |

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -19,18 +19,18 @@ provider "aws" {
 }
 
 locals {
-  kube_cluster_tag      = "kubernetes.io/cluster/${var.cluster_name}"
-  ami                   = var.ami == "" ? data.aws_ami.ami.id : var.ami
-  zoneA                 = data.aws_availability_zones.available.names[0]
-  zoneB                 = data.aws_availability_zones.available.names[1]
-  zoneC                 = data.aws_availability_zones.available.names[2]
-  vpc_mask              = parseint(split("/", data.aws_vpc.selected.cidr_block)[1], 10)
-  subnet_total          = pow(2, var.subnets_cidr - local.vpc_mask)
-  subnet_newbits        = var.subnets_cidr - (32 - local.vpc_mask)
-  worker_os             = var.worker_os == "" ? var.ami_filters[var.os].worker_os : var.worker_os
-  worker_deploy_ssh_key = var.worker_deploy_ssh_key ? [aws_key_pair.deployer.public_key] : []
-  ssh_username          = var.ssh_username == "" ? var.ami_filters[var.os].ssh_username : var.ssh_username
-  bastion_user          = var.bastion_user == "" ? var.ami_filters[var.os].ssh_username : var.bastion_user
+  kube_cluster_tag                        = "kubernetes.io/cluster/${var.cluster_name}"
+  ami                                     = var.ami == "" ? data.aws_ami.ami.id : var.ami
+  zoneA                                   = data.aws_availability_zones.available.names[0]
+  zoneB                                   = data.aws_availability_zones.available.names[1]
+  zoneC                                   = data.aws_availability_zones.available.names[2]
+  vpc_mask                                = parseint(split("/", data.aws_vpc.selected.cidr_block)[1], 10)
+  subnet_total                            = pow(2, var.subnets_cidr - local.vpc_mask)
+  subnet_newbits                          = var.subnets_cidr - (32 - local.vpc_mask)
+  worker_os                               = var.worker_os == "" ? var.ami_filters[var.os].worker_os : var.worker_os
+  worker_deploy_ssh_key                   = var.worker_deploy_ssh_key ? [aws_key_pair.deployer.public_key] : []
+  ssh_username                            = var.ssh_username == "" ? var.ami_filters[var.os].ssh_username : var.ssh_username
+  bastion_user                            = var.bastion_user == "" ? var.ami_filters[var.os].ssh_username : var.bastion_user
   initial_machinedeployment_spotinstances = var.initial_machinedeployment_spotinstances_max_price > 0
 
   subnets = {

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -19,19 +19,20 @@ provider "aws" {
 }
 
 locals {
-  kube_cluster_tag                        = "kubernetes.io/cluster/${var.cluster_name}"
-  ami                                     = var.ami == "" ? data.aws_ami.ami.id : var.ami
-  zoneA                                   = data.aws_availability_zones.available.names[0]
-  zoneB                                   = data.aws_availability_zones.available.names[1]
-  zoneC                                   = data.aws_availability_zones.available.names[2]
-  vpc_mask                                = parseint(split("/", data.aws_vpc.selected.cidr_block)[1], 10)
-  subnet_total                            = pow(2, var.subnets_cidr - local.vpc_mask)
-  subnet_newbits                          = var.subnets_cidr - (32 - local.vpc_mask)
-  worker_os                               = var.worker_os == "" ? var.ami_filters[var.os].worker_os : var.worker_os
-  worker_deploy_ssh_key                   = var.worker_deploy_ssh_key ? [aws_key_pair.deployer.public_key] : []
-  ssh_username                            = var.ssh_username == "" ? var.ami_filters[var.os].ssh_username : var.ssh_username
-  bastion_user                            = var.bastion_user == "" ? var.ami_filters[var.os].ssh_username : var.bastion_user
-  initial_machinedeployment_spotinstances = var.initial_machinedeployment_spotinstances_max_price > 0
+  kube_cluster_tag                                   = "kubernetes.io/cluster/${var.cluster_name}"
+  ami                                                = var.ami == "" ? data.aws_ami.ami.id : var.ami
+  zoneA                                              = data.aws_availability_zones.available.names[0]
+  zoneB                                              = data.aws_availability_zones.available.names[1]
+  zoneC                                              = data.aws_availability_zones.available.names[2]
+  vpc_mask                                           = parseint(split("/", data.aws_vpc.selected.cidr_block)[1], 10)
+  subnet_total                                       = pow(2, var.subnets_cidr - local.vpc_mask)
+  subnet_newbits                                     = var.subnets_cidr - (32 - local.vpc_mask)
+  worker_os                                          = var.worker_os == "" ? var.ami_filters[var.os].worker_os : var.worker_os
+  worker_deploy_ssh_key                              = var.worker_deploy_ssh_key ? [aws_key_pair.deployer.public_key] : []
+  ssh_username                                       = var.ssh_username == "" ? var.ami_filters[var.os].ssh_username : var.ssh_username
+  bastion_user                                       = var.bastion_user == "" ? var.ami_filters[var.os].ssh_username : var.bastion_user
+  initial_machinedeployment_spotinstances            = var.initial_machinedeployment_spotinstances_max_price > 0
+  initial_machinedeployment_operating_system_profile = var.initial_machinedeployment_operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.initial_machinedeployment_operating_system_profile
 
   subnets = {
     (local.zoneA) = length(aws_subnet.public.*.id) > 0 ? aws_subnet.public[0].id : ""

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -85,7 +85,7 @@ output "kubeone_workers" {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
-          "k8c.io/operating-system-profile" = var.operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.operating_system_profile
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.initial_machinedeployment_operating_system_profile
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -143,7 +143,7 @@ output "kubeone_workers" {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
-          "k8c.io/operating-system-profile" = var.operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.operating_system_profile
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.initial_machinedeployment_operating_system_profile
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -85,7 +85,7 @@ output "kubeone_workers" {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
-          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.initial_machinedeployment_operating_system_profile
+          "k8c.io/operating-system-profile" = local.initial_machinedeployment_operating_system_profile
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -143,7 +143,7 @@ output "kubeone_workers" {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
-          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.initial_machinedeployment_operating_system_profile
+          "k8c.io/operating-system-profile" = local.initial_machinedeployment_operating_system_profile
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -201,7 +201,7 @@ output "kubeone_workers" {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
-          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.initial_machinedeployment_operating_system_profile
+          "k8c.io/operating-system-profile" = local.initial_machinedeployment_operating_system_profile
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -85,7 +85,7 @@ output "kubeone_workers" {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
-          "k8c.io/operating-system-profile" = var.ami_filters[var.os].osp_name
+          "k8c.io/operating-system-profile" = var.operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.operating_system_profile
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -125,8 +125,8 @@ output "kubeone_workers" {
           diskSize         = 50
           diskType         = "gp2"
           ## Only applicable if diskType = io1
-          diskIops           = 500
-          isSpotInstance     = local.initial_machinedeployment_spotinstances
+          diskIops       = 500
+          isSpotInstance = local.initial_machinedeployment_spotinstances
           ## Only applicable if isSpotInstance is true
           spotInstanceConfig = {
             maxPrice = format("%f", var.initial_machinedeployment_spotinstances_max_price)
@@ -143,7 +143,7 @@ output "kubeone_workers" {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
-          "k8c.io/operating-system-profile" = var.ami_filters[var.os].osp_name
+          "k8c.io/operating-system-profile" = var.operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.operating_system_profile
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -183,8 +183,8 @@ output "kubeone_workers" {
           diskSize         = 50
           diskType         = "gp2"
           ## Only applicable if diskType = io1
-          diskIops           = 500
-          isSpotInstance     = local.initial_machinedeployment_spotinstances
+          diskIops       = 500
+          isSpotInstance = local.initial_machinedeployment_spotinstances
           ## Only applicable if isSpotInstance is true
           spotInstanceConfig = {
             maxPrice = format("%f", var.initial_machinedeployment_spotinstances_max_price)
@@ -201,7 +201,7 @@ output "kubeone_workers" {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
-          "k8c.io/operating-system-profile" = var.ami_filters[var.os].osp_name
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile == "" ? var.ami_filters[var.os].osp_name : var.initial_machinedeployment_operating_system_profile
         }
         sshPublicKeys   = local.worker_deploy_ssh_key
         operatingSystem = local.worker_os
@@ -241,8 +241,8 @@ output "kubeone_workers" {
           diskSize         = 50
           diskType         = "gp2"
           ## Only applicable if diskType = io1
-          diskIops           = 500
-          isSpotInstance     = local.initial_machinedeployment_spotinstances
+          diskIops       = 500
+          isSpotInstance = local.initial_machinedeployment_spotinstances
           ## Only applicable if isSpotInstance is true
           spotInstanceConfig = {
             maxPrice = format("%f", var.initial_machinedeployment_spotinstances_max_price)

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -222,8 +222,8 @@ variable "static_workers_count" {
 variable "initial_machinedeployment_spotinstances_max_price" {
   description = "used to specify max spot instance price for initial machine-deployment"
   # we intentionally set minimum max price to ensure that user specifies it explicitly
-  default     = 0
-  type        = number
+  default = 0
+  type    = number
 }
 
 variable "worker_deploy_ssh_key" {
@@ -236,4 +236,13 @@ variable "control_plane_vm_count" {
   description = "number of control plane instances"
   default     = 3
   type        = number
+}
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified default is used based on the OS specified for workers.
+EOF
 }

--- a/examples/terraform/azure/README.md
+++ b/examples/terraform/azure/README.md
@@ -21,6 +21,7 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 | ssh\_username | SSH user, used only in output | string | `"ubuntu"` | no |
 | worker\_os | OS to run on worker machines | string | `"ubuntu"` | no |
 | worker\_vm\_size |  | string | `"Standard_B2s"` | no |
+| initial\_machinedeployments\_operating\_system\_profiles | Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled | string | `""` | no |
 
 ## Outputs
 
@@ -29,4 +30,3 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 | kubeone\_api | kube-apiserver LB endpoint |
 | kubeone\_hosts | Control plane endpoints to SSH to |
 | kubeone\_workers | Workers definitions, that will be transformed into MachineDeployment object |
-

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = azurerm_public_ip.lbip.ip_address
+    endpoint                    = azurerm_public_ip.lbip.ip_address
     apiserver_alternative_names = var.apiserver_alternative_names
   }
 }
@@ -50,6 +50,9 @@ output "kubeone_workers" {
     "${var.cluster_name}-pool1" = {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
         operatingSystemSpec = {
@@ -57,20 +60,20 @@ output "kubeone_workers" {
         }
         cloudProviderSpec = {
           # provider specific fields:
-          # see example under `cloudProviderSpec` section at: 
+          # see example under `cloudProviderSpec` section at:
           # https://github.com/kubermatic/machine-controller/blob/master/examples/azure-machinedeployment.yaml
-          location                = var.location
-          resourceGroup           = azurerm_resource_group.rg.name
+          location      = var.location
+          resourceGroup = azurerm_resource_group.rg.name
           # vnetResourceGroup     = ""
-          vmSize                  = var.worker_vm_size
-          vnetName                = azurerm_virtual_network.vpc.name
-          subnetName              = azurerm_subnet.subnet.name
+          vmSize     = var.worker_vm_size
+          vnetName   = azurerm_virtual_network.vpc.name
+          subnetName = azurerm_subnet.subnet.name
           # loadBalancerSku       = ""
-          routeTableName          = azurerm_route_table.rt.name
-          availabilitySet         = azurerm_availability_set.avset_workers.name
+          routeTableName  = azurerm_route_table.rt.name
+          availabilitySet = azurerm_availability_set.avset_workers.name
           # assignAvailabilitySet = true/false
-          securityGroupName       = azurerm_network_security_group.sg.name
-          assignPublicIP          = true
+          securityGroupName = azurerm_network_security_group.sg.name
+          assignPublicIP    = true
           # Zones (optional)
           # Represents Availability Zones is a high-availability offering
           # that protects your applications and data from datacenter failures.
@@ -93,4 +96,3 @@ output "kubeone_workers" {
     }
   }
 }
-

--- a/examples/terraform/azure/variables.tf
+++ b/examples/terraform/azure/variables.tf
@@ -101,3 +101,12 @@ variable "initial_machinedeployment_replicas" {
   default     = 1
   type        = number
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}

--- a/examples/terraform/digitalocean/README.md
+++ b/examples/terraform/digitalocean/README.md
@@ -14,6 +14,7 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 | cluster\_name | Name of the cluster | string | n/a | yes |
 | control\_plane\_droplet\_image | Image to use for provisioning control plane droplets | string | `"ubuntu-18-04-x64"` | no |
 | control\_plane\_size | Size of control plane nodes | string | `"s-2vcpu-4gb"` | no |
+| initial\_machinedeployments\_operating\_system\_profiles | Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled | string | `""` | no |
 | region | Region to speak to | string | `"fra1"` | no |
 | ssh\_agent\_socket | SSH Agent socket, default to grab from $SSH_AUTH_SOCK | string | `"env:SSH_AUTH_SOCK"` | no |
 | ssh\_port | SSH port to be used to provision instances | string | `"22"` | no |

--- a/examples/terraform/digitalocean/output.tf
+++ b/examples/terraform/digitalocean/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = digitalocean_loadbalancer.control_plane.ip
+    endpoint                    = digitalocean_loadbalancer.control_plane.ip
     apiserver_alternative_names = var.apiserver_alternative_names
   }
 }
@@ -49,6 +49,9 @@ output "kubeone_workers" {
     "${var.cluster_name}-pool1" = {
       replicas = 1
       providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
         sshPublicKeys   = [digitalocean_ssh_key.deployer.public_key]
         operatingSystem = var.worker_os
         operatingSystemSpec = {
@@ -73,4 +76,3 @@ output "kubeone_workers" {
     }
   }
 }
-

--- a/examples/terraform/digitalocean/variables.tf
+++ b/examples/terraform/digitalocean/variables.tf
@@ -95,3 +95,12 @@ variable "worker_size" {
   default     = "s-2vcpu-4gb"
   type        = string
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}

--- a/examples/terraform/equinixmetal/README.md
+++ b/examples/terraform/equinixmetal/README.md
@@ -20,6 +20,7 @@ See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 | control\_plane\_operating\_system | Image to use for control plane provisioning | string | `"ubuntu_18_04"` | no |
 | device\_type | type (size) of the device | string | `"t1.small.x86"` | no |
 | facility | Facility (datacenter) | string | `"ams1"` | no |
+| initial\_machinedeployments\_operating\_system\_profiles | Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled | string | `""` | no |
 | lb\_operating\_system | Image to use for loadbalancer provisioning | string | `"ubuntu_18_04"` | no |
 | project\_id | project ID | string | n/a | yes |
 | ssh\_agent\_socket | SSH Agent socket, default to grab from $SSH_AUTH_SOCK | string | `"env:SSH_AUTH_SOCK"` | no |

--- a/examples/terraform/equinixmetal/output.tf
+++ b/examples/terraform/equinixmetal/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = metal_device.lb.access_public_ipv4
+    endpoint                    = metal_device.lb.access_public_ipv4
     apiserver_alternative_names = var.apiserver_alternative_names
   }
 }
@@ -49,6 +49,9 @@ output "kubeone_workers" {
     "${var.cluster_name}-pool1" = {
       replicas = 1
       providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
         operatingSystemSpec = {

--- a/examples/terraform/equinixmetal/variables.tf
+++ b/examples/terraform/equinixmetal/variables.tf
@@ -107,3 +107,12 @@ variable "project_id" {
   description = "project ID"
   type        = string
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}

--- a/examples/terraform/equinixmetal/versions.tf
+++ b/examples/terraform/equinixmetal/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0.0"
   required_providers {
     metal = {
-      source = "equinix/metal"
+      source  = "equinix/metal"
       version = "~> 3.2.0"
     }
   }

--- a/examples/terraform/gce/README.md
+++ b/examples/terraform/gce/README.md
@@ -11,11 +11,13 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 ### Credentials
 
-Per https://www.terraform.io/docs/providers/google/provider_reference.html#configuration-reference
+Per <https://www.terraform.io/docs/providers/google/provider_reference.html#configuration-reference>
 either of the following ENV variables should be accessible:
+
 * `GOOGLE_CREDENTIALS`
 * `GOOGLE_CLOUD_KEYFILE_JSON`
 * `GCLOUD_KEYFILE_JSON`
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -27,6 +29,7 @@ either of the following ENV variables should be accessible:
 | control\_plane\_target\_pool\_members\_count |  | string | `"3"` | no |
 | control\_plane\_type | GCE instance type | string | `"n1-standard-2"` | no |
 | control\_plane\_volume\_size | Size of the boot volume, in GB | string | `"100"` | no |
+| initial\_machinedeployments\_operating\_system\_profiles | Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled | string | `""` | no |
 | project | Project to be used for all resources | string | n/a | yes |
 | region | GCP region to speak to | string | `"europe-west3"` | no |
 | ssh\_agent\_socket | SSH Agent socket, default to grab from $SSH_AUTH_SOCK | string | `"env:SSH_AUTH_SOCK"` | no |
@@ -44,4 +47,3 @@ either of the following ENV variables should be accessible:
 | kubeone\_api | kube-apiserver LB endpoint |
 | kubeone\_hosts | Control plane endpoints to SSH to |
 | kubeone\_workers | Workers definitions, that will be transformed into MachineDeployment object |
-

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = google_compute_address.lb_ip.address
+    endpoint                    = google_compute_address.lb_ip.address
     apiserver_alternative_names = var.apiserver_alternative_names
   }
 }
@@ -50,6 +50,9 @@ output "kubeone_workers" {
     "${var.cluster_name}-pool1" = {
       replicas = 1
       providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
         operatingSystemSpec = {
@@ -81,4 +84,3 @@ output "kubeone_workers" {
     }
   }
 }
-

--- a/examples/terraform/gce/variables.tf
+++ b/examples/terraform/gce/variables.tf
@@ -122,3 +122,12 @@ variable "cluster_network_cidr" {
   description = "Cluster network subnet cidr"
   type        = string
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -20,6 +20,7 @@ See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 | control\_plane\_type |  | string | `"cx21"` | no |
 | datacenter |  | string | `"fsn1"` | no |
 | image |  | string | `"ubuntu-20.04"` | no |
+| initial\_machinedeployments\_operating\_system\_profiles | Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled | string | `""` | no |
 | lb\_type |  | string | `"lb11"` | no |
 | ssh\_agent\_socket | SSH Agent socket, default to grab from $SSH_AUTH_SOCK | string | `"env:SSH_AUTH_SOCK"` | no |
 | ssh\_port | SSH port to be used to provision instances | string | `"22"` | no |

--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -55,6 +55,9 @@ output "kubeone_workers" {
     "${var.cluster_name}-pool1" = {
       replicas = var.workers_replicas
       providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
         operatingSystemSpec = {

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -118,3 +118,12 @@ variable "network_zone" {
   description = "network zone to use for private network"
   type        = string
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}

--- a/examples/terraform/nutanix/README.md
+++ b/examples/terraform/nutanix/README.md
@@ -72,6 +72,7 @@ See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 | <a name="input_worker_os"></a> [worker\_os](#input\_worker\_os) | OS to run on worker machines, default to var.os | `string` | `"ubuntu"` | no |
 | <a name="input_worker_sockets"></a> [worker\_sockets](#input\_worker\_sockets) | Number of sockets for worker nodes | `number` | `1` | no |
 | <a name="input_worker_vcpus"></a> [worker\_vcpus](#input\_worker\_vcpus) | Number of vCPUs per socket for worker nodes | `number` | `2` | no |
+| <a name="initial_machinedeployment_operating_system_profile"></a> [initial\_machinedeployment\_operating\_system\_profile](#input\_initial\_machinedeployment\_operating\_system\_profile) | Name of operating system profile for MachineDeployment, only applicable if operatng-system-manager addon is enabled | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/terraform/nutanix/main.tf
+++ b/examples/terraform/nutanix/main.tf
@@ -63,7 +63,7 @@ resource "nutanix_virtual_machine" "control_plane" {
 
   disk_list {
     disk_size_mib = var.control_plane_disk_size
-    
+
     data_source_reference = {
       kind = "image"
       uuid = data.nutanix_image.image.metadata.uuid
@@ -72,12 +72,12 @@ resource "nutanix_virtual_machine" "control_plane" {
 
   guest_customization_cloud_init_user_data = base64encode(templatefile("./cloud-config.tftpl", {
     machine_name = "${var.cluster_name}-cp-${count.index}"
-    ssh_key = file(var.ssh_public_key_file)
+    ssh_key      = file(var.ssh_public_key_file)
   }))
 
   categories {
-    name   = nutanix_category_key.category_key.name
-    value  = nutanix_category_value.category_value.value
+    name  = nutanix_category_key.category_key.name
+    value = nutanix_category_value.category_value.value
   }
 }
 
@@ -100,7 +100,7 @@ resource "nutanix_virtual_machine" "lb" {
 
   disk_list {
     disk_size_mib = var.bastion_disk_size
-    
+
     data_source_reference = {
       kind = "image"
       uuid = data.nutanix_image.image.metadata.uuid
@@ -109,12 +109,12 @@ resource "nutanix_virtual_machine" "lb" {
 
   guest_customization_cloud_init_user_data = base64encode(templatefile("./cloud-config.tftpl", {
     machine_name = "${var.cluster_name}-lb"
-    ssh_key = file(var.ssh_public_key_file)
+    ssh_key      = file(var.ssh_public_key_file)
   }))
 
   categories {
-    name   = nutanix_category_key.category_key.name
-    value  = nutanix_category_value.category_value.value
+    name  = nutanix_category_key.category_key.name
+    value = nutanix_category_value.category_value.value
   }
 
   connection {

--- a/examples/terraform/nutanix/output.tf
+++ b/examples/terraform/nutanix/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = nutanix_virtual_machine.lb.nic_list.0.ip_endpoint_list.0.ip
+    endpoint                    = nutanix_virtual_machine.lb.nic_list.0.ip_endpoint_list.0.ip
     apiserver_alternative_names = var.apiserver_alternative_names
   }
 }
@@ -53,12 +53,15 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas     = var.initial_machinedeployment_replicas
+      replicas = var.initial_machinedeployment_replicas
       providerSpec = {
-        sshPublicKeys       = [file(var.ssh_public_key_file)]
-        operatingSystem     = var.worker_os
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
+        sshPublicKeys   = [file(var.ssh_public_key_file)]
+        operatingSystem = var.worker_os
         operatingSystemSpec = {
-          distUpgradeOnBoot   = false
+          distUpgradeOnBoot = false
         }
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {
@@ -85,7 +88,7 @@ output "kubeone_workers" {
           cpuCores    = var.worker_vcpus
           memoryMB    = var.worker_memory_size
           diskSize    = var.worker_disk_size
-          categories  = {
+          categories = {
             "KubeOneCluster" = var.cluster_name
           }
         }
@@ -93,4 +96,3 @@ output "kubeone_workers" {
     }
   }
 }
-

--- a/examples/terraform/nutanix/variables.tf
+++ b/examples/terraform/nutanix/variables.tf
@@ -181,3 +181,12 @@ variable "initial_machinedeployment_replicas" {
   description = "number of replicas per MachineDeployment"
   type        = number
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}

--- a/examples/terraform/nutanix/versions.tf
+++ b/examples/terraform/nutanix/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_version = ">= 1.0.0"
   required_providers {
     nutanix = {
-      source = "nutanix/nutanix"
+      source  = "nutanix/nutanix"
       version = "1.2.2"
     }
   }

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -20,6 +20,7 @@ See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 | control\_plane\_flavor | OpenStack instance flavor for the control plane nodes | string | `"m1.small"` | no |
 | external\_network\_name | OpenStack external network name | string | n/a | yes |
 | image | image name to use | string | `"Ubuntu 20.04"` | no |
+| initial\_machinedeployments\_operating\_system\_profiles | Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled | string | `""` | no |
 | lb\_flavor | OpenStack instance flavor for the LoadBalancer node | string | `"m1.micro"` | no |
 | ssh\_agent\_socket | SSH Agent socket, default to grab from $SSH_AUTH_SOCK | string | `"env:SSH_AUTH_SOCK"` | no |
 | ssh\_port | SSH port to be used to provision instances | string | `"22"` | no |

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -18,7 +18,7 @@ output "kubeone_api" {
   description = "kube-apiserver LB endpoint"
 
   value = {
-    endpoint = openstack_networking_floatingip_v2.lb.address
+    endpoint                    = openstack_networking_floatingip_v2.lb.address
     apiserver_alternative_names = var.apiserver_alternative_names
   }
 }
@@ -56,6 +56,9 @@ output "kubeone_workers" {
     "${var.cluster_name}-pool1" = {
       replicas = 1
       providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
         operatingSystemSpec = {
@@ -85,4 +88,3 @@ output "kubeone_workers" {
     }
   }
 }
-

--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -132,3 +132,12 @@ variable "subnet_dns_servers" {
   type    = list(string)
   default = ["8.8.8.8", "8.8.4.4"]
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}

--- a/examples/terraform/vmware-cloud-director/README.md
+++ b/examples/terraform/vmware-cloud-director/README.md
@@ -78,6 +78,7 @@ Following environment variables or terraform variables can be used to authentica
 | worker\_cpu\_cores | Number of cores per socket for the worker VMs | number | `1` | no |
 | worker\_disk\_size | Disk size for worker VMs in MB | number | `25600` | no |
 | worker\_disk\_storage\_profile | Name of storage profile to use for worker VMs attached disks | string | `""` | no |
+| initial\_machinedeployments\_operating\_system\_profiles | Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled | string | `""` | no |
 
 ## Outputs
 

--- a/examples/terraform/vmware-cloud-director/output.tf
+++ b/examples/terraform/vmware-cloud-director/output.tf
@@ -51,6 +51,9 @@ output "kubeone_workers" {
     "${var.cluster_name}-pool1" = {
       replicas = var.initial_machinedeployment_replicas
       providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
         operatingSystemSpec = {

--- a/examples/terraform/vmware-cloud-director/variables.tf
+++ b/examples/terraform/vmware-cloud-director/variables.tf
@@ -248,3 +248,12 @@ variable "worker_disk_storage_profile" {
   default     = ""
   type        = string
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}

--- a/examples/terraform/vsphere/README.md
+++ b/examples/terraform/vsphere/README.md
@@ -14,7 +14,7 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 ## How to prepare a template
 
-See https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md
+See <https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md>
 
 ## Kubernetes API Server Load Balancing
 
@@ -32,6 +32,7 @@ See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 | datastore\_name | datastore name | string | `"datastore1"` | no |
 | dc\_name | datacenter name | string | `"dc-1"` | no |
 | disk\_size | disk size | string | `"50"` | no |
+| initial\_machinedeployments\_operating\_system\_profiles | Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled | string | `""` | no |
 | network\_name | network name | string | `"public"` | no |
 | ssh\_agent\_socket | SSH Agent socket, default to grab from $SSH_AUTH_SOCK | string | `"env:SSH_AUTH_SOCK"` | no |
 | ssh\_port | SSH port to be used to provision instances | string | `"22"` | no |
@@ -51,4 +52,3 @@ See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 | kubeone\_api | kube-apiserver endpoint. Either configured virtual IP or first node |
 | kubeone\_hosts | Control plane endpoints to SSH to |
 | kubeone\_workers | Workers definitions, that will be transformed into MachineDeployment object |
-

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -50,6 +50,9 @@ output "kubeone_workers" {
     "${var.cluster_name}-pool1" = {
       replicas = 1
       providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
         operatingSystemSpec = {
@@ -79,4 +82,3 @@ output "kubeone_workers" {
     }
   }
 }
-

--- a/examples/terraform/vsphere/variables.tf
+++ b/examples/terraform/vsphere/variables.tf
@@ -162,3 +162,12 @@ variable "vrrp_router_id" {
   description = "vrrp router id for API virtual IP. Must be unique in used subnet"
   type        = number
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}

--- a/examples/terraform/vsphere_flatcar/README.md
+++ b/examples/terraform/vsphere_flatcar/README.md
@@ -14,7 +14,7 @@ use the configs and how to provision a Kubernetes cluster using KubeOne.
 
 ## How to prepare a template
 
-See https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md
+See <https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md>
 
 ## Kubernetes API Server Load Balancing
 
@@ -77,6 +77,7 @@ No modules.
 | <a name="input_worker_disk"></a> [worker\_disk](#input\_worker\_disk) | disk size of each worker node in GB | `number` | `10` | no |
 | <a name="input_worker_memory"></a> [worker\_memory](#input\_worker\_memory) | memory size of each worker node in MB | `number` | `2048` | no |
 | <a name="input_worker_os"></a> [worker\_os](#input\_worker\_os) | OS to run on worker machines | `string` | `"flarcar"` | no |
+| <a name="initial_machinedeployment_operating_system_profile"></a> [initial\_machinedeployment\_operating\_system\_profile](#input\_initial\_machinedeployment\_operating\_system\_profile) | Name of operating system profile for MachineDeployment, only applicable if operatng-system-manager addon is enabled | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/terraform/vsphere_flatcar/outputs.tf
+++ b/examples/terraform/vsphere_flatcar/outputs.tf
@@ -50,6 +50,9 @@ output "kubeone_workers" {
     "${var.cluster_name}-pool1" = {
       replicas = 1
       providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = var.worker_os
         operatingSystemSpec = {
@@ -79,4 +82,3 @@ output "kubeone_workers" {
     }
   }
 }
-

--- a/examples/terraform/vsphere_flatcar/variables.tf
+++ b/examples/terraform/vsphere_flatcar/variables.tf
@@ -147,3 +147,12 @@ variable "api_vip" {
   description = "virtual IP address for Kubernetes API"
   type        = string
 }
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind question
-->
/kind feature

**What this PR does / why we need it**:
Introduce a new variable `initial_machinedeployment_operating_system_profile` for specifying custom operating system profiles. By default, the value will be an empty string and machine-controller's wehook will default it. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
initial_machinedeployment_operating_system_profile was added to specify operating system profile for initial machinedeployments.
```
