### PR TITLE
Schedule GCP CSI driver on control plane nodes

### DIFF
--- a/addons/csi-gcp-compute-persistent/controller.yaml
+++ b/addons/csi-gcp-compute-persistent/controller.yaml
@@ -20,8 +20,21 @@ spec:
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
+        node-role.kubernetes.io/control-plane: ""
       serviceAccountName: csi-gce-pd-controller-sa
       priorityClassName: csi-gce-pd-controller
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
       containers:
         - name: csi-provisioner
           image: {{ .InternalImages.Get "GCPComputeCSIProvisioner" }}

--- a/addons/csi-gcp-compute-persistent/snapshot-controller.yaml
+++ b/addons/csi-gcp-compute-persistent/snapshot-controller.yaml
@@ -22,6 +22,21 @@ spec:
       labels:
         app: snapshot-controller
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
       serviceAccount: snapshot-controller
       containers:
         - name: snapshot-controller

--- a/addons/csi-gcp-compute-persistent/snapshot-webhook.yaml
+++ b/addons/csi-gcp-compute-persistent/snapshot-webhook.yaml
@@ -51,6 +51,21 @@ spec:
       labels:
         app: snapshot-validation
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
       containers:
       - name: snapshot-validation
         image: {{ .InternalImages.Get "GCPComputeCSISnapshotValidationWebhook" }}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR modifies the GCP CSI driver addon to schedule all relevant components on the control plane nodes. This should ensure better stability as the worker nodes might get rotated more often.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 