### PR TITLE
Improve kubeone-e2e image

### DIFF
--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,7 +14,7 @@
 
 # building image
 
-FROM golang:1.18.3 as builder
+FROM golang:1.18.4 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip
@@ -29,13 +29,16 @@ ENV SONOBUOY_VERSION "0.56.7"
 RUN curl -fL https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz | tar vxz
 RUN chmod +x sonobuoy
 
+ENV KUBECTL_VERSION="v1.23.9"
+RUN curl --fail -Lo kubectl https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
+RUN chmod +x kubectl
+
 COPY install-kube-tests-binaries.sh /opt/install-kube-tests-binaries.sh
 RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
-
-FROM golang:1.18.3
+FROM golang:1.18.4
 
 ARG version
 
@@ -47,6 +50,30 @@ LABEL maintainer="https://github.com/kubermatic/kubeone/blob/master/OWNERS"
 ENV KUBETESTS_ROOT "/opt/kube-test"
 ENV USER root
 
+# install base tools
+RUN apt-get update && \
+    apt-get install -y \
+      apt-transport-https \
+      bash \
+      bash-completion \
+      ca-certificates \
+      curl \
+      git \
+      htop \
+      make \
+      nano \
+      openssh-client \
+      rsync \
+      software-properties-common \
+      unzip \
+      vim \
+      zip
+
+# make bash much more pleasant to use
+COPY bashrc /root/.bashrc
+COPY htoprc /root/.config/htop/htoprc
+
 COPY --from=builder /usr/local/bin/terraform /usr/local/bin/terraform
 COPY --from=builder /download/sonobuoy /usr/local/bin/sonobuoy
+COPY --from=builder /download/kubectl /usr/local/bin/kubectl
 COPY --from=builder ${KUBETESTS_ROOT} ${KUBETESTS_ROOT}

--- a/hack/images/kubeone-e2e/bashrc
+++ b/hack/images/kubeone-e2e/bashrc
@@ -1,0 +1,26 @@
+# make sure Prow presets do not influence the current kubeconfig for
+# interactive debugging sessions
+unset KUBECONFIG
+
+source /usr/share/bash-completion/bash_completion
+alias k=kubectl
+source <(kubectl completion bash)
+source <(kubectl completion bash | sed s/kubectl/k/g)
+
+cn() {
+    kubectl config set-context $(kubectl config current-context) --namespace=$1
+}
+
+kcfg() {
+    export KUBECONFIG="$1"
+}
+
+eval "$(ssh-agent)"
+
+# suuuper ugly hack to make "watch" also respect aliases, so "watch k get pods" works
+alias watch='watch '
+alias ls='ls -lh --file-type --group-directories-first'
+alias l='ls -lh --file-type --group-directories-first'
+alias ll='ls -lh --file-type --group-directories-first'
+alias cd..='cd ..'
+alias ..='cd ..'

--- a/hack/images/kubeone-e2e/htoprc
+++ b/hack/images/kubeone-e2e/htoprc
@@ -1,0 +1,5 @@
+hide_kernel_threads=1
+hide_userland_threads=1
+highlight_base_name=1
+tree_view=1
+tree_view_always_by_pid=1

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,10 +17,10 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.21"]="v1.21.12"
-full_versions["1.22"]="v1.22.9"
-full_versions["1.23"]="v1.23.6"
-full_versions["1.24"]="v1.24.0"
+full_versions["1.21"]="v1.21.14"
+full_versions["1.22"]="v1.22.12"
+full_versions["1.23"]="v1.23.9"
+full_versions["1.24"]="v1.24.3"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.23
+TAG=v0.1.24
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR introduces various improvements to the `kubeone-e2e` image:

* Install `kubectl`
* Install various packages such as text editors, `curl`, and more
* Add `bashrc` and `htoprc` to improve the usability of those tools
* Update Kubernetes binaries to their latest versions

Additionally, the image is now based on Go 1.18.4. I'll update other images in a follow-up PR.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```