### PR TITLE
Set iptables backend to NFT for Canal and Calico VXLAN on Flatcar clusters

### DIFF
--- a/addons/calico-vxlan/calico-vxlan.yaml
+++ b/addons/calico-vxlan/calico-vxlan.yaml
@@ -4483,6 +4483,8 @@ spec:
               value: "false"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            - name: FELIX_IPTABLESBACKEND
+              value: "{{ default .CalicoIptablesBackend .Params.iptablesBackend }}"
           securityContext:
             privileged: true
           resources:

--- a/addons/cni-canal/canal.yaml
+++ b/addons/cni-canal/canal.yaml
@@ -4479,6 +4479,8 @@ spec:
               value: "false"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            - name: FELIX_IPTABLESBACKEND
+              value: "{{ default .CalicoIptablesBackend .Params.iptablesBackend }}"
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

It happens that after upgrading Canal/Calico to a newer minor version, the pod network connectivity stops working for some reason. This mostly happens on Flatcar-based clusters and not always, but from time to time. This is a known upstream Calico issue and it's being tracked here: https://github.com/projectcalico/calico/issues/5760

As mentioned in https://github.com/projectcalico/calico/issues/5760#issuecomment-1123745297, the solution is to set `FELIX_IPTABLESBACKEND` to `NFT`.

If there's a Flatcar control plane node in the cluster, KubeOne will set `FELIX_IPTABLESBACKEND` to `NFT`. Otherwise, KubeOne will set `FELIX_IPTABLESBACKEND` to `Auto`, which is the current default value and results in Calico automatically determining the iptables backend.

This can be overridden by setting the `iptablesBackend` parameter on Canal or Calico VXLAN addon. For example:

```yaml
apiVersion: kubeone.k8c.io/v1beta2
kind: KubeOneCluster
...
addons:
  enable: true
  addons:
    - name: cni-canal # or calico-vxlan if cluster is running Calico VXLAN
      params:
        iptablesBackend: "Auto"
```

This might also affect RHEL, but from our testing, it's much less frequent than for Flatcar. To reduce the scope of changes before the release, we'll revisit this after releasing KubeOne 1.5.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Set iptables backend (`FELIX_IPTABLESBACKEND`) to `NFT` for Canal and Calico VXLAN on clusters running Flatcar Linux. For non Flatcar clusters, iptables backend is set to Auto, which is the default value and results in Calico determining the iptables backend automatically. The value can be overridden by setting the `iptablesBackend` addon parameter (see the PR description for an example).
```

**Documentation**:
```documentation
NONE
```