### PR TITLE
Update Kubernetes versions used in the old E2E tests

### DIFF
--- a/.prow/1.21.yaml
+++ b/.prow/1.21.yaml
@@ -18,7 +18,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -43,7 +43,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -68,7 +68,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -93,7 +93,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -120,7 +120,7 @@ presubmits:
             - name: PROVIDER
               value: "equinixmetal"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -145,7 +145,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -172,9 +172,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -200,9 +200,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -228,9 +228,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -256,9 +256,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -286,9 +286,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -314,9 +314,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.12"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN

--- a/.prow/1.22.yaml
+++ b/.prow/1.22.yaml
@@ -20,7 +20,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -47,7 +47,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -74,7 +74,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -101,7 +101,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -130,7 +130,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -157,7 +157,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -184,9 +184,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -212,9 +212,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -240,9 +240,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -268,9 +268,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -298,9 +298,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.9"
+              value: "1.22.12"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN

--- a/.prow/1.23.yaml
+++ b/.prow/1.23.yaml
@@ -20,7 +20,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -47,7 +47,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_CONFIG_API_VERSION
               value: "v1beta1"
             - name: KUBEONE_TEST_RUN
@@ -76,7 +76,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -103,7 +103,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -130,7 +130,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -159,7 +159,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -186,7 +186,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -213,9 +213,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -241,9 +241,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -269,9 +269,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -297,9 +297,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -327,9 +327,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.23.6"
+              value: "1.23.9"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN

--- a/.prow/1.24.yaml
+++ b/.prow/1.24.yaml
@@ -20,7 +20,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -47,7 +47,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: TEST_CONFIG_API_VERSION
               value: "v1beta1"
             - name: KUBEONE_TEST_RUN
@@ -76,7 +76,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -103,7 +103,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -130,7 +130,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -159,7 +159,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -186,7 +186,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.24.0"
+              value: "1.24.3"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Update the Kubernetes versions used in the old E2E tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```