### PR TITLE
[release/v1.4] Revert "Update Calico VXLAN addon to v3.22.4"

### DIFF
--- a/addons/calico-vxlan/calico-vxlan.yaml
+++ b/addons/calico-vxlan/calico-vxlan.yaml
@@ -4201,7 +4201,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ Registry "quay.io" }}/calico/cni:v3.22.4
+          image: {{ Registry "quay.io" }}/calico/cni:v3.22.2
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -4228,7 +4228,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ Registry "quay.io" }}/calico/cni:v3.22.4
+          image: {{ Registry "quay.io" }}/calico/cni:v3.22.2
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4269,42 +4269,18 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         # - name: flexvol-driver
-        #   image: {{ Registry "docker.io" }}/calico/pod2daemon-flexvol:v3.22.4
+        #   image: {{ Registry "docker.io" }}/calico/pod2daemon-flexvol:v3.22.2
         #   volumeMounts:
         #   - name: flexvol-driver-host
         #     mountPath: /host/driver
         #   securityContext:
         #     privileged: true
-        # This init container mounts the necessary filesystems needed by the BPF data plane
-        # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
-        # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
-        - name: "mount-bpffs"
-          image: {{ Registry "quay.io" }}/calico/node:v3.22.4
-          command: ["calico-node", "-init", "-best-effort"]
-          volumeMounts:
-            - mountPath: /sys/fs
-              name: sys-fs
-              # Bidirectional is required to ensure that the new mount we make at /sys/fs/bpf propagates to the host
-              # so that it outlives the init container.
-              mountPropagation: Bidirectional
-            - mountPath: /var/run/calico
-              name: var-run-calico
-              # Bidirectional is required to ensure that the new mount we make at /run/calico/cgroup propagates to the host
-              # so that it outlives the init container.
-              mountPropagation: Bidirectional
-            # Mount /proc/ from host which usually is an init program at /nodeproc. It's needed by mountns binary,
-            # executed by calico-node, to mount root cgroup2 fs at /run/calico/cgroup to attach CTLB programs correctly.
-            - mountPath: /nodeproc
-              name: nodeproc
-              readOnly: true
-          securityContext:
-            privileged: true
       containers:
         # Runs calico-node container on each Kubernetes node. This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ Registry "quay.io" }}/calico/node:v3.22.4
+          image: {{ Registry "quay.io" }}/calico/node:v3.22.2
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4358,6 +4334,9 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: veth_mtu
+            # Disable AWS source-destination check on nodes.
+            # - name: FELIX_AWSSRCDSTCHECK
+            #   value: Disable
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
@@ -4422,8 +4401,11 @@ spec:
               mountPath: /var/run/nodeagent
             # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
             # parent directory.
-            - name: bpffs
-              mountPath: /sys/fs/bpf
+            - name: sysfs
+              mountPath: /sys/fs/
+              # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
+              # If the host is known to mount that filesystem already then Bidirectional can be omitted.
+              mountPropagation: Bidirectional
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -4442,18 +4424,10 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
-        - name: sys-fs
+        - name: sysfs
           hostPath:
             path: /sys/fs/
             type: DirectoryOrCreate
-        - name: bpffs
-          hostPath:
-            path: /sys/fs/bpf
-            type: Directory
-        # mount /proc at /nodeproc to be used by mount-bpffs initContainer to mount root cgroup2 fs.
-        - name: nodeproc
-          hostPath:
-            path: /proc
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -4526,7 +4500,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ Registry "quay.io" }}/calico/kube-controllers:v3.22.4
+          image: {{ Registry "quay.io" }}/calico/kube-controllers:v3.22.2
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
**What type of PR is this?**

/kind regression

**What this PR does / why we need it**:

We found some issues while testing Calico VXLAN in #2188 so we're reverting this update to be on the safe side.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2119 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```