### PR TITLE
Add default VolumeSnapshotClass for OpenStack Cinder CSI

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -57,6 +57,7 @@
 
 - Add CSI snapshot controller and webhook to the Cinder CSI driver ([#2067](https://github.com/kubermatic/kubeone/pull/2067), [@xmudrii](https://github.com/xmudrii))
 - Add missing Snapshot CRDs for Openstack CSI ([#1871](https://github.com/kubermatic/kubeone/pull/1871), [@WeirdMachine](https://github.com/WeirdMachine))
+- Add default VolumeSnapshotClass for OpenStack Cinder CSI ([#2217](https://github.com/kubermatic/kubeone/pull/2217), [@xmudrii](https://github.com/xmudrii))
 - Add CSI snapshot controller and webhook to the vSphere CSI driver. Add the default VolumeSnapshotClass for vSphere ([#2050](https://github.com/kubermatic/kubeone/pull/2050), [@xmudrii](https://github.com/xmudrii))
 - Add GCP Compute Persistent Disk CSI driver. The CSI driver is deployed by default for all GCE clusters running Kubernetes 1.23 or newer. ([#2137](https://github.com/kubermatic/kubeone/pull/2137), [@xmudrii](https://github.com/xmudrii))
 - Add the VMware Cloud Director CSI driver addon. Add default StorageClass for the VMware Cloud Director CSI driver. ([#2092](https://github.com/kubermatic/kubeone/pull/2092), [@ahmedwaleedmalik](https://github.com/ahmedwaleedmalik))

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -132,6 +132,17 @@ metadata:
     kubernetes.io/cluster-service: "true"
   name: standard
 provisioner: kubernetes.io/cinder
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: cinder-csi
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: cinder.csi.openstack.org
+parameters:
+  force-create: "true" # required by external-snapshotter, otherwise it errors with "volume in-use"
+deletionPolicy: Delete
 {{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "gce" }}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add default VolumeSnapshotClass for OpenStack Cinder CSI.

I've tested it manually and snapshots are properly created with this VolumeSnapshotClass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2051 

**Does this PR introduce a user-facing change?**:
```release-note
Add default VolumeSnapshotClass for OpenStack Cinder CSI
```