### PR TITLE
testv2/upgrade: Fix MachineDeployment updating and rolling out

### DIFF
--- a/testv2/e2e/scenario_upgrade.go
+++ b/testv2/e2e/scenario_upgrade.go
@@ -242,10 +242,10 @@ func (scenario *scenarioUpgrade) upgradeMachineDeployments(t *testing.T, client 
 		mdOld := md.DeepCopy()
 		mdNew := md
 
-		md.Spec.Template.Spec.Versions.Kubelet = kubeletVersion
+		mdNew.Spec.Template.Spec.Versions.Kubelet = kubeletVersion
 
 		providerConfig := providerconfigtypes.Config{}
-		if err := jsonutil.StrictUnmarshal(md.Spec.Template.Spec.ProviderSpec.Value.Raw, &providerConfig); err != nil {
+		if err := jsonutil.StrictUnmarshal(mdNew.Spec.Template.Spec.ProviderSpec.Value.Raw, &providerConfig); err != nil {
 			t.Fatalf("decoding provider config: %v", err)
 		}
 
@@ -265,6 +265,13 @@ func (scenario *scenarioUpgrade) upgradeMachineDeployments(t *testing.T, client 
 				if err != nil {
 					t.Fatalf("updating operating system config: %v", err)
 				}
+
+				b, err := json.Marshal(providerConfig)
+				if err != nil {
+					t.Fatalf("marshalling new provider config")
+				}
+
+				mdNew.Spec.Template.Spec.ProviderSpec.Value.Raw = b
 			}
 		}
 

--- a/testv2/e2e/scenario_upgrade.go
+++ b/testv2/e2e/scenario_upgrade.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const kubeoneVersionToInit = "1.4.6"
+const kubeoneVersionToInit = "1.4.7"
 
 type scenarioUpgrade struct {
 	Name                 string


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes updating and rolling out MachineDeployments when upgrading the cluster in the new E2E tests.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```