### PR TITLE
Upgrade OpenStack CCM and Cinder CSI for Kubernetes 1.24 and 1.23 clusters

### DIFF
--- a/addons/csi-openstack-cinder/controllerplugin.yaml
+++ b/addons/csi-openstack-cinder/controllerplugin.yaml
@@ -145,6 +145,12 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
+            - mountPath: /etc/ssl/certs
+              name: ca-certs
+              readOnly: true
+            - mountPath: /usr/share/ca-certificates
+              name: usr-ca-certs
+              readOnly: true
 {{ if .Config.CABundle }}
 {{ caBundleVolumeMount | indent 12 }}
 {{ end }}
@@ -154,6 +160,14 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
+        - name: ca-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: DirectoryOrCreate
+        - hostPath:
+            path: /usr/share/ca-certificates
+            type: DirectoryOrCreate
+          name: usr-ca-certs
 {{ if .Config.CABundle }}
 {{ caBundleVolume | indent 8 }}
 {{ end }}

--- a/addons/csi-openstack-cinder/nodeplugin.yaml
+++ b/addons/csi-openstack-cinder/nodeplugin.yaml
@@ -111,6 +111,12 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
+            - mountPath: /etc/ssl/certs
+              name: ca-certs
+              readOnly: true
+            - mountPath: /usr/share/ca-certificates
+              name: usr-ca-certs
+              readOnly: true
 {{ if .Config.CABundle }}
 {{ caBundleVolumeMount | indent 12 }}
 {{ end }}
@@ -134,6 +140,14 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
+        - name: ca-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: DirectoryOrCreate
+        - hostPath:
+            path: /usr/share/ca-certificates
+            type: DirectoryOrCreate
+          name: usr-ca-certs
 {{ if .Config.CABundle }}
 {{ caBundleVolume | indent 8 }}
 {{ end }}

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -301,8 +301,8 @@ func optionalResources() map[Resource]map[string]string {
 			"1.20.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2",
 			"1.21.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0",
 			"1.22.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0",
-			"1.23.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.1",
-			">= 1.24.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.0",
+			"1.23.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.3",
+			">= 1.24.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.2",
 		},
 
 		// OpenStack CSI
@@ -310,8 +310,8 @@ func optionalResources() map[Resource]map[string]string {
 			"1.20.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.3",
 			"1.21.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.21.0",
 			"1.22.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
-			"1.23.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.0",
-			">= 1.24.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.24.0",
+			"1.23.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.3",
+			">= 1.24.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.24.2",
 		},
 		OpenstackCSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
 		OpenstackCSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.6.0"},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Update OpenStack CCM and Cinder CSI to v1.24.2 for Kubernetes 1.24 clusters and v1.23.3 for Kubernetes 1.23 clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2150

**Does this PR introduce a user-facing change?**:
```release-note
Update OpenStack CCM and Cinder CSI to v1.24.2 for Kubernetes 1.24 clusters and v1.23.3 for Kubernetes 1.23 clusters
```