### PR TITLE
Fix Flatcar: mkdir /opt/bin before untar anything in it

### DIFF
--- a/pkg/scripts/os_flatcar.go
+++ b/pkg/scripts/os_flatcar.go
@@ -30,7 +30,7 @@ source /etc/kubeone/proxy-env
 {{ template "sysctl-k8s" . }}
 {{ template "journald-config" }}
 
-sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v{{ .KUBERNETES_CNI_VERSION }}/cni-plugins-linux-${HOST_ARCH}-v{{ .KUBERNETES_CNI_VERSION }}.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
@@ -48,7 +48,6 @@ curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOO
 {{ template "flatcar-containerd" . }}
 {{ end }}
 
-sudo mkdir -p /opt/bin
 cd /opt/bin
 k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
 for binary in kubeadm kubelet kubectl; do

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
@@ -98,7 +98,6 @@ fi
 
 
 
-sudo mkdir -p /opt/bin
 cd /opt/bin
 k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
 for binary in kubeadm kubelet kubectl; do

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
@@ -98,7 +98,6 @@ fi
 
 
 
-sudo mkdir -p /opt/bin
 cd /opt/bin
 k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
 for binary in kubeadm kubelet kubectl; do

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
@@ -101,7 +101,6 @@ fi
 
 
 
-sudo mkdir -p /opt/bin
 cd /opt/bin
 k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
 for binary in kubeadm kubelet kubectl; do

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
@@ -98,7 +98,6 @@ fi
 
 
 
-sudo mkdir -p /opt/bin
 cd /opt/bin
 k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
 for binary in kubeadm kubelet kubectl; do

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -60,7 +60,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
@@ -74,7 +74,6 @@ curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOO
 
 
 
-sudo mkdir -p /opt/bin
 cd /opt/bin
 k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
 for binary in kubeadm kubelet kubectl; do

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
@@ -111,7 +111,6 @@ sudo systemctl restart containerd
 
 
 
-sudo mkdir -p /opt/bin
 cd /opt/bin
 k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
 for binary in kubeadm kubelet kubectl; do

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -54,7 +54,7 @@ EOF
 sudo systemctl force-reload systemd-journald
 
 
-sudo mkdir -p /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
+sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
 curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
@@ -113,7 +113,6 @@ sudo systemctl restart containerd
 
 
 
-sudo mkdir -p /opt/bin
 cd /opt/bin
 k8s_rel_baseurl=https://storage.googleapis.com/kubernetes-release/release
 for binary in kubeadm kubelet kubectl; do


### PR DESCRIPTION
**What this PR does / why we need it**:

We found an issue with Flatcar where we're trying to untar archives to `/opt/bin` before actually creating that directory. If that directory doesn't exist beforehand, the provisioning process will fail:

```
tar: /opt/bin: Cannot open: No such file or directory
```

This has been discovered while testing the Flatcar support on OpenStack in #2273

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Explicitly create `/opt/bin` on Flatcar before trying to untar anything to that directory
```

**Documentation**:
```documentation
NONE
```