### PR TITLE
testv2: Fix mode name for Sonobuoy conformance tests

### DIFF
--- a/testv2/e2e/sonobuoy.go
+++ b/testv2/e2e/sonobuoy.go
@@ -44,7 +44,7 @@ type sonobuoyReportDetails struct {
 type sonobuoyMode string
 
 const (
-	sonobuoyConformance     sonobuoyMode = "conformance"
+	sonobuoyConformance     sonobuoyMode = "non-disruptive-conformance"
 	sonobuoyConformanceLite sonobuoyMode = "conformance-lite"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We're using a mode called `conformance` for conformance tests, however, the such mode doesn't exist. The following modes exist:

```
  -m, --mode Mode                                What mode to run the e2e plugin in. Valid modes are [certified-conformance conformance-lite non-disruptive-conformance quick]. (default non-disruptive-conformance)
```

`non-disruptive-conformance` is the mode that we should be using instead:

```
Mode: non-disruptive-conformance
Description: Non-destructive conformance mode runs all of the conformance tests except those that would disrupt other cluster operations (e.g. tests that may cause nodes to be restarted or impact clus... (truncated) ...
E2E_FOCUS: \[Conformance\]
E2E_SKIP: \[Disruptive\]|NoExecuteTaintManager
E2E_PARALLEL: false
```

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```