### PR TITLE
Build stable KubeOne binary instead of downloading it from GitHub

### DIFF
--- a/testv2/e2e/prow.yaml
+++ b/testv2/e2e/prow.yaml
@@ -8,6 +8,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -30,6 +31,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -52,6 +54,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -74,6 +77,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -96,6 +100,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -118,6 +123,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -140,6 +146,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -164,6 +171,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -188,6 +196,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -212,6 +221,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -236,6 +246,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -260,6 +271,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -282,6 +294,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -304,6 +317,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -326,6 +340,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -348,6 +363,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -370,6 +386,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -392,6 +409,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -414,6 +432,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -436,6 +455,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -458,6 +478,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -480,6 +501,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -502,6 +524,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -524,6 +547,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -546,6 +570,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -568,6 +593,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -592,6 +618,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -616,6 +643,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -640,6 +668,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -664,6 +693,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -688,6 +718,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -710,6 +741,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -732,6 +764,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -754,6 +787,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -776,6 +810,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -798,6 +833,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -820,6 +856,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -842,6 +879,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -864,6 +902,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -886,6 +925,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -908,6 +948,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -930,6 +971,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -952,6 +994,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -974,6 +1017,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -996,6 +1040,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1020,6 +1065,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1044,6 +1090,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1068,6 +1115,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1092,6 +1140,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1116,6 +1165,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1138,6 +1188,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1160,6 +1211,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1182,6 +1234,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1204,6 +1257,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1226,6 +1280,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1248,6 +1303,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1270,6 +1326,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1292,6 +1349,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1314,6 +1372,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1336,6 +1395,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1358,6 +1418,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1380,6 +1441,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1402,6 +1464,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1424,6 +1487,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1448,6 +1512,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1472,6 +1537,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1496,6 +1562,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1520,6 +1587,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1544,6 +1612,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1566,6 +1635,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1588,6 +1658,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1610,6 +1681,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1632,6 +1704,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1654,6 +1727,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1676,6 +1750,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1698,6 +1773,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1720,6 +1796,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1742,6 +1819,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1764,6 +1842,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1786,6 +1865,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1808,6 +1888,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1830,6 +1911,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1852,6 +1934,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1876,6 +1959,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1900,6 +1984,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1924,6 +2009,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1948,6 +2034,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1972,6 +2059,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -1994,6 +2082,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2016,6 +2105,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2038,6 +2128,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2060,6 +2151,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2082,6 +2174,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2104,6 +2197,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2126,6 +2220,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2143,11 +2238,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2165,11 +2266,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2187,11 +2294,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2209,11 +2322,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2231,11 +2350,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2253,11 +2378,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2275,11 +2406,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2299,11 +2436,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2323,11 +2466,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2347,11 +2496,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2371,11 +2526,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2395,11 +2556,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2417,11 +2584,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2439,11 +2612,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2461,11 +2640,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2483,11 +2668,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2505,11 +2696,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2527,11 +2724,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2549,11 +2752,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2571,11 +2780,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2593,11 +2808,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2615,11 +2836,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2637,11 +2864,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2659,11 +2892,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2681,11 +2920,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2703,11 +2948,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2727,11 +2978,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2751,11 +3008,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2775,11 +3038,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2799,11 +3068,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2823,11 +3098,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2845,11 +3126,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2867,11 +3154,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2889,11 +3182,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2911,11 +3210,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2933,11 +3238,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2955,11 +3266,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2977,11 +3294,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -2999,11 +3322,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3021,11 +3350,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3043,11 +3378,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3065,11 +3406,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3087,11 +3434,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3109,11 +3462,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3131,11 +3490,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3155,11 +3520,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3179,11 +3550,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3203,11 +3580,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3227,11 +3610,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3251,11 +3640,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3273,11 +3668,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3295,11 +3696,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3317,11 +3724,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3339,11 +3752,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3361,11 +3780,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3383,11 +3808,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3405,11 +3836,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3427,11 +3864,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3449,11 +3892,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3471,11 +3920,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3493,11 +3948,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3515,11 +3976,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3537,11 +4004,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3559,11 +4032,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3583,11 +4062,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3607,11 +4092,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3631,11 +4122,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3655,11 +4152,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3679,11 +4182,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3701,11 +4210,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3723,11 +4238,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3745,11 +4266,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3767,11 +4294,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3789,11 +4322,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3811,11 +4350,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3833,11 +4378,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3855,11 +4406,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3877,11 +4434,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3899,11 +4462,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3921,11 +4490,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3943,11 +4518,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3965,11 +4546,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -3987,11 +4574,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4011,11 +4604,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4035,11 +4634,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4059,11 +4664,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4083,11 +4694,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4107,11 +4724,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4129,11 +4752,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4151,11 +4780,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4173,11 +4808,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4195,11 +4836,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4217,11 +4864,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4239,11 +4892,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4261,11 +4920,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4288,6 +4953,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4310,6 +4976,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4332,6 +4999,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4354,6 +5022,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4376,6 +5045,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4398,6 +5068,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4420,6 +5091,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4444,6 +5116,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4468,6 +5141,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4492,6 +5166,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4516,6 +5191,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4540,6 +5216,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4562,6 +5239,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4584,6 +5262,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4606,6 +5285,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4628,6 +5308,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4650,6 +5331,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4672,6 +5354,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4694,6 +5377,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4716,6 +5400,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4738,6 +5423,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4760,6 +5446,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4782,6 +5469,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4804,6 +5492,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4826,6 +5515,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4848,6 +5538,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4872,6 +5563,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4896,6 +5588,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4920,6 +5613,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4944,6 +5638,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4968,6 +5663,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -4990,6 +5686,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5012,6 +5709,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5034,6 +5732,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5056,6 +5755,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5078,6 +5778,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5100,6 +5801,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5122,6 +5824,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-calico-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5144,6 +5847,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5166,6 +5870,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5188,6 +5893,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5210,6 +5916,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5232,6 +5939,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5254,6 +5962,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5276,6 +5985,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5300,6 +6010,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5324,6 +6035,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5348,6 +6060,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5372,6 +6085,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5396,6 +6110,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5418,6 +6133,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5440,6 +6156,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5462,6 +6179,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5484,6 +6202,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5506,6 +6225,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5528,6 +6248,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5550,6 +6271,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5572,6 +6294,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5594,6 +6317,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5616,6 +6340,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5638,6 +6363,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5660,6 +6386,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5682,6 +6409,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5704,6 +6432,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5728,6 +6457,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5752,6 +6482,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5776,6 +6507,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5800,6 +6532,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5824,6 +6557,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5846,6 +6580,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5868,6 +6603,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5890,6 +6626,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5912,6 +6649,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5934,6 +6672,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5956,6 +6695,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -5978,6 +6718,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-weave-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6000,6 +6741,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6022,6 +6764,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6044,6 +6787,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6066,6 +6810,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6088,6 +6833,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6110,6 +6856,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6132,6 +6879,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6156,6 +6904,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6180,6 +6929,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6204,6 +6954,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6228,6 +6979,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6252,6 +7004,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6274,6 +7027,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6296,6 +7050,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6318,6 +7073,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6340,6 +7096,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6362,6 +7119,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6384,6 +7142,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6406,6 +7165,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6428,6 +7188,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6450,6 +7211,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6472,6 +7234,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6494,6 +7257,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6516,6 +7280,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6538,6 +7303,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6560,6 +7326,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6584,6 +7351,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6608,6 +7376,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6632,6 +7401,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6656,6 +7426,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6680,6 +7451,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6702,6 +7474,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6724,6 +7497,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6746,6 +7520,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6768,6 +7543,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6790,6 +7566,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6812,6 +7589,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6834,6 +7612,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-cilium-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6856,6 +7635,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6880,6 +7660,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6904,6 +7685,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6928,6 +7710,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6952,6 +7735,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -6976,6 +7760,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7000,6 +7785,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7022,6 +7808,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7044,6 +7831,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7066,6 +7854,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7088,6 +7877,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7110,6 +7900,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7132,6 +7923,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7154,6 +7946,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7176,6 +7969,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7200,6 +7994,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7224,6 +8019,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7248,6 +8044,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7272,6 +8069,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7296,6 +8094,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7318,6 +8117,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7340,6 +8140,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7362,6 +8163,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7384,6 +8186,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7406,6 +8209,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7428,6 +8232,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7450,6 +8255,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7472,6 +8278,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7494,6 +8301,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7516,6 +8324,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7538,6 +8347,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7560,6 +8370,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7582,6 +8393,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7604,6 +8416,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7628,6 +8441,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7652,6 +8466,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7676,6 +8491,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7700,6 +8516,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7724,6 +8541,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7746,6 +8564,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7768,6 +8587,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7790,6 +8610,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7812,6 +8633,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7834,6 +8656,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7856,6 +8679,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7878,6 +8702,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7900,6 +8725,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7922,6 +8748,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7944,6 +8771,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7966,6 +8794,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -7988,6 +8817,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8010,6 +8840,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8032,6 +8863,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8056,6 +8888,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8080,6 +8913,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8104,6 +8938,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8128,6 +8963,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8152,6 +8988,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8174,6 +9011,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8196,6 +9034,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8218,6 +9057,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8240,6 +9080,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8262,6 +9103,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8284,6 +9126,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8306,6 +9149,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8328,6 +9172,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8350,6 +9195,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8372,6 +9218,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8394,6 +9241,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8416,6 +9264,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8438,6 +9287,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8460,6 +9310,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8484,6 +9335,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8508,6 +9360,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8532,6 +9385,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8556,6 +9410,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8580,6 +9435,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8602,6 +9458,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8624,6 +9481,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8646,6 +9504,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8668,6 +9527,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8690,6 +9550,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8712,6 +9573,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8734,6 +9596,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8756,6 +9619,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8778,6 +9642,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8800,6 +9665,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8822,6 +9688,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8844,6 +9711,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8866,6 +9734,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8888,6 +9757,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8912,6 +9782,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8936,6 +9807,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8960,6 +9832,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -8984,6 +9857,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9008,6 +9882,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9030,6 +9905,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9052,6 +9928,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9074,6 +9951,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9096,6 +9974,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9118,6 +9997,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9140,6 +10020,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9162,6 +10043,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9184,6 +10066,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9206,6 +10089,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9228,6 +10112,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9250,6 +10135,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9272,6 +10158,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9294,6 +10181,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9316,6 +10204,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9338,6 +10227,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9362,6 +10252,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9386,6 +10277,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9410,6 +10302,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9434,6 +10327,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9458,6 +10352,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9480,6 +10375,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9502,6 +10398,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9524,6 +10421,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9546,6 +10444,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9568,6 +10467,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9590,6 +10490,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9612,6 +10513,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9634,6 +10536,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9658,6 +10561,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9682,6 +10586,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9706,6 +10611,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9730,6 +10636,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9754,6 +10661,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9776,6 +10684,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9798,6 +10707,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9820,6 +10730,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9842,6 +10753,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9864,6 +10776,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9886,6 +10799,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9908,6 +10822,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9930,6 +10845,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9954,6 +10870,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -9978,6 +10895,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10002,6 +10920,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10026,6 +10945,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10050,6 +10970,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10072,6 +10993,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10094,6 +11016,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10116,6 +11039,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10138,6 +11062,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10160,6 +11085,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10182,6 +11108,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10204,6 +11131,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10226,6 +11154,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10250,6 +11179,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10274,6 +11204,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10298,6 +11229,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10322,6 +11254,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10346,6 +11279,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10368,6 +11302,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10390,6 +11325,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10412,6 +11348,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10434,6 +11371,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10456,6 +11394,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10478,6 +11417,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10500,6 +11440,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10522,6 +11463,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10544,6 +11486,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10566,6 +11509,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10588,6 +11532,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10610,6 +11555,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10632,6 +11578,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10654,6 +11601,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10676,6 +11624,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10698,6 +11647,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10720,6 +11670,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10742,6 +11693,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10764,6 +11716,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10786,6 +11739,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10808,6 +11762,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10830,6 +11785,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10852,6 +11808,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10876,6 +11833,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10900,6 +11858,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10924,6 +11883,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10948,6 +11908,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10972,6 +11933,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -10994,6 +11956,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11016,6 +11979,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11038,6 +12002,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11060,6 +12025,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11082,6 +12048,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11104,6 +12071,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11126,6 +12094,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11148,6 +12117,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11170,6 +12140,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11192,6 +12163,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11214,6 +12186,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11236,6 +12209,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11258,6 +12232,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11280,6 +12255,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11302,6 +12278,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11324,6 +12301,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11346,6 +12324,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11368,6 +12347,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11390,6 +12370,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11412,6 +12393,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11434,6 +12416,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11456,6 +12439,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11478,6 +12462,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11502,6 +12487,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11526,6 +12512,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11550,6 +12537,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11574,6 +12562,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11598,6 +12587,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11620,6 +12610,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11642,6 +12633,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11664,6 +12656,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11686,6 +12679,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11708,6 +12702,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11730,6 +12725,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11752,6 +12748,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11774,6 +12771,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11796,6 +12794,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11818,6 +12817,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11840,6 +12840,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11862,6 +12863,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11884,6 +12886,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11906,6 +12909,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11928,6 +12932,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11950,6 +12955,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11972,6 +12978,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -11994,6 +13001,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12016,6 +13024,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12038,6 +13047,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12060,6 +13070,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12082,6 +13093,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12104,6 +13116,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12128,6 +13141,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12152,6 +13166,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12176,6 +13191,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12200,6 +13216,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12224,6 +13241,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12246,6 +13264,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12268,6 +13287,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12290,6 +13310,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12312,6 +13333,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12334,6 +13356,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12356,6 +13379,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12378,6 +13402,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12400,6 +13425,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12422,6 +13448,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12444,6 +13471,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12466,6 +13494,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12488,6 +13517,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12510,6 +13540,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12532,6 +13563,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12554,6 +13586,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12576,6 +13609,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12598,6 +13632,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12620,6 +13655,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12642,6 +13678,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12664,6 +13701,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12686,6 +13724,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12708,6 +13747,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12730,6 +13770,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12754,6 +13795,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12778,6 +13820,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12802,6 +13845,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12826,6 +13870,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12850,6 +13895,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12872,6 +13918,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12894,6 +13941,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12916,6 +13964,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12938,6 +13987,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12960,6 +14010,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -12982,6 +14033,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13004,6 +14056,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13026,6 +14079,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13048,6 +14102,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13070,6 +14125,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13092,6 +14148,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13114,6 +14171,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13136,6 +14194,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13158,6 +14217,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13180,6 +14240,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13202,6 +14263,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13219,11 +14281,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13241,11 +14309,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13263,11 +14337,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13285,11 +14365,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13307,11 +14393,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13329,11 +14421,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13351,11 +14449,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13375,11 +14479,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13399,11 +14509,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13423,11 +14539,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13447,11 +14569,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13471,11 +14599,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13493,11 +14627,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13515,11 +14655,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13537,11 +14683,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13559,11 +14711,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13581,11 +14739,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13603,11 +14767,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13625,11 +14795,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13647,11 +14823,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13669,11 +14851,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13691,11 +14879,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13713,11 +14907,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13735,11 +14935,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13757,11 +14963,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13779,11 +14991,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13801,11 +15019,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13823,11 +15047,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13845,11 +15075,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13867,11 +15103,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13889,11 +15131,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13911,11 +15159,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13933,11 +15187,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13955,11 +15215,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -13977,11 +15243,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14001,11 +15273,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14025,11 +15303,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14049,11 +15333,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14073,11 +15363,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14097,11 +15393,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14119,11 +15421,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14141,11 +15449,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14163,11 +15477,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14185,11 +15505,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14207,11 +15533,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14229,11 +15561,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14251,11 +15589,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14273,11 +15617,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14295,11 +15645,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14317,11 +15673,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14339,11 +15701,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14361,11 +15729,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14383,11 +15757,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14405,11 +15785,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14427,11 +15813,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14449,11 +15841,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14471,11 +15869,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14493,11 +15897,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14515,11 +15925,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14537,11 +15953,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14559,11 +15981,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14581,11 +16009,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14603,11 +16037,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14627,11 +16067,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14651,11 +16097,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14675,11 +16127,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14699,11 +16157,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14723,11 +16187,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14745,11 +16215,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14767,11 +16243,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14789,11 +16271,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14811,11 +16299,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14833,11 +16327,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14855,11 +16355,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14877,11 +16383,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14899,11 +16411,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14921,11 +16439,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14943,11 +16467,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14965,11 +16495,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -14987,11 +16523,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15009,11 +16551,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15031,11 +16579,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15053,11 +16607,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15075,11 +16635,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15097,11 +16663,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15119,11 +16691,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15141,11 +16719,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15163,11 +16747,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15185,11 +16775,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15207,11 +16803,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15229,11 +16831,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15253,11 +16861,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15277,11 +16891,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15301,11 +16921,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15325,11 +16951,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15349,11 +16981,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15371,11 +17009,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15393,11 +17037,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15415,11 +17065,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15437,11 +17093,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15459,11 +17121,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15481,11 +17149,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15503,11 +17177,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15525,11 +17205,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15547,11 +17233,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15569,11 +17261,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15591,11 +17289,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15613,11 +17317,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15635,11 +17345,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15657,11 +17373,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15679,11 +17401,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15701,11 +17429,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15723,11 +17457,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15745,11 +17485,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15767,11 +17513,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15789,11 +17541,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15811,11 +17569,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15833,11 +17597,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15855,11 +17625,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15879,11 +17655,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15903,11 +17685,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15927,11 +17715,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15951,11 +17745,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15975,11 +17775,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -15997,11 +17803,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16019,11 +17831,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16041,11 +17859,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16063,11 +17887,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16085,11 +17915,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16107,11 +17943,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16129,11 +17971,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16151,11 +17999,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16173,11 +18027,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16195,11 +18055,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16217,11 +18083,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16239,11 +18111,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16261,11 +18139,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16283,11 +18167,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16305,11 +18195,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16327,11 +18223,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16354,6 +18256,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16376,6 +18279,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16398,6 +18302,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16420,6 +18325,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16442,6 +18348,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16464,6 +18371,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16486,6 +18394,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16510,6 +18419,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16534,6 +18444,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16558,6 +18469,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16582,6 +18494,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16606,6 +18519,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16628,6 +18542,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16650,6 +18565,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16672,6 +18588,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16694,6 +18611,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16716,6 +18634,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16738,6 +18657,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16760,6 +18680,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16782,6 +18703,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16804,6 +18726,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16826,6 +18749,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16848,6 +18772,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16870,6 +18795,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16892,6 +18818,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16914,6 +18841,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16936,6 +18864,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16958,6 +18887,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -16980,6 +18910,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17002,6 +18933,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17024,6 +18956,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17046,6 +18979,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17068,6 +19002,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17090,6 +19025,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17112,6 +19048,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17136,6 +19073,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17160,6 +19098,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17184,6 +19123,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17208,6 +19148,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17232,6 +19173,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17254,6 +19196,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17276,6 +19219,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17298,6 +19242,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17320,6 +19265,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17342,6 +19288,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17364,6 +19311,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17386,6 +19334,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17408,6 +19357,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17430,6 +19380,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17452,6 +19403,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17474,6 +19426,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17496,6 +19449,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17518,6 +19472,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17540,6 +19495,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17562,6 +19518,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17584,6 +19541,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17606,6 +19564,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17628,6 +19587,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17650,6 +19610,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17672,6 +19633,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17694,6 +19656,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17716,6 +19679,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17738,6 +19702,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17762,6 +19727,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17786,6 +19752,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17810,6 +19777,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17834,6 +19802,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17858,6 +19827,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17880,6 +19850,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17902,6 +19873,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17924,6 +19896,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17946,6 +19919,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17968,6 +19942,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -17990,6 +19965,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18012,6 +19988,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18034,6 +20011,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18056,6 +20034,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18078,6 +20057,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18100,6 +20080,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18122,6 +20103,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18144,6 +20126,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18166,6 +20149,7 @@ presubmits:
     preset-openstack: "true"
   name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18188,6 +20172,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18210,6 +20195,7 @@ presubmits:
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18232,6 +20218,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18254,6 +20241,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18276,6 +20264,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18298,6 +20287,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18320,6 +20310,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18342,6 +20333,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18364,6 +20356,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18386,6 +20379,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18408,6 +20402,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18430,6 +20425,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.22.12
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18452,6 +20448,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18474,6 +20471,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18496,6 +20494,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18518,6 +20517,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18540,6 +20540,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18562,6 +20563,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18584,6 +20586,7 @@ presubmits:
     preset-goproxy: "true"
   name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18606,6 +20609,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18628,6 +20632,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
@@ -18650,6 +20655,7 @@ presubmits:
     preset-hetzner: "true"
   name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.9
   optional: false
+  path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:

--- a/testv2/e2e/scenario_install.go
+++ b/testv2/e2e/scenario_install.go
@@ -190,6 +190,7 @@ func (scenario *scenarioInstall) GenerateTests(wr io.Writer, generatorType Gener
 			scenario.infra.labels,
 			testTitle,
 			cfg,
+			nil,
 		),
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now, we're downloading the latest stable KubeOne binary from GitHub and we use it to provision the cluster in the upgrade tests. After that, we build the binary based on PR's ref and use it to upgrade the cluster.

The issue with downloading the KubeOne binary from GitHub is that it might miss some changes required for tests to pass. For example, we had a problem with OpenStack CentOS upgrade tests failing because of missing volume mounts. We cherry-picked the fix in #2303, but we would have to release a new KubeOne patch release to be able to use that fix in tests. This is not optimal as we would have to cut patch releases way too often.

To mitigate this, this PR proposes building the stable binary directory from the release branch (e.g. `release/v1.4`). In this case, we have all the latest fixes without needing to cut a patch release.

The old logic is still in code, so we can easily switch back to download the latest stable binary from GitHub.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```