### PR TITLE
Remove defaulting for provisioning utility in AWS configs

### DIFF
--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -73,7 +73,7 @@ No modules.
 | <a name="input_initial_machinedeployment_spotinstances_max_price"></a> [initial\_machinedeployment\_spotinstances\_max\_price](#input\_initial\_machinedeployment\_spotinstances\_max\_price) | used to specify max spot instance price for initial machine-deployment | `number` | `0` | no |
 | <a name="input_internal_api_lb"></a> [internal\_api\_lb](#input\_internal\_api\_lb) | make kubernetes API loadbalancer internal (reachible only from inside the VPC) | `bool` | `false` | no |
 | <a name="input_os"></a> [os](#input\_os) | Operating System to use in AMI filtering and MachineDeployment | `string` | `"ubuntu"` | no |
-| <a name="input_provisioning_utility"></a> [provisioning\_utility](#input\_provisioning\_utility) | provisioning utility to be used for Flatcar worker nodes | `string` | `"ignition"` | no |
+| <a name="input_provisioning_utility"></a> [provisioning\_utility](#input\_provisioning\_utility) | provisioning utility to be used for Flatcar worker nodes | `string` | `""` | no |
 | <a name="input_ssh_agent_socket"></a> [ssh\_agent\_socket](#input\_ssh\_agent\_socket) | SSH Agent socket, default to grab from $SSH\_AUTH\_SOCK | `string` | `"env:SSH_AUTH_SOCK"` | no |
 | <a name="input_ssh_port"></a> [ssh\_port](#input\_ssh\_port) | SSH port to be used to provision instances | `number` | `22` | no |
 | <a name="input_ssh_private_key_file"></a> [ssh\_private\_key\_file](#input\_ssh\_private\_key\_file) | SSH private key file used to access instances | `string` | `""` | no |

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -259,7 +259,7 @@ variable "control_plane_vm_count" {
 
 variable "provisioning_utility" {
   description = "provisioning utility to be used for Flatcar worker nodes"
-  default     = "ignition"
+  default     = ""
   type        = string
 }
 

--- a/testv2/e2e/tests_definitions.go
+++ b/testv2/e2e/tests_definitions.go
@@ -133,7 +133,6 @@ var (
 					"os=flatcar",
 					"ssh_username=core",
 					"bastion_user=core",
-					"provisioning_utility=cloud-init",
 					"worker_deploy_ssh_key=false",
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove defaulting for provisioning utility in example Terraform configs for AWS. The provisioning utility is defaulted by machine-controller.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Remove defaulting for Flatcar provisioning utility in example Terraform configs for AWS (defaulted to Ignition by machine-controller). If you have Flatcar-based MachineDeployments that use the `cloud-init` provisioning utility, you must change the provisioning utility to `ignition` (or leave it empty) for Operating System Manager (OSM) to work properly
```

**Documentation**:
```documentation
NONE
```