### PR TITLE
Rollout pods if credentials are changed

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -39,6 +39,7 @@
 - Enable the etcd integrity checks (on startup and every 4 hours) for Kubernetes 1.22+ clusters. See the official etcd announcement for more details (https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ). ([#1907](https://github.com/kubermatic/kubeone/pull/1907), [@xmudrii](https://github.com/xmudrii))
 - Add `kubeone local` subcommand used to provision single-node Kubernetes cluster on current machine ([#2125](https://github.com/kubermatic/kubeone/pull/2125), [@kron4eg](https://github.com/kron4eg))
 - Implement the `kubeone config dump` command used to merge the KubeOneCluster manifest with the Terraform output. The resulting (merged) manifest is printed to stdout. ([#1874](https://github.com/kubermatic/kubeone/pull/1874), [@xmudrii](https://github.com/xmudrii))
+- Rollout pods that are using `kubeone-*-credentials` Secrets if credentials are changed ([#2214](https://github.com/kubermatic/kubeone/pull/2214), [@xmudrii](https://github.com/xmudrii))
 - Error reporting in CLI now exists with different codes for different error reasons ([#1882](https://github.com/kubermatic/kubeone/pull/1882), [@kron4eg](https://github.com/kron4eg))
 - More error handling with new error types ([#1890](https://github.com/kubermatic/kubeone/pull/1890), [@kron4eg](https://github.com/kron4eg))
 - Add dedicated error type (and error code) for exec adapter ([#2139](https://github.com/kubermatic/kubeone/pull/2139), [@kron4eg](https://github.com/kron4eg))

--- a/addons/ccm-digitalocean/ccm-digitalocean.yaml
+++ b/addons/ccm-digitalocean/ccm-digitalocean.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: digitalocean-cloud-controller-manager
+      annotations:
+        "credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       priorityClassName: system-cluster-critical
       dnsPolicy: Default

--- a/addons/ccm-digitalocean/ccm-digitalocean.yaml
+++ b/addons/ccm-digitalocean/ccm-digitalocean.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: digitalocean-cloud-controller-manager
       annotations:
-        "credentials-hash": "{{ .CredentialsCCMHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       priorityClassName: system-cluster-critical
       dnsPolicy: Default

--- a/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
+++ b/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: equinixmetal-cloud-controller-manager
       annotations:
-        "credentials-hash": "{{ .CredentialsCCMHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       dnsPolicy: Default
       hostNetwork: true

--- a/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
+++ b/addons/ccm-equinixmetal/ccm-equinixmetal.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         app: equinixmetal-cloud-controller-manager
+      annotations:
+        "credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       dnsPolicy: Default
       hostNetwork: true

--- a/addons/ccm-hetzner/ccm-hetzner.yaml
+++ b/addons/ccm-hetzner/ccm-hetzner.yaml
@@ -33,6 +33,8 @@ spec:
     metadata:
       labels:
         app: hcloud-cloud-controller-manager
+      annotations:
+        "credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager

--- a/addons/ccm-hetzner/ccm-hetzner.yaml
+++ b/addons/ccm-hetzner/ccm-hetzner.yaml
@@ -34,7 +34,7 @@ spec:
       labels:
         app: hcloud-cloud-controller-manager
       annotations:
-        "credentials-hash": "{{ .CredentialsCCMHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager

--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -163,8 +163,8 @@ spec:
   template:
     metadata:
       annotations:
-        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
-        "cloudConfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
+        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "kubeone.k8c.io/cloudconfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
       labels:
         k8s-app: "openstack-cloud-controller-manager"
     spec:

--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -163,8 +163,8 @@ spec:
   template:
     metadata:
       annotations:
-         "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
-         "cloudConfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
+        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "cloudConfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
       labels:
         k8s-app: "openstack-cloud-controller-manager"
     spec:

--- a/addons/ccm-vsphere/ccm-vsphere.yaml
+++ b/addons/ccm-vsphere/ccm-vsphere.yaml
@@ -160,8 +160,8 @@ spec:
         component: cloud-controller-manager
         tier: control-plane
       annotations:
-        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
-        "cloudConfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
+        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "kubeone.k8c.io/cloudconfig-hash": "{{ .Config.CloudProvider.CloudConfig | sha256sum }}"
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:

--- a/addons/csi-digitalocean/driver.yaml
+++ b/addons/csi-digitalocean/driver.yaml
@@ -45,6 +45,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: csi-do-plugin
+        "credentials-hash": "{{ .CredentialsCCMHash }}"
       labels:
         app: csi-do-controller
         role: csi-do

--- a/addons/csi-digitalocean/driver.yaml
+++ b/addons/csi-digitalocean/driver.yaml
@@ -45,7 +45,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: csi-do-plugin
-        "credentials-hash": "{{ .CredentialsCCMHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .CredentialsCCMHash }}"
       labels:
         app: csi-do-controller
         role: csi-do

--- a/addons/csi-gcp-compute-persistent/controller.yaml
+++ b/addons/csi-gcp-compute-persistent/controller.yaml
@@ -13,7 +13,7 @@ spec:
       labels:
         app: gcp-compute-persistent-disk-csi-driver
       annotations:
-        "credentials-hash": "{{ .CredentialsCCMHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       # Host network must be used for interaction with Workload Identity in GKE
       # since it replaces GCE Metadata Server with GKE Metadata Server. Remove

--- a/addons/csi-gcp-compute-persistent/controller.yaml
+++ b/addons/csi-gcp-compute-persistent/controller.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app: gcp-compute-persistent-disk-csi-driver
+      annotations:
+        "credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       # Host network must be used for interaction with Workload Identity in GKE
       # since it replaces GCE Metadata Server with GKE Metadata Server. Remove

--- a/addons/csi-hetzner/hcloud-csi.yml
+++ b/addons/csi-hetzner/hcloud-csi.yml
@@ -110,7 +110,7 @@ spec:
       labels:
         app: hcloud-csi-controller
       annotations:
-        "credentials-hash": "{{ .CredentialsCCMHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       serviceAccount: hcloud-csi
       tolerations:
@@ -222,7 +222,7 @@ spec:
       labels:
         app: hcloud-csi
       annotations:
-        "credentials-hash": "{{ .CredentialsCCMHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       tolerations:
         - effect: NoExecute

--- a/addons/csi-hetzner/hcloud-csi.yml
+++ b/addons/csi-hetzner/hcloud-csi.yml
@@ -109,6 +109,8 @@ spec:
     metadata:
       labels:
         app: hcloud-csi-controller
+      annotations:
+        "credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       serviceAccount: hcloud-csi
       tolerations:
@@ -219,6 +221,8 @@ spec:
     metadata:
       labels:
         app: hcloud-csi
+      annotations:
+        "credentials-hash": "{{ .CredentialsCCMHash }}"
     spec:
       tolerations:
         - effect: NoExecute

--- a/addons/csi-nutanix/ntnx-csi-controller-deployment.yaml
+++ b/addons/csi-nutanix/ntnx-csi-controller-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         app: nutanix-csi-controller
       annotations:
-        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
     spec:
       affinity:
         podAntiAffinity:

--- a/addons/csi-nutanix/ntnx-csi-node-ds.yaml
+++ b/addons/csi-nutanix/ntnx-csi-node-ds.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: nutanix-csi-node
       annotations:
-        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
     spec:
       serviceAccount: nutanix-csi-node
       hostNetwork: true

--- a/addons/csi-vsphere/validatingwebhook.yaml
+++ b/addons/csi-vsphere/validatingwebhook.yaml
@@ -127,7 +127,7 @@ spec:
         app: vsphere-csi-webhook
         role: vsphere-csi-webhook
       annotations:
-        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
         "csiConfig-hash": "{{ .Config.CloudProvider.CSIConfig | sha256sum }}"
     spec:
       serviceAccountName: vsphere-csi-webhook

--- a/addons/csi-vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi-vsphere/vsphere-csi-driver.yaml
@@ -216,7 +216,7 @@ spec:
         app: vsphere-csi-controller
         role: vsphere-csi
       annotations:
-        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
         "csiConfig-hash": "{{ .Config.CloudProvider.CSIConfig | sha256sum }}"
     spec:
       affinity:
@@ -443,7 +443,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
       annotations:
-        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
         "csiConfig-hash": "{{ .Config.CloudProvider.CSIConfig | sha256sum }}"
     spec:
       nodeSelector:

--- a/addons/machinecontroller/deployment-controller.yaml
+++ b/addons/machinecontroller/deployment-controller.yaml
@@ -16,8 +16,8 @@ spec:
         "prometheus.io/scrape": "true"
         "prometheus.io/port": "8080"
         "prometheus.io/path": "/metrics"
-        "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
-        "credentials-hash": "{{ .MachineControllerCredentialsHash }}"
+        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .MachineControllerCredentialsHash }}"
       labels:
         app: machine-controller
     spec:

--- a/addons/machinecontroller/deployment-controller.yaml
+++ b/addons/machinecontroller/deployment-controller.yaml
@@ -17,6 +17,7 @@ spec:
         "prometheus.io/port": "8080"
         "prometheus.io/path": "/metrics"
         "caBundle-hash": "{{ .Config.CABundle | sha256sum }}"
+        "credentials-hash": "{{ .MachineControllerCredentialsHash }}"
       labels:
         app: machine-controller
     spec:

--- a/addons/machinecontroller/webhook.yaml
+++ b/addons/machinecontroller/webhook.yaml
@@ -58,7 +58,7 @@ spec:
       labels:
         app: machine-controller-webhook
       annotations:
-        "credentials-hash": "{{ .MachineControllerCredentialsHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .MachineControllerCredentialsHash }}"
     spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""

--- a/addons/machinecontroller/webhook.yaml
+++ b/addons/machinecontroller/webhook.yaml
@@ -57,6 +57,8 @@ spec:
     metadata:
       labels:
         app: machine-controller-webhook
+      annotations:
+        "credentials-hash": "{{ .MachineControllerCredentialsHash }}"
     spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""

--- a/addons/operating-system-manager/deployment-controller.yaml
+++ b/addons/operating-system-manager/deployment-controller.yaml
@@ -16,7 +16,7 @@ spec:
         "prometheus.io/scrape": "true"
         "prometheus.io/port": "8080"
         "prometheus.io/path": "/metrics"
-        "credentials-hash": "{{ .OperatingSystemManagerCredentialsHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .OperatingSystemManagerCredentialsHash }}"
       labels:
         app: operating-system-manager
     spec:

--- a/addons/operating-system-manager/deployment-controller.yaml
+++ b/addons/operating-system-manager/deployment-controller.yaml
@@ -16,6 +16,7 @@ spec:
         "prometheus.io/scrape": "true"
         "prometheus.io/port": "8080"
         "prometheus.io/path": "/metrics"
+        "credentials-hash": "{{ .OperatingSystemManagerCredentialsHash }}"
       labels:
         app: operating-system-manager
     spec:

--- a/addons/operating-system-manager/webhook.yaml
+++ b/addons/operating-system-manager/webhook.yaml
@@ -46,6 +46,8 @@ spec:
     metadata:
       labels:
         app: operating-system-manager-webhook
+      annotations:
+        "credentials-hash": "{{ .OperatingSystemManagerCredentialsHash }}"
     spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""

--- a/addons/operating-system-manager/webhook.yaml
+++ b/addons/operating-system-manager/webhook.yaml
@@ -47,7 +47,7 @@ spec:
       labels:
         app: operating-system-manager-webhook
       annotations:
-        "credentials-hash": "{{ .OperatingSystemManagerCredentialsHash }}"
+        "kubeone.k8c.io/credentials-hash": "{{ .OperatingSystemManagerCredentialsHash }}"
     spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""

--- a/pkg/certificate/cabundle/ca-bundle.go
+++ b/pkg/certificate/cabundle/ca-bundle.go
@@ -46,7 +46,7 @@ func Inject(caBundle string, podTpl *corev1.PodTemplateSpec) {
 
 	hsh := sha256.New()
 	hsh.Write([]byte(caBundle))
-	podTpl.Annotations["caBundle-hash"] = fmt.Sprintf("%x", hsh.Sum(nil))
+	podTpl.Annotations["kubeone.k8c.io/cabundle-hash"] = fmt.Sprintf("%x", hsh.Sum(nil))
 	podTpl.Spec.Volumes = append(podTpl.Spec.Volumes, Volume())
 
 	for idx := range podTpl.Spec.Containers {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR implements rolling out pods that are using `kubeone-*-credentials` Secrets if credentials are changed.

The implementation is based on applying annotation to all pods that are using `kubeone-*-credentials` Secrets. The annotation contains salt and credentials hashed using the SHA256 algorithm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2180 

**Does this PR introduce a user-facing change?**:
```release-note
Rollout pods that are using `kubeone-*-credentials` Secrets if credentials are changed
```