### PR TITLE
Use kubeone-e2e:v0.1.23 is some postsubmits

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.12-1
+        - image: kubermatic/kubeone-e2e:v0.1.23
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -87,7 +87,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.12-1
+        - image: kubermatic/kubeone-e2e:v0.1.23
           command:
             - ./hack/ci/upload-gocache.sh
           env:


### PR DESCRIPTION
**What type of PR is this?**
/kind regression

**What this PR does / why we need it**:
To use updated GOCACHE with newer Go version (currently 1.18.3), otherwise gocache is always outdated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
