### PR TITLE
Force regenerating CSRs for Kubelet serving certificates after CCM is deployed

### DIFF
--- a/pkg/scripts/ccm_csi_migration.go
+++ b/pkg/scripts/ccm_csi_migration.go
@@ -35,10 +35,6 @@ var (
 		sudo kubeadm {{ .VERBOSE }} init phase kubelet-start \
 			--config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
 	`)
-
-	ccmMigrationRestartKubelet = heredoc.Doc(`
-		sudo systemctl restart kubelet
-	`)
 )
 
 func CCMMigrationRegenerateControlPlaneManifests(workdir string, nodeID int, verboseFlag string) (string, error) {
@@ -59,10 +55,4 @@ func CCMMigrationUpdateKubeletConfig(workdir string, nodeID int, verboseFlag str
 	})
 
 	return result, fail.Runtime(err, "rendering ccmMigrationUpdateKubeletConfig")
-}
-
-func CCMMigrationRestartKubelet() (string, error) {
-	result, err := Render(ccmMigrationRestartKubelet, Data{})
-
-	return result, fail.Runtime(err, "rendering ccmMigrationRestartKubelet script")
 }

--- a/pkg/scripts/node.go
+++ b/pkg/scripts/node.go
@@ -51,6 +51,10 @@ var (
 		fi
 	{{ end }}
 	`)
+
+	restartKubeletTemplate = heredoc.Doc(`
+		sudo systemctl restart kubelet
+	`)
 )
 
 func Hostname() string {
@@ -63,4 +67,8 @@ func RestartKubeAPIServerCrictl(ensure bool) (string, error) {
 	})
 
 	return result, fail.Runtime(err, "rendering restartKubeAPIServerCrictlTemplate script")
+}
+
+func RestartKubelet() string {
+	return restartKubeletTemplate
 }

--- a/pkg/tasks/ccm_csi_migration.go
+++ b/pkg/tasks/ccm_csi_migration.go
@@ -209,12 +209,7 @@ func ccmMigrationUpdateStaticWorkersKubeletConfigInternal(s *state.State, node *
 
 	// Restart Kubelet
 	logger.Info("Restarting Kubelet...")
-	script, err := scripts.CCMMigrationRestartKubelet()
-	if err != nil {
-		return err
-	}
-
-	_, _, err = s.Runner.RunRaw(script)
+	_, _, err := s.Runner.RunRaw(scripts.RestartKubelet())
 	if err != nil {
 		return fail.SSH(err, "restarting kubelet for CCM migration")
 	}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -171,6 +171,31 @@ func WithFullInstall(t Tasks) Tasks {
 		append(WithResources(nil)...).
 		append(
 			Task{
+				// Node might emit one more CSR for kubelet serving certificates
+				// after external CCM initializes the node. That's because
+				// CCM modifies IP addresses in the Node object to properly set
+				// private and public addresses, DNS names, etc...
+				// To ensure that we approve those CSRs, we need to force kubelet
+				// to generate new CSRs as soon as possible, and then approve
+				// those new CSRs.
+				// NB: We intentionally do this only on FullInstall because in
+				// other cases we already have CCM deployed, so this is not
+				// an issue. Additionally, we do this only for control plane
+				// nodes because static workers are joined after the CCM is
+				// deployed.
+				Fn: func(s *state.State) error {
+					if err := restartKubeletOnControlPlane(s); err != nil {
+						return err
+					}
+
+					return s.RunTaskOnAllNodes(approvePendingCSR, true)
+				},
+				Operation: "removing old and approving new kubelet CSRs",
+				Predicate: func(s *state.State) bool { return s.Cluster.CloudProvider.External },
+			},
+		).
+		append(
+			Task{
 				Fn:        createMachineDeployments,
 				Operation: "creating worker machines",
 				Predicate: func(s *state.State) bool { return !s.LiveCluster.IsProvisioned() },


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Our current CSR approval workflow is that we approve CSRs for Kubelet serving certificates after the node joins the cluster.

This doesn't work well when the external CCM is used. That's because when external CCM initializes nodes, Node objects are updated with proper internal and external IP addresses, DNS names, and so on. That's causing Kubelet to invalidate old serving certificates and request new ones.

Kubelet logs on verbosity level 4 confirm this:

```
Jul 27 19:21:59 marko-1-control-plane-3 kubelet[53194]: I0727 19:21:59.986617   53194 certificate_manager.go:270] kubernetes.io/kubelet-serving: Current certificate is missing requested IP addresses [162.55.51.125]
Jul 27 19:21:59 marko-1-control-plane-3 kubelet[53194]: I0727 19:21:59.987715   53194 certificate_manager.go:270] kubernetes.io/kubelet-serving: Certificate template changed, rotating
Jul 27 19:21:59 marko-1-control-plane-3 kubelet[53194]: I0727 19:21:59.988216   53194 certificate_manager.go:270] kubernetes.io/kubelet-serving: Rotating certificates
Jul 27 19:22:00 marko-1-control-plane-3 kubelet[53194]: I0727 19:22:00.018338   53194 reflector.go:219] Starting reflector *v1.CertificateSigningRequest (0s) from k8s.io/client-go/tools/watch/informerwatcher.go:146
Jul 27 19:22:00 marko-1-control-plane-3 kubelet[53194]: I0727 19:22:00.018736   53194 reflector.go:255] Listing and watching *v1.CertificateSigningRequest from k8s.io/client-go/tools/watch/informerwatcher.go:146
Jul 27 19:22:00 marko-1-control-plane-3 kubelet[53194]: I0727 19:22:00.988711   53194 certificate_manager.go:270] kubernetes.io/kubelet-serving: Current certificate is missing requested IP addresses [162.55.51.125]
```

This issue is fixed by restarting Kubelet on all control plane nodes after CCM initializes nodes. Kubelet will automatically generate new CSRs when starting, which we approve after a minute or so (we give some time to be sure that all CSRs soaked in). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2114 

**Does this PR introduce a user-facing change?**:
```release-note
Force regenerating CSRs for Kubelet serving certificates after CCM is deployed. This fixes an issue with Kubelet generating CSRs that are stuck in Pending.
```