### PR TITLE
Update Go to 1.19.0

### DIFF
--- a/.prow/1.21.yaml
+++ b/.prow/1.21.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -33,7 +33,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -58,7 +58,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -83,7 +83,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -110,7 +110,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -135,7 +135,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -160,7 +160,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -188,7 +188,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -216,7 +216,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -244,7 +244,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -274,7 +274,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -302,7 +302,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make

--- a/.prow/1.22.yaml
+++ b/.prow/1.22.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -35,7 +35,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -62,7 +62,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -89,7 +89,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -118,7 +118,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -145,7 +145,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -172,7 +172,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -200,7 +200,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -228,7 +228,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -256,7 +256,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -286,7 +286,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make

--- a/.prow/1.23.yaml
+++ b/.prow/1.23.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -35,7 +35,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -64,7 +64,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -91,7 +91,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -118,7 +118,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -147,7 +147,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -174,7 +174,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -201,7 +201,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -229,7 +229,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -257,7 +257,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -285,7 +285,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -315,7 +315,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make

--- a/.prow/1.24.yaml
+++ b/.prow/1.24.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -35,7 +35,7 @@ presubmits:
       preset-aws: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -64,7 +64,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -91,7 +91,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -118,7 +118,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -147,7 +147,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make
@@ -174,7 +174,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           imagePullPolicy: Always
           command:
             - make

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
           command:
             - /bin/bash
             - -c
@@ -44,7 +44,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
           command:
             - /bin/bash
             - -c
@@ -68,7 +68,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -87,7 +87,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: kubermatic/kubeone-e2e:v0.1.24
+        - image: kubermatic/kubeone-e2e:v0.1.25
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.4
+        - image: golang:1.19.0
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.4
+        - image: golang:1.19.0
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.4
+        - image: golang:1.19.0
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.4
+        - image: golang:1.19.0
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
           command:
             - /bin/bash
             - -c

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -69,6 +69,7 @@
 
 #### Go
 
+- KubeOne is now built using Go 1.19.0 ([#2226](https://github.com/kubermatic/kubeone/pull/2226), [@xmudrii](https://github.com/xmudrii))
 - KubeOne is now built using Go 1.18.4 ([#2179](https://github.com/kubermatic/kubeone/pull/2179), [@xmudrii](https://github.com/xmudrii))
 - KubeOne is now built using Go 1.18.1 ([#2018](https://github.com/kubermatic/kubeone/pull/2018), [@xmudrii](https://github.com/xmudrii))
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.18.4 as builder
+FROM docker.io/golang:1.19.0 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -689,17 +689,17 @@ func detectCCMMigrationStatus(s *state.State) (*state.CCMStatus, error) {
 // backwards compatibility.
 //
 // The function works in the following way:
-//   * if the cluster is not provisioned, or if the cluster is not an OpenStack
+//   - if the cluster is not provisioned, or if the cluster is not an OpenStack
 //     cluster, return the KubeOne cluster name
-//   * if it's an existing OpenStack cluster:
-//      * if cluster is running in-tree cloud provider: return the KubeOne
-//        cluster name because the in-tree provider already has the
-//        --cluster-name flag set
-//      * if cluster is running external cloud provider: check if there is
-//        `--cluster-name` flag on the OpenStack CCM. If there is, read the
-//        value and return it, otherwise don't set the OpenStack cluster name,
-//        in which case it defaults to `kubernetes`
-//   * if cluster is migrated to external CCM, return the KubeOne cluster name
+//   - if it's an existing OpenStack cluster:
+//   - if cluster is running in-tree cloud provider: return the KubeOne
+//     cluster name because the in-tree provider already has the
+//     --cluster-name flag set
+//   - if cluster is running external cloud provider: check if there is
+//     `--cluster-name` flag on the OpenStack CCM. If there is, read the
+//     value and return it, otherwise don't set the OpenStack cluster name,
+//     in which case it defaults to `kubernetes`
+//   - if cluster is migrated to external CCM, return the KubeOne cluster name
 //
 // If an operator wants to change the --cluster-name flag on OpenStack external
 // CCM, they need to edit the CCM DaemonSet manually. KubeOne will

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -79,8 +79,8 @@ func WithBinariesOnly(t Tasks) Tasks {
 }
 
 // WithHostnameOS will prepend passed tasks with 2 basic tasks:
-//  * detect OS on all cluster hosts
-//  * detect hostnames  on all cluster hosts
+//   - detect OS on all cluster hosts
+//   - detect hostnames  on all cluster hosts
 func WithHostnameOS(t Tasks) Tasks {
 	return t.prepend(
 		Task{Fn: determineHostname, Operation: "detecting hostname"},

--- a/testv2/e2e/helpers.go
+++ b/testv2/e2e/helpers.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "kubermatic/kubeone-e2e:v0.1.24"
+	prowImage             = "kubermatic/kubeone-e2e:v0.1.25"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/testv2/e2e/prow.yaml
+++ b/testv2/e2e/prow.yaml
@@ -16,7 +16,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -38,7 +38,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -60,7 +60,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -82,7 +82,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -104,7 +104,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -126,7 +126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -150,7 +150,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -172,7 +172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -194,7 +194,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -216,7 +216,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -238,7 +238,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -260,7 +260,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -282,7 +282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -304,7 +304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -326,7 +326,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -348,7 +348,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -370,7 +370,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -394,7 +394,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -416,7 +416,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -438,7 +438,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -460,7 +460,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -482,7 +482,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -504,7 +504,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -526,7 +526,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -548,7 +548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -570,7 +570,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -592,7 +592,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -614,7 +614,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -638,7 +638,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -660,7 +660,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -682,7 +682,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -704,7 +704,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -726,7 +726,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -748,7 +748,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -770,7 +770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -792,7 +792,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -814,7 +814,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -836,7 +836,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -858,7 +858,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -882,7 +882,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -904,7 +904,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -926,7 +926,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -948,7 +948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -970,7 +970,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -992,7 +992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1014,7 +1014,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1036,7 +1036,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1058,7 +1058,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1080,7 +1080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1102,7 +1102,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1126,7 +1126,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1148,7 +1148,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1170,7 +1170,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1192,7 +1192,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1214,7 +1214,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1236,7 +1236,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1258,7 +1258,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1280,7 +1280,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1302,7 +1302,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1324,7 +1324,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1346,7 +1346,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1370,7 +1370,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1392,7 +1392,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1414,7 +1414,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1436,7 +1436,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1458,7 +1458,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1480,7 +1480,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1502,7 +1502,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1524,7 +1524,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1546,7 +1546,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1568,7 +1568,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1590,7 +1590,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1614,7 +1614,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1636,7 +1636,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1658,7 +1658,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1680,7 +1680,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1702,7 +1702,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1724,7 +1724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1746,7 +1746,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1768,7 +1768,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1790,7 +1790,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1812,7 +1812,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1834,7 +1834,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1858,7 +1858,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1880,7 +1880,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1902,7 +1902,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1924,7 +1924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1946,7 +1946,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1968,7 +1968,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1990,7 +1990,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2012,7 +2012,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2034,7 +2034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2056,7 +2056,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2078,7 +2078,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2102,7 +2102,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2124,7 +2124,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2146,7 +2146,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2168,7 +2168,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2190,7 +2190,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2212,7 +2212,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2234,7 +2234,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2256,7 +2256,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2278,7 +2278,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2300,7 +2300,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2322,7 +2322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2346,7 +2346,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2368,7 +2368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2390,7 +2390,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2412,7 +2412,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2434,7 +2434,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2456,7 +2456,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2478,7 +2478,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2500,7 +2500,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2522,7 +2522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2544,7 +2544,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2566,7 +2566,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2590,7 +2590,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2612,7 +2612,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2634,7 +2634,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2656,7 +2656,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2678,7 +2678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2700,7 +2700,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2722,7 +2722,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2744,7 +2744,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2766,7 +2766,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2788,7 +2788,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2810,7 +2810,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2834,7 +2834,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2856,7 +2856,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2878,7 +2878,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2900,7 +2900,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2922,7 +2922,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2944,7 +2944,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2966,7 +2966,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2988,7 +2988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3010,7 +3010,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3032,7 +3032,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3054,7 +3054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3078,7 +3078,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3100,7 +3100,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3122,7 +3122,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3144,7 +3144,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3166,7 +3166,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3188,7 +3188,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3210,7 +3210,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3232,7 +3232,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3254,7 +3254,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3276,7 +3276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3298,7 +3298,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3322,7 +3322,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3344,7 +3344,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3366,7 +3366,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3388,7 +3388,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3410,7 +3410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3432,7 +3432,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3454,7 +3454,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3476,7 +3476,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3498,7 +3498,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3520,7 +3520,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3542,7 +3542,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3566,7 +3566,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3588,7 +3588,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3610,7 +3610,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3632,7 +3632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3654,7 +3654,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3676,7 +3676,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3698,7 +3698,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3720,7 +3720,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3742,7 +3742,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3764,7 +3764,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3786,7 +3786,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3810,7 +3810,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3832,7 +3832,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3854,7 +3854,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3876,7 +3876,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3898,7 +3898,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3922,7 +3922,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3946,7 +3946,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3970,7 +3970,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3994,7 +3994,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4018,7 +4018,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4042,7 +4042,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4066,7 +4066,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4090,7 +4090,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4112,7 +4112,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4134,7 +4134,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4156,7 +4156,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4178,7 +4178,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4200,7 +4200,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4222,7 +4222,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4244,7 +4244,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4266,7 +4266,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4288,7 +4288,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4310,7 +4310,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4332,7 +4332,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4354,7 +4354,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4378,7 +4378,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4400,7 +4400,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4422,7 +4422,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4444,7 +4444,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4466,7 +4466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4488,7 +4488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4510,7 +4510,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4532,7 +4532,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4554,7 +4554,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4576,7 +4576,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4598,7 +4598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4620,7 +4620,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4642,7 +4642,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4666,7 +4666,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4688,7 +4688,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4710,7 +4710,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4732,7 +4732,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4754,7 +4754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4776,7 +4776,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4798,7 +4798,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4820,7 +4820,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4842,7 +4842,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4864,7 +4864,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4886,7 +4886,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4908,7 +4908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4930,7 +4930,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4954,7 +4954,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4976,7 +4976,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4998,7 +4998,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5020,7 +5020,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5042,7 +5042,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5064,7 +5064,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5086,7 +5086,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5108,7 +5108,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5130,7 +5130,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5152,7 +5152,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5174,7 +5174,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5196,7 +5196,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5218,7 +5218,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5242,7 +5242,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5264,7 +5264,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5286,7 +5286,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5308,7 +5308,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5330,7 +5330,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5352,7 +5352,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5374,7 +5374,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5396,7 +5396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5418,7 +5418,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5440,7 +5440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5462,7 +5462,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5484,7 +5484,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5506,7 +5506,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5530,7 +5530,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5552,7 +5552,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5574,7 +5574,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5596,7 +5596,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5618,7 +5618,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5640,7 +5640,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5662,7 +5662,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5684,7 +5684,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5706,7 +5706,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5728,7 +5728,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5750,7 +5750,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5772,7 +5772,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5794,7 +5794,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5818,7 +5818,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5840,7 +5840,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5862,7 +5862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5884,7 +5884,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5906,7 +5906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5928,7 +5928,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5950,7 +5950,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5972,7 +5972,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5994,7 +5994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6016,7 +6016,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6038,7 +6038,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6060,7 +6060,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6082,7 +6082,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6106,7 +6106,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6128,7 +6128,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6150,7 +6150,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6172,7 +6172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6194,7 +6194,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6216,7 +6216,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6238,7 +6238,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6260,7 +6260,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6282,7 +6282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6304,7 +6304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6326,7 +6326,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6348,7 +6348,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6370,7 +6370,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6394,7 +6394,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6416,7 +6416,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6438,7 +6438,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6460,7 +6460,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6482,7 +6482,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6504,7 +6504,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6526,7 +6526,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6548,7 +6548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6570,7 +6570,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6592,7 +6592,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6614,7 +6614,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6636,7 +6636,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6658,7 +6658,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6682,7 +6682,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6704,7 +6704,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6726,7 +6726,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6748,7 +6748,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6770,7 +6770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6792,7 +6792,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6814,7 +6814,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6836,7 +6836,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6858,7 +6858,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6880,7 +6880,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6902,7 +6902,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6924,7 +6924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6946,7 +6946,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6970,7 +6970,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6992,7 +6992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7014,7 +7014,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7036,7 +7036,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7058,7 +7058,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7080,7 +7080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7102,7 +7102,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.24
+      image: kubermatic/kubeone-e2e:v0.1.25
       imagePullPolicy: Always
       name: ""
       resources:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR updates all jobs and Docker images to Go 1.19.0. Code is also `gofmt`-ed with Go 1.19.0.

**Does this PR introduce a user-facing change?**:
```release-note
KubeOne is now built using Go 1.19.0
```