### PR TITLE
Make provisioningUtility configurable in Terraform configs for AWS

### DIFF
--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -73,6 +73,7 @@ No modules.
 | <a name="input_initial_machinedeployment_spotinstances_max_price"></a> [initial\_machinedeployment\_spotinstances\_max\_price](#input\_initial\_machinedeployment\_spotinstances\_max\_price) | used to specify max spot instance price for initial machine-deployment | `number` | `0` | no |
 | <a name="input_internal_api_lb"></a> [internal\_api\_lb](#input\_internal\_api\_lb) | make kubernetes API loadbalancer internal (reachible only from inside the VPC) | `bool` | `false` | no |
 | <a name="input_os"></a> [os](#input\_os) | Operating System to use in AMI filtering and MachineDeployment | `string` | `"ubuntu"` | no |
+| <a name="input_provisioning_utility"></a> [provisioning\_utility](#input\_provisioning\_utility) | provisioning utility to be used for Flatcar worker nodes | `string` | `"ignition"` | no |
 | <a name="input_ssh_agent_socket"></a> [ssh\_agent\_socket](#input\_ssh\_agent\_socket) | SSH Agent socket, default to grab from $SSH\_AUTH\_SOCK | `string` | `"env:SSH_AUTH_SOCK"` | no |
 | <a name="input_ssh_port"></a> [ssh\_port](#input\_ssh\_port) | SSH port to be used to provision instances | `number` | `22` | no |
 | <a name="input_ssh_private_key_file"></a> [ssh\_private\_key\_file](#input\_ssh\_private\_key\_file) | SSH private key file used to access instances | `string` | `""` | no |

--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -92,7 +92,7 @@ output "kubeone_workers" {
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot   = false
-          provisioningUtility = "ignition"
+          provisioningUtility = var.provisioning_utility
         }
         labels = {
           isSpotInstance = format("%t", local.initial_machinedeployment_spotinstances)
@@ -150,7 +150,7 @@ output "kubeone_workers" {
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot   = false
-          provisioningUtility = "ignition"
+          provisioningUtility = var.provisioning_utility
         }
         labels = {
           isSpotInstance = format("%t", local.initial_machinedeployment_spotinstances)
@@ -208,7 +208,7 @@ output "kubeone_workers" {
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot   = false
-          provisioningUtility = "ignition"
+          provisioningUtility = var.provisioning_utility
         }
         labels = {
           isSpotInstance = format("%t", local.initial_machinedeployment_spotinstances)

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -257,6 +257,12 @@ variable "control_plane_vm_count" {
   type        = number
 }
 
+variable "provisioning_utility" {
+  description = "provisioning utility to be used for Flatcar worker nodes"
+  default     = "ignition"
+  type        = string
+}
+
 variable "initial_machinedeployment_operating_system_profile" {
   default     = ""
   type        = string

--- a/testv2/e2e/prow.yaml
+++ b/testv2/e2e/prow.yaml
@@ -5572,13 +5572,13 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-v1.22.12
   optional: false
   spec:
     containers:
     - command:
       - ./testv2/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_22_12
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_12
       env:
       - name: PROVIDER
         value: aws
@@ -13154,13 +13154,13 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
   spec:
     containers:
     - command:
       - ./testv2/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_12
       env:
       - name: PROVIDER
         value: aws
@@ -13684,13 +13684,13 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
   spec:
     containers:
     - command:
       - ./testv2/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_9
       env:
       - name: PROVIDER
         value: aws

--- a/testv2/e2e/tests_definitions.go
+++ b/testv2/e2e/tests_definitions.go
@@ -116,6 +116,28 @@ var (
 				},
 			},
 		},
+		"aws_flatcar_cloud_init": {
+			name: "aws_flatcar_cloud_init",
+			environ: map[string]string{
+				"PROVIDER": "aws",
+			},
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-aws":     "true",
+			},
+			terraform: terraformBin{
+				path: "../../examples/terraform/aws",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"subnets_cidr=27",
+					"os=flatcar",
+					"ssh_username=core",
+					"bastion_user=core",
+					"provisioning_utility=cloud-init",
+					"worker_deploy_ssh_key=false",
+				},
+			},
+		},
 		"aws_amzn": {
 			name: "aws_amzn",
 			environ: map[string]string{

--- a/testv2/e2e/tests_test.go
+++ b/testv2/e2e/tests_test.go
@@ -2018,8 +2018,8 @@ func TestAwsDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
 	scenario.Run(t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
-	infra := Infrastructures["aws_flatcar"]
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.12")
@@ -4762,8 +4762,8 @@ func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.
 	scenario.Run(t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
-	infra := Infrastructures["aws_flatcar"]
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.12")
@@ -4954,8 +4954,8 @@ func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T
 	scenario.Run(t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
-	infra := Infrastructures["aws_flatcar"]
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.9")

--- a/testv2/tests.yml
+++ b/testv2/tests.yml
@@ -353,7 +353,7 @@
     - name: aws_amzn
     - name: aws_centos
     - name: aws_default
-    - name: aws_flatcar
+    - name: aws_flatcar_cloud_init
     - name: aws_rhel
     - name: aws_rockylinux
     - name: azure_default
@@ -777,7 +777,7 @@
     - name: aws_amzn
     - name: aws_centos
     - name: aws_default
-    - name: aws_flatcar
+    - name: aws_flatcar_cloud_init
     - name: aws_rhel
     - name: aws_rockylinux
     - name: azure_default
@@ -805,7 +805,7 @@
     - name: aws_amzn
     - name: aws_centos
     - name: aws_default
-    - name: aws_flatcar
+    - name: aws_flatcar_cloud_init
     - name: aws_rhel
     - name: aws_rockylinux
     - name: azure_default


### PR DESCRIPTION
**What this PR does / why we need it**:

While testing cluster provisioning on AWS, I discovered that some legacy Flatcar tests are failing because of the user-data limits. In the past, we fixed that by using cloud-init provisioner and removing SSH keys from MachineDeployments. We reverted that when switching to OSM because that's no longer needed.

I added a new test definition called `aws_flatcar_cloud_init` which uses cloud-init instead of Ignition and disables deploying SSH key to the worker nodes. With this test definition, affected Flatcar tests are passing.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```