### PR TITLE
[release/v1.4] Update machine-controller to v1.43.6

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -188,7 +188,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:        {"*": "quay.io/calico/node:v3.22.4"},
 		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
 		Flannel:           {"*": "quay.io/coreos/flannel:v0.15.1"},
-		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.43.5"},
+		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.43.6"},
 		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Update machine-controller to v1.43.6. This release uses containerd 1.5 instead of 1.4 for all Kubernetes versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2215 

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.43.6
```