### PR TITLE
testv2/upgrade: Wait for nodes to become ready before upgrading

### DIFF
--- a/testv2/e2e/scenario_upgrade.go
+++ b/testv2/e2e/scenario_upgrade.go
@@ -94,6 +94,9 @@ func (scenario *scenarioUpgrade) upgrade(t *testing.T) {
 	// otherwise upgrade might get stuck due to pods not able to get
 	// rescheduled.
 	k1 := scenario.kubeone(t, scenario.versions[0])
+
+	waitKubeOneNodesReady(t, k1)
+
 	if err := k1.Apply(); err != nil {
 		t.Fatalf("kubeone apply failed: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that we wait for all nodes to join the cluster before proceeding with upgrading the cluster in the new tests.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```