### PR TITLE
Update golangci-lint image to v1.47.1

### DIFF
--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -125,7 +125,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.45.2
+        - image: golangci/golangci-lint:v1.47.1
           command:
             - make
           args:

--- a/pkg/cmd/proxy.go
+++ b/pkg/cmd/proxy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/pkg/errors"
@@ -97,6 +98,7 @@ func setupProxyTunnel(opts *proxyOpts) error {
 				http.Error(w, err.Error(), code)
 			}
 		}),
+		ReadHeaderTimeout: 1 * time.Minute,
 	}
 
 	fmt.Println("SSH tunnel started, please open another terminal and setup environment")

--- a/pkg/tasks/kubeadm_env.go
+++ b/pkg/tasks/kubeadm_env.go
@@ -33,13 +33,13 @@ type kubeadmFlagsModifier func(flags map[string]string)
 
 func updateKubeadmFlagsEnv(s *state.State, node *kubeoneapi.HostConfig) error {
 	modifiers := []kubeadmFlagsModifier{
-		updateKubeletNodeValues(s, node),
+		updateKubeletNodeValues(node),
 	}
 	if m := removeNetworkPluginFlagKubelet(s, node); m != nil {
 		modifiers = append(modifiers, m)
 	}
 
-	return updateKubeadmFlagsEnvFile(s, node, modifiers...)
+	return updateKubeadmFlagsEnvFile(s, modifiers...)
 }
 
 // removeNetworkPluginFlagKubelet removes --network-plugin flag from Kubelet
@@ -69,7 +69,7 @@ func removeNetworkPluginFlagKubelet(s *state.State, node *kubeoneapi.HostConfig)
 	}
 }
 
-func updateKubeletNodeValues(s *state.State, node *kubeoneapi.HostConfig) kubeadmFlagsModifier {
+func updateKubeletNodeValues(node *kubeoneapi.HostConfig) kubeadmFlagsModifier {
 	return func(flags map[string]string) {
 		if m := node.Kubelet.SystemReserved; m != nil {
 			flags["--system-reserved"] = kubeoneapi.MapStringStringToString(m, "=")
@@ -88,7 +88,7 @@ func updateKubeletNodeValues(s *state.State, node *kubeoneapi.HostConfig) kubead
 	}
 }
 
-func updateKubeadmFlagsEnvFile(s *state.State, node *kubeoneapi.HostConfig, modifiers ...kubeadmFlagsModifier) error {
+func updateKubeadmFlagsEnvFile(s *state.State, modifiers ...kubeadmFlagsModifier) error {
 	return updateRemoteFile(s, kubeadmEnvFlagsFile, func(content []byte) ([]byte, error) {
 		kubeletFlags, err := unmarshalKubeletFlags(content)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR updates the `golangci-lint` image to v1.47.1. This release re-enables some of the linters disabled because of Go 1.18 in the previous `golangci-lint` release.

There are three new lint errors. Two errors are related to unused function arguments. The third error is related to the `kubeone proxy` Server, which is fixed by adding `ReadHeaderTimeout` of 1 minute to the `kubeone proxy` Server:

```
pkg/cmd/proxy.go:82:13: G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```