### PR TITLE
[release/v1.4] Remove defaulting for provisioning utility in AWS configs

### DIFF
--- a/examples/terraform/aws/output.tf
+++ b/examples/terraform/aws/output.tf
@@ -91,7 +91,7 @@ output "kubeone_workers" {
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot   = false
-          provisioningUtility = "cloud-init"
+          provisioningUtility = ""
         }
         labels = {
           isSpotInstance = format("%t", var.initial_machinedeployment_spotinstances)
@@ -145,7 +145,7 @@ output "kubeone_workers" {
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot   = false
-          provisioningUtility = "cloud-init"
+          provisioningUtility = ""
         }
         labels = {
           isSpotInstance = format("%t", var.initial_machinedeployment_spotinstances)
@@ -199,7 +199,7 @@ output "kubeone_workers" {
         operatingSystem = local.worker_os
         operatingSystemSpec = {
           distUpgradeOnBoot   = false
-          provisioningUtility = "cloud-init"
+          provisioningUtility = ""
         }
         labels = {
           isSpotInstance = format("%t", var.initial_machinedeployment_spotinstances)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual cherry-pick of #2285 to the release/v1.4 branch.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Remove defaulting for the Flatcar provisioning utility in example Terraform configs for AWS (defaulted to cloud-init by machine-controller)
```

**Documentation**:
```documentation
NONE
```