### PR TITLE
Mark `install` and `upgrade` subcommands deprecated

### DIFF
--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -52,14 +52,17 @@ func installCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Install Kubernetes",
+		Short: "[DEPRECATED] Install Kubernetes",
 		Long: heredoc.Doc(`
+			[DEPRECATED] This command is deprecated, please use kubeone apply instead.
+
 			Install Kubernetes on pre-existing machines
 
 			This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
 			It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.
 		`),
 		Example:       `kubeone install -m mycluster.yaml -t terraformoutput.json`,
+		Hidden:        true,
 		SilenceErrors: true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -47,14 +47,17 @@ func upgradeCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	opts := &upgradeOpts{}
 	cmd := &cobra.Command{
 		Use:   "upgrade <manifest>",
-		Short: "Upgrade Kubernetes",
+		Short: "[DEPRECATED] Upgrade Kubernetes",
 		Long: heredoc.Doc(`
+			[DEPRECATED] This command is deprecated, please use kubeone apply instead.
+
 			Upgrade Kubernetes
 
 			This command takes KubeOne manifest which contains information about hosts and how the cluster should be provisioned.
 			It's possible to source information about hosts from Terraform output, using the '--tfjson' flag.
 		`),
 		Example:       `kubeone upgrade -m mycluster.yaml -t terraformoutput.json`,
+		Hidden:        true,
 		SilenceErrors: true,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			gopts, err := persistentGlobalOptions(rootFlags)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
We had `kubeone apply` since long time, and nowadays even started to use it in e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[ACTION REQUIRED] We announced with the KubeOne 1.4.0 release that kubeone install and kubeone upgrade commands are deprecated in favor of kubeone apply. This time we're marking those commands as hidden, so they'll not show in the help output. In the next release, we'll completely remove those commands, so we strongly recommend migrating to kubeone apply as soon as possible.
```
