### PR TITLE
testv2/upgrade: Open ZIP as RDWR and provide only one version to install

### DIFF
--- a/testv2/e2e/helpers.go
+++ b/testv2/e2e/helpers.go
@@ -147,7 +147,7 @@ func downloadKubeone(t *testing.T, version string) string {
 	}
 	defer resp.Body.Close()
 
-	zipBin, err := os.OpenFile(zipPath, os.O_CREATE|os.O_WRONLY, 0600)
+	zipBin, err := os.OpenFile(zipPath, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		t.Fatalf("open kubeone destination file: %v", err)
 	}

--- a/testv2/e2e/scenario_upgrade.go
+++ b/testv2/e2e/scenario_upgrade.go
@@ -53,7 +53,7 @@ func (scenario *scenarioUpgrade) Run(t *testing.T) {
 		Name:                 scenario.name,
 		ManifestTemplatePath: scenario.manifestTemplatePath,
 		infra:                scenario.infra,
-		versions:             scenario.versions,
+		versions:             []string{scenario.versions[0]},
 		kubeonePath:          downloadKubeone(t, kubeoneVersionToInit),
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

New upgrade tests are failing with:

1. Bad descriptor error because we open KubeOne ZIP archive as `WRONLY`, but we also try to read it
    ```
    helpers.go:168: opening zip file for reading: read /tmp/TestHetznerDefaultUpgradeContainerdFromV1_21_14_ToV1_22_111377836571/001/kubeone-1.4.4.zip: bad file descriptor
    ```
2. We provide two versions to the install scenario which causes a validation error
    ```
    scenario_install.go:66: only 1 version is expected to be set, got [v1.21.14 v1.22.11]
    ```

This PR fixes both issues.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```