### PR TITLE
Disable --configure-cloud-routes on Azure CCM

### DIFF
--- a/addons/ccm-azure/ccm-azure.yaml
+++ b/addons/ccm-azure/ccm-azure.yaml
@@ -172,7 +172,7 @@ spec:
             - "--cloud-provider=azure"
             - "--cluster-name={{ .Config.Name }}"
             - "--controllers=*,-cloud-node" # disable cloud-node controller
-            - "--configure-cloud-routes=true" # "false" for Azure CNI and "true" for other network plugins
+            - "--configure-cloud-routes=false" # "false" because we use VXLAN overlay
             - "--leader-elect=true"
             - "--route-reconciliation-period=10s"
             - "--v=4"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Azure CCM is crashlooping because we have `--configure-cloud-routes` enabled, however, the Cluster CIDR is not provided:

```
I0724 11:53:43.518721       1 controllermanager.go:366] Starting "route"
E0724 11:53:43.518882       1 controllermanager.go:369] Error starting "route": failed to parse cidr value:"" with error:invalid CIDR address:
F0724 11:53:43.518898       1 controllermanager.go:343] error running controllers: failed to parse cidr value:"" with error:invalid CIDR address:
```

Recently, we removed the `-cluster-cidr` flag as part of #2106, but we didn't disable the routes controller. In KKP, we fixed this by disabling the routes controller, so this PR proposes the same fix for KubeOne.

The idea behind this fix is that we use VXLAN overlay, so we don't need CCM to manage cloud routes. This should work well if Canal, Calico VXLAN, or Cilium is used, but there might be a problem if someone uses some external CNI without VXLAN overlay. We might have to consider adding some option to enable this flag if needed, but that's yet to be discussed.

**Does this PR introduce a user-facing change?**:
```release-note
Disable `--configure-cloud-routes` on Azure CCM to fix errors when starting the CCM
```

/assign @rastislavs 