### PR TITLE
Fix KubeOne failing to restart RHEL VMs

### DIFF
--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -166,7 +166,9 @@ func disableNMCloudSetup(s *state.State, node *kubeoneapi.HostConfig, _ executor
 			// NB: In some cases, KubeOne might not be able to re-use SSH connections
 			// after rebooting nodes. Because of that, we close all connections here,
 			// and then KubeOne will automatically reinitialize them on the next task.
-			s.Runner.Executor.Close()
+			if s.Runner != nil && s.Runner.Executor != nil {
+				s.Runner.Executor.Close()
+			}
 		}
 	}
 

--- a/testv2/e2e/tests_definitions.go
+++ b/testv2/e2e/tests_definitions.go
@@ -77,6 +77,7 @@ var (
 					"os=rhel",
 					"ssh_username=ec2-user",
 					"bastion_user=ec2-user",
+					"bastion_type=t3.micro",
 				},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

RHEL periodic tests have been failing since June 29th with the following stacktrace:

```
time="06:04:08 UTC" level=info msg="Waiting for 1m0s before proceeding to give machines time to boot up..." node=172.31.16.22
time="06:04:08 UTC" level=info msg="Waiting for 1m0s before proceeding to give machines time to boot up..." node=172.31.16.79
time="06:04:09 UTC" level=info msg="Waiting for 1m0s before proceeding to give machines time to boot up..." node=172.31.16.60
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x18049f8]
goroutine 226 [running]:
k8c.io/kubeone/pkg/tasks.disableNMCloudSetup(0xc0005ca2d0, 0xc000640400, {0xc00061ddf8?, 0x1?})
	k8c.io/kubeone/pkg/tasks/prerequisites.go:169 +0x2f8
k8c.io/kubeone/pkg/state.(*State).runTask(0xc0005ca2d0, 0xc000640400, 0x1fa6148)
	k8c.io/kubeone/pkg/state/task.go:54 +0x212
k8c.io/kubeone/pkg/state.(*State).RunTaskOnNodes.func1(0xc0005ca2d0, 0xc000640400)
	k8c.io/kubeone/pkg/state/task.go:73 +0x6e
created by k8c.io/kubeone/pkg/state.(*State).RunTaskOnNodes
	k8c.io/kubeone/pkg/state/task.go:72 +0x2fb
    conformance_test.go:243: failed to install cluster ('kubeone install'): k8s cluster deployment failed: exit status 2
    panic.go:482: cleanup ....
```

I assume this is a regression from #2095 when we started closing SSH connection on error. `reboot` call can be parsed as an error, therefore causing KubeOne to automatically close the connection. When we try to close the connection explicitly, KubeOne throws an NPE because the connection doesn't exist.

This PR fixes it in a way that we validate if the connection is open before trying to close it.

Additionally, this PR modifies AWS RHEL tests to use `t3.micro` for bastion because `t3.nano` is not supported with RHEL.

```
Error: Error launching source instance: UnsupportedOperation: Red Hat Enterprise Linux is not supported for the instance type 't3.nano'.
	status code: 400, request id: b8cac8f5-be05-46b2-820d-6d592b93986e
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
