### PR TITLE
Migrate GCE standard StorageClass to set proper volumeBindingMode

### DIFF
--- a/pkg/addons/helpers.go
+++ b/pkg/addons/helpers.go
@@ -32,9 +32,22 @@ import (
 )
 
 const (
-	azureDiskCSIDriverName = "disk.csi.azure.com"
-	vSphereDeploymentName  = "vsphere-cloud-controller-manager"
+	azureDiskCSIDriverName      = "disk.csi.azure.com"
+	gceStandardStorageClassName = "standard"
+	vSphereDeploymentName       = "vsphere-cloud-controller-manager"
 )
+
+func migrateGCEStandardStorageClass(s *state.State) error {
+	return clientutil.DeleteIfExists(s.Context, s.DynamicClient, gceStandardStorageClass())
+}
+
+func gceStandardStorageClass() *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gceStandardStorageClassName,
+		},
+	}
+}
 
 func migrateAzureDiskCSIDriver(s *state.State) error {
 	return clientutil.DeleteIfExists(s.Context, s.DynamicClient, azureDiskCSIDriver())


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We were not setting VolumeBindingMode on default StorageClass for GCE. In this case, Kubernetes automatically defaults VolumeBindingMode to `Immediate` which doesn't work well for GCP.

If VolumeBindingMode is `Immediate`, the CSI driver (or in-tree provider) will bind the volume to some random node. This can be an issue if you have nodes across multiple zones. Volume can get created in one zone, but if you're not able to schedule pods on a Node in the same zone, the pod will get stuck in Pending.

For example, look at the following scenario:

* You have 3 control plane nodes in zones A, B, C
* You have 1 worker node in zone A
* You create a PVC
* CSI driver creates a volume in zone C and binds that volume to the control plane VM in zone C
* You can't get a Pod running (it's stuck in Pending) because your worker node is in zone A, and you can't schedule pods on the control plane node in zone C

This is resolved by setting VolumeBindingMode to `WaitForFirstConsumer` so volumes are created and bound only on demand. Migration is required because StorageClasses are immutable, so we have to delete the old one first and then create a new one.

**Does this PR introduce a user-facing change?**:
```release-note
Migrate GCE `standard` default StorageClass to set volumeBindingMode to WaitForFirstConsumer. The StorageClass will be automatically recreated the next time you run `kubeone apply`
```

/assign @kron4eg 