### PR TITLE
testv2: Rollout MachineDeployments on upgrade

### DIFF
--- a/testv2/e2e/helpers.go
+++ b/testv2/e2e/helpers.go
@@ -214,6 +214,10 @@ func withKubeoneCredentials(credentialsPath string) kubeoneBinOpts {
 	}
 }
 
+func withKubeoneUpgradeMachineDeployments(kb *kubeoneBin) {
+	kb.upgradeMachineDeployments = true
+}
+
 func newKubeoneBin(terraformPath, manifestPath string, opts ...kubeoneBinOpts) *kubeoneBin {
 	k1 := &kubeoneBin{
 		bin:          getKubeoneDistPath(),

--- a/testv2/e2e/kubeone.go
+++ b/testv2/e2e/kubeone.go
@@ -43,16 +43,23 @@ var (
 )
 
 type kubeoneBin struct {
-	bin             string
-	dir             string
-	tfjsonPath      string
-	manifestPath    string
-	credentialsPath string
-	verbose         bool
+	bin                       string
+	dir                       string
+	tfjsonPath                string
+	manifestPath              string
+	credentialsPath           string
+	verbose                   bool
+	upgradeMachineDeployments bool
 }
 
 func (k1 *kubeoneBin) Apply() error {
-	return k1.run("apply", "--auto-approve")
+	args := []string{"apply", "--auto-approve"}
+
+	if k1.upgradeMachineDeployments {
+		args = append(args, "--upgrade-machine-deployments")
+	}
+
+	return k1.run(args...)
 }
 
 func (k1 *kubeoneBin) Kubeconfig() ([]byte, error) {

--- a/testv2/e2e/scenario_upgrade.go
+++ b/testv2/e2e/scenario_upgrade.go
@@ -139,7 +139,8 @@ func (scenario *scenarioUpgrade) test(t *testing.T) {
 	cpTests := newCloudProviderTests(client, scenario.infra.Provider())
 	cpTests.runWithCleanup(t)
 
-	sonobuoyRun(t, k1, sonobuoyConformanceLite, proxyURL)
+	// sonobuoyRun(t, k1, sonobuoyConformanceLite, proxyURL)
+	sonobuoyRun(t, k1, sonobuoyQuick, proxyURL)
 }
 
 func (scenario *scenarioUpgrade) GenerateTests(wr io.Writer, generatorType GeneratorType, cfg ProwConfig) error {

--- a/testv2/e2e/scenario_upgrade.go
+++ b/testv2/e2e/scenario_upgrade.go
@@ -76,6 +76,8 @@ func (scenario *scenarioUpgrade) kubeone(t *testing.T, version string) *kubeoneB
 		k1Opts = append(k1Opts, withKubeoneCredentials(*credentialsFlag))
 	}
 
+	k1Opts = append(k1Opts, withKubeoneUpgradeMachineDeployments)
+
 	return newKubeoneBin(
 		scenario.infra.terraform.path,
 		renderManifest(t,
@@ -129,9 +131,11 @@ func (scenario *scenarioUpgrade) test(t *testing.T) {
 	time.Sleep(5 * time.Second)
 	t.Logf("kubeone proxy is running on %s", proxyURL)
 
+	client := dynamicClientRetriable(t, k1)
+
+	waitMachinesHasNodes(t, client)
 	waitKubeOneNodesReady(t, k1)
 
-	client := dynamicClientRetriable(t, k1)
 	cpTests := newCloudProviderTests(client, scenario.infra.Provider())
 	cpTests.runWithCleanup(t)
 

--- a/testv2/e2e/sonobuoy.go
+++ b/testv2/e2e/sonobuoy.go
@@ -46,6 +46,7 @@ type sonobuoyMode string
 const (
 	sonobuoyConformance     sonobuoyMode = "non-disruptive-conformance"
 	sonobuoyConformanceLite sonobuoyMode = "conformance-lite"
+	sonobuoyQuick           sonobuoyMode = "quick"
 )
 
 type sonobuoyBin struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that we rollout MachineDeployments when running the upgrade scenario. In addition to that, this PR temporarily changes the Sonobuoy mode to `quick` to speed up tests. We already did conformance tests with #2232, so we're not getting much by running them again.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```