### PR TITLE
[release/v1.4] Add missing snapshot controller and webhook for OpenStack Cinder CSI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,4 +97,4 @@ issues:
     text: "cyclomatic complexity 36 of func `openstackValidationFunc` is high"
 
   - path: pkg/addons
-    text: "cyclomatic complexity 39 of func `newAddonsApplier` is high"
+    text: "cyclomatic complexity 41 of func `newAddonsApplier` is high"

--- a/addons/csi-openstack-cinder/controllerplugin-rbac.yaml
+++ b/addons/csi-openstack-cinder/controllerplugin-rbac.yaml
@@ -26,7 +26,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: ClusterRoleBinding
@@ -76,7 +78,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -109,10 +113,13 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -150,11 +157,13 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
-    verbs: ["patch", "update"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -167,30 +176,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: csi-resizer-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: kube-system
-  name: external-resizer-cfg
-rules:
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-resizer-role-cfg
-  namespace: kube-system
-subjects:
-  - kind: ServiceAccount
-    name: csi-cinder-controller-sa
-    namespace: kube-system
-roleRef:
-  kind: Role
-  name: external-resizer-cfg
   apiGroup: rbac.authorization.k8s.io

--- a/addons/csi-openstack-cinder/controllerplugin.yaml
+++ b/addons/csi-openstack-cinder/controllerplugin.yaml
@@ -2,30 +2,19 @@
 # external-attacher, external-provisioner, external-snapshotter
 # external-resize, liveness-probe
 {{ $version := semver .Config.Versions.Kubernetes }}
-
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-cinder-controller-service
-  namespace: kube-system
-  labels:
-    app: csi-cinder-controllerplugin
-spec:
-  selector:
-    app: csi-cinder-controllerplugin
-  ports:
-    - name: dummy
-      port: 12345
-
 ---
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-cinder-controllerplugin
   namespace: kube-system
 spec:
-  serviceName: "csi-cinder-controller-service"
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: csi-cinder-controllerplugin
@@ -42,10 +31,11 @@ spec:
           effect: NoSchedule
       containers:
         - name: csi-attacher
-          image: {{ .InternalImages.Get "CSIAttacher" }}
+          image: {{ .InternalImages.Get "OpenstackCSIAttacher" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -54,7 +44,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: {{ .InternalImages.Get "CSIProvisioner" }}
+          image: {{ .InternalImages.Get "OpenstackCSIProvisioner" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -67,6 +57,7 @@ spec:
             # --extra-create-metadata is only used since CSI v1.20.0
             - "--extra-create-metadata"
 {{ end }}
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -75,7 +66,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: {{ .InternalImages.Get "CSISnapshotter" }}
+          image: {{ .InternalImages.Get "OpenstackCSISnapshotter" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -83,6 +74,7 @@ spec:
             # --extra-create-metadata is only used since CSI v1.20.0
             - "--extra-create-metadata"
 {{ end }}
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -91,11 +83,12 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: {{ .InternalImages.Get "CSIResizer" }}
+          image: {{ .InternalImages.Get "OpenstackCSIResizer" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--handle-volume-inuse-error=false"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -104,7 +97,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: {{ .InternalImages.Get "CSILivenessProbe" }}
+          image: {{ .InternalImages.Get "OpenstackCSILivenessProbe" }}
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/addons/csi-openstack-cinder/nodeplugin.yaml
+++ b/addons/csi-openstack-cinder/nodeplugin.yaml
@@ -1,7 +1,7 @@
 # This YAML file contains driver-registrar & csi driver nodeplugin API objects,
 # which are necessary to run csi nodeplugin for cinder.
 {{ $version := semver .Config.Versions.Kubernetes }}
-
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -22,7 +22,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: {{ .InternalImages.Get "CSINodeDriverRegistar" }}
+          image: {{ .InternalImages.Get "OpenstackCSINodeDriverRegistar" }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -49,7 +49,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: {{ .InternalImages.Get "CSILivenessProbe" }}
+          image: {{ .InternalImages.Get "OpenstackCSILivenessProbe" }}
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/addons/csi-openstack-cinder/snapshot-controller-rbac.yaml
+++ b/addons/csi-openstack-cinder/snapshot-controller-rbac.yaml
@@ -1,0 +1,90 @@
+# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v5.0.1/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+---
+# RBAC file for the snapshot controller.
+#
+# The snapshot controller implements the control loop for CSI snapshot functionality.
+# It should be installed as part of the base Kubernetes distribution in an appropriate
+# namespace for components implementing base system functionality. For installing with
+# Vanilla Kubernetes, kube-system makes sense for the namespace.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-controller
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update", "patch"]
+  # Enable this RBAC rule only when using distributed snapshotting, i.e. when the enable-distributed-snapshotting flag is set to true
+  # - apiGroups: [""]
+  #   resources: ["nodes"]
+  #   verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: snapshot-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: kube-system
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+roleRef:
+  kind: Role
+  name: snapshot-controller-leaderelection
+  apiGroup: rbac.authorization.k8s.io

--- a/addons/csi-openstack-cinder/snapshot-controller.yaml
+++ b/addons/csi-openstack-cinder/snapshot-controller.yaml
@@ -1,0 +1,40 @@
+# This YAML file shows how to deploy the snapshot controller
+
+# The snapshot controller implements the control loop for CSI snapshot functionality.
+# It should be installed as part of the base Kubernetes distribution in an appropriate
+# namespace for components implementing base system functionality. For installing with
+# Vanilla Kubernetes, kube-system makes sense for the namespace.
+# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v5.0.1/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: snapshot-controller
+  namespace: kube-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: snapshot-controller
+  # the snapshot controller won't be marked as ready if the v1 CRDs are unavailable
+  # in #504 the snapshot-controller will exit after around 7.5 seconds if it
+  # can't find the v1 CRDs so this value should be greater than that
+  minReadySeconds: 15
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: snapshot-controller
+    spec:
+      serviceAccount: snapshot-controller
+      containers:
+        - name: snapshot-controller
+          image: {{ .InternalImages.Get "OpenstackCSISnapshotController" }}
+          args:
+            - "--v=5"
+            - "--leader-election=true"
+          imagePullPolicy: IfNotPresent

--- a/addons/csi-openstack-cinder/snapshot-crds.yaml
+++ b/addons/csi-openstack-cinder/snapshot-crds.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Sourced from
-# https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.2/client/config/crd
+# https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -30,6 +30,8 @@ spec:
     kind: VolumeSnapshot
     listKind: VolumeSnapshotList
     plural: volumesnapshots
+    shortNames:
+    - vs
     singular: volumesnapshot
   scope: Namespaced
   versions:
@@ -109,7 +111,7 @@ spec:
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
                     description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
@@ -213,7 +215,7 @@ spec:
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
                     description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
@@ -262,6 +264,9 @@ spec:
     kind: VolumeSnapshotContent
     listKind: VolumeSnapshotContentList
     plural: volumesnapshotcontents
+    shortNames:
+    - vsc
+    - vscs
     singular: volumesnapshotcontent
   scope: Cluster
   versions:
@@ -568,6 +573,9 @@ spec:
     kind: VolumeSnapshotClass
     listKind: VolumeSnapshotClassList
     plural: volumesnapshotclasses
+    shortNames:
+    - vsclass
+    - vsclasses
     singular: volumesnapshotclass
   scope: Cluster
   versions:
@@ -668,3 +676,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+

--- a/addons/csi-openstack-cinder/snapshot-webhook.yaml
+++ b/addons/csi-openstack-cinder/snapshot-webhook.yaml
@@ -1,0 +1,83 @@
+# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v5.0.1/deploy/kubernetes/webhook-example/webhook.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: snapshot-validation-secret
+  namespace: kube-system
+data:
+  "cert.pem": |
+{{ .Certificates.OpenstackCSIWebhookCert | b64enc | indent 4 }}
+  "key.pem": |
+{{ .Certificates.OpenstackCSIWebhookKey | b64enc | indent 4 }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "validation-webhook.snapshot.storage.k8s.io"
+  namespace: kube-system
+webhooks:
+- name: "validation-webhook.snapshot.storage.k8s.io"
+  rules:
+  - apiGroups:   ["snapshot.storage.k8s.io"]
+    apiVersions: ["v1", "v1beta1"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["volumesnapshots", "volumesnapshotcontents"]
+    scope:       "*"
+  clientConfig:
+    service:
+      namespace: kube-system
+      name: "snapshot-validation-service"
+      path: "/volumesnapshot"
+    caBundle: |
+{{ .Certificates.KubernetesCA | b64enc | indent 6 }}
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  failurePolicy: Fail
+  timeoutSeconds: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snapshot-validation-deployment
+  namespace: kube-system
+  labels:
+    app: snapshot-validation
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: snapshot-validation
+  template:
+    metadata:
+      labels:
+        app: snapshot-validation
+    spec:
+      containers:
+      - name: snapshot-validation
+        image: {{ .InternalImages.Get "OpenstackCSISnapshotWebhook" }}
+        imagePullPolicy: IfNotPresent
+        args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/key.pem']
+        ports:
+        - containerPort: 443 # change the port as needed
+        volumeMounts:
+          - name: snapshot-validation-webhook-certs
+            mountPath: /etc/snapshot-validation-webhook/certs
+            readOnly: true
+      volumes:
+        - name: snapshot-validation-webhook-certs
+          secret:
+            secretName: snapshot-validation-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: snapshot-validation-service
+  namespace: kube-system # NOTE: change the namespace
+spec:
+  selector:
+    app: snapshot-validation
+  ports:
+    - protocol: TCP
+      port: 443 # Change if needed
+      targetPort: 443 # Change if the webserver image expects a different port

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -126,6 +126,17 @@ metadata:
     kubernetes.io/cluster-service: "true"
   name: standard
 provisioner: kubernetes.io/cinder
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: cinder-csi
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: cinder.csi.openstack.org
+parameters:
+  force-create: "true" # required by external-snapshotter, otherwise it errors with "volume in-use"
+deletionPolicy: Delete
 {{ end }}
 
 {{ if eq .Config.CloudProvider.CloudProviderName "gce" }}

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -252,6 +252,19 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 
 	// Certs for CSI plugins
 	switch {
+	case s.Cluster.CloudProvider.Openstack != nil:
+		openstackCertsMap, err := certificate.NewSignedTLSCert(
+			resources.OpenstackCSIWebhookName,
+			resources.OpenstackCSIWebhookNamespace,
+			s.Cluster.ClusterNetwork.ServiceDomainName,
+			kubeCAPrivateKey,
+			kubeCACert,
+		)
+		if err != nil {
+			return nil, err
+		}
+		data.Certificates["OpenstackCSIWebhookCert"] = openstackCertsMap[resources.TLSCertName]
+		data.Certificates["OpenstackCSIWebhookKey"] = openstackCertsMap[resources.TLSKeyName]
 	// Certs for vsphere-csi-webhook (deployed only if CSIMigration is enabled)
 	case csiMigration && s.Cluster.CloudProvider.Vsphere != nil:
 		vsphereCSICertsMap, err := certificate.NewSignedTLSCert(

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -138,12 +138,22 @@ const (
 	DigitalOceanCSISnapshotValidationWebhook
 	DigitalOceanCSISnapshotter
 
+	// OpenStack CSI
+	OpenstackCSI
+	OpenstackCSINodeDriverRegistar
+	OpenstackCSILivenessProbe
+	OpenstackCSIAttacher
+	OpenstackCSIProvisioner
+	OpenstackCSIResizer
+	OpenstackCSISnapshotter
+	OpenstackCSISnapshotController
+	OpenstackCSISnapshotWebhook
+
 	// CCMs and CSI plugins
 	DigitaloceanCCM
 	HetznerCCM
 	HetznerCSI
 	OpenstackCCM
-	OpenstackCSI
 	EquinixMetalCCM
 	VsphereCCM
 	VsphereCSIDriver
@@ -292,6 +302,14 @@ func optionalResources() map[Resource]map[string]string {
 			"1.22.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
 			">= 1.23.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.4",
 		},
+		OpenstackCSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
+		OpenstackCSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.6.0"},
+		OpenstackCSIAttacher:           {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
+		OpenstackCSIProvisioner:        {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"},
+		OpenstackCSIResizer:            {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},
+		OpenstackCSISnapshotter:        {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1"},
+		OpenstackCSISnapshotController: {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v5.0.1"},
+		OpenstackCSISnapshotWebhook:    {"*": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v5.0.1"},
 
 		// Equinix Metal CCM
 		EquinixMetalCCM: {"*": "docker.io/equinix/cloud-provider-equinix-metal:v3.3.0"},

--- a/pkg/templates/images/resource_string.go
+++ b/pkg/templates/images/resource_string.go
@@ -76,29 +76,37 @@ func _() {
 	_ = x[DigitalOceanCSISnapshotController-66]
 	_ = x[DigitalOceanCSISnapshotValidationWebhook-67]
 	_ = x[DigitalOceanCSISnapshotter-68]
-	_ = x[DigitaloceanCCM-69]
-	_ = x[HetznerCCM-70]
-	_ = x[HetznerCSI-71]
-	_ = x[OpenstackCCM-72]
-	_ = x[OpenstackCSI-73]
-	_ = x[EquinixMetalCCM-74]
-	_ = x[VsphereCCM-75]
-	_ = x[VsphereCSIDriver-76]
-	_ = x[VsphereCSISyncer-77]
-	_ = x[VsphereCSIProvisioner-78]
-	_ = x[GCPComputeCSIDriver-79]
-	_ = x[GCPComputeCSIProvisioner-80]
-	_ = x[GCPComputeCSIAttacher-81]
-	_ = x[GCPComputeCSIResizer-82]
-	_ = x[GCPComputeCSISnapshotter-83]
-	_ = x[GCPComputeCSISnapshotController-84]
-	_ = x[GCPComputeCSISnapshotValidationWebhook-85]
-	_ = x[GCPComputeCSINodeDriverRegistrar-86]
+	_ = x[OpenstackCSI-69]
+	_ = x[OpenstackCSINodeDriverRegistar-70]
+	_ = x[OpenstackCSILivenessProbe-71]
+	_ = x[OpenstackCSIAttacher-72]
+	_ = x[OpenstackCSIProvisioner-73]
+	_ = x[OpenstackCSIResizer-74]
+	_ = x[OpenstackCSISnapshotter-75]
+	_ = x[OpenstackCSISnapshotController-76]
+	_ = x[OpenstackCSISnapshotWebhook-77]
+	_ = x[DigitaloceanCCM-78]
+	_ = x[HetznerCCM-79]
+	_ = x[HetznerCSI-80]
+	_ = x[OpenstackCCM-81]
+	_ = x[EquinixMetalCCM-82]
+	_ = x[VsphereCCM-83]
+	_ = x[VsphereCSIDriver-84]
+	_ = x[VsphereCSISyncer-85]
+	_ = x[VsphereCSIProvisioner-86]
+	_ = x[GCPComputeCSIDriver-87]
+	_ = x[GCPComputeCSIProvisioner-88]
+	_ = x[GCPComputeCSIAttacher-89]
+	_ = x[GCPComputeCSIResizer-90]
+	_ = x[GCPComputeCSISnapshotter-91]
+	_ = x[GCPComputeCSISnapshotController-92]
+	_ = x[GCPComputeCSISnapshotValidationWebhook-93]
+	_ = x[GCPComputeCSINodeDriverRegistrar-94]
 }
 
-const _Resource_name = "CalicoCNICalicoControllerCalicoNodeFlannelCiliumCiliumOperatorHubbleRelayHubbleUIHubbleUIBackendHubbleProxyCiliumCertGenWeaveNetCNIKubeWeaveNetCNINPCDNSNodeCacheMachineControllerMetricsServerOperatingSystemManagerClusterAutoscalerCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeAwsCCMAzureCCMAzureCNMAwsEbsCSIAwsEbsCSIAttacherAwsEbsCSILivenessProbeAwsEbsCSINodeDriverRegistrarAwsEbsCSIProvisionerAwsEbsCSIResizerAwsEbsCSISnapshotterAwsEbsCSISnapshotControllerAzureFileCSIAzureFileCSIAttacherAzureFileCSILivenessProbeAzureFileCSINodeDriverRegistarAzureFileCSIProvisionerAzureFileCSIResizerAzureFileCSISnapshotterAzureFileCSISnapshotterControllerNutanixCSISnapshotControllerNutanixCSISnapshotValidationWebhookAzureDiskCSIAzureDiskCSIAttacherAzureDiskCSILivenessProbeAzureDiskCSINodeDriverRegistarAzureDiskCSIProvisionerAzureDiskCSIResizerAzureDiskCSISnapshotterAzureDiskCSISnapshotterControllerNutanixCSILivenessProbeNutanixCSINutanixCSIProvisionerNutanixCSIRegistrarNutanixCSIResizerNutanixCSISnapshotterDigitalOceanCSIDigitalOceanCSIAlpineDigitalOceanCSIAttacherDigitalOceanCSINodeDriverRegistarDigitalOceanCSIProvisionerDigitalOceanCSIResizerDigitalOceanCSISnapshotControllerDigitalOceanCSISnapshotValidationWebhookDigitalOceanCSISnapshotterDigitaloceanCCMHetznerCCMHetznerCSIOpenstackCCMOpenstackCSIEquinixMetalCCMVsphereCCMVsphereCSIDriverVsphereCSISyncerVsphereCSIProvisionerGCPComputeCSIDriverGCPComputeCSIProvisionerGCPComputeCSIAttacherGCPComputeCSIResizerGCPComputeCSISnapshotterGCPComputeCSISnapshotControllerGCPComputeCSISnapshotValidationWebhookGCPComputeCSINodeDriverRegistrar"
+const _Resource_name = "CalicoCNICalicoControllerCalicoNodeFlannelCiliumCiliumOperatorHubbleRelayHubbleUIHubbleUIBackendHubbleProxyCiliumCertGenWeaveNetCNIKubeWeaveNetCNINPCDNSNodeCacheMachineControllerMetricsServerOperatingSystemManagerClusterAutoscalerCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeAwsCCMAzureCCMAzureCNMAwsEbsCSIAwsEbsCSIAttacherAwsEbsCSILivenessProbeAwsEbsCSINodeDriverRegistrarAwsEbsCSIProvisionerAwsEbsCSIResizerAwsEbsCSISnapshotterAwsEbsCSISnapshotControllerAzureFileCSIAzureFileCSIAttacherAzureFileCSILivenessProbeAzureFileCSINodeDriverRegistarAzureFileCSIProvisionerAzureFileCSIResizerAzureFileCSISnapshotterAzureFileCSISnapshotterControllerNutanixCSISnapshotControllerNutanixCSISnapshotValidationWebhookAzureDiskCSIAzureDiskCSIAttacherAzureDiskCSILivenessProbeAzureDiskCSINodeDriverRegistarAzureDiskCSIProvisionerAzureDiskCSIResizerAzureDiskCSISnapshotterAzureDiskCSISnapshotterControllerNutanixCSILivenessProbeNutanixCSINutanixCSIProvisionerNutanixCSIRegistrarNutanixCSIResizerNutanixCSISnapshotterDigitalOceanCSIDigitalOceanCSIAlpineDigitalOceanCSIAttacherDigitalOceanCSINodeDriverRegistarDigitalOceanCSIProvisionerDigitalOceanCSIResizerDigitalOceanCSISnapshotControllerDigitalOceanCSISnapshotValidationWebhookDigitalOceanCSISnapshotterOpenstackCSIOpenstackCSINodeDriverRegistarOpenstackCSILivenessProbeOpenstackCSIAttacherOpenstackCSIProvisionerOpenstackCSIResizerOpenstackCSISnapshotterOpenstackCSISnapshotControllerOpenstackCSISnapshotWebhookDigitaloceanCCMHetznerCCMHetznerCSIOpenstackCCMEquinixMetalCCMVsphereCCMVsphereCSIDriverVsphereCSISyncerVsphereCSIProvisionerGCPComputeCSIDriverGCPComputeCSIProvisionerGCPComputeCSIAttacherGCPComputeCSIResizerGCPComputeCSISnapshotterGCPComputeCSISnapshotControllerGCPComputeCSISnapshotValidationWebhookGCPComputeCSINodeDriverRegistrar"
 
-var _Resource_index = [...]uint16{0, 9, 25, 35, 42, 48, 62, 73, 81, 96, 107, 120, 135, 149, 161, 178, 191, 213, 230, 241, 262, 276, 290, 300, 316, 322, 330, 338, 347, 364, 386, 414, 434, 450, 470, 497, 509, 529, 554, 584, 607, 626, 649, 682, 710, 745, 757, 777, 802, 832, 855, 874, 897, 930, 953, 963, 984, 1003, 1020, 1041, 1056, 1077, 1100, 1133, 1159, 1181, 1214, 1254, 1280, 1295, 1305, 1315, 1327, 1339, 1354, 1364, 1380, 1396, 1417, 1436, 1460, 1481, 1501, 1525, 1556, 1594, 1626}
+var _Resource_index = [...]uint16{0, 9, 25, 35, 42, 48, 62, 73, 81, 96, 107, 120, 135, 149, 161, 178, 191, 213, 230, 241, 262, 276, 290, 300, 316, 322, 330, 338, 347, 364, 386, 414, 434, 450, 470, 497, 509, 529, 554, 584, 607, 626, 649, 682, 710, 745, 757, 777, 802, 832, 855, 874, 897, 930, 953, 963, 984, 1003, 1020, 1041, 1056, 1077, 1100, 1133, 1159, 1181, 1214, 1254, 1280, 1292, 1322, 1347, 1367, 1390, 1409, 1432, 1462, 1489, 1504, 1514, 1524, 1536, 1551, 1561, 1577, 1593, 1614, 1633, 1657, 1678, 1698, 1722, 1753, 1791, 1823}
 
 func (i Resource) String() string {
 	i -= 1

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -67,6 +67,9 @@ const (
 	MetricsServerName      = "metrics-server"
 	MetricsServerNamespace = metav1.NamespaceSystem
 
+	OpenstackCSIWebhookName      = "snapshot-validation-service"
+	OpenstackCSIWebhookNamespace = metav1.NamespaceSystem
+
 	VsphereCSIWebhookName      = "vsphere-webhook-svc"
 	VsphereCSIWebhookNamespace = metav1.NamespaceSystem
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds the missing snapshot controller and webhook for OpenStack Cinder CSI. Additionally, manifests are updated to include the latest updates from upstream and to match what we have on the master branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #2051 

**Does this PR introduce a user-facing change?**:
```release-note
Add missing snapshot controller and webhook for OpenStack Cinder CSI
```