### PR TITLE
Make KubeletConfiguration and KubeProxyConfiguration to be readable again on the older kubernetes versions

### DIFF
--- a/pkg/templates/kubeadm/v1beta3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm.go
@@ -34,14 +34,11 @@ import (
 	"k8c.io/kubeone/pkg/semverutil"
 	"k8c.io/kubeone/pkg/state"
 	"k8c.io/kubeone/pkg/templates/kubeadm/kubeadmargs"
-	"k8c.io/kubeone/pkg/templates/resources"
+	"k8c.io/kubeone/pkg/templates/kubernetesconfigs"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	componentbasev1alpha1 "k8s.io/component-base/config/v1alpha1"
-	kubeproxyv1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
-	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
 
 const (
@@ -174,27 +171,6 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		},
 	}
 
-	bfalse := false
-	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kubelet.config.k8s.io/v1beta1",
-			Kind:       "KubeletConfiguration",
-		},
-		CgroupDriver:         "systemd",
-		ReadOnlyPort:         0,
-		RotateCertificates:   true,
-		ServerTLSBootstrap:   true,
-		ClusterDNS:           []string{resources.NodeLocalDNSVirtualIP},
-		ContainerLogMaxSize:  cluster.LoggingConfig.ContainerLogMaxSize,
-		ContainerLogMaxFiles: &cluster.LoggingConfig.ContainerLogMaxFiles,
-		Authentication: kubeletconfigv1beta1.KubeletAuthentication{
-			Anonymous: kubeletconfigv1beta1.KubeletAnonymousAuthentication{
-				Enabled: &bfalse,
-			},
-		},
-		FeatureGates: map[string]bool{},
-	}
-
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
 		nodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = cluster.AssetConfiguration.Pause.ImageRepository + "/pause:" + cluster.AssetConfiguration.Pause.ImageTag
 	}
@@ -230,6 +206,11 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		}
 	}
 
+	var (
+		kubeletFeatureGates map[string]bool
+		featureGatesFlag    string
+	)
+
 	if cluster.CloudProvider.External {
 		if !s.ShouldEnableInTreeCloudProvider() {
 			delete(clusterConfig.APIServer.ExtraArgs, "cloud-provider")
@@ -244,7 +225,7 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		}
 
 		if s.ShouldEnableCSIMigration() {
-			featureGates, featureGatesFlag, err := s.Cluster.CSIMigrationFeatureGates(s.ShouldUnregisterInTreeCloudProvider())
+			kubeletFeatureGates, featureGatesFlag, err = s.Cluster.CSIMigrationFeatureGates(s.ShouldUnregisterInTreeCloudProvider())
 			if err != nil {
 				return nil, err
 			}
@@ -261,11 +242,6 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 				clusterConfig.ControllerManager.ExtraArgs["feature-gates"] = fmt.Sprintf("%s,%s", clusterConfig.ControllerManager.ExtraArgs["feature-gates"], featureGatesFlag)
 			} else {
 				clusterConfig.ControllerManager.ExtraArgs["feature-gates"] = featureGatesFlag
-			}
-
-			// Kubelet
-			for k, v := range featureGates {
-				kubeletConfig.FeatureGates[k] = v
 			}
 		}
 	}
@@ -314,9 +290,9 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		// Handle external KMS case.
 		if s.LiveCluster.CustomEncryptionEnabled() ||
 			s.Cluster.Features.EncryptionProviders != nil && s.Cluster.Features.EncryptionProviders.CustomEncryptionConfiguration != "" {
-			ksmSocket, err := s.GetKMSSocketPath()
-			if err != nil {
-				return nil, err
+			ksmSocket, socketErr := s.GetKMSSocketPath()
+			if socketErr != nil {
+				return nil, socketErr
 			}
 			if ksmSocket != "" {
 				clusterConfig.APIServer.ExtraVolumes = append(clusterConfig.APIServer.ExtraVolumes, kubeadmv1beta3.HostPathMount{
@@ -338,7 +314,15 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 	initConfig.NodeRegistration = nodeRegistration
 	joinConfig.NodeRegistration = nodeRegistration
 
-	kubeproxyConfig := kubeProxyConfiguration(s)
+	kubeletConfig, err := kubernetesconfigs.NewKubeletConfiguration(s.Cluster, kubeletFeatureGates)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeproxyConfig, err := kubernetesconfigs.NewKubeProxyConfiguration(s.Cluster)
+	if err != nil {
+		return nil, err
+	}
 
 	return []runtime.Object{initConfig, joinConfig, clusterConfig, kubeletConfig, kubeproxyConfig}, nil
 }
@@ -368,27 +352,6 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 		},
 	}
 
-	bfalse := false
-	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kubelet.config.k8s.io/v1beta1",
-			Kind:       "KubeletConfiguration",
-		},
-		CgroupDriver:         "systemd",
-		ReadOnlyPort:         0,
-		RotateCertificates:   true,
-		ServerTLSBootstrap:   true,
-		ClusterDNS:           []string{resources.NodeLocalDNSVirtualIP},
-		ContainerLogMaxSize:  cluster.LoggingConfig.ContainerLogMaxSize,
-		ContainerLogMaxFiles: &cluster.LoggingConfig.ContainerLogMaxFiles,
-		Authentication: kubeletconfigv1beta1.KubeletAuthentication{
-			Anonymous: kubeletconfigv1beta1.KubeletAnonymousAuthentication{
-				Enabled: &bfalse,
-			},
-		},
-		FeatureGates: map[string]bool{},
-	}
-
 	if cluster.AssetConfiguration.Pause.ImageRepository != "" {
 		nodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = cluster.AssetConfiguration.Pause.ImageRepository + "/pause:" + cluster.AssetConfiguration.Pause.ImageTag
 	}
@@ -404,22 +367,11 @@ func NewConfigWorker(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Obje
 		if !s.ShouldEnableInTreeCloudProvider() {
 			nodeRegistration.KubeletExtraArgs["cloud-provider"] = "external"
 		}
-		if s.ShouldEnableCSIMigration() {
-			featureGates, _, err := s.Cluster.CSIMigrationFeatureGates(s.ShouldUnregisterInTreeCloudProvider())
-			if err != nil {
-				return nil, err
-			}
-			for k, v := range featureGates {
-				kubeletConfig.FeatureGates[k] = v
-			}
-		}
 	}
 
 	joinConfig.NodeRegistration = nodeRegistration
 
-	kubeproxyConfig := kubeProxyConfiguration(s)
-
-	return []runtime.Object{joinConfig, kubeletConfig, kubeproxyConfig}, nil
+	return []runtime.Object{joinConfig}, nil
 }
 
 func newNodeIP(host kubeoneapi.HostConfig) string {
@@ -458,38 +410,6 @@ func newNodeRegistration(s *state.State, host kubeoneapi.HostConfig) kubeadmv1be
 		CRISocket:        s.Cluster.ContainerRuntime.CRISocket(),
 		KubeletExtraArgs: kubeletCLIFlags,
 	}
-}
-
-func kubeProxyConfiguration(s *state.State) *kubeproxyv1alpha1.KubeProxyConfiguration {
-	kubeProxyConfig := &kubeproxyv1alpha1.KubeProxyConfiguration{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "KubeProxyConfiguration",
-			APIVersion: "kubeproxy.config.k8s.io/v1alpha1",
-		},
-		ClusterCIDR: s.Cluster.ClusterNetwork.PodSubnet,
-		ClientConnection: componentbasev1alpha1.ClientConnectionConfiguration{
-			Kubeconfig: "/var/lib/kube-proxy/kubeconfig.conf",
-		},
-	}
-
-	if kbPrx := s.Cluster.ClusterNetwork.KubeProxy; kbPrx != nil {
-		switch {
-		case kbPrx.IPVS != nil:
-			kubeProxyConfig.Mode = kubeproxyv1alpha1.ProxyMode("ipvs")
-			kubeProxyConfig.IPVS = kubeproxyv1alpha1.KubeProxyIPVSConfiguration{
-				StrictARP:     kbPrx.IPVS.StrictARP,
-				Scheduler:     kbPrx.IPVS.Scheduler,
-				ExcludeCIDRs:  kbPrx.IPVS.ExcludeCIDRs,
-				TCPTimeout:    kbPrx.IPVS.TCPTimeout,
-				TCPFinTimeout: kbPrx.IPVS.TCPFinTimeout,
-				UDPTimeout:    kbPrx.IPVS.UDPTimeout,
-			}
-		case kbPrx.IPTables != nil:
-			kubeProxyConfig.Mode = kubeproxyv1alpha1.ProxyMode("iptables")
-		}
-	}
-
-	return kubeProxyConfig
 }
 
 func etcdVersionCorruptCheckExtraArgs(kubeSemVer *semver.Version, etcdImageTag string) (string, map[string]string) {

--- a/pkg/templates/kubernetesconfigs/kubelet.go
+++ b/pkg/templates/kubernetesconfigs/kubelet.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetesconfigs
+
+import (
+	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
+	"k8c.io/kubeone/pkg/templates/resources"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+)
+
+func NewKubeletConfiguration(cluster *kubeoneapi.KubeOneCluster, featureGates map[string]bool) (runtime.Object, error) {
+	bfalse := false
+	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubelet.config.k8s.io/v1beta1",
+			Kind:       "KubeletConfiguration",
+		},
+		CgroupDriver:         "systemd",
+		ReadOnlyPort:         0,
+		RotateCertificates:   true,
+		ServerTLSBootstrap:   true,
+		ClusterDNS:           []string{resources.NodeLocalDNSVirtualIP},
+		ContainerLogMaxSize:  cluster.LoggingConfig.ContainerLogMaxSize,
+		ContainerLogMaxFiles: &cluster.LoggingConfig.ContainerLogMaxFiles,
+		Authentication: kubeletconfigv1beta1.KubeletAuthentication{
+			Anonymous: kubeletconfigv1beta1.KubeletAnonymousAuthentication{
+				Enabled: &bfalse,
+			},
+		},
+		FeatureGates: featureGates,
+	}
+
+	return dropFields(kubeletConfig, []string{"logging"})
+}

--- a/pkg/templates/kubernetesconfigs/kubeproxy.go
+++ b/pkg/templates/kubernetesconfigs/kubeproxy.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetesconfigs
+
+import (
+	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	componentbasev1alpha1 "k8s.io/component-base/config/v1alpha1"
+	kubeproxyv1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
+)
+
+func NewKubeProxyConfiguration(cluster *kubeoneapi.KubeOneCluster) (runtime.Object, error) {
+	kubeProxyConfig := &kubeproxyv1alpha1.KubeProxyConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeProxyConfiguration",
+			APIVersion: "kubeproxy.config.k8s.io/v1alpha1",
+		},
+		ClusterCIDR: cluster.ClusterNetwork.PodSubnet,
+		ClientConnection: componentbasev1alpha1.ClientConnectionConfiguration{
+			Kubeconfig: "/var/lib/kube-proxy/kubeconfig.conf",
+		},
+	}
+
+	if kbPrx := cluster.ClusterNetwork.KubeProxy; kbPrx != nil {
+		switch {
+		case kbPrx.IPVS != nil:
+			kubeProxyConfig.Mode = kubeproxyv1alpha1.ProxyMode("ipvs")
+			kubeProxyConfig.IPVS = kubeproxyv1alpha1.KubeProxyIPVSConfiguration{
+				StrictARP:     kbPrx.IPVS.StrictARP,
+				Scheduler:     kbPrx.IPVS.Scheduler,
+				ExcludeCIDRs:  kbPrx.IPVS.ExcludeCIDRs,
+				TCPTimeout:    kbPrx.IPVS.TCPTimeout,
+				TCPFinTimeout: kbPrx.IPVS.TCPFinTimeout,
+				UDPTimeout:    kbPrx.IPVS.UDPTimeout,
+			}
+		case kbPrx.IPTables != nil:
+			kubeProxyConfig.Mode = kubeproxyv1alpha1.ProxyMode("iptables")
+		}
+	}
+
+	return dropFields(kubeProxyConfig, []string{"detectLocal"}, []string{"winkernel"})
+}

--- a/pkg/templates/kubernetesconfigs/util.go
+++ b/pkg/templates/kubernetesconfigs/util.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetesconfigs
+
+import (
+	"encoding/json"
+
+	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func dropFields(obj runtime.Object, fields ...[]string) (runtime.Object, error) {
+	buf, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	var uObj metav1unstructured.Unstructured
+
+	_, _, err = metav1unstructured.UnstructuredJSONScheme.Decode(buf, nil, &uObj)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, fieldSet := range fields {
+		metav1unstructured.RemoveNestedField(uObj.Object, fieldSet...)
+	}
+
+	return &uObj, nil
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Internal upgrade (#2126) to the latest 0.24.2 of all kubernetes dependencies inadvertly added new fields to the KubeletConfiguration and KubeProxyConfiguration, but older kubeadm don't know about them and refuse to unmarshal (it uses strict mode)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2136

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed KubeletConfiguration and KubeProxyConfiguration for kubernetes prior v1.23.x
```
