### PR TITLE
Fix terraform consistent variables for machine deployment replicas

### DIFF
--- a/examples/terraform/digitalocean/output.tf
+++ b/examples/terraform/digitalocean/output.tf
@@ -47,7 +47,7 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas = 1
+      replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
           "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile

--- a/examples/terraform/digitalocean/variables.tf
+++ b/examples/terraform/digitalocean/variables.tf
@@ -96,6 +96,12 @@ variable "worker_size" {
   type        = string
 }
 
+variable "initial_machinedeployment_replicas" {
+  description = "Number of replicas per MachineDeployment"
+  default     = 1
+  type        = number
+}
+
 variable "initial_machinedeployment_operating_system_profile" {
   default     = ""
   type        = string

--- a/examples/terraform/equinixmetal/output.tf
+++ b/examples/terraform/equinixmetal/output.tf
@@ -47,7 +47,7 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas = 1
+      replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
           "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile

--- a/examples/terraform/equinixmetal/variables.tf
+++ b/examples/terraform/equinixmetal/variables.tf
@@ -108,6 +108,12 @@ variable "project_id" {
   type        = string
 }
 
+variable "initial_machinedeployment_replicas" {
+  description = "Number of replicas per MachineDeployment"
+  default     = 1
+  type        = number
+}
+
 variable "initial_machinedeployment_operating_system_profile" {
   default     = ""
   type        = string

--- a/examples/terraform/gce/output.tf
+++ b/examples/terraform/gce/output.tf
@@ -48,7 +48,7 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas = 1
+      replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
           "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile

--- a/examples/terraform/gce/variables.tf
+++ b/examples/terraform/gce/variables.tf
@@ -123,6 +123,12 @@ variable "cluster_network_cidr" {
   type        = string
 }
 
+variable "initial_machinedeployment_replicas" {
+  description = "Number of replicas per MachineDeployment"
+  default     = 1
+  type        = number
+}
+
 variable "initial_machinedeployment_operating_system_profile" {
   default     = ""
   type        = string

--- a/examples/terraform/hetzner/output.tf
+++ b/examples/terraform/hetzner/output.tf
@@ -53,7 +53,7 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas = var.workers_replicas
+      replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
           "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -87,9 +87,10 @@ variable "worker_type" {
   type    = string
 }
 
-variable "workers_replicas" {
-  default = 1
-  type    = number
+variable "initial_machinedeployment_replicas" {
+  description = "Number of replicas per MachineDeployment"
+  default     = 1
+  type        = number
 }
 
 variable "lb_type" {

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -54,7 +54,7 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas = 1
+      replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
           "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile

--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -133,6 +133,12 @@ variable "subnet_dns_servers" {
   default = ["8.8.8.8", "8.8.4.4"]
 }
 
+variable "initial_machinedeployment_replicas" {
+  description = "Number of replicas per MachineDeployment"
+  default     = 1
+  type        = number
+}
+
 variable "initial_machinedeployment_operating_system_profile" {
   default     = ""
   type        = string

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -48,7 +48,7 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas = 1
+      replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
           "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile

--- a/examples/terraform/vsphere/variables.tf
+++ b/examples/terraform/vsphere/variables.tf
@@ -163,6 +163,12 @@ variable "vrrp_router_id" {
   type        = number
 }
 
+variable "initial_machinedeployment_replicas" {
+  description = "Number of replicas per MachineDeployment"
+  default     = 1
+  type        = number
+}
+
 variable "initial_machinedeployment_operating_system_profile" {
   default     = ""
   type        = string

--- a/examples/terraform/vsphere_flatcar/outputs.tf
+++ b/examples/terraform/vsphere_flatcar/outputs.tf
@@ -48,7 +48,7 @@ output "kubeone_workers" {
     # following outputs will be parsed by kubeone and automatically merged into
     # corresponding (by name) worker definition
     "${var.cluster_name}-pool1" = {
-      replicas = 1
+      replicas = var.initial_machinedeployment_replicas
       providerSpec = {
         annotations = {
           "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile

--- a/examples/terraform/vsphere_flatcar/variables.tf
+++ b/examples/terraform/vsphere_flatcar/variables.tf
@@ -148,6 +148,12 @@ variable "api_vip" {
   type        = string
 }
 
+variable "initial_machinedeployment_replicas" {
+  description = "Number of replicas per MachineDeployment"
+  default     = 1
+  type        = number
+}
+
 variable "initial_machinedeployment_operating_system_profile" {
   default     = ""
   type        = string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
Fixing terraform variables for consistency among cloud providers
/kind feature

<!--
Add one of the following kinds: 
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind question
-->

**What this PR does / why we need it**:
To enable consistent variables among cloud providers for the machine deployment replicas.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/ps-team-flotilla/issues/99 ticket 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BREAKING: hetzner terraform config rename variable `workers_replicas` to `initial_machinedeployment_replicas`
```
