### PR TITLE
[release/v1.4] Mount /etc/pki to the OpenStack CCM container

### DIFF
--- a/addons/ccm-openstack/ccm-openstack.yaml
+++ b/addons/ccm-openstack/ccm-openstack.yaml
@@ -206,6 +206,9 @@ spec:
             - mountPath: /etc/ssl/certs
               name: ca-certs
               readOnly: true
+            - mountPath: /etc/pki
+              name: pki-certs
+              readOnly: true
             - mountPath: /usr/share/ca-certificates
               name: usr-ca-certs
               readOnly: true
@@ -227,6 +230,10 @@ spec:
       - name: ca-certs
         hostPath:
           path: /etc/ssl/certs
+          type: DirectoryOrCreate
+      - name: pki-certs
+        hostPath:
+          path: /etc/pki
           type: DirectoryOrCreate
       - hostPath:
           path: /usr/share/ca-certificates


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a partial cherry-pick of #2299 to the `release/v1.4` branch to fix an issue with the OpenStack CCM crashing on clusters running CentOS 7.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Mount `/etc/pki` to the OpenStack CCM container to fix CrashLoopBackoff on clusters running CentOS 7 
```

**Documentation**:
```documentation
NONE
```