### PR TITLE
Updating defaultContainerdVersion

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -82,6 +82,6 @@ var (
 const (
 	defaultDockerVersion           = "'19.03.*'"
 	latestDockerVersion            = "'20.10.*'"
-	defaultContainerdVersion       = "'1.5.*'"
+	defaultContainerdVersion       = "'1.6.*'"
 	defaultAmazonContainerdVersion = "'1.4.*'"
 )


### PR DESCRIPTION
Signed-off-by: Oscar Daniel Villarraga <dvillarraga@gmail.com>

**What type of PR is this?**

/kind bug
/kind deprecation

**What this PR does / why we need it**:

By updating defaultContainerdVersion to > 1.6 we enable CentOS Stream 9 compatibility

**Which issue(s) this PR fixes**
Fixes #2027

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

/assign @xmudrii