### PR TITLE
Fix tolerations for metrics-server

### DIFF
--- a/addons/metrics-server/metrics-server.yaml
+++ b/addons/metrics-server/metrics-server.yaml
@@ -123,7 +123,12 @@ spec:
         k8s-app: metrics-server
     spec:
       tolerations:
-        - operator: Exists
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       serviceAccountName: metrics-server
       volumes:
       # mount in tmp so we can safely use from-scratch images and/or read-only containers


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently, metrics-server is tolerating everything with:

```yaml
tolerations:
  - operator: Exists
```

This is breaking eviction because this toleration ignores it. This toleration is not present in the upstream manifests, nor in KKP, so I believe this is some leftover. Considering that, this PR proposes replacing that toleration with the control plane tolerations, so metrics-server can run on control plane nodes if needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2153

**Does this PR introduce a user-facing change?**:
```release-note
Replace `operator: Exists` toleration with the control plane tolerations for metrics-server. This fixes an issue with metrics-server pods breaking eviction
```