### PR TITLE
default-storage-class: Fix logic for determining if the CSI driver is deployed

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -1,8 +1,5 @@
-{{ $version := semver .Config.Versions.Kubernetes }}
-{{ $csi := or .Config.CloudProvider.External (ge $version.Minor 23) }}
-
 {{ if eq .Config.CloudProvider.CloudProviderName "azure" }}
-{{ if $csi }}
+{{ if .DeployCSIAddon }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -34,7 +31,7 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-{{ if not $csi }}
+{{ if not .DeployCSIAddon }}
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
 {{ end }}
@@ -48,7 +45,7 @@ parameters:
 {{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "aws" }}
-{{ if $csi }}
+{{ if .DeployCSIAddon }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -66,7 +63,7 @@ volumeBindingMode: WaitForFirstConsumer
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-{{ if not $csi }}
+{{ if not .DeployCSIAddon }}
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
 {{ end }}
@@ -80,7 +77,7 @@ volumeBindingMode: WaitForFirstConsumer
 {{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "vsphere" }}
-{{ if $csi }}
+{{ if .DeployCSIAddon }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -104,7 +101,7 @@ deletionPolicy: Delete
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-{{ if not $csi }}
+{{ if not .DeployCSIAddon }}
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
 {{ end }}
@@ -138,7 +135,7 @@ provisioner: kubernetes.io/cinder
 {{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "gce" }}
-{{ if $csi }}
+{{ if .DeployCSIAddon }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -164,7 +161,7 @@ deletionPolicy: Delete
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-{{ if not $csi }}
+{{ if not .DeployCSIAddon }}
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
 {{ end }}

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -66,6 +66,7 @@ type templateData struct {
 	CCMClusterName                           string
 	CSIMigration                             bool
 	CSIMigrationFeatureGates                 string
+	DeployCSIAddon                           bool
 	MachineControllerCredentialsEnvVars      string
 	OperatingSystemManagerEnabled            bool
 	OperatingSystemManagerCredentialsEnvVars string
@@ -153,6 +154,9 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 		return nil, err
 	}
 
+	// Check are we deploying the CSI driver
+	deployCSI := len(ensureCSIAddons(s, []addonAction{})) > 0
+
 	data := templateData{
 		Config: s.Cluster,
 		Certificates: map[string]string{
@@ -167,6 +171,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 		CCMClusterName:                      s.LiveCluster.CCMClusterName,
 		CSIMigration:                        csiMigration,
 		CSIMigrationFeatureGates:            csiMigrationFeatureGates,
+		DeployCSIAddon:                      deployCSI,
 		MachineControllerCredentialsEnvVars: string(credsEnvVarsMC),
 		OperatingSystemManagerEnabled:       s.Cluster.OperatingSystemManagerEnabled(),
 		RegistryCredentials:                 containerdRegistryCredentials(s.Cluster.ContainerRuntime.Containerd),


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We are determining if the CSI driver-based StorageClass should be deployed based on if the external CCM is enabled or if the Kubernetes version is >= 1.23. However, this is not always correct. In the case of vSphere, we require the external CCM to be enabled and we ignore the Kubernetes version.

This PR fixes this issue by using the `ensureCSIAddons` function to determine if the CSI driver will be deployed or not.

**Does this PR introduce a user-facing change?**:
```release-note
Fix the logic for determining if the CSI driver is deployed in the default-storage-class addon. This fixes an issue with deploying the default-storage-class addon on vSphere clusters using the in-tree cloud provider
```