### PR TITLE
Fix invalid resource reference in azure terraform config

### DIFF
--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -20,8 +20,9 @@ provider "azurerm" {
 }
 
 locals {
-  kubeapi_endpoint   = var.disable_kubeapi_loadbalancer ? azurerm_network_interface.control_plane.0.private_ip_address : azurerm_public_ip.lbip.0.ip_address
-  loadbalancer_count = var.disable_kubeapi_loadbalancer ? 0 : 1
+  kubeapi_endpoint                   = var.disable_kubeapi_loadbalancer ? azurerm_network_interface.control_plane.0.private_ip_address : azurerm_public_ip.lbip.0.ip_address
+  loadbalancer_count                 = var.disable_kubeapi_loadbalancer ? 0 : 1
+  nic_address_pool_association_count = local.loadbalancer_count > 0 ? var.control_plane_vm_count : 0
 }
 
 provider "time" {
@@ -228,7 +229,7 @@ resource "azurerm_network_interface" "control_plane" {
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "control_plane" {
-  count = var.control_plane_vm_count
+  count = local.nic_address_pool_association_count
 
   ip_configuration_name   = "${var.cluster_name}-cp-${count.index}"
   network_interface_id    = element(azurerm_network_interface.control_plane.*.id, count.index)


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind question
-->
/kind bug

**What this PR does / why we need it**:
For azure, `azurerm_lb_backend_address_pool` will not be created when `disable_kubeapi_loadbalancer` is set to true. This relation was not being respected in case of the resource `azurerm_network_interface_backend_address_pool_association`, which in turn consumes `azurerm_lb_backend_address_pool`. 

```
  on main.tf line 235, in resource "azurerm_network_interface_backend_address_pool_association" "control_plane":
 235:   backend_address_pool_id = azurerm_lb_backend_address_pool.backend_pool.0.id
    ├────────────────
    │ azurerm_lb_backend_address_pool.backend_pool is empty tuple

The given key does not identify an element in this collection value: the
collection has no elements.

 +in dir: ../../examples/terraform/azure, [terraform apply -auto-approve -var disable_kubeapi_loadbalancer=true]

Error: Invalid index
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
