### PR TITLE
Openstack: Tenant ID/Name is not required with application credentials

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,7 +93,7 @@ issues:
     text: "`registry` always receives `\"127.0.0.1:5000\"`"
 
   - path: pkg/credentials
-    text: "cyclomatic complexity 34 of func `openstackValidationFunc` is high"
+    text: "cyclomatic complexity 36 of func `openstackValidationFunc` is high"
 
   - path: pkg/apis/kubeone
     text: "cyclomatic complexity 31 of func `ValidateCloudProviderSpec` is high"

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -560,16 +560,19 @@ func openstackValidationFunc(creds map[string]string) error {
 		}
 	}
 
-	if v, ok := creds[OpenStackTenantID]; !ok || len(v) == 0 {
-		if v, ok := creds[OpenStackTenantName]; !ok || len(v) == 0 {
-			return fail.CredentialsError{
-				Op:       "validating",
-				Provider: "Openstack",
-				Err: errors.Errorf(
-					"key %v or %v is required but isn't present",
-					OpenStackTenantID,
-					OpenStackTenantName,
-				),
+	// Tenant ID/Name are not required when using application credentials
+	if userCredsUsernameOkay && userCredsPasswordOkay {
+		if v, ok := creds[OpenStackTenantID]; !ok || len(v) == 0 {
+			if v, ok := creds[OpenStackTenantName]; !ok || len(v) == 0 {
+				return fail.CredentialsError{
+					Op:       "validating",
+					Provider: "Openstack",
+					Err: errors.Errorf(
+						"key %v or %v is required but isn't present",
+						OpenStackTenantID,
+						OpenStackTenantName,
+					),
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind question
-->
/kind bug

**What this PR does / why we need it**:
Currently, `OS_TENANT_NAME` or `OS_TENANT_ID` are mandatory environment variables when working with the Openstack cloud provider. Although these environment variables are not required or used when we are specifying application credentials.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Tenant ID or Name is not required when using application credentials
```
