### PR TITLE
testv2: Extend logic for rolling-out MachineDeployments

### DIFF
--- a/testv2/e2e/helpers.go
+++ b/testv2/e2e/helpers.go
@@ -214,10 +214,6 @@ func withKubeoneCredentials(credentialsPath string) kubeoneBinOpts {
 	}
 }
 
-func withKubeoneUpgradeMachineDeployments(kb *kubeoneBin) {
-	kb.upgradeMachineDeployments = true
-}
-
 func newKubeoneBin(terraformPath, manifestPath string, opts ...kubeoneBinOpts) *kubeoneBin {
 	k1 := &kubeoneBin{
 		bin:          getKubeoneDistPath(),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR replaces using the `--upgrade-machine-deployments` flag with a dedicated function that rotates and upgrades MachineDeployments. This is needed in order to handle Flatcar-based MachineDeployments where manual migration from cloud-init to Ignition is required.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```