### PR TITLE
VCD: Fix for worker machine disk size

### DIFF
--- a/examples/terraform/vmware-cloud-director/README.md
+++ b/examples/terraform/vmware-cloud-director/README.md
@@ -92,7 +92,7 @@ No modules.
 | <a name="input_vcd_vdc_name"></a> [vcd\_vdc\_name](#input\_vcd\_vdc\_name) | Virtual datacenter name | `string` | n/a | yes |
 | <a name="input_worker_cpu_cores"></a> [worker\_cpu\_cores](#input\_worker\_cpu\_cores) | Number of cores per socket for the worker VMs | `number` | `1` | no |
 | <a name="input_worker_cpus"></a> [worker\_cpus](#input\_worker\_cpus) | Number of CPUs for the worker VMs | `number` | `2` | no |
-| <a name="input_worker_disk_size"></a> [worker\_disk\_size](#input\_worker\_disk\_size) | Disk size for worker VMs in MB | `number` | `25600` | no |
+| <a name="input_worker_disk_size_gb"></a> [worker\_disk\_size\_gb](#input\_worker\_disk\_size\_gb) | Disk size for worker VMs in GB | `number` | `25` | no |
 | <a name="input_worker_disk_storage_profile"></a> [worker\_disk\_storage\_profile](#input\_worker\_disk\_storage\_profile) | Name of storage profile to use for worker VMs attached disks | `string` | `""` | no |
 | <a name="input_worker_memory"></a> [worker\_memory](#input\_worker\_memory) | Memory size of each worker VM in MB | `number` | `4096` | no |
 | <a name="input_worker_os"></a> [worker\_os](#input\_worker\_os) | OS to run on worker machines | `string` | `"ubuntu"` | no |

--- a/examples/terraform/vmware-cloud-director/output.tf
+++ b/examples/terraform/vmware-cloud-director/output.tf
@@ -85,7 +85,7 @@ output "kubeone_workers" {
           cpus             = var.worker_cpus
           cpuCores         = var.worker_cpu_cores
           memoryMB         = var.worker_memory
-          diskSizeGB       = var.worker_disk_size
+          diskSizeGB       = var.worker_disk_size_gb
           storageProfile   = var.worker_disk_storage_profile
           ipAllocationMode = "DHCP"
           metadata = {

--- a/examples/terraform/vmware-cloud-director/variables.tf
+++ b/examples/terraform/vmware-cloud-director/variables.tf
@@ -237,9 +237,9 @@ variable "worker_cpu_cores" {
   type        = number
 }
 
-variable "worker_disk_size" {
-  description = "Disk size for worker VMs in MB"
-  default     = 25600 # 25 GiB
+variable "worker_disk_size_gb" {
+  description = "Disk size for worker VMs in GB"
+  default     = 25
   type        = number
 }
 


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
This fixes a bug where we were erroneously assuming that disk size will be specified in MBs for the worker machines. Although this is not the case and it should be specified in GBs instead.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
