### PR TITLE
Remove hcloud-volumes StorageClass from csi-hcloud addon

### DIFF
--- a/addons/csi-hetzner/hcloud-csi.yml
+++ b/addons/csi-hetzner/hcloud-csi.yml
@@ -9,17 +9,6 @@ spec:
   volumeLifecycleModes:
     - Persistent
 ---
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  namespace: kube-system
-  name: hcloud-volumes
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-provisioner: csi.hetzner.cloud
-volumeBindingMode: WaitForFirstConsumer
-allowVolumeExpansion: true
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/testv2/e2e/testdata/legacy_machine_controller_containerd.yaml
+++ b/testv2/e2e/testdata/legacy_machine_controller_containerd.yaml
@@ -9,3 +9,8 @@ containerRuntime:
 
 operatingSystemManager:
   deploy: false
+
+addons:
+  enable: true
+  addons:
+  - name: default-storage-class

--- a/testv2/e2e/testdata/legacy_machine_controller_containerd_external.yaml
+++ b/testv2/e2e/testdata/legacy_machine_controller_containerd_external.yaml
@@ -12,3 +12,8 @@ operatingSystemManager:
 
 cloudProvider:
   external: true
+
+addons:
+  enable: true
+  addons:
+  - name: default-storage-class

--- a/testv2/e2e/testdata/legacy_machine_controller_docker.yaml
+++ b/testv2/e2e/testdata/legacy_machine_controller_docker.yaml
@@ -9,3 +9,8 @@ containerRuntime:
 
 operatingSystemManager:
   deploy: false
+
+addons:
+  enable: true
+  addons:
+  - name: default-storage-class

--- a/testv2/e2e/testdata/legacy_machine_controller_docker_external.yaml
+++ b/testv2/e2e/testdata/legacy_machine_controller_docker_external.yaml
@@ -12,3 +12,8 @@ operatingSystemManager:
 
 cloudProvider:
   external: true
+
+addons:
+  enable: true
+  addons:
+  - name: default-storage-class


### PR DESCRIPTION
**What this PR does / why we need it**:

* Ensure that we deploy the `default-storage-class` addon for non-OSM tests
* Remove the `hcloud-volumes` StorageClass in favor of `hcloud-volumes` StorageClass deployed by the `default-storage-class` addon. If you're using `hcloud-volumes` StorageClass, make sure that you have the `default-storage-class` addon enabled before upgrading to KubeOne 1.5

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Remove the `hcloud-volumes` StorageClass in favor of `hcloud-volumes` StorageClass deployed by the `default-storage-class` addon. If you're using `hcloud-volumes` StorageClass, make sure that you have the `default-storage-class` addon enabled before upgrading to KubeOne 1.5
```

**Documentation**:
```documentation
TBD
```