### PR TITLE
[release/v1.4] Upgrade OpenStack CCM and Cinder CSI for Kubernetes 1.23 clusters

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -281,7 +281,7 @@ func optionalResources() map[Resource]map[string]string {
 			"1.20.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2",
 			"1.21.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0",
 			"1.22.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0",
-			">= 1.23.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.0",
+			">= 1.23.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.4",
 		},
 
 		// OpenStack CSI
@@ -290,7 +290,7 @@ func optionalResources() map[Resource]map[string]string {
 			"1.20.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.3",
 			"1.21.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.21.0",
 			"1.22.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
-			">= 1.23.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.0",
+			">= 1.23.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.4",
 		},
 
 		// Equinix Metal CCM


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR is a manual cherry-pick of #2195.

Update OpenStack CCM and Cinder CSI to v1.23.4 for Kubernetes 1.23 clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2150 

**Does this PR introduce a user-facing change?**:
```release-note
Update OpenStack CCM and Cinder CSI to v1.23.4 for Kubernetes 1.23 clusters
```

/assign @ahmedwaleedmalik 