### PR TITLE
Equinix Metal: use Metro instead of facilities

### DIFF
--- a/examples/terraform/equinixmetal/README.md
+++ b/examples/terraform/equinixmetal/README.md
@@ -17,13 +17,13 @@ See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_metal"></a> [metal](#requirement\_metal) | ~> 3.2.0 |
+| <a name="requirement_metal"></a> [metal](#requirement\_metal) | ~> 3.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_metal"></a> [metal](#provider\_metal) | ~> 3.2.0 |
+| <a name="provider_metal"></a> [metal](#provider\_metal) | ~> 3.3.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
@@ -46,12 +46,12 @@ No modules.
 | <a name="input_apiserver_alternative_names"></a> [apiserver\_alternative\_names](#input\_apiserver\_alternative\_names) | subject alternative names for the API Server signing cert. | `list(string)` | `[]` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
 | <a name="input_control_plane_operating_system"></a> [control\_plane\_operating\_system](#input\_control\_plane\_operating\_system) | Image to use for control plane provisioning | `string` | `"ubuntu_18_04"` | no |
-| <a name="input_device_type"></a> [device\_type](#input\_device\_type) | type (size) of the device | `string` | `"c3.small.x86"` | no |
-| <a name="input_facility"></a> [facility](#input\_facility) | Facility (datacenter) | `string` | `"ams1"` | no |
+| <a name="input_device_type"></a> [device\_type](#input\_device\_type) | type (size) of the device | `string` | `"m3.small.x86"` | no |
 | <a name="input_initial_machinedeployment_operating_system_profile"></a> [initial\_machinedeployment\_operating\_system\_profile](#input\_initial\_machinedeployment\_operating\_system\_profile) | Name of operating system profile for MachineDeployments, only applicable if operatng-system-manager addon is enabled.<br>If not specified, the default value will be added by machine-controller addon. | `string` | `""` | no |
 | <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | Number of replicas per MachineDeployment | `number` | `2` | no |
-| <a name="input_lb_device_type"></a> [lb\_device\_type](#input\_lb\_device\_type) | type (size) of the load balancer device | `string` | `"c3.small.x86"` | no |
+| <a name="input_lb_device_type"></a> [lb\_device\_type](#input\_lb\_device\_type) | type (size) of the load balancer device | `string` | `"m3.small.x86"` | no |
 | <a name="input_lb_operating_system"></a> [lb\_operating\_system](#input\_lb\_operating\_system) | Image to use for loadbalancer provisioning | `string` | `"ubuntu_18_04"` | no |
+| <a name="input_metro"></a> [metro](#input\_metro) | Metro area for cluster | `string` | `"AM"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | project ID | `string` | n/a | yes |
 | <a name="input_ssh_agent_socket"></a> [ssh\_agent\_socket](#input\_ssh\_agent\_socket) | SSH Agent socket, default to grab from $SSH\_AUTH\_SOCK | `string` | `"env:SSH_AUTH_SOCK"` | no |
 | <a name="input_ssh_port"></a> [ssh\_port](#input\_ssh\_port) | SSH port to be used to provision instances | `number` | `22` | no |

--- a/examples/terraform/equinixmetal/main.tf
+++ b/examples/terraform/equinixmetal/main.tf
@@ -32,7 +32,7 @@ resource "metal_device" "control_plane" {
 
   hostname         = "${var.cluster_name}-control-plane-${count.index + 1}"
   plan             = var.device_type
-  facilities       = [var.facility]
+  metro            = var.metro
   operating_system = var.control_plane_operating_system
   billing_cycle    = "hourly"
   project_id       = var.project_id
@@ -44,7 +44,7 @@ resource "metal_device" "lb" {
 
   hostname         = "${var.cluster_name}-lb"
   plan             = var.lb_device_type
-  facilities       = [var.facility]
+  metro            = var.metro
   operating_system = var.lb_operating_system
   billing_cycle    = "hourly"
   project_id       = var.project_id

--- a/examples/terraform/equinixmetal/output.tf
+++ b/examples/terraform/equinixmetal/output.tf
@@ -75,7 +75,7 @@ output "kubeone_workers" {
           # see example under `cloudProviderSpec` section at:
           # https://github.com/kubermatic/machine-controller/blob/master/examples/equinixmetal-machinedeployment.yaml
           projectID    = var.project_id
-          facilities   = [var.facility]
+          metro        = var.metro
           instanceType = var.device_type
           tags = [
             "${var.cluster_name}-workers-pool1"

--- a/examples/terraform/equinixmetal/variables.tf
+++ b/examples/terraform/equinixmetal/variables.tf
@@ -74,9 +74,9 @@ variable "ssh_agent_socket" {
 
 # Provider specific settings
 
-variable "facility" {
-  default     = "ams1"
-  description = "Facility (datacenter)"
+variable "metro" {
+  default     = "AM"
+  description = "Metro area for cluster"
   type        = string
 }
 
@@ -93,13 +93,13 @@ variable "lb_operating_system" {
 }
 
 variable "device_type" {
-  default     = "c3.small.x86"
+  default     = "m3.small.x86"
   description = "type (size) of the device"
   type        = string
 }
 
 variable "lb_device_type" {
-  default     = "c3.small.x86"
+  default     = "m3.small.x86"
   description = "type (size) of the load balancer device"
   type        = string
 }

--- a/examples/terraform/equinixmetal/versions.tf
+++ b/examples/terraform/equinixmetal/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     metal = {
       source  = "equinix/metal"
-      version = "~> 3.2.0"
+      version = "~> 3.3.0"
     }
   }
 }

--- a/pkg/templates/machinecontroller/cloudprovider_specs.go
+++ b/pkg/templates/machinecontroller/cloudprovider_specs.go
@@ -117,6 +117,7 @@ type NutanixSpec struct {
 type EquinixMetalSpec struct {
 	ProjectID    string   `json:"projectID"`
 	BillingCycle string   `json:"billingCycle"`
+	Metro        string   `json:"metro"`
 	Facilities   []string `json:"facilities"`
 	InstanceType string   `json:"instanceType"`
 	Tags         []string `json:"tags,omitempty"`

--- a/pkg/terraform/v1beta2/update.go
+++ b/pkg/terraform/v1beta2/update.go
@@ -257,6 +257,7 @@ func updateEquinixMetalWorkerset(existingWorkerSet *kubeonev1beta2.DynamicWorker
 
 	flags := []cloudProviderFlags{
 		{key: "projectID", value: metalConfig.ProjectID},
+		{key: "metro", value: metalConfig.Metro},
 		{key: "facilities", value: metalConfig.Facilities},
 		{key: "instanceType", value: metalConfig.InstanceType},
 		{key: "billingCycle", value: metalConfig.BillingCycle},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Equinix Metal now recommends using Metros instead of Facilities. This PR modifies Terraform configs for Equinix Metal to remove facilities in favor of Metros. By default, we use `AM` (Amsterdam) metro.

This PR also changes default instance size to `m3.small.x86` because it has better capacity than `c3.small.x86`. The new instance size doesn't support Flatcar, but we don't run Equinix Metal E2E tests on Flatcar.

**Does this PR introduce a user-facing change?**:
```release-note
Equinix Metal: Replace Facilities with Metro in Terraform configs
```

/assign @kron4eg 