### PR TITLE
Revert "Upgrade OpenStack CCM and Cinder CSI for Kubernetes 1.24 and 1.23 clusters"

### DIFF
--- a/addons/csi-openstack-cinder/controllerplugin.yaml
+++ b/addons/csi-openstack-cinder/controllerplugin.yaml
@@ -145,12 +145,6 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
-            - mountPath: /etc/ssl/certs
-              name: ca-certs
-              readOnly: true
-            - mountPath: /usr/share/ca-certificates
-              name: usr-ca-certs
-              readOnly: true
 {{ if .Config.CABundle }}
 {{ caBundleVolumeMount | indent 12 }}
 {{ end }}
@@ -160,14 +154,6 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
-        - name: ca-certs
-          hostPath:
-            path: /etc/ssl/certs
-            type: DirectoryOrCreate
-        - hostPath:
-            path: /usr/share/ca-certificates
-            type: DirectoryOrCreate
-          name: usr-ca-certs
 {{ if .Config.CABundle }}
 {{ caBundleVolume | indent 8 }}
 {{ end }}

--- a/addons/csi-openstack-cinder/nodeplugin.yaml
+++ b/addons/csi-openstack-cinder/nodeplugin.yaml
@@ -111,12 +111,6 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
-            - mountPath: /etc/ssl/certs
-              name: ca-certs
-              readOnly: true
-            - mountPath: /usr/share/ca-certificates
-              name: usr-ca-certs
-              readOnly: true
 {{ if .Config.CABundle }}
 {{ caBundleVolumeMount | indent 12 }}
 {{ end }}
@@ -140,14 +134,6 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
-        - name: ca-certs
-          hostPath:
-            path: /etc/ssl/certs
-            type: DirectoryOrCreate
-        - hostPath:
-            path: /usr/share/ca-certificates
-            type: DirectoryOrCreate
-          name: usr-ca-certs
 {{ if .Config.CABundle }}
 {{ caBundleVolume | indent 8 }}
 {{ end }}

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -310,8 +310,8 @@ func optionalResources() map[Resource]map[string]string {
 			"1.20.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.20.2",
 			"1.21.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.21.0",
 			"1.22.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0",
-			"1.23.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.3",
-			">= 1.24.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.2",
+			"1.23.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.1",
+			">= 1.24.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.0",
 		},
 
 		// OpenStack CSI
@@ -319,8 +319,8 @@ func optionalResources() map[Resource]map[string]string {
 			"1.20.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.20.3",
 			"1.21.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.21.0",
 			"1.22.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
-			"1.23.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.3",
-			">= 1.24.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.24.2",
+			"1.23.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.0",
+			">= 1.24.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.24.0",
 		},
 		OpenstackCSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
 		OpenstackCSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.6.0"},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

This PR is a temporary revert of #2151

It appears that the latest few OpenStack CCM and Cinder CSI releases are broken:

* https://github.com/kubernetes/cloud-provider-openstack/issues/1948 -- we managed to mitigate this one, but it might be a regression
* https://github.com/kubernetes/cloud-provider-openstack/issues/1938 -- this one prevents volumes from being attached and there's no known mitigation

```
  Warning  FailedMount             5m52s (x8 over 6m57s)  kubelet                  MountVolume.MountDevice failed for volume "pvc-398a4281-c3e6-490e-b62a-34ceadf8341e" : rpc error: code = Internal desc = failed to get disk format of disk /dev/disk/by-id/virtio-63083dd1-3bce-4212-8: executable file not found in $PATH
```

To be on the safe side, this PR proposes reverting updates, so we use releases that are known to work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2150 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @ahmedwaleedmalik 