### PR TITLE
Lower exponential backoff times

### DIFF
--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -29,8 +29,8 @@ import (
 func defaultRetryBackoff(retries int) wait.Backoff {
 	return wait.Backoff{
 		Steps:    retries,
-		Duration: 5 * time.Second,
-		Factor:   2.0,
+		Duration: 10 * time.Second,
+		Factor:   1.4,
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When some task if keep failing, the backoff times are getting out of hand (on 10th time retry, it will wait 42 minutes!). Absolutely annoying. This PR lowers those backoff times to at maximum 4 minutes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Lower exponential backoff times
```
