### PR TITLE
[release/v1.4] Update containerd to v1.5

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -80,8 +80,8 @@ var (
 )
 
 const (
-	defaultDockerVersion           = "19.03.*"
-	latestDockerVersion            = "20.10.*"
-	defaultContainerdVersion       = "1.4.*"
-	defaultAmazonContainerdVersion = "1.4.*"
+	defaultDockerVersion           = "'19.03.*'"
+	latestDockerVersion            = "'20.10.*'"
+	defaultContainerdVersion       = "'1.5.*'"
+	defaultAmazonContainerdVersion = "'1.4.*'"
 )

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.*
+	docker-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.*
+	docker-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.*
+	docker-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.*
+	docker-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.*
+	docker-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.*
+	docker-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -73,7 +73,7 @@ sudo yum install -y \
 
 
 sudo yum versionlock delete containerd || true
-sudo yum install -y containerd-1.4.*
+sudo yum install -y containerd-'1.4.*'
 sudo yum versionlock add containerd
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -73,7 +73,7 @@ sudo yum install -y \
 
 
 sudo yum versionlock delete containerd || true
-sudo yum install -y containerd-1.4.*
+sudo yum install -y containerd-'1.4.*'
 sudo yum versionlock add containerd
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -84,9 +84,9 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
+	docker-ce-'19.03.*' \
+	docker-ce-cli-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -84,9 +84,9 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
+	docker-ce-'19.03.*' \
+	docker-ce-cli-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -84,9 +84,9 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
+	docker-ce-'19.03.*' \
+	docker-ce-cli-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -84,9 +84,9 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
+	docker-ce-'19.03.*' \
+	docker-ce-cli-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -84,9 +84,9 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
+	docker-ce-'19.03.*' \
+	docker-ce-cli-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -84,9 +84,9 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
+	docker-ce-'19.03.*' \
+	docker-ce-cli-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -85,7 +85,7 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
 sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-1.4.*
+sudo yum install -y containerd.io-'1.5.*'
 sudo yum versionlock add containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -85,7 +85,7 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 
 sudo yum versionlock delete containerd.io || true
-sudo yum install -y containerd.io-1.4.*
+sudo yum install -y containerd.io-'1.5.*'
 sudo yum versionlock add containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -80,9 +80,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.* \
-	docker-ce-cli=5:19.03.* \
-	containerd.io=1.4.*
+	docker-ce=5:'19.03.*' \
+	docker-ce-cli=5:'19.03.*' \
+	containerd.io='1.5.*'
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -80,9 +80,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.* \
-	docker-ce-cli=5:19.03.* \
-	containerd.io=1.4.*
+	docker-ce=5:'19.03.*' \
+	docker-ce-cli=5:'19.03.*' \
+	containerd.io='1.5.*'
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -80,9 +80,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.* \
-	docker-ce-cli=5:19.03.* \
-	containerd.io=1.4.*
+	docker-ce=5:'19.03.*' \
+	docker-ce-cli=5:'19.03.*' \
+	containerd.io='1.5.*'
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -79,7 +79,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	containerd.io=1.4.*
+	containerd.io='1.5.*'
 sudo apt-mark hold containerd.io
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -79,7 +79,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	containerd.io=1.4.*
+	containerd.io='1.5.*'
 sudo apt-mark hold containerd.io
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.*
+	docker-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -84,9 +84,9 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
+	docker-ce-'19.03.*' \
+	docker-ce-cli-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -81,9 +81,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.* \
-	docker-ce-cli=5:19.03.* \
-	containerd.io=1.4.*
+	docker-ce=5:'19.03.*' \
+	docker-ce-cli=5:'19.03.*' \
+	containerd.io='1.5.*'
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -73,8 +73,8 @@ sudo yum install -y \
 sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
-	docker-19.03.* \
-	containerd.io-1.4.*
+	docker-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -84,9 +84,9 @@ sudo yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true >/
 sudo yum versionlock delete docker-ce docker-ce-cli containerd.io || true
 
 sudo yum install -y \
-	docker-ce-19.03.* \
-	docker-ce-cli-19.03.* \
-	containerd.io-1.4.*
+	docker-ce-'19.03.*' \
+	docker-ce-cli-'19.03.*' \
+	containerd.io-'1.5.*'
 sudo yum versionlock add docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -81,9 +81,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--option "Dpkg::Options::=--force-confold" \
 	--no-install-recommends \
 	-y \
-	docker-ce=5:19.03.* \
-	docker-ce-cli=5:19.03.* \
-	containerd.io=1.4.*
+	docker-ce=5:'19.03.*' \
+	docker-ce-cli=5:'19.03.*' \
+	containerd.io='1.5.*'
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR is a manual cherry-pick of #2020 and #1941.

The reason for updating containerd to v1.5 is that v1.4 has reached EOL. machine-controller v1.43.6 also uses containerd 1.5 (see #2227).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2215 

**Does this PR introduce a user-facing change?**:
```release-note
Update containerd to v1.5. Escape docker/containerd versions to avoid wildcard matching
```