### PR TITLE
Mount /etc/pki to the Azure CCM container

### DIFF
--- a/addons/ccm-azure/ccm-azure.yaml
+++ b/addons/ccm-azure/ccm-azure.yaml
@@ -197,6 +197,9 @@ spec:
             - name: etc-ssl
               mountPath: /etc/ssl
               readOnly: true
+            - name: etc-pki
+              mountPath: /etc/pki
+              readOnly: true
             - name: msi
               mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
@@ -207,6 +210,9 @@ spec:
         - name: etc-ssl
           hostPath:
             path: /etc/ssl
+        - name: etc-pki
+          hostPath:
+            path: /etc/pki
         - name: msi
           hostPath:
             path: /var/lib/waagent/ManagedIdentity-Settings


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a PR similar to #2299, but for Azure.

CA certificates in the `/etc/ssl/certs` directory on CentOS 7 and Rocky Linux are only symlinks pointing to `/etc/pki`. We only mount `/etc/ssl/certs` in the Azure CCM container, so symlinks are not working at all. This is causing the Azure CCM to end up in a CrashLoopBackoff. To fix this issue, we are now mounting `/etc/pki` to the Azure CCM container.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Mount `/etc/pki` to the Azure CCM container to fix CrashLoopBackoff on clusters running CentOS 7 and Rocky Linux
```

**Documentation**:
```documentation
NONE
```