### PR TITLE
Update kubeone-e2e image to Go 1.19.0

### DIFF
--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,18 +14,18 @@
 
 # building image
 
-FROM golang:1.18.4 as builder
+FROM golang:1.19.0 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip
 
 WORKDIR /download
 
-ENV TERRAFORM_VERSION "1.2.3"
+ENV TERRAFORM_VERSION "1.2.6"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform
 RUN chmod +x /usr/local/bin/terraform
 
-ENV SONOBUOY_VERSION "0.56.7"
+ENV SONOBUOY_VERSION "0.56.8"
 RUN curl -fL https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz | tar vxz
 RUN chmod +x sonobuoy
 
@@ -38,7 +38,7 @@ RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
-FROM golang:1.18.4
+FROM golang:1.19.0
 
 ARG version
 

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.24
+TAG=v0.1.25
 
 docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
 docker push kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Update kubeone-e2e image to Go 1.19.0. This PR also updates:

* Terraform from v1.2.3 to v1.2.6
* Sonobuoy from v0.56.7 to v0.56.8

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```