### PR TITLE
CCM/CSI migration: merge steps for manifests and kubelet config updates

### DIFF
--- a/pkg/scripts/ccm_csi_migration.go
+++ b/pkg/scripts/ccm_csi_migration.go
@@ -23,36 +23,24 @@ import (
 )
 
 var (
-	ccmMigrationRegenerateControlPlaneManifests = heredoc.Doc(`
+	ccmMigrationRegenerateControlPlaneConfigs = heredoc.Doc(`
 		sudo kubeadm {{ .VERBOSE }} init phase control-plane apiserver \
 			--config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
 
 		sudo kubeadm {{ .VERBOSE }} init phase control-plane controller-manager \
 			--config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
-	`)
-
-	ccmMigrationUpdateKubeletConfig = heredoc.Doc(`
+		
 		sudo kubeadm {{ .VERBOSE }} init phase kubelet-start \
 			--config={{ .WORK_DIR }}/cfg/master_{{ .NODE_ID }}.yaml
 	`)
 )
 
-func CCMMigrationRegenerateControlPlaneManifests(workdir string, nodeID int, verboseFlag string) (string, error) {
-	result, err := Render(ccmMigrationRegenerateControlPlaneManifests, Data{
+func CCMMigrationRegenerateControlPlaneConfigs(workdir string, nodeID int, verboseFlag string) (string, error) {
+	result, err := Render(ccmMigrationRegenerateControlPlaneConfigs, Data{
 		"WORK_DIR": workdir,
 		"NODE_ID":  nodeID,
 		"VERBOSE":  verboseFlag,
 	})
 
-	return result, fail.Runtime(err, "rendering ccmMigrationRegenerateControlPlaneManifests script")
-}
-
-func CCMMigrationUpdateKubeletConfig(workdir string, nodeID int, verboseFlag string) (string, error) {
-	result, err := Render(ccmMigrationUpdateKubeletConfig, Data{
-		"WORK_DIR": workdir,
-		"NODE_ID":  nodeID,
-		"VERBOSE":  verboseFlag,
-	})
-
-	return result, fail.Runtime(err, "rendering ccmMigrationUpdateKubeletConfig")
+	return result, fail.Runtime(err, "rendering ccmMigrationRegenerateControlPlaneConfigs script")
 }

--- a/pkg/scripts/ccm_csi_migration_test.go
+++ b/pkg/scripts/ccm_csi_migration_test.go
@@ -23,7 +23,7 @@ import (
 	"k8c.io/kubeone/pkg/testhelper"
 )
 
-func TestCCMMigrationRegenerateControlPlaneManifests(t *testing.T) {
+func TestCCMMigrationRegenerateControlPlaneConfigs(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
@@ -57,55 +57,9 @@ func TestCCMMigrationRegenerateControlPlaneManifests(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := CCMMigrationRegenerateControlPlaneManifests(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag)
+			got, err := CCMMigrationRegenerateControlPlaneConfigs(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag)
 			if !errors.Is(err, tt.err) {
-				t.Errorf("TestCCMMigrationRegenerateControlPlaneManifests() error = %v, wantErr %v", err, tt.err)
-
-				return
-			}
-
-			testhelper.DiffOutput(t, testhelper.FSGoldenName(t), got, *updateFlag)
-		})
-	}
-}
-
-func TestCCMMigrationUpdateKubeletConfig(t *testing.T) {
-	t.Parallel()
-
-	type args struct {
-		workdir     string
-		nodeID      int
-		verboseFlag string
-	}
-
-	tests := []struct {
-		name string
-		args args
-		err  error
-	}{
-		{
-			name: "verbose",
-			args: args{
-				workdir:     "test-wd",
-				nodeID:      0,
-				verboseFlag: "--v=6",
-			},
-		},
-		{
-			name: "not-verbose",
-			args: args{
-				workdir: "test-wd",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got, err := CCMMigrationUpdateKubeletConfig(tt.args.workdir, tt.args.nodeID, tt.args.verboseFlag)
-			if !errors.Is(err, tt.err) {
-				t.Errorf("CCMMigrationUpdateKubeletConfig() error = %v, wantErr %v", err, tt.err)
+				t.Errorf("TestCCMMigrationRegenerateControlPlaneConfigs() error = %v, wantErr %v", err, tt.err)
 
 				return
 			}

--- a/pkg/scripts/testdata/TestCCMMigrationRegenerateControlPlaneConfigs-not-verbose.golden
+++ b/pkg/scripts/testdata/TestCCMMigrationRegenerateControlPlaneConfigs-not-verbose.golden
@@ -1,0 +1,10 @@
+set -xeuo pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+sudo kubeadm  init phase control-plane apiserver \
+	--config=test-wd/cfg/master_0.yaml
+
+sudo kubeadm  init phase control-plane controller-manager \
+	--config=test-wd/cfg/master_0.yaml
+
+sudo kubeadm  init phase kubelet-start \
+	--config=test-wd/cfg/master_0.yaml

--- a/pkg/scripts/testdata/TestCCMMigrationRegenerateControlPlaneConfigs-verbose.golden
+++ b/pkg/scripts/testdata/TestCCMMigrationRegenerateControlPlaneConfigs-verbose.golden
@@ -1,0 +1,10 @@
+set -xeuo pipefail
+export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
+sudo kubeadm --v=6 init phase control-plane apiserver \
+	--config=test-wd/cfg/master_0.yaml
+
+sudo kubeadm --v=6 init phase control-plane controller-manager \
+	--config=test-wd/cfg/master_0.yaml
+
+sudo kubeadm --v=6 init phase kubelet-start \
+	--config=test-wd/cfg/master_0.yaml

--- a/pkg/tasks/ccm_csi_migration.go
+++ b/pkg/tasks/ccm_csi_migration.go
@@ -92,55 +92,13 @@ func readyToCompleteCCMMigration(s *state.State) error {
 	return nil
 }
 
-func ccmMigrationRegenerateControlPlaneManifests(s *state.State) error {
-	return s.RunTaskOnControlPlane(ccmMigrationRegenerateControlPlaneManifestsInternal, state.RunSequentially)
+func ccmMigrationRegenerateControlPlaneManifestsAndKubeletConfig(s *state.State) error {
+	return s.RunTaskOnControlPlane(ccmMigrationRegenerateControlPlaneManifestsAndKubeletConfigInternal, state.RunSequentially)
 }
 
-func ccmMigrationRegenerateControlPlaneManifestsInternal(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
+func ccmMigrationRegenerateControlPlaneManifestsAndKubeletConfigInternal(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
 	logger := s.Logger.WithField("node", node.PublicAddress)
-	logger.Info("Regenerating Kubernetes API server and kube-controller-manager manifests...")
-
-	var (
-		apiserverPodName         = fmt.Sprintf("kube-apiserver-%s", node.Hostname)
-		controllerManagerPodName = fmt.Sprintf("kube-controller-manager-%s", node.Hostname)
-	)
-
-	cmd, err := scripts.CCMMigrationRegenerateControlPlaneManifests(s.WorkDir, node.ID, s.KubeadmVerboseFlag())
-	if err != nil {
-		return err
-	}
-	_, _, err = s.Runner.RunRaw(cmd)
-	if err != nil {
-		return fail.SSH(err, "regenerate control-plane manifests for CCM migration")
-	}
-
-	timeout := 30 * time.Second
-	logger.Infof("Waiting %s for Kubelet to roll-out static pods...", timeout)
-	time.Sleep(timeout)
-
-	timeout = 2 * time.Minute
-	logger.Infof("Waiting up to %s for API server to become healthy...", timeout)
-	err = waitForStaticPodReady(s, timeout, apiserverPodName, metav1.NamespaceSystem)
-	if err != nil {
-		return err
-	}
-
-	logger.Infof("Waiting up to %s for kube-controller-manager roll-out...", timeout)
-	err = waitForStaticPodReady(s, timeout, controllerManagerPodName, metav1.NamespaceSystem)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func ccmMigrationUpdateControlPlaneKubeletConfig(s *state.State) error {
-	return s.RunTaskOnControlPlane(ccmMigrationUpdateControlPlaneKubeletConfigInternal, state.RunSequentially)
-}
-
-func ccmMigrationUpdateControlPlaneKubeletConfigInternal(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {
-	logger := s.Logger.WithField("node", node.PublicAddress)
-	logger.Info("Updating config and restarting Kubelet...")
+	logger.Info("Starting CCM/CSI migration...")
 
 	drainer := nodeutils.NewDrainer(s.RESTConfig, logger)
 
@@ -154,19 +112,41 @@ func ccmMigrationUpdateControlPlaneKubeletConfigInternal(s *state.State, node *k
 		return err
 	}
 
-	logger.Info("Updating Kubelet config...")
-	cmd, err := scripts.CCMMigrationUpdateKubeletConfig(s.WorkDir, node.ID, s.KubeadmVerboseFlag())
+	logger.Info("Regenerating API server and kube-controller-manager manifests, and Kubelet configuration...")
+
+	cmd, err := scripts.CCMMigrationRegenerateControlPlaneConfigs(s.WorkDir, node.ID, s.KubeadmVerboseFlag())
 	if err != nil {
 		return err
 	}
 	_, _, err = s.Runner.RunRaw(cmd)
 	if err != nil {
-		return fail.SSH(err, "updating kubelet config for CCM migration")
+		return fail.SSH(err, "regenerate control-plane manifests for CCM migration")
 	}
 
-	timeout := 2 * time.Minute
+	var (
+		apiserverPodName         = fmt.Sprintf("kube-apiserver-%s", node.Hostname)
+		controllerManagerPodName = fmt.Sprintf("kube-controller-manager-%s", node.Hostname)
+		timeout                  = 2 * time.Minute
+	)
+
+	logger.Debugf("Waiting %s for control plane components to stabilize...", timeout)
+	time.Sleep(timeout)
+
 	logger.Debugf("Waiting up to %s for Kubelet to become running...", timeout)
-	if err := waitForKubeletReady(conn, timeout); err != nil {
+	err = waitForKubeletReady(conn, timeout)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Waiting up to %s for API server to become healthy...", timeout)
+	err = waitForStaticPodReady(s, timeout, apiserverPodName, metav1.NamespaceSystem)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Waiting up to %s for kube-controller-manager roll-out...", timeout)
+	err = waitForStaticPodReady(s, timeout, controllerManagerPodName, metav1.NamespaceSystem)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -510,8 +510,7 @@ func WithCCMCSIMigration(t Tasks) Tasks {
 	}...).
 		append(kubernetesConfigFiles()...).
 		append(
-			Task{Fn: ccmMigrationRegenerateControlPlaneManifests, Operation: "regenerating static pod manifests"},
-			Task{Fn: ccmMigrationUpdateControlPlaneKubeletConfig, Operation: "updating kubelet config on control plane nodes"},
+			Task{Fn: ccmMigrationRegenerateControlPlaneManifestsAndKubeletConfig, Operation: "regenerating static pod manifests and kubelet config"},
 			Task{
 				Fn:        ccmMigrationUpdateStaticWorkersKubeletConfig,
 				Operation: "updating kubelet config on static worker nodes",


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now, the core of the CCM/CSI migration are the following two steps needed to enable the needed feature gates and disable the in-tree cloud provider:

* Update kube-apiserver and kube-controller-manager manifests
  * This step consists of running `kubeadm` on each node (sequentially) to update static pod manifests and then waiting for Kubelet to rollout those static pods
* Update the Kubelet config
  * This step consists of draining and cordoning the node, running `kubeadm` on the node to update the Kubelet config, and then waiting for Kubelet to become running and healthy, followed by uncordoning the node at the end

This worked well until Kubernetes 1.24. For some reason, with Kubernetes 1.24, **if the API endpoint is one of the control plane nodes (instead of a Load Balancer)**, completing the CCM/CSI migration fails:

```
time="10:53:57 UTC" level=info msg="Regenerating Kubernetes API server and kube-controller-manager manifests..." node=172.31.125.60
time="10:53:58 UTC" level=info msg="Waiting 30s for Kubelet to roll-out static pods..." node=172.31.125.60
time="10:54:28 UTC" level=info msg="Waiting up to 2m0s for API server to become healthy..." node=172.31.125.60
time="10:54:28 UTC" level=info msg="Waiting up to 2m0s for kube-controller-manager roll-out..." node=172.31.125.60
time="10:56:28 UTC" level=warning msg="Task failed, error was: runtime: running task on \"172.31.125.60\"\ntimed out waiting for the condition"
```

The reason why this happens is that the kube-controller-manager fails when the API server is restarted and never comes up again. Kubelet logs some errors saying the static pod manifest is invalid, however, it is correct. It's needed to restart Kubelet for that error to go away.

This can be seen in #2323, e.g. https://public-prow.loodse.com/view/gs/prow-dev-public-data/pr-logs/pull/kubermatic_kubeone/2323/pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.3/1563852242006577152

This issue is fixed by merging the two steps mentioned above into a single step that:

* Cordons and drains the node
* Runs `kubeadm` to update static pods manifests **AND** Kubelet config
  * Kubeadm automatically restarts Kubelet when the Kubelet config is updated
* Waits for 2 minutes to give time to the control plane components and Kubelet to stabilize
* Waits for Kubelet to become running and healthy
* Waits for kube-apiserver and kube-controller-manager to become running and healthy
* Uncordons the node

Since Kubelet is restarted right after updating the static pod manifests, the error described above doesn't occur any longer.

The root cause of why this happens is still unknown, but it might be some bug in Kubelet itself.

**Which issue(s) this PR fixes**:
Fixes #2324

**What type of PR is this?**

/kind bug
/priority critical-urgent

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Merge the CCM/CSI migration steps for updating the control plane static pod manifests and Kubelet configuration into a single step. This fixes an issue with the CCM/CSI migration failing on clusters running Kubernetes 1.24+ when the API endpoint is one of the control plane nodes.
```

**Documentation**:
```documentation
NONE
```