### PR TITLE
testv2: Replace nginx with echoserver

### DIFF
--- a/testv2/e2e/cloudprovider.go
+++ b/testv2/e2e/cloudprovider.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -120,12 +121,12 @@ func (c *cloudProviderTests) createStatefulSetWithStorage(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "nginx",
-							Image: "nginx",
+							Name:  "echoserver",
+							Image: "k8s.gcr.io/echoserver:1.10",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "web",
-									ContainerPort: 80,
+									ContainerPort: 8080,
 								},
 							},
 						},
@@ -227,9 +228,10 @@ func (c *cloudProviderTests) exposeStatefulSet(t *testing.T) {
 			Selector: cloudProviderPodLabels,
 			Ports: []corev1.ServicePort{
 				{
-					Name:     "web",
-					Protocol: corev1.ProtocolTCP,
-					Port:     80,
+					Name:       "web",
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(8080),
+					Port:       80,
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR replaces nginx container with echoserver container in the new cloud provider tests. The reason behind this is to avoid potential Docker Hub rate limits on providers that are prone to this.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```