### PR TITLE
[release/v1.43] Update machine-controller to v1.43.4

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -178,7 +178,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:        {"*": "quay.io/calico/node:v3.22.4"},
 		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
 		Flannel:           {"*": "quay.io/coreos/flannel:v0.15.1"},
-		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.43.3"},
+		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.43.4"},
 		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Update machine-controller to v1.43.4.

This machine-controller release fixes an issue with finding Node objects by ProviderID.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.43.4. This machine-controller release fixes an issue with finding Node objects by ProviderID
```

/assign @kron4eg 