### PR TITLE
Prevent NPE on ssh connection close

### DIFF
--- a/pkg/ssh/connection.go
+++ b/pkg/ssh/connection.go
@@ -236,6 +236,13 @@ func (c *connection) TunnelTo(_ context.Context, network, addr string) (net.Conn
 	// the voided context.Context is voided as a workaround of always Done
 	// context that being passed. Please don't try to <-ctx.Done(), it will
 	// always return immediately
+	if c.sshclient == nil {
+		return nil, fail.SSHError{
+			Err: fail.Connection(errors.New("no SSH connection established"), addr),
+			Op:  "tunneling",
+		}
+	}
+
 	netconn, err := c.sshclient.Dial(network, addr)
 	if err != nil {
 		return nil, fail.SSH(fail.Connection(err, addr), "tunneling")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Our periodic e2e testing job revealed this:
```
goroutine 1724 [running]:
golang.org/x/crypto/ssh.(*Client).dial(0x0, {0xc000a6eca8, 0x7}, 0x0, {0xc0004d0370, 0x43}, 0x192b)
	golang.org/x/crypto@v0.0.0-20220525230936-793ad666bf5e/ssh/tcpip.go:422 +0x145
golang.org/x/crypto/ssh.(*Client).Dial(0x203000?, {0x1d7635d?, 0xc000730d80?}, {0xc0004d0370?, 0x7f8223e34368?})
	golang.org/x/crypto@v0.0.0-20220525230936-793ad666bf5e/ssh/tcpip.go:350 +0xfa
k8c.io/kubeone/pkg/ssh.(*connection).TunnelTo(0xc000012cf0, {0x120?, 0x7f8123c25f80?}, {0x1d7635d?, 0x824aad9f18?}, {0xc0004d0370, 0x48})
	k8c.io/kubeone/pkg/ssh/connection.go:239 +0x4a
net/http.(*Transport).dial(0x1000000000010?, {0x218f538?, 0xc00005c0b0?}, {0x1d7635d?, 0x2?}, {0xc0004d0370?, 0x44a672?})
	net/http/transport.go:1169 +0xda
net/http.(*Transport).dialConn(0xc0008e6000, {0x218f538, 0xc00005c0b0}, {{}, 0x0, {0xc0006660a0, 0x5}, {0xc0004d0370, 0x48}, 0x0})
	net/http/transport.go:1607 +0x83f
net/http.(*Transport).dialConnFor(0x0?, 0xc0001af760)
	net/http/transport.go:1449 +0xb0
created by net/http.(*Transport).queueForDial
	net/http/transport.go:1418 +0x3d2
    upgrade_test.go:319: failed to upgrade the cluster ('kubeone upgrade'): k8s cluster upgrade failed: exit status 2
    panic.go:482: cleanup ....
```



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent NPE on ssh connection close
```
