### PR TITLE
Extend Terraform configs for Azure to automatically subscribe to RHSM

### DIFF
--- a/examples/terraform/azure/README.md
+++ b/examples/terraform/azure/README.md
@@ -62,6 +62,9 @@ No modules.
 | <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | Number of replicas per MachineDeployment | `number` | `2` | no |
 | <a name="input_location"></a> [location](#input\_location) | Azure datacenter to use | `string` | `"westeurope"` | no |
 | <a name="input_os"></a> [os](#input\_os) | Operating System to use for finding image reference and in MachineDeployment | `string` | `"ubuntu"` | no |
+| <a name="input_rhsm_offline_token"></a> [rhsm\_offline\_token](#input\_rhsm\_offline\_token) | RHSM offline token | `string` | `""` | no |
+| <a name="input_rhsm_password"></a> [rhsm\_password](#input\_rhsm\_password) | RHSM password | `string` | `""` | no |
+| <a name="input_rhsm_username"></a> [rhsm\_username](#input\_rhsm\_username) | RHSM username | `string` | `""` | no |
 | <a name="input_ssh_agent_socket"></a> [ssh\_agent\_socket](#input\_ssh\_agent\_socket) | SSH Agent socket, default to grab from $SSH\_AUTH\_SOCK | `string` | `"env:SSH_AUTH_SOCK"` | no |
 | <a name="input_ssh_port"></a> [ssh\_port](#input\_ssh\_port) | SSH port to be used to provision instances | `number` | `22` | no |
 | <a name="input_ssh_private_key_file"></a> [ssh\_private\_key\_file](#input\_ssh\_private\_key\_file) | SSH private key file used to access instances | `string` | `""` | no |

--- a/examples/terraform/azure/cloud-config.tftpl
+++ b/examples/terraform/azure/cloud-config.tftpl
@@ -1,0 +1,7 @@
+#cloud-config
+%{ if os == "rhel" }
+rh_subscription:
+  username: ${rhsm_username}
+  password: '${rhsm_password}'
+  auto-attach: false
+%{ endif }

--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -277,6 +277,11 @@ resource "azurerm_virtual_machine" "control_plane" {
   os_profile {
     computer_name  = "${var.cluster_name}-cp-${count.index}"
     admin_username = local.ssh_username
+    custom_data = templatefile("./cloud-config.tftpl", {
+      os            = var.os
+      rhsm_username = var.rhsm_username
+      rhsm_password = var.rhsm_password
+    })
   }
 
   os_profile_linux_config {

--- a/examples/terraform/azure/output.tf
+++ b/examples/terraform/azure/output.tf
@@ -43,6 +43,7 @@ output "kubeone_hosts" {
 
 output "kubeone_workers" {
   description = "Workers definitions, that will be transformed into MachineDeployment object"
+  sensitive   = true
 
   value = {
     # following outputs will be parsed by kubeone and automatically merged into
@@ -56,7 +57,10 @@ output "kubeone_workers" {
         sshPublicKeys   = [file(var.ssh_public_key_file)]
         operatingSystem = local.worker_os
         operatingSystemSpec = {
-          distUpgradeOnBoot = false
+          distUpgradeOnBoot               = false
+          rhelSubscriptionManagerUser     = var.rhsm_username
+          rhelSubscriptionManagerPassword = var.rhsm_password
+          rhsmOfflineToken                = var.rhsm_offline_token
         }
         # nodeAnnotations are applied on resulting Node objects
         # nodeAnnotations = {

--- a/examples/terraform/azure/variables.tf
+++ b/examples/terraform/azure/variables.tf
@@ -224,3 +224,25 @@ Name of operating system profile for MachineDeployments, only applicable if oper
 If not specified, the default value will be added by machine-controller addon.
 EOF
 }
+
+# RHEL subscription
+variable "rhsm_username" {
+  description = "RHSM username"
+  default     = ""
+  type        = string
+  sensitive   = true
+}
+
+variable "rhsm_password" {
+  description = "RHSM password"
+  default     = ""
+  type        = string
+  sensitive   = true
+}
+
+variable "rhsm_offline_token" {
+  description = "RHSM offline token"
+  default     = ""
+  type        = string
+  sensitive   = true
+}

--- a/testv2/e2e/prow.yaml
+++ b/testv2/e2e/prow.yaml
@@ -219,6 +219,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -666,6 +667,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -1113,6 +1115,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -1560,6 +1563,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -2007,6 +2011,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -2504,6 +2509,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -3046,6 +3052,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -3588,6 +3595,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -4130,6 +4138,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -4672,6 +4681,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -5164,6 +5174,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -5611,6 +5622,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -6058,6 +6070,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -6505,6 +6518,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -6952,6 +6966,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -7399,6 +7414,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -8042,6 +8058,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -8489,6 +8506,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -8936,6 +8954,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -9383,6 +9402,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -9830,6 +9850,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -10300,6 +10321,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -10609,6 +10631,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -10918,6 +10941,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -11227,6 +11251,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -11881,6 +11906,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -12535,6 +12561,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -13189,6 +13216,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -13843,6 +13871,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -14547,6 +14576,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -15341,6 +15371,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -16135,6 +16166,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -16929,6 +16961,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -17723,6 +17756,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -18467,6 +18501,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -19121,6 +19156,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -19775,6 +19811,7 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
+    preset-rhel: "true"
   name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone

--- a/testv2/e2e/tests_definitions.go
+++ b/testv2/e2e/tests_definitions.go
@@ -230,6 +230,7 @@ var (
 			labels: map[string]string{
 				"preset-goproxy": "true",
 				"preset-azure":   "true",
+				"preset-rhel":    "true",
 			},
 			environ: map[string]string{
 				"PROVIDER":     "azure",

--- a/testv2/go-test-e2e.sh
+++ b/testv2/go-test-e2e.sh
@@ -73,6 +73,9 @@ function setup_ci_environment_vars() {
     export ARM_CLIENT_SECRET=${AZURE_E2E_TESTS_CLIENT_SECRET}
     export ARM_SUBSCRIPTION_ID=${AZURE_E2E_TESTS_SUBSCRIPTION_ID}
     export ARM_TENANT_ID=${AZURE_E2E_TESTS_TENANT_ID}
+    export TF_VAR_rhsm_username=${RHEL_SUBSCRIPTION_MANAGER_USER:-""}
+    export TF_VAR_rhsm_password=${RHEL_SUBSCRIPTION_MANAGER_PASSWORD:-""}
+    export TF_VAR_rhsm_offline_token=${REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN:-""}
     CREDENTIALS_FILE_PATH="${BUILD_DIR}/credentials.yaml"
 
     cat > "${CREDENTIALS_FILE_PATH}" << EOL


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the example Terraform configs for Azure to automatically subscribe RHEL instances to RHSM. This is done via cloud-init and rh_subscription module. To make this work, the following Terraform variables are required:

* rhsm_username
* rhsm_password
* rhsm_offline_token (used by machine-controller to unregister worker nodes on deletion)

**Important notice:** VMs created by Terraform are **NOT** automatically unregistered on deletion. You have to manually unregister those VMs by running `sudo subscription-manager unregister`. The worker nodes created by machine-controller are automatically unregistered as long as the RHSM Offline Token (`rhsm_offline_token`) is provided.

The values of those Terraform variables are passed to machine-controller to be used for creating worker nodes. All three variables are marked as sensitive to avoid accidental leaking of credentials. Additionally, the `kubeone_workers` output object has been marked as sensitive as it's required by Terraform because we're using sensitive variables in the object.

It's possible to opt-out of automatic subscription by:

* modifying the `cloud-config.tftpl` file
* removing `custom_data` in `main.tf`

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

I'll extend the new E2E tests to automatically unregister VMs on cleanup in a follow-up PR. I've already tried the `remote-exec` provisioner, but it doesn't work with Azure because it cannot access other objects, so it's impossible to get the IP address of the VM.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Extend example Terraform configs for Azure to automatically subscribe RHEL instances to RHSM (see the PR for more details and instructions on how to opt-out). Important: VMs created by Terraform are **NOT** automatically unregistered on deletion. You have to manually unregister those VMs by running `sudo subscription-manager unregister`. The worker nodes created by machine-controller are automatically unregistered as long as the RHSM Offline Token (`rhsm_offline_token`) is provided.
```

**Documentation**:
```documentation
NONE
```