### PR TITLE
Use --max-pods flag instead of kubelet config file

### DIFF
--- a/pkg/tasks/common.go
+++ b/pkg/tasks/common.go
@@ -90,7 +90,8 @@ func unmarshalKubeletFlags(buf []byte) (map[string]string, error) {
 		}
 	}
 
-	envValue := strings.Trim(s1[1], `"`)
+	envValue := strings.Trim(s1[1], "\n")
+	envValue = strings.Trim(envValue, `"`)
 	flagsvalues := strings.Split(envValue, " ")
 	kubeletflagsMap := map[string]string{}
 

--- a/pkg/tasks/kubeadm_env.go
+++ b/pkg/tasks/kubeadm_env.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tasks
 
 import (
+	"strconv"
+
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/semverutil"
 	"k8c.io/kubeone/pkg/state"
@@ -27,11 +29,24 @@ var (
 	version123 = semverutil.MustParseConstraint("1.23.*")
 )
 
+type kubeadmFlagsModifier func(flags map[string]string)
+
+func updateKubeadmFlagsEnv(s *state.State, node *kubeoneapi.HostConfig) error {
+	modifiers := []kubeadmFlagsModifier{
+		updateKubeletNodeValues(s, node),
+	}
+	if m := removeNetworkPluginFlagKubelet(s, node); m != nil {
+		modifiers = append(modifiers, m)
+	}
+
+	return updateKubeadmFlagsEnvFile(s, node, modifiers...)
+}
+
 // removeNetworkPluginFlagKubelet removes --network-plugin flag from Kubelet
 // config because it has been removed in Kubernetes 1.24.
 // This function is executed only when upgrading cluster from 1.23 to 1.24.
 // TODO: Remove this function after dropping support for Kubernetes 1.23.
-func removeNetworkPluginFlagKubelet(s *state.State, node kubeoneapi.HostConfig) error {
+func removeNetworkPluginFlagKubelet(s *state.State, node *kubeoneapi.HostConfig) kubeadmFlagsModifier {
 	needed := false
 	if !version124.Check(s.LiveCluster.ExpectedVersion) {
 		return nil
@@ -47,17 +62,42 @@ func removeNetworkPluginFlagKubelet(s *state.State, node kubeoneapi.HostConfig) 
 		return nil
 	}
 
-	s.Logger.Info("Removing --network-plugin flag from Kubelet config")
+	return func(flags map[string]string) {
+		// --network-plugin flag is not used with containerd and has been
+		// removed in Kubernetes 1.24
+		delete(flags, networkPluginFlag)
+	}
+}
 
+func updateKubeletNodeValues(s *state.State, node *kubeoneapi.HostConfig) kubeadmFlagsModifier {
+	return func(flags map[string]string) {
+		if m := node.Kubelet.SystemReserved; m != nil {
+			flags["--system-reserved"] = kubeoneapi.MapStringStringToString(m, "=")
+		}
+
+		if m := node.Kubelet.KubeReserved; m != nil {
+			flags["--kube-reserved"] = kubeoneapi.MapStringStringToString(m, "=")
+		}
+
+		if m := node.Kubelet.EvictionHard; m != nil {
+			flags["--eviction-hard"] = kubeoneapi.MapStringStringToString(m, "<")
+		}
+		if m := node.Kubelet.MaxPods; m != nil {
+			flags["--max-pods"] = strconv.Itoa(int(*m))
+		}
+	}
+}
+
+func updateKubeadmFlagsEnvFile(s *state.State, node *kubeoneapi.HostConfig, modifiers ...kubeadmFlagsModifier) error {
 	return updateRemoteFile(s, kubeadmEnvFlagsFile, func(content []byte) ([]byte, error) {
 		kubeletFlags, err := unmarshalKubeletFlags(content)
 		if err != nil {
 			return nil, err
 		}
 
-		// --network-plugin flag is not used with containerd and has been
-		// removed in Kubernetes 1.24
-		delete(kubeletFlags, networkPluginFlag)
+		for _, m := range modifiers {
+			m(kubeletFlags)
+		}
 
 		buf := marshalKubeletFlags(kubeletFlags)
 

--- a/pkg/tasks/upgrade_follower.go
+++ b/pkg/tasks/upgrade_follower.go
@@ -53,7 +53,7 @@ func upgradeFollowerExecutor(s *state.State, node *kubeoneapi.HostConfig, conn s
 		return err
 	}
 
-	if err := removeNetworkPluginFlagKubelet(s, *node); err != nil {
+	if err := updateKubeadmFlagsEnv(s, node); err != nil {
 		return err
 	}
 

--- a/pkg/tasks/upgrade_leader.go
+++ b/pkg/tasks/upgrade_leader.go
@@ -53,7 +53,7 @@ func upgradeLeaderExecutor(s *state.State, node *kubeoneapi.HostConfig, conn ssh
 		return err
 	}
 
-	if err := removeNetworkPluginFlagKubelet(s, *node); err != nil {
+	if err := updateKubeadmFlagsEnv(s, node); err != nil {
 		return err
 	}
 

--- a/pkg/templates/kubeadm/v1beta2/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta2/kubeadm.go
@@ -19,6 +19,7 @@ package v1beta2
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -179,10 +180,6 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			},
 		},
 		FeatureGates: map[string]bool{},
-	}
-
-	if host.Kubelet.MaxPods != nil {
-		kubeletConfig.MaxPods = *host.Kubelet.MaxPods
 	}
 
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
@@ -379,10 +376,6 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 		FeatureGates: map[string]bool{},
 	}
 
-	if host.Kubelet.MaxPods != nil {
-		kubeletConfig.MaxPods = *host.Kubelet.MaxPods
-	}
-
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
 		nodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = cluster.AssetConfiguration.Pause.ImageRepository + "/pause:" + cluster.AssetConfiguration.Pause.ImageTag
 	}
@@ -441,6 +434,9 @@ func newNodeRegistration(s *state.State, host kubeoneapi.HostConfig) kubeadmv1be
 
 	if m := host.Kubelet.EvictionHard; m != nil {
 		kubeletCLIFlags["eviction-hard"] = kubeoneapi.MapStringStringToString(m, "<")
+	}
+	if m := host.Kubelet.MaxPods; m != nil {
+		kubeletCLIFlags["max-pods"] = strconv.Itoa(int(*m))
 	}
 
 	return kubeadmv1beta2.NodeRegistrationOptions{

--- a/pkg/templates/kubeadm/v1beta3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm.go
@@ -19,6 +19,7 @@ package v1beta3
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -192,10 +193,6 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			},
 		},
 		FeatureGates: map[string]bool{},
-	}
-
-	if host.Kubelet.MaxPods != nil {
-		kubeletConfig.MaxPods = *host.Kubelet.MaxPods
 	}
 
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
@@ -392,10 +389,6 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 		FeatureGates: map[string]bool{},
 	}
 
-	if host.Kubelet.MaxPods != nil {
-		kubeletConfig.MaxPods = *host.Kubelet.MaxPods
-	}
-
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
 		nodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = cluster.AssetConfiguration.Pause.ImageRepository + "/pause:" + cluster.AssetConfiguration.Pause.ImageTag
 	}
@@ -454,6 +447,9 @@ func newNodeRegistration(s *state.State, host kubeoneapi.HostConfig) kubeadmv1be
 
 	if m := host.Kubelet.EvictionHard; m != nil {
 		kubeletCLIFlags["eviction-hard"] = kubeoneapi.MapStringStringToString(m, "<")
+	}
+	if m := host.Kubelet.MaxPods; m != nil {
+		kubeletCLIFlags["max-pods"] = strconv.Itoa(int(*m))
 	}
 
 	return kubeadmv1beta3.NodeRegistrationOptions{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Kubelet configuration file provided via kubeadm config is respected only on the first (leader) node. Kubeadm will create the `kubelet-config` ConfigMap based on config provided for the first node. Other nodes will read the ConfigMap instead of the kubelet config provided via kubeadm config.

That effectively means that other nodes (follower control plane and static workers nodes) will use maxPods value of the first control plane node, even if maxPods is or isn't provided for that node. To fix that, we're providing maxPods as a kubelet flag, similar to what we do for few other options.

We provide kubelet flags via `kubeadm-flags.env`, however, that file is generated only when provisioning the cluster. To mitigate that, we're now manually updating this file when upgrading the cluster. We might want to consider regenerating this file if we add more flags in the future.

**Does this PR introduce a user-facing change?**:
```release-note
Fix wrong maxPods value on follower control plane nodes and static worker nodes
```

/assign @kron4eg 