### PR TITLE
Run kubeone proxy after provisioning the cluster

### DIFF
--- a/testv2/e2e/helpers.go
+++ b/testv2/e2e/helpers.go
@@ -482,31 +482,11 @@ func basicTest(t *testing.T, k1 *kubeoneBin, data manifestData) {
 	}
 }
 
-func sonobuoyRun(t *testing.T, k1 *kubeoneBin, mode sonobuoyMode) {
+func sonobuoyRun(t *testing.T, k1 *kubeoneBin, mode sonobuoyMode, proxyURL string) {
 	kubeconfigPath, err := k1.kubeconfigPath(t.TempDir())
 	if err != nil {
 		t.Fatalf("fetching kubeconfig failed")
 	}
-
-	// launch kubeone proxy, to have a HTTPS proxy through the SSH tunnel
-	// to open access to the kubeapi behind the bastion host
-	proxyCtx, killProxy := context.WithCancel(context.Background())
-	proxyURL, waitK1, err := k1.AsyncProxy(proxyCtx)
-	if err != nil {
-		t.Fatalf("starting kubeone proxy: %v", err)
-	}
-	defer func() {
-		waitErr := waitK1()
-		if waitErr != nil {
-			t.Logf("wait kubeone proxy: %v", waitErr)
-		}
-	}()
-	defer killProxy()
-
-	t.Logf("kubeone proxy is running on %s", proxyURL)
-
-	// let kubeone proxy start and open the port
-	time.Sleep(5 * time.Second)
 
 	sb := sonobuoyBin{
 		kubeconfig: kubeconfigPath,

--- a/testv2/e2e/scenario_install.go
+++ b/testv2/e2e/scenario_install.go
@@ -17,10 +17,12 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"testing"
 	"text/template"
+	"time"
 
 	"sigs.k8s.io/yaml"
 )
@@ -128,8 +130,27 @@ func (scenario *scenarioInstall) test(t *testing.T) {
 		k1   = scenario.kubeone(t)
 	)
 
+	// launch kubeone proxy, to have a HTTPS proxy through the SSH tunnel
+	// to open access to the kubeapi behind the bastion host
+	proxyCtx, killProxy := context.WithCancel(context.Background())
+	proxyURL, waitK1, err := k1.AsyncProxy(proxyCtx)
+	if err != nil {
+		t.Fatalf("starting kubeone proxy: %v", err)
+	}
+	defer func() {
+		waitErr := waitK1()
+		if waitErr != nil {
+			t.Logf("wait kubeone proxy: %v", waitErr)
+		}
+	}()
+	defer killProxy()
+
+	// let kubeone proxy start and open the port
+	time.Sleep(5 * time.Second)
+	t.Logf("kubeone proxy is running on %s", proxyURL)
+
 	basicTest(t, k1, data)
-	sonobuoyRun(t, k1, sonobuoyConformanceLite)
+	sonobuoyRun(t, k1, sonobuoyConformanceLite, proxyURL)
 }
 
 func (scenario *scenarioInstall) GenerateTests(wr io.Writer, generatorType GeneratorType, cfg ProwConfig) error {


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

We are using the private IP address of the first node as the API endpoint in our new E2E tests. Because of that, kubeconfig is using the private IP address and we need `kubeone proxy` to be able to access the API server. Access to the API server is needed for:

1. Checking are nodes ready and running the expected Kubernetes version
2. Running conformance tests using Sonobuoy

We're already using `kubeone proxy` with Sonobuoy and it worked fine for vSphere. For vSphere, we use a jumphost that has access to nodes via private IP addresses, so we didn't need `kubeone proxy` to access the API server for checking nodes. On other providers, we don't have a jumphost and we can't access the private IP address from the test pod, so we need `kubeone proxy`. This PR moves running `kubeone proxy` from the Sonobuoy runner to after provisioning the cluster (and before checking nodes).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```