### PR TITLE
Canal: disable preserveUnknownFields

### DIFF
--- a/addons/cni-canal/canal.yaml
+++ b/addons/cni-canal/canal.yaml
@@ -88,6 +88,7 @@ spec:
     plural: bgpconfigurations
     singular: bgpconfiguration
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -233,6 +234,7 @@ spec:
     plural: bgppeers
     singular: bgppeer
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -348,6 +350,7 @@ spec:
     plural: blockaffinities
     singular: blockaffinity
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -414,6 +417,7 @@ spec:
     plural: caliconodestatuses
     singular: caliconodestatus
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -676,6 +680,7 @@ spec:
     plural: clusterinformations
     singular: clusterinformation
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -742,6 +747,7 @@ spec:
     plural: felixconfigurations
     singular: felixconfiguration
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -1345,6 +1351,7 @@ spec:
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2202,6 +2209,7 @@ spec:
     plural: globalnetworksets
     singular: globalnetworkset
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2257,6 +2265,7 @@ spec:
     plural: hostendpoints
     singular: hostendpoint
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2367,6 +2376,7 @@ spec:
     plural: ipamblocks
     singular: ipamblock
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2488,6 +2498,7 @@ spec:
     plural: ipamconfigs
     singular: ipamconfig
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2546,6 +2557,7 @@ spec:
     plural: ipamhandles
     singular: ipamhandle
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2604,6 +2616,7 @@ spec:
     plural: ippools
     singular: ippool
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2718,6 +2731,7 @@ spec:
     plural: ipreservations
     singular: ipreservation
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -2771,6 +2785,7 @@ spec:
     plural: kubecontrollersconfigurations
     singular: kubecontrollersconfiguration
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -3026,6 +3041,7 @@ spec:
     plural: networkpolicies
     singular: networkpolicy
   scope: Namespaced
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:
@@ -3864,6 +3880,7 @@ spec:
     plural: networksets
     singular: networkset
   scope: Namespaced
+  preserveUnknownFields: false
   versions:
   - name: v1
     schema:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR explicitly sets `preserveUnknownFields: false` to all Canal CRDs.

We didn't have OpenAPI scheme for Canal CRDs in KubeOne 1.2 and older, so Kubernetes automatically defaulted `preserveUnknownFields` to `true`. Starting with KubeOne 1.3, we added OpenAPI scheme to all Canal CRDs, however, `preserveUnknownFields` was not changed to `false` for clusters created with KubeOne 1.2 and older.

In KubeOne 1.4.4, we upgraded Canal to v3.22.2 which uses defaulting, but defaulting requires `preserveUnknownFields` to be disabled. This caused issues with clusters created with KubeOne 1.2 and older because Canal CRDs in those clusters still have `preserveUnknownFields` enabled.

Clusters created with KubeOne 1.3 and newer are not affected by this issue -- those clusters already have `preserveUnknownFields` disabled by default (since there is OpenAPI scheme provided).

Calico VXLAN is not affected since it had scheme from the beginning.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2099 

**Does this PR introduce a user-facing change?**:
```release-note
Disable preserveUnknownFields in all Canal CRDs. This fixes an issue preventing upgrading Canal to v3.22 for KubeOne clusters created with KubeOne 1.2 and older
```

/assign @kron4eg 