### PR TITLE
Add external Cloud Provider and CSI migration flags to OSM

### DIFF
--- a/addons/operating-system-manager/deployment-controller.yaml
+++ b/addons/operating-system-manager/deployment-controller.yaml
@@ -48,6 +48,12 @@ spec:
             - -namespace=kube-system
             - -container-runtime={{ .Config.ContainerRuntime }}
             - -pause-image={{ .InternalImages.Get "PauseImage" }}
+            {{ if .Config.CloudProvider.External }}
+            - -external-cloud-provider
+            {{ end }}
+            {{ if .CSIMigrationFeatureGates }}
+            - -node-kubelet-feature-gates={{ .CSIMigrationFeatureGates }}
+            {{ end }}
             {{ range .Config.ContainerRuntime.MachineControllerFlags -}}
             - {{ . }}
             {{ end -}}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR ensures we properly propagate external cloud provider and CSI migration options to OSM.

**Does this PR introduce a user-facing change?**:
```release-note
Properly propagate external cloud provider and CSI migration options to OSM
```