### PR TITLE
[release/v1.4] Enable nf_conntrack module by default

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -47,6 +47,11 @@ var (
 		sudo modprobe overlay
 		sudo modprobe br_netfilter
 		sudo modprobe ip_tables
+		if modinfo nf_conntrack_ipv4 &> /dev/null; then
+			sudo modprobe nf_conntrack_ipv4
+		else
+			sudo modprobe nf_conntrack
+		fi
 		sudo mkdir -p /etc/sysctl.d
 		cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 		fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -16,6 +16,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -16,6 +16,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -16,6 +16,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -16,6 +16,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -16,6 +16,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -16,6 +16,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -16,6 +16,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -27,6 +27,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -27,6 +27,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -27,6 +27,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -27,6 +27,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -27,6 +27,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -27,6 +27,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -16,6 +16,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -18,6 +18,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -16,6 +16,11 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo modprobe ip_tables
+if modinfo nf_conntrack_ipv4 &> /dev/null; then
+	sudo modprobe nf_conntrack_ipv4
+else
+	sudo modprobe nf_conntrack
+fi
 sudo mkdir -p /etc/sysctl.d
 cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
 fs.inotify.max_user_watches         = 1048576


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a manual cherry-pick of #2282.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Enable `nf_conntrack` (`nf_conntrack_ipv4`) module by default on all operating systems. This fixes an issue with pods unable to reach services running on a host on operating systems that are using the NFT backend.
```

**Documentation**:
```documentation
NONE
```