### PR TITLE
Hetzner: remove server selector and update label selector to also match kubeone_cluster_name label

### DIFF
--- a/examples/terraform/hetzner/main.tf
+++ b/examples/terraform/hetzner/main.tf
@@ -157,8 +157,7 @@ resource "hcloud_load_balancer_target" "load_balancer_target" {
 
   type             = "label_selector"
   load_balancer_id = hcloud_load_balancer.load_balancer.0.id
-  server_id        = element(hcloud_server.control_plane.*.id, count.index)
-  label_selector   = "role=api"
+  label_selector   = "kubeone_cluster_name=${var.cluster_name},role=api"
   use_private_ip   = true
   depends_on = [
     hcloud_server_network.control_plane,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Terraform configs for Hetzner are failing to create the kube-apiserver LB because LB can't have both label and server selectors:

```
╷
│ Error: Invalid combination of arguments
│
│   with hcloud_load_balancer_target.load_balancer_target[0],
│   on main.tf line 155, in resource "hcloud_load_balancer_target" "load_balancer_target":
│  155: resource "hcloud_load_balancer_target" "load_balancer_target" {
│
│ "ip": only one of `ip,label_selector,server_id` can be specified, but `label_selector,server_id` were specified.
╵
╷
│ Error: Invalid combination of arguments
│
│   with hcloud_load_balancer_target.load_balancer_target[0],
│   on main.tf line 160, in resource "hcloud_load_balancer_target" "load_balancer_target":
│  160:   server_id        = element(hcloud_server.control_plane.*.id, count.index)
│
│ "server_id": only one of `ip,label_selector,server_id` can be specified, but `label_selector,server_id` were specified.
╵
╷
│ Error: Invalid combination of arguments
│
│   with hcloud_load_balancer_target.load_balancer_target[0],
│   on main.tf line 161, in resource "hcloud_load_balancer_target" "load_balancer_target":
│  161:   label_selector   = "role=api"
│
│ "label_selector": only one of `ip,label_selector,server_id` can be specified, but `label_selector,server_id` were specified.
╵
```

I've removed the server selector and updated the label selector to match both `kubeone_cluster_name` and `role` labels, so it works properly if there are multiple clusters in the same account.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg 