### PR TITLE
Add new HostConfig.Labels API to manage custom labels on the static Nodes

### DIFF
--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2022-07-06T13:29:16+03:00
+date = 2022-07-06T15:55:07+03:00
 weight = 11
 +++
 ## v1beta2
@@ -402,7 +402,7 @@ HostConfig describes a single control plane node.
 | hostname | Hostname is the hostname(1) of the host. Default value is populated at the runtime via running `hostname -f` command over ssh. | string | false |
 | isLeader | IsLeader indicates this host as a session leader. Default value is populated at the runtime. | bool | false |
 | taints | Taints are taints applied to nodes. Those taints are only applied when the node is being provisioned. If not provided (i.e. nil) for control plane nodes, it defaults to:\n  * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master\n  * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys\n    node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master\nExplicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes). | [][corev1.Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#taint-v1-core) | false |
-| labels | Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node | map[string]string | false |
+| labels | Lables to be used to apply (or remove, with minus symbol suffix, see more kubectl help label) lables to/from node | map[string]string | false |
 | kubelet | Kubelet | [KubeletConfig](#kubeletconfig) | false |
 | operatingSystem | OperatingSystem information, can be populated at the runtime. | OperatingSystemName | false |
 

--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2022-07-04T17:53:53+03:00
+date = 2022-07-06T13:29:16+03:00
 weight = 11
 +++
 ## v1beta2
@@ -402,7 +402,7 @@ HostConfig describes a single control plane node.
 | hostname | Hostname is the hostname(1) of the host. Default value is populated at the runtime via running `hostname -f` command over ssh. | string | false |
 | isLeader | IsLeader indicates this host as a session leader. Default value is populated at the runtime. | bool | false |
 | taints | Taints are taints applied to nodes. Those taints are only applied when the node is being provisioned. If not provided (i.e. nil) for control plane nodes, it defaults to:\n  * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master\n  * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys\n    node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master\nExplicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes). | [][corev1.Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#taint-v1-core) | false |
-| labels | Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node | map[string]string | true |
+| labels | Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node | map[string]string | false |
 | kubelet | Kubelet | [KubeletConfig](#kubeletconfig) | false |
 | operatingSystem | OperatingSystem information, can be populated at the runtime. | OperatingSystemName | false |
 

--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2022-06-07T19:50:42+05:00
+date = 2022-07-04T17:53:53+03:00
 weight = 11
 +++
 ## v1beta2
@@ -180,7 +180,7 @@ Only one cloud provider must be defined at the single time.
 | hetzner | Hetzner | *[HetznerSpec](#hetznerspec) | false |
 | nutanix | Nutanix | *[NutanixSpec](#nutanixspec) | false |
 | openstack | Openstack | *[OpenstackSpec](#openstackspec) | false |
-| equinixmetal | Equinix Metal | *[EquinixMetalSpec](#equinixmetalspec) | false |
+| equinixmetal | EquinixMetal | *[EquinixMetalSpec](#equinixmetalspec) | false |
 | vmwareCloudDirector | VMware Cloud Director | *[VMwareCloudDirectorSpec](#vmwareclouddirectorspec) | false |
 | vsphere | Vsphere | *[VsphereSpec](#vspherespec) | false |
 | none | None | *[NoneSpec](#nonespec) | false |
@@ -401,7 +401,8 @@ HostConfig describes a single control plane node.
 | bastionUser | BastionUser is system login name to use when connecting to bastion host. Default value is \"root\". | string | false |
 | hostname | Hostname is the hostname(1) of the host. Default value is populated at the runtime via running `hostname -f` command over ssh. | string | false |
 | isLeader | IsLeader indicates this host as a session leader. Default value is populated at the runtime. | bool | false |
-| taints | Taints are taints applied to nodes. If not provided (i.e. nil) for control plane nodes, it defaults to:\n  * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master\n  * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys\n    node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master\nExplicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes). | [][corev1.Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#taint-v1-core) | false |
+| taints | Taints are taints applied to nodes. Those taints are only applied when the node is being provisioned. If not provided (i.e. nil) for control plane nodes, it defaults to:\n  * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master\n  * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys\n    node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master\nExplicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes). | [][corev1.Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#taint-v1-core) | false |
+| labels | Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node | map[string]string | true |
 | kubelet | Kubelet | [KubeletConfig](#kubeletconfig) | false |
 | operatingSystem | OperatingSystem information, can be populated at the runtime. | OperatingSystemName | false |
 
@@ -464,7 +465,7 @@ KubeOneCluster is KubeOne Cluster API Schema
 | addons | Addons are used to deploy additional manifests. | *[Addons](#addons) | false |
 | systemPackages | SystemPackages configure kubeone behaviour regarding OS packages. | *[SystemPackages](#systempackages) | false |
 | registryConfiguration | RegistryConfiguration configures how Docker images are pulled from an image registry | *[RegistryConfiguration](#registryconfiguration) | false |
-| loggingConfig | LoggingConfig configures the Kubelet's log configuration | [LoggingConfig](#loggingconfig) | false |
+| loggingConfig | LoggingConfig configures the Kubelet's log rotation | [LoggingConfig](#loggingconfig) | false |
 
 [Back to Group](#v1beta2)
 

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -63,6 +63,7 @@ No modules.
 | <a name="input_bastion_type"></a> [bastion\_type](#input\_bastion\_type) | instance type for bastion | `string` | `"t3.nano"` | no |
 | <a name="input_bastion_user"></a> [bastion\_user](#input\_bastion\_user) | Bastion SSH username | `string` | `""` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
+| <a name="input_control_plane_labels"></a> [control\_plane\_labels](#input\_control\_plane\_labels) | custom labels to add (and remove) to control plane | `map(string)` | <pre>{<br>  "custom-label-to-add": "custom-value",<br>  "custom-label-to-remove-": ""<br>}</pre> | no |
 | <a name="input_control_plane_type"></a> [control\_plane\_type](#input\_control\_plane\_type) | AWS instance type | `string` | `"t3.medium"` | no |
 | <a name="input_control_plane_vm_count"></a> [control\_plane\_vm\_count](#input\_control\_plane\_vm\_count) | number of control plane instances | `number` | `3` | no |
 | <a name="input_control_plane_volume_size"></a> [control\_plane\_volume\_size](#input\_control\_plane\_volume\_size) | Size of the EBS volume, in Gb | `number` | `100` | no |

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -44,6 +44,7 @@ output "kubeone_hosts" {
       bastion              = aws_instance.bastion.public_ip
       bastion_port         = var.bastion_port
       bastion_user         = local.bastion_user
+      labels               = var.control_plane_labels
       # uncomment to following to set those kubelet parameters. More into at:
       # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
       # kubelet            = {

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -86,6 +86,16 @@ variable "bastion_user" {
   type        = string
 }
 
+variable "control_plane_labels" {
+  description = "custom labels to add (and remove) to control plane"
+  type        = map(string)
+  default = {
+    "custom-label-to-add" = "custom-value"
+    # note the minus sign suffix
+    "custom-label-to-remove-" = ""
+  }
+}
+
 # Provider specific settings
 
 variable "aws_region" {

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -91,7 +91,7 @@ variable "control_plane_labels" {
   type        = map(string)
   default = {
     "custom-label-to-add" = "custom-value"
-    # note the minus sign suffix
+    # note the minus symbol suffix
     "custom-label-to-remove-" = ""
   }
 }

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -212,7 +212,7 @@ type HostConfig struct {
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
 	// Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node
-	Labels map[string]string `json:"labels"`
+	Labels map[string]string `json:"labels,omitempty"`
 
 	// Kubelet
 	Kubelet KubeletConfig `json:"kubelet,omitempty"`

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -31,38 +31,55 @@ type KubeOneCluster struct {
 
 	// Name is the name of the cluster.
 	Name string `json:"name"`
+
 	// ControlPlane describes the control plane nodes and how to access them.
 	ControlPlane ControlPlaneConfig `json:"controlPlane"`
+
 	// APIEndpoint are pairs of address and port used to communicate with the Kubernetes API.
 	APIEndpoint APIEndpoint `json:"apiEndpoint"`
+
 	// CloudProvider configures the cloud provider specific features.
 	CloudProvider CloudProviderSpec `json:"cloudProvider"`
+
 	// Versions defines which Kubernetes version will be installed.
 	Versions VersionConfig `json:"versions"`
+
 	// ContainerRuntime defines which container runtime will be installed
 	ContainerRuntime ContainerRuntimeConfig `json:"containerRuntime,omitempty"`
+
 	// ClusterNetwork configures the in-cluster networking.
 	ClusterNetwork ClusterNetworkConfig `json:"clusterNetwork,omitempty"`
+
 	// Proxy configures proxy used while installing Kubernetes and by the Docker daemon.
 	Proxy ProxyConfig `json:"proxy,omitempty"`
+
 	// StaticWorkers describes the worker nodes that are managed by KubeOne/kubeadm.
 	StaticWorkers StaticWorkersConfig `json:"staticWorkers,omitempty"`
+
 	// DynamicWorkers describes the worker nodes that are managed by Kubermatic machine-controller/Cluster-API.
 	DynamicWorkers []DynamicWorkerConfig `json:"dynamicWorkers,omitempty"`
+
 	// MachineController configures the Kubermatic machine-controller component.
 	MachineController *MachineControllerConfig `json:"machineController,omitempty"`
+
 	// CABundle PEM encoded global CA
 	CABundle string `json:"caBundle,omitempty"`
+
 	// Features enables and configures additional cluster features.
 	Features Features `json:"features,omitempty"`
+
 	// Addons are used to deploy additional manifests.
 	Addons *Addons `json:"addons,omitempty"`
+
 	// SystemPackages configure kubeone behaviour regarding OS packages.
 	SystemPackages *SystemPackages `json:"systemPackages,omitempty"`
+
 	// AssetConfiguration configures how are binaries and container images downloaded
 	AssetConfiguration AssetConfiguration `json:"assetConfiguration,omitempty"`
+
 	// RegistryConfiguration configures how Docker images are pulled from an image registry
 	RegistryConfiguration *RegistryConfiguration `json:"registryConfiguration,omitempty"`
+
 	// LoggingConfig configures the Kubelet's log rotation
 	LoggingConfig LoggingConfig `json:"loggingConfig,omitempty"`
 }
@@ -72,6 +89,7 @@ type LoggingConfig struct {
 	// ContainerLogMaxSize configures the maximum size of container log file before it is rotated
 	// See more at: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
 	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty"`
+
 	// ContainerLogMaxFiles configures the maximum number of container log files that can be present for a container
 	// See more at: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
 	ContainerLogMaxFiles int32 `json:"containerLogMaxFiles,omitempty"`
@@ -142,37 +160,49 @@ const (
 type HostConfig struct {
 	// ID automatically assigned at runtime.
 	ID int `json:"-"`
+
 	// PublicAddress is externally accessible IP address from public internet.
 	PublicAddress string `json:"publicAddress"`
+
 	// PrivateAddress is internal RFC-1918 IP address.
 	PrivateAddress string `json:"privateAddress"`
+
 	// SSHPort is port to connect ssh to.
 	// Default value is 22.
 	SSHPort int `json:"sshPort,omitempty"`
+
 	// SSHUsername is system login name.
 	// Default value is "root".
 	SSHUsername string `json:"sshUsername,omitempty"`
+
 	// SSHPrivateKeyFile is path to the file with PRIVATE AND CLEANTEXT ssh key.
 	// Default value is "".
 	SSHPrivateKeyFile string `json:"sshPrivateKeyFile,omitempty"`
+
 	// SSHAgentSocket path (or reference to the environment) to the SSH agent unix domain socket.
 	// Default value is "env:SSH_AUTH_SOCK".
 	SSHAgentSocket string `json:"sshAgentSocket,omitempty"`
+
 	// Bastion is an IP or hostname of the bastion (or jump) host to connect to.
 	// Default value is "".
 	Bastion string `json:"bastion,omitempty"`
+
 	// BastionPort is SSH port to use when connecting to the bastion if it's configured in .Bastion.
 	// Default value is 22.
 	BastionPort int `json:"bastionPort,omitempty"`
+
 	// BastionUser is system login name to use when connecting to bastion host.
 	// Default value is "root".
 	BastionUser string `json:"bastionUser,omitempty"`
+
 	// Hostname is the hostname(1) of the host.
 	// Default value is populated at the runtime via running `hostname -f` command over ssh.
 	Hostname string `json:"hostname,omitempty"`
+
 	// IsLeader indicates this host as a session leader.
 	// Default value is populated at the runtime.
 	IsLeader bool `json:"isLeader,omitempty"`
+
 	// Taints are taints applied to nodes. Those taints are only applied when the node is being provisioned.
 	// If not provided (i.e. nil) for control plane nodes, it defaults to:
 	//   * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master
@@ -180,8 +210,13 @@ type HostConfig struct {
 	//     node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master
 	// Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes).
 	Taints []corev1.Taint `json:"taints,omitempty"`
+
+	// Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node
+	Labels map[string]string `json:"labels"`
+
 	// Kubelet
 	Kubelet KubeletConfig `json:"kubelet,omitempty"`
+
 	// OperatingSystem information, can be populated at the runtime.
 	OperatingSystem OperatingSystemName `json:"operatingSystem,omitempty"`
 }
@@ -203,12 +238,15 @@ type KubeletConfig struct {
 	// SystemReserved configure --system-reserved command-line flag of the kubelet.
 	// See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
 	SystemReserved map[string]string `json:"systemReserved,omitempty"`
+
 	// KubeReserved configure --kube-reserved command-line flag of the kubelet.
 	// See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
 	KubeReserved map[string]string `json:"kubeReserved,omitempty"`
+
 	// EvictionHard configure --eviction-hard command-line flag of the kubelet.
 	// See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
 	EvictionHard map[string]string `json:"evictionHard,omitempty"`
+
 	// MaxPods configures maximum number of pods per node.
 	// If not provided, default value provided by kubelet will be used
 	// (max. 110 pods per node)
@@ -219,9 +257,11 @@ type KubeletConfig struct {
 type APIEndpoint struct {
 	// Host is the hostname or IP on which API is running.
 	Host string `json:"host"`
+
 	// Port is the port used to reach to the API.
 	// Default value is 6443.
 	Port int `json:"port,omitempty"`
+
 	// AlternativeNames is a list of Subject Alternative Names for the API Server signing cert.
 	AlternativeNames []string `json:"alternativeNames,omitempty"`
 }
@@ -231,30 +271,43 @@ type APIEndpoint struct {
 type CloudProviderSpec struct {
 	// External
 	External bool `json:"external,omitempty"`
+
 	// CloudConfig
 	CloudConfig string `json:"cloudConfig,omitempty"`
+
 	// CSIConfig
 	CSIConfig string `json:"csiConfig,omitempty"`
+
 	// AWS
 	AWS *AWSSpec `json:"aws,omitempty"`
+
 	// Azure
 	Azure *AzureSpec `json:"azure,omitempty"`
+
 	// DigitalOcean
 	DigitalOcean *DigitalOceanSpec `json:"digitalocean,omitempty"`
+
 	// GCE
 	GCE *GCESpec `json:"gce,omitempty"`
+
 	// Hetzner
 	Hetzner *HetznerSpec `json:"hetzner,omitempty"`
+
 	// Nutanix
 	Nutanix *NutanixSpec `json:"nutanix,omitempty"`
+
 	// Openstack
 	Openstack *OpenstackSpec `json:"openstack,omitempty"`
+
 	// EquinixMetal
 	EquinixMetal *EquinixMetalSpec `json:"equinixmetal,omitempty"`
+
 	// VMware Cloud Director
 	VMwareCloudDirector *VMwareCloudDirectorSpec `json:"vmwareCloudDirector,omitempty"`
+
 	// Vsphere
 	Vsphere *VsphereSpec `json:"vsphere,omitempty"`
+
 	// None
 	None *NoneSpec `json:"none,omitempty"`
 }
@@ -311,18 +364,23 @@ type ClusterNetworkConfig struct {
 	// PodSubnet
 	// default value is "10.244.0.0/16"
 	PodSubnet string `json:"podSubnet,omitempty"`
+
 	// ServiceSubnet
 	// default value is "10.96.0.0/12"
 	ServiceSubnet string `json:"serviceSubnet,omitempty"`
+
 	// ServiceDomainName
 	// default value is "cluster.local"
 	ServiceDomainName string `json:"serviceDomainName,omitempty"`
+
 	// NodePortRange
 	// default value is "30000-32767"
 	NodePortRange string `json:"nodePortRange,omitempty"`
+
 	// CNI
 	// default value is {canal: {mtu: 1450}}
 	CNI *CNI `json:"cni,omitempty"`
+
 	// KubeProxy config
 	KubeProxy *KubeProxyConfig `json:"kubeProxy,omitempty"`
 }
@@ -380,10 +438,13 @@ type IPTables struct{}
 type CNI struct {
 	// Canal
 	Canal *CanalSpec `json:"canal,omitempty"`
+
 	// Cilium
 	Cilium *CiliumSpec `json:"cilium,omitempty"`
+
 	// WeaveNet
 	WeaveNet *WeaveNetSpec `json:"weaveNet,omitempty"`
+
 	// External
 	External *ExternalCNISpec `json:"external,omitempty"`
 }
@@ -429,8 +490,10 @@ type ExternalCNISpec struct{}
 type ProxyConfig struct {
 	// HTTP
 	HTTP string `json:"http,omitempty"`
+
 	// HTTPS
 	HTTPS string `json:"https,omitempty"`
+
 	// NoProxy
 	NoProxy string `json:"noProxy,omitempty"`
 }
@@ -439,8 +502,10 @@ type ProxyConfig struct {
 type DynamicWorkerConfig struct {
 	// Name
 	Name string `json:"name"`
+
 	// Replicas
 	Replicas *int `json:"replicas"`
+
 	// Config
 	Config ProviderSpec `json:"providerSpec"`
 }
@@ -449,32 +514,43 @@ type DynamicWorkerConfig struct {
 type ProviderSpec struct {
 	// CloudProviderSpec
 	CloudProviderSpec json.RawMessage `json:"cloudProviderSpec"`
+
 	// Annotations set MachineDeployment.ObjectMeta.Annotations
 	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// MachineAnnotations set MachineDeployment.Spec.Template.Spec.ObjectMeta.Annotations
 	// as a way to annotate resulting Nodes
 	// Deprecated: Use NodeAnnotations instead.
 	MachineAnnotations map[string]string `json:"machineAnnotations,omitempty"`
+
 	// NodeAnnotations set MachineDeployment.Spec.Template.Spec.ObjectMeta.Annotations
 	// as a way to annotate resulting Nodes
 	NodeAnnotations map[string]string `json:"nodeAnnotations,omitempty"`
+
 	// MachineObjectAnnotations set MachineDeployment.Spec.Template.Metadata.Annotations
 	// as a way to annotate resulting Machine objects. Those annotations are not
 	// propagated to Node objects. If you want to annotate resulting Nodes as well,
 	// see NodeAnnotations
 	MachineObjectAnnotations map[string]string `json:"machineObjectAnnotations,omitempty"`
+
 	// Labels
 	Labels map[string]string `json:"labels,omitempty"`
+
 	// Taints
 	Taints []corev1.Taint `json:"taints,omitempty"`
+
 	// SSHPublicKeys
 	SSHPublicKeys []string `json:"sshPublicKeys,omitempty"`
+
 	// OperatingSystem
 	OperatingSystem string `json:"operatingSystem"`
+
 	// OperatingSystemSpec
 	OperatingSystemSpec json.RawMessage `json:"operatingSystemSpec,omitempty"`
+
 	// Network
 	Network *ProviderStaticNetworkConfig `json:"network,omitempty"`
+
 	// OverwriteCloudConfig
 	OverwriteCloudConfig *string `json:"overwriteCloudConfig,omitempty"`
 }
@@ -489,8 +565,10 @@ type DNSConfig struct {
 type ProviderStaticNetworkConfig struct {
 	// CIDR
 	CIDR string `json:"cidr"`
+
 	// Gateway
 	Gateway string `json:"gateway"`
+
 	// DNS
 	DNS DNSConfig `json:"dns"`
 }
@@ -505,17 +583,23 @@ type MachineControllerConfig struct {
 type Features struct {
 	// PodNodeSelector
 	PodNodeSelector *PodNodeSelector `json:"podNodeSelector,omitempty"`
+
 	// PodSecurityPolicy
 	// Deprecated: will be removed once Kubernetes 1.24 reaches EOL
 	PodSecurityPolicy *PodSecurityPolicy `json:"podSecurityPolicy,omitempty"`
+
 	// StaticAuditLog
 	StaticAuditLog *StaticAuditLog `json:"staticAuditLog,omitempty"`
+
 	// DynamicAuditLog
 	DynamicAuditLog *DynamicAuditLog `json:"dynamicAuditLog,omitempty"`
+
 	// MetricsServer
 	MetricsServer *MetricsServer `json:"metricsServer,omitempty"`
+
 	// OpenIDConnect
 	OpenIDConnect *OpenIDConnect `json:"openidConnect,omitempty"`
+
 	// Encryption Providers
 	EncryptionProviders *EncryptionProviders `json:"encryptionProviders,omitempty"`
 }
@@ -540,33 +624,39 @@ type AssetConfiguration struct {
 	// Defaults to RegistryConfiguration.OverwriteRegistry if left empty
 	// and RegistryConfiguration.OverwriteRegistry is specified.
 	Kubernetes ImageAsset `json:"kubernetes,omitempty"`
+
 	// Pause configures the sandbox (pause) image to be used by Kubelet.
 	// Default image repository and tag: defaulted dynamically by Kubeadm.
 	// Defaults to RegistryConfiguration.OverwriteRegistry if left empty
 	// and RegistryConfiguration.OverwriteRegistry is specified.
 	Pause ImageAsset `json:"pause,omitempty"`
+
 	// CoreDNS configures the image registry and tag to be used for deploying
 	// the CoreDNS component.
 	// Default image repository and tag: defaulted dynamically by Kubeadm.
 	// Defaults to RegistryConfiguration.OverwriteRegistry if left empty
 	// and RegistryConfiguration.OverwriteRegistry is specified.
 	CoreDNS ImageAsset `json:"coreDNS,omitempty"`
+
 	// Etcd configures the image registry and tag to be used for deploying
 	// the Etcd component.
 	// Default image repository and tag: defaulted dynamically by Kubeadm.
 	// Defaults to RegistryConfiguration.OverwriteRegistry if left empty
 	// and RegistryConfiguration.OverwriteRegistry is specified.
 	Etcd ImageAsset `json:"etcd,omitempty"`
+
 	// MetricsServer configures the image registry and tag to be used for deploying
 	// the metrics-server component.
 	// Default image repository and tag: defaulted dynamically by KubeOne.
 	// Defaults to RegistryConfiguration.OverwriteRegistry if left empty
 	// and RegistryConfiguration.OverwriteRegistry is specified.
 	MetricsServer ImageAsset `json:"metricsServer,omitempty"`
+
 	// CNI configures the source for downloading the CNI binaries.
 	// If not specified, kubernetes-cni package will be installed.
 	// Default: none
 	CNI BinaryAsset `json:"cni,omitempty"`
+
 	// NodeBinaries configures the source for downloading the
 	// Kubernetes Node Binaries tarball (e.g. kubernetes-node-linux-amd64.tar.gz).
 	// The tarball must have .tar.gz as the extension and must contain the
@@ -576,6 +666,7 @@ type AssetConfiguration struct {
 	// If not specified, kubelet and kubeadm packages will be installed.
 	// Default: none
 	NodeBinaries BinaryAsset `json:"nodeBinaries,omitempty"`
+
 	// Kubectl configures the source for downloading the Kubectl binary.
 	// If not specified, kubelet package will be installed.
 	// Default: none
@@ -586,6 +677,7 @@ type AssetConfiguration struct {
 type ImageAsset struct {
 	// ImageRepository customizes the registry/repository
 	ImageRepository string `json:"imageRepository,omitempty"`
+
 	// ImageTag customizes the image tag
 	ImageTag string `json:"imageTag,omitempty"`
 }
@@ -607,6 +699,7 @@ type RegistryConfiguration struct {
 	// calico/cni would translate to 127.0.0.1:5000/example/calico/cni.
 	// Default: ""
 	OverwriteRegistry string `json:"overwriteRegistry,omitempty"`
+
 	// InsecureRegistry configures Docker to threat the registry specified
 	// in OverwriteRegistry as an insecure registry. This is also propagated
 	// to the worker nodes managed by machine-controller and/or KubeOne.
@@ -617,6 +710,7 @@ type RegistryConfiguration struct {
 type PodNodeSelector struct {
 	// Enable
 	Enable bool `json:"enable,omitempty"`
+
 	// Config
 	Config PodNodeSelectorConfig `json:"config"`
 }
@@ -642,6 +736,7 @@ type PodSecurityPolicy struct {
 type StaticAuditLog struct {
 	// Enable
 	Enable bool `json:"enable,omitempty"`
+
 	// Config
 	Config StaticAuditLogConfig `json:"config"`
 }
@@ -653,15 +748,19 @@ type StaticAuditLogConfig struct {
 	// PolicyFilePath is a required field.
 	// More info: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy
 	PolicyFilePath string `json:"policyFilePath"`
+
 	// LogPath is path on control plane instances where audit log files are stored.
 	// Default value is /var/log/kubernetes/audit.log
 	LogPath string `json:"logPath,omitempty"`
+
 	// LogMaxAge is maximum number of days to retain old audit log files.
 	// Default value is 30
 	LogMaxAge int `json:"logMaxAge,omitempty"`
+
 	// LogMaxBackup is maximum number of audit log files to retain.
 	// Default value is 3.
 	LogMaxBackup int `json:"logMaxBackup,omitempty"`
+
 	// LogMaxSize is maximum size in megabytes of audit log file before it gets rotated.
 	// Default value is 100.
 	LogMaxSize int `json:"logMaxSize,omitempty"`
@@ -685,6 +784,7 @@ type MetricsServer struct {
 type OpenIDConnect struct {
 	// Enable
 	Enable bool `json:"enable,omitempty"`
+
 	// Config
 	Config OpenIDConnectConfig `json:"config"`
 }
@@ -693,20 +793,28 @@ type OpenIDConnect struct {
 type OpenIDConnectConfig struct {
 	// IssuerURL
 	IssuerURL string `json:"issuerUrl"`
+
 	// ClientID
 	ClientID string `json:"clientId,omitempty"`
+
 	// UsernameClaim
 	UsernameClaim string `json:"usernameClaim,omitempty"`
+
 	// UsernamePrefix. The value `-` can be used to disable all prefixing.
 	UsernamePrefix string `json:"usernamePrefix,omitempty"`
+
 	// GroupsClaim
 	GroupsClaim string `json:"groupsClaim,omitempty"`
+
 	// GroupsPrefix. The value `-` can be used to disable all prefixing.
 	GroupsPrefix string `json:"groupsPrefix,omitempty"`
+
 	// RequiredClaim
 	RequiredClaim string `json:"requiredClaim"`
+
 	// SigningAlgs
 	SigningAlgs string `json:"signingAlgs,omitempty"`
+
 	// CAFile
 	CAFile string `json:"caFile"`
 }
@@ -742,6 +850,7 @@ type Addons struct {
 type EncryptionProviders struct {
 	// Enable
 	Enable bool `json:"enable"`
+
 	// CustomEncryptionConfiguration
 	CustomEncryptionConfiguration string `json:"customEncryptionConfiguration"`
 }

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -211,7 +211,7 @@ type HostConfig struct {
 	// Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes).
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
-	// Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node
+	// Lables to be used to apply (or remove, with minus symbol suffix, see more kubectl help label) lables to/from node
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Kubelet

--- a/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta1/zz_generated.conversion.go
@@ -1230,6 +1230,7 @@ func autoConvert_kubeone_HostConfig_To_v1beta1_HostConfig(in *kubeone.HostConfig
 	out.Hostname = in.Hostname
 	out.IsLeader = in.IsLeader
 	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
+	// WARNING: in.Labels requires manual conversion: does not exist in peer-type
 	// WARNING: in.Kubelet requires manual conversion: does not exist in peer-type
 	out.OperatingSystem = OperatingSystemName(in.OperatingSystem)
 	return nil

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -209,7 +209,7 @@ type HostConfig struct {
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
 	// Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node
-	Labels map[string]string `json:"labels"`
+	Labels map[string]string `json:"labels,omitempty"`
 
 	// Kubelet
 	Kubelet KubeletConfig `json:"kubelet,omitempty"`

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -208,7 +208,7 @@ type HostConfig struct {
 	// Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes).
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
-	// Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node
+	// Lables to be used to apply (or remove, with minus symbol suffix, see more kubectl help label) lables to/from node
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Kubelet

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -31,37 +31,53 @@ type KubeOneCluster struct {
 
 	// Name is the name of the cluster.
 	Name string `json:"name"`
+
 	// ControlPlane describes the control plane nodes and how to access them.
 	ControlPlane ControlPlaneConfig `json:"controlPlane"`
+
 	// APIEndpoint are pairs of address and port used to communicate with the Kubernetes API.
 	APIEndpoint APIEndpoint `json:"apiEndpoint"`
+
 	// CloudProvider configures the cloud provider specific features.
 	CloudProvider CloudProviderSpec `json:"cloudProvider"`
+
 	// Versions defines which Kubernetes version will be installed.
 	Versions VersionConfig `json:"versions"`
+
 	// ContainerRuntime defines which container runtime will be installed
 	ContainerRuntime ContainerRuntimeConfig `json:"containerRuntime,omitempty"`
+
 	// ClusterNetwork configures the in-cluster networking.
 	ClusterNetwork ClusterNetworkConfig `json:"clusterNetwork,omitempty"`
+
 	// Proxy configures proxy used while installing Kubernetes and by the Docker daemon.
 	Proxy ProxyConfig `json:"proxy,omitempty"`
+
 	// StaticWorkers describes the worker nodes that are managed by KubeOne/kubeadm.
 	StaticWorkers StaticWorkersConfig `json:"staticWorkers,omitempty"`
+
 	// DynamicWorkers describes the worker nodes that are managed by Kubermatic machine-controller/Cluster-API.
 	DynamicWorkers []DynamicWorkerConfig `json:"dynamicWorkers,omitempty"`
+
 	// MachineController configures the Kubermatic machine-controller component.
 	MachineController *MachineControllerConfig `json:"machineController,omitempty"`
+
 	// CABundle PEM encoded global CA
 	CABundle string `json:"caBundle,omitempty"`
+
 	// Features enables and configures additional cluster features.
 	Features Features `json:"features,omitempty"`
+
 	// Addons are used to deploy additional manifests.
 	Addons *Addons `json:"addons,omitempty"`
+
 	// SystemPackages configure kubeone behaviour regarding OS packages.
 	SystemPackages *SystemPackages `json:"systemPackages,omitempty"`
+
 	// RegistryConfiguration configures how Docker images are pulled from an image registry
 	RegistryConfiguration *RegistryConfiguration `json:"registryConfiguration,omitempty"`
-	// LoggingConfig configures the Kubelet's log configuration
+
+	// LoggingConfig configures the Kubelet's log rotation
 	LoggingConfig LoggingConfig `json:"loggingConfig,omitempty"`
 }
 
@@ -70,6 +86,7 @@ type LoggingConfig struct {
 	// ContainerLogMaxSize configures the maximum size of container log file before it is rotated
 	// See more at: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
 	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty"`
+
 	// ContainerLogMaxFiles configures the maximum number of container log files that can be present for a container
 	// See more at: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
 	ContainerLogMaxFiles int32 `json:"containerLogMaxFiles,omitempty"`
@@ -140,46 +157,63 @@ const (
 type HostConfig struct {
 	// ID automatically assigned at runtime.
 	ID int `json:"-"`
+
 	// PublicAddress is externally accessible IP address from public internet.
 	PublicAddress string `json:"publicAddress"`
+
 	// PrivateAddress is internal RFC-1918 IP address.
 	PrivateAddress string `json:"privateAddress"`
+
 	// SSHPort is port to connect ssh to.
 	// Default value is 22.
 	SSHPort int `json:"sshPort,omitempty"`
+
 	// SSHUsername is system login name.
 	// Default value is "root".
 	SSHUsername string `json:"sshUsername,omitempty"`
+
 	// SSHPrivateKeyFile is path to the file with PRIVATE AND CLEANTEXT ssh key.
 	// Default value is "".
 	SSHPrivateKeyFile string `json:"sshPrivateKeyFile,omitempty"`
+
 	// SSHAgentSocket path (or reference to the environment) to the SSH agent unix domain socket.
 	// Default value is "env:SSH_AUTH_SOCK".
 	SSHAgentSocket string `json:"sshAgentSocket,omitempty"`
+
 	// Bastion is an IP or hostname of the bastion (or jump) host to connect to.
 	// Default value is "".
 	Bastion string `json:"bastion,omitempty"`
+
 	// BastionPort is SSH port to use when connecting to the bastion if it's configured in .Bastion.
 	// Default value is 22.
 	BastionPort int `json:"bastionPort,omitempty"`
+
 	// BastionUser is system login name to use when connecting to bastion host.
 	// Default value is "root".
 	BastionUser string `json:"bastionUser,omitempty"`
+
 	// Hostname is the hostname(1) of the host.
 	// Default value is populated at the runtime via running `hostname -f` command over ssh.
 	Hostname string `json:"hostname,omitempty"`
+
 	// IsLeader indicates this host as a session leader.
 	// Default value is populated at the runtime.
 	IsLeader bool `json:"isLeader,omitempty"`
-	// Taints are taints applied to nodes. If not provided (i.e. nil) for control plane nodes,
-	// it defaults to:
+
+	// Taints are taints applied to nodes. Those taints are only applied when the node is being provisioned.
+	// If not provided (i.e. nil) for control plane nodes, it defaults to:
 	//   * For Kubernetes 1.23 and older: TaintEffectNoSchedule with key node-role.kubernetes.io/master
 	//   * For Kubernetes 1.24 and newer: TaintEffectNoSchedule with keys
 	//     node-role.kubernetes.io/control-plane and node-role.kubernetes.io/master
 	// Explicitly empty (i.e. []corev1.Taint{}) means no taints will be applied (this is default for worker nodes).
 	Taints []corev1.Taint `json:"taints,omitempty"`
+
+	// Lables to be used to apply (or remove, with minus sign suffix, see more kubectl help label) lables to/from node
+	Labels map[string]string `json:"labels"`
+
 	// Kubelet
 	Kubelet KubeletConfig `json:"kubelet,omitempty"`
+
 	// OperatingSystem information, can be populated at the runtime.
 	OperatingSystem OperatingSystemName `json:"operatingSystem,omitempty"`
 }
@@ -201,12 +235,15 @@ type KubeletConfig struct {
 	// SystemReserved configure --system-reserved command-line flag of the kubelet.
 	// See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
 	SystemReserved map[string]string `json:"systemReserved,omitempty"`
+
 	// KubeReserved configure --kube-reserved command-line flag of the kubelet.
 	// See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
 	KubeReserved map[string]string `json:"kubeReserved,omitempty"`
+
 	// EvictionHard configure --eviction-hard command-line flag of the kubelet.
 	// See more at: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
 	EvictionHard map[string]string `json:"evictionHard,omitempty"`
+
 	// MaxPods configures maximum number of pods per node.
 	// If not provided, default value provided by kubelet will be used
 	// (max. 110 pods per node)
@@ -217,9 +254,11 @@ type KubeletConfig struct {
 type APIEndpoint struct {
 	// Host is the hostname or IP on which API is running.
 	Host string `json:"host"`
+
 	// Port is the port used to reach to the API.
 	// Default value is 6443.
 	Port int `json:"port,omitempty"`
+
 	// AlternativeNames is a list of Subject Alternative Names for the API Server signing cert.
 	AlternativeNames []string `json:"alternativeNames,omitempty"`
 }
@@ -229,30 +268,43 @@ type APIEndpoint struct {
 type CloudProviderSpec struct {
 	// External
 	External bool `json:"external,omitempty"`
+
 	// CloudConfig
 	CloudConfig string `json:"cloudConfig,omitempty"`
+
 	// CSIConfig
 	CSIConfig string `json:"csiConfig,omitempty"`
+
 	// AWS
 	AWS *AWSSpec `json:"aws,omitempty"`
+
 	// Azure
 	Azure *AzureSpec `json:"azure,omitempty"`
+
 	// DigitalOcean
 	DigitalOcean *DigitalOceanSpec `json:"digitalocean,omitempty"`
+
 	// GCE
 	GCE *GCESpec `json:"gce,omitempty"`
+
 	// Hetzner
 	Hetzner *HetznerSpec `json:"hetzner,omitempty"`
+
 	// Nutanix
 	Nutanix *NutanixSpec `json:"nutanix,omitempty"`
+
 	// Openstack
 	Openstack *OpenstackSpec `json:"openstack,omitempty"`
-	// Equinix Metal
+
+	// EquinixMetal
 	EquinixMetal *EquinixMetalSpec `json:"equinixmetal,omitempty"`
+
 	// VMware Cloud Director
 	VMwareCloudDirector *VMwareCloudDirectorSpec `json:"vmwareCloudDirector,omitempty"`
+
 	// Vsphere
 	Vsphere *VsphereSpec `json:"vsphere,omitempty"`
+
 	// None
 	None *NoneSpec `json:"none,omitempty"`
 }
@@ -309,18 +361,23 @@ type ClusterNetworkConfig struct {
 	// PodSubnet
 	// default value is "10.244.0.0/16"
 	PodSubnet string `json:"podSubnet,omitempty"`
+
 	// ServiceSubnet
 	// default value is "10.96.0.0/12"
 	ServiceSubnet string `json:"serviceSubnet,omitempty"`
+
 	// ServiceDomainName
 	// default value is "cluster.local"
 	ServiceDomainName string `json:"serviceDomainName,omitempty"`
+
 	// NodePortRange
 	// default value is "30000-32767"
 	NodePortRange string `json:"nodePortRange,omitempty"`
+
 	// CNI
 	// default value is {canal: {mtu: 1450}}
 	CNI *CNI `json:"cni,omitempty"`
+
 	// KubeProxy config
 	KubeProxy *KubeProxyConfig `json:"kubeProxy,omitempty"`
 }
@@ -378,10 +435,13 @@ type IPTables struct{}
 type CNI struct {
 	// Canal
 	Canal *CanalSpec `json:"canal,omitempty"`
+
 	// Cilium
 	Cilium *CiliumSpec `json:"cilium,omitempty"`
+
 	// WeaveNet
 	WeaveNet *WeaveNetSpec `json:"weaveNet,omitempty"`
+
 	// External
 	External *ExternalCNISpec `json:"external,omitempty"`
 }
@@ -427,8 +487,10 @@ type ExternalCNISpec struct{}
 type ProxyConfig struct {
 	// HTTP
 	HTTP string `json:"http,omitempty"`
+
 	// HTTPS
 	HTTPS string `json:"https,omitempty"`
+
 	// NoProxy
 	NoProxy string `json:"noProxy,omitempty"`
 }
@@ -437,8 +499,10 @@ type ProxyConfig struct {
 type DynamicWorkerConfig struct {
 	// Name
 	Name string `json:"name"`
+
 	// Replicas
 	Replicas *int `json:"replicas"`
+
 	// Config
 	Config ProviderSpec `json:"providerSpec"`
 }
@@ -447,32 +511,43 @@ type DynamicWorkerConfig struct {
 type ProviderSpec struct {
 	// CloudProviderSpec
 	CloudProviderSpec json.RawMessage `json:"cloudProviderSpec"`
+
 	// Annotations set MachineDeployment.ObjectMeta.Annotations
 	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// MachineAnnotations set MachineDeployment.Spec.Template.Spec.ObjectMeta.Annotations
 	// as a way to annotate resulting Nodes
 	// Deprecated: Use NodeAnnotations instead.
 	MachineAnnotations map[string]string `json:"machineAnnotations,omitempty"`
+
 	// NodeAnnotations set MachineDeployment.Spec.Template.Spec.ObjectMeta.Annotations
 	// as a way to annotate resulting Nodes
 	NodeAnnotations map[string]string `json:"nodeAnnotations,omitempty"`
+
 	// MachineObjectAnnotations set MachineDeployment.Spec.Template.Metadata.Annotations
 	// as a way to annotate resulting Machine objects. Those annotations are not
 	// propagated to Node objects. If you want to annotate resulting Nodes as well,
 	// see NodeAnnotations
 	MachineObjectAnnotations map[string]string `json:"machineObjectAnnotations,omitempty"`
+
 	// Labels
 	Labels map[string]string `json:"labels,omitempty"`
+
 	// Taints
 	Taints []corev1.Taint `json:"taints,omitempty"`
+
 	// SSHPublicKeys
 	SSHPublicKeys []string `json:"sshPublicKeys,omitempty"`
+
 	// OperatingSystem
 	OperatingSystem string `json:"operatingSystem"`
+
 	// OperatingSystemSpec
 	OperatingSystemSpec json.RawMessage `json:"operatingSystemSpec,omitempty"`
+
 	// Network
 	Network *ProviderStaticNetworkConfig `json:"network,omitempty"`
+
 	// OverwriteCloudConfig
 	OverwriteCloudConfig *string `json:"overwriteCloudConfig,omitempty"`
 }
@@ -487,8 +562,10 @@ type DNSConfig struct {
 type ProviderStaticNetworkConfig struct {
 	// CIDR
 	CIDR string `json:"cidr"`
+
 	// Gateway
 	Gateway string `json:"gateway"`
+
 	// DNS
 	DNS DNSConfig `json:"dns"`
 }
@@ -503,17 +580,23 @@ type MachineControllerConfig struct {
 type Features struct {
 	// PodNodeSelector
 	PodNodeSelector *PodNodeSelector `json:"podNodeSelector,omitempty"`
+
 	// PodSecurityPolicy
 	// Deprecated: will be removed once Kubernetes 1.24 reaches EOL
 	PodSecurityPolicy *PodSecurityPolicy `json:"podSecurityPolicy,omitempty"`
+
 	// StaticAuditLog
 	StaticAuditLog *StaticAuditLog `json:"staticAuditLog,omitempty"`
+
 	// DynamicAuditLog
 	DynamicAuditLog *DynamicAuditLog `json:"dynamicAuditLog,omitempty"`
+
 	// MetricsServer
 	MetricsServer *MetricsServer `json:"metricsServer,omitempty"`
+
 	// OpenIDConnect
 	OpenIDConnect *OpenIDConnect `json:"openidConnect,omitempty"`
+
 	// Encryption Providers
 	EncryptionProviders *EncryptionProviders `json:"encryptionProviders,omitempty"`
 }
@@ -529,6 +612,7 @@ type SystemPackages struct {
 type ImageAsset struct {
 	// ImageRepository customizes the registry/repository
 	ImageRepository string `json:"imageRepository,omitempty"`
+
 	// ImageTag customizes the image tag
 	ImageTag string `json:"imageTag,omitempty"`
 }
@@ -550,6 +634,7 @@ type RegistryConfiguration struct {
 	// calico/cni would translate to 127.0.0.1:5000/example/calico/cni.
 	// Default: ""
 	OverwriteRegistry string `json:"overwriteRegistry,omitempty"`
+
 	// InsecureRegistry configures Docker to threat the registry specified
 	// in OverwriteRegistry as an insecure registry. This is also propagated
 	// to the worker nodes managed by machine-controller and/or KubeOne.
@@ -560,6 +645,7 @@ type RegistryConfiguration struct {
 type PodNodeSelector struct {
 	// Enable
 	Enable bool `json:"enable,omitempty"`
+
 	// Config
 	Config PodNodeSelectorConfig `json:"config"`
 }
@@ -585,6 +671,7 @@ type PodSecurityPolicy struct {
 type StaticAuditLog struct {
 	// Enable
 	Enable bool `json:"enable,omitempty"`
+
 	// Config
 	Config StaticAuditLogConfig `json:"config"`
 }
@@ -596,15 +683,19 @@ type StaticAuditLogConfig struct {
 	// PolicyFilePath is a required field.
 	// More info: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy
 	PolicyFilePath string `json:"policyFilePath"`
+
 	// LogPath is path on control plane instances where audit log files are stored.
 	// Default value is /var/log/kubernetes/audit.log
 	LogPath string `json:"logPath,omitempty"`
+
 	// LogMaxAge is maximum number of days to retain old audit log files.
 	// Default value is 30
 	LogMaxAge int `json:"logMaxAge,omitempty"`
+
 	// LogMaxBackup is maximum number of audit log files to retain.
 	// Default value is 3.
 	LogMaxBackup int `json:"logMaxBackup,omitempty"`
+
 	// LogMaxSize is maximum size in megabytes of audit log file before it gets rotated.
 	// Default value is 100.
 	LogMaxSize int `json:"logMaxSize,omitempty"`
@@ -628,6 +719,7 @@ type MetricsServer struct {
 type OpenIDConnect struct {
 	// Enable
 	Enable bool `json:"enable,omitempty"`
+
 	// Config
 	Config OpenIDConnectConfig `json:"config"`
 }
@@ -636,20 +728,28 @@ type OpenIDConnect struct {
 type OpenIDConnectConfig struct {
 	// IssuerURL
 	IssuerURL string `json:"issuerUrl"`
+
 	// ClientID
 	ClientID string `json:"clientId,omitempty"`
+
 	// UsernameClaim
 	UsernameClaim string `json:"usernameClaim,omitempty"`
+
 	// UsernamePrefix. The value `-` can be used to disable all prefixing.
 	UsernamePrefix string `json:"usernamePrefix,omitempty"`
+
 	// GroupsClaim
 	GroupsClaim string `json:"groupsClaim,omitempty"`
+
 	// GroupsPrefix. The value `-` can be used to disable all prefixing.
 	GroupsPrefix string `json:"groupsPrefix,omitempty"`
+
 	// RequiredClaim
 	RequiredClaim string `json:"requiredClaim"`
+
 	// SigningAlgs
 	SigningAlgs string `json:"signingAlgs,omitempty"`
+
 	// CAFile
 	CAFile string `json:"caFile"`
 }
@@ -685,6 +785,7 @@ type Addons struct {
 type EncryptionProviders struct {
 	// Enable
 	Enable bool `json:"enable"`
+
 	// CustomEncryptionConfiguration
 	CustomEncryptionConfiguration string `json:"customEncryptionConfiguration"`
 }

--- a/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
@@ -1275,6 +1275,7 @@ func autoConvert_v1beta2_HostConfig_To_kubeone_HostConfig(in *HostConfig, out *k
 	out.Hostname = in.Hostname
 	out.IsLeader = in.IsLeader
 	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
+	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	if err := Convert_v1beta2_KubeletConfig_To_kubeone_KubeletConfig(&in.Kubelet, &out.Kubelet, s); err != nil {
 		return err
 	}
@@ -1301,6 +1302,7 @@ func autoConvert_kubeone_HostConfig_To_v1beta2_HostConfig(in *kubeone.HostConfig
 	out.Hostname = in.Hostname
 	out.IsLeader = in.IsLeader
 	out.Taints = *(*[]v1.Taint)(unsafe.Pointer(&in.Taints))
+	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	if err := Convert_kubeone_KubeletConfig_To_v1beta2_KubeletConfig(&in.Kubelet, &out.Kubelet, s); err != nil {
 		return err
 	}

--- a/pkg/apis/kubeone/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.deepcopy.go
@@ -687,6 +687,13 @@ func (in *HostConfig) DeepCopyInto(out *HostConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Kubelet.DeepCopyInto(&out.Kubelet)
 	return
 }

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -599,7 +599,7 @@ func ValidateHostConfig(hosts []kubeoneapi.HostConfig, fldPath *field.Path) fiel
 		}
 		for labelKey, labelValue := range h.Labels {
 			if strings.HasSuffix(labelKey, "-") && labelValue != "" {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("labels"), labelValue, "label to remove can not have value"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("labels"), labelValue, "label to remove cannot have value"))
 			}
 		}
 	}

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -597,6 +597,11 @@ func ValidateHostConfig(hosts []kubeoneapi.HostConfig, fldPath *field.Path) fiel
 		if h.Kubelet.MaxPods != nil && *h.Kubelet.MaxPods <= 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("kubelet").Child("maxPods"), h.Kubelet.MaxPods, "maxPods must be a positive number"))
 		}
+		for labelKey, labelValue := range h.Labels {
+			if strings.HasSuffix(labelKey, "-") && labelValue != "" {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("labels"), labelValue, "label to remove can not have value"))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -1888,6 +1888,38 @@ func TestValidateHostConfig(t *testing.T) {
 			},
 			expectedError: true,
 		},
+		{
+			name: "incorrect label marked to remove",
+			hostConfig: []kubeoneapi.HostConfig{
+				{
+					PublicAddress:     "192.168.1.1",
+					PrivateAddress:    "192.168.0.1",
+					SSHPrivateKeyFile: "test",
+					SSHAgentSocket:    "test",
+					SSHUsername:       "root",
+					Labels: map[string]string{
+						"label-to-remove-": "this values has to be empty",
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "correct label marked to remove",
+			hostConfig: []kubeoneapi.HostConfig{
+				{
+					PublicAddress:     "192.168.1.1",
+					PrivateAddress:    "192.168.0.1",
+					SSHPrivateKeyFile: "test",
+					SSHAgentSocket:    "test",
+					SSHUsername:       "root",
+					Labels: map[string]string{
+						"label-to-remove-": "",
+					},
+				},
+			},
+			expectedError: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/apis/kubeone/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeone/zz_generated.deepcopy.go
@@ -711,6 +711,13 @@ func (in *HostConfig) DeepCopyInto(out *HostConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Kubelet.DeepCopyInto(&out.Kubelet)
 	return
 }

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -819,6 +819,11 @@ addons:
 #     taints:
 #     - key: "node-role.kubernetes.io/master"
 #       effect: "NoSchedule"
+#     labels:
+#       # to add new custom label
+#       "new-custom-label": "custom-value"
+#       # to delete existing label (use minus symbol with empty value)
+#       "node.kubernetes.io/exclude-from-external-load-balancers-": ""
 #     # kubelet is used to control kubelet configuration
 #     # uncomment the following to set those kubelet parameters. More into at:
 #     # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#

--- a/pkg/tasks/nodes.go
+++ b/pkg/tasks/nodes.go
@@ -134,14 +134,9 @@ func labelNodes(s *state.State) error {
 
 			for labKey, labVal := range host.Labels {
 				if strings.HasSuffix(labKey, "-") {
-					// additional `if` instead of `if strings.HasSuffix(labKey, "-") && labVal == ""` is used to avoid
-					// entering `else` section when the labVal is not empty.
-					if labVal == "" {
-						// drop minus from the suffix
-						labelToDelete := labKey[:len(labKey)-1]
-						// delete the label
-						delete(node.Labels, labelToDelete)
-					}
+					// drop minus from the suffix
+					labelToDelete := labKey[:len(labKey)-1]
+					delete(node.Labels, labelToDelete)
 				} else {
 					node.Labels[labKey] = labVal
 				}

--- a/pkg/tasks/nodes.go
+++ b/pkg/tasks/nodes.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"io"
 	"path/filepath"
+	"strings"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
 	"k8c.io/kubeone/pkg/certificate/cabundle"
@@ -96,7 +97,7 @@ func ensureRestartKubeAPIServerCrictl(s *state.State) error {
 	return fail.SSH(err, "restarting kubeapi-server pod")
 }
 
-func labelNodeOSes(s *state.State) error {
+func labelNodes(s *state.State) error {
 	candidateNodes := sets.NewString()
 	nodeList := corev1.NodeList{}
 
@@ -130,6 +131,21 @@ func labelNodeOSes(s *state.State) error {
 			}
 
 			node.Labels["v1.kubeone.io/operating-system"] = string(host.OperatingSystem)
+
+			for labKey, labVal := range host.Labels {
+				if strings.HasSuffix(labKey, "-") {
+					// additional `if` instead of `if strings.HasSuffix(labKey, "-") && labVal == ""` is used to avoid
+					// entering `else` section when the labVal is not empty.
+					if labVal == "" {
+						// drop minus from the suffix
+						labelToDelete := labKey[:len(labKey)-1]
+						// delete the label
+						delete(node.Labels, labelToDelete)
+					}
+				} else {
+					node.Labels[labKey] = labVal
+				}
+			}
 
 			return s.DynamicClient.Update(s.Context, &node)
 		})

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -258,8 +258,8 @@ func WithResources(t Tasks) Tasks {
 				Operation: "joining static worker nodes to the cluster",
 			},
 			{
-				Fn:        labelNodeOSes,
-				Operation: "labelling nodes with their OS",
+				Fn:        labelNodes,
+				Operation: "labeling nodes",
 			},
 			{
 				Fn:        machinecontroller.WaitReady,

--- a/pkg/terraform/v1beta2/config.go
+++ b/pkg/terraform/v1beta2/config.go
@@ -86,18 +86,19 @@ type controlPlane struct {
 }
 
 type hostsSpec struct {
-	PublicAddress     []string    `json:"public_address"`
-	PrivateAddress    []string    `json:"private_address"`
-	Hostnames         []string    `json:"hostnames"`
-	OperatingSystem   string      `json:"operating_system"`
-	SSHUser           string      `json:"ssh_user"`
-	SSHPort           int         `json:"ssh_port"`
-	SSHPrivateKeyFile string      `json:"ssh_private_key_file"`
-	SSHAgentSocket    string      `json:"ssh_agent_socket"`
-	Bastion           string      `json:"bastion"`
-	BastionPort       int         `json:"bastion_port"`
-	BastionUser       string      `json:"bastion_user"`
-	Kubelet           kubeletSpec `json:"kubelet,omitempty"`
+	PublicAddress     []string          `json:"public_address"`
+	PrivateAddress    []string          `json:"private_address"`
+	Hostnames         []string          `json:"hostnames"`
+	OperatingSystem   string            `json:"operating_system"`
+	SSHUser           string            `json:"ssh_user"`
+	SSHPort           int               `json:"ssh_port"`
+	SSHPrivateKeyFile string            `json:"ssh_private_key_file"`
+	SSHAgentSocket    string            `json:"ssh_agent_socket"`
+	Bastion           string            `json:"bastion"`
+	BastionPort       int               `json:"bastion_port"`
+	BastionUser       string            `json:"bastion_user"`
+	Kubelet           kubeletSpec       `json:"kubelet,omitempty"`
+	Labels            map[string]string `json:"labels"`
 }
 
 type kubeletSpec struct {
@@ -355,6 +356,7 @@ func newHostConfig(publicIP, privateIP, hostname string, hs *hostsSpec) kubeonev
 		SSHUsername:       hs.SSHUser,
 		SSHPort:           hs.SSHPort,
 		Kubelet:           kubeonev1beta2.KubeletConfig{},
+		Labels:            hs.Labels,
 	}
 
 	parseKubeletResourceParams(hs.Kubelet, &hc.Kubelet)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind api-change

**What this PR does / why we need it**:
To allow better management of the workloads distribution across different Nodes we need ability to add/remove custom labels on the control plane and static worker Nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1822

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add new HostConfig.Labels API to manage custom labels on the static Nodes
```
