### PR TITLE
Update kubeadm-flags.env when upgrading static worker nodes

### DIFF
--- a/pkg/tasks/upgrade_static_workers.go
+++ b/pkg/tasks/upgrade_static_workers.go
@@ -55,6 +55,10 @@ func upgradeStaticWorkersExecutor(s *state.State, node *kubeoneapi.HostConfig, c
 		return err
 	}
 
+	if err := updateKubeadmFlagsEnv(s, node); err != nil {
+		return err
+	}
+
 	logger.Infoln("Upgrading Kubernetes binaries on static worker node...")
 	if err := upgradeKubeadmAndCNIBinaries(s, *node); err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

For some reason, we don't update `kubeadm-flags.env` file when upgrading static worker nodes. This can also cause issues when upgrading from 1.23 to 1.24 because of the `--network-plugin` flag. This PR ensures that we update the `kubeadm-flags.env` file when upgrading static worker nodes.

**Does this PR introduce a user-facing change?**:
```release-note
Update `kubeadm-flags.env` file when upgrading static worker nodes
```

/assign @kron4eg 