### PR TITLE
[release/v1.4] Force regenerating CSRs after CCM is deployed

### DIFF
--- a/pkg/scripts/ccm_csi_migration.go
+++ b/pkg/scripts/ccm_csi_migration.go
@@ -31,10 +31,6 @@ var (
 		sudo kubeadm {{ .VERBOSE }} init phase kubelet-start \
 			--config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
 	`)
-
-	ccmMigrationRestartKubelet = heredoc.Doc(`
-		sudo systemctl restart kubelet
-	`)
 )
 
 func CCMMigrationRegenerateControlPlaneManifests(workdir string, nodeID int, verboseFlag string) (string, error) {
@@ -51,8 +47,4 @@ func CCMMigrationUpdateKubeletConfig(workdir string, nodeID int, verboseFlag str
 		"NODE_ID":  nodeID,
 		"VERBOSE":  verboseFlag,
 	})
-}
-
-func CCMMigrationRestartKubelet() (string, error) {
-	return Render(ccmMigrationRestartKubelet, Data{})
 }

--- a/pkg/scripts/node.go
+++ b/pkg/scripts/node.go
@@ -47,6 +47,10 @@ var (
 		fi
 	{{ end }}
 	`)
+
+	restartKubeletTemplate = heredoc.Doc(`
+		sudo systemctl restart kubelet
+	`)
 )
 
 func Hostname() string {
@@ -57,4 +61,8 @@ func RestartKubeAPIServerCrictl(ensure bool) (string, error) {
 	return Render(restartKubeAPIServerCrictlTemplate, Data{
 		"ENSURE": ensure,
 	})
+}
+
+func RestartKubelet() string {
+	return restartKubeletTemplate
 }

--- a/pkg/tasks/ccm_csi_migration.go
+++ b/pkg/tasks/ccm_csi_migration.go
@@ -207,12 +207,7 @@ func ccmMigrationUpdateStaticWorkersKubeletConfigInternal(s *state.State, node *
 
 	// Restart Kubelet
 	logger.Info("Restarting Kubelet...")
-	script, err := scripts.CCMMigrationRestartKubelet()
-	if err != nil {
-		return err
-	}
-
-	_, _, err = s.Runner.RunRaw(script)
+	_, _, err := s.Runner.RunRaw(scripts.RestartKubelet())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is a manual cherry-pick of #2199 to the `release/v1.4` branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2114

**Does this PR introduce a user-facing change?**:
```release-note
Force regenerating CSRs for Kubelet serving certificates after CCM is deployed. This fixes an issue with Kubelet generating CSRs that are stuck in Pending.
```