### PR TITLE
[release/v1.4] Update machine-controller to v1.43.7

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -188,7 +188,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:        {"*": "quay.io/calico/node:v3.22.4"},
 		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
 		Flannel:           {"*": "quay.io/coreos/flannel:v0.15.1"},
-		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.43.6"},
+		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.43.7"},
 		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Update machine-controller to v1.43.7.

**IMPORTANT:** This update fixes several issues for RHEL clusters on Azure. If you have RHEL-based MachineDeployments on Azure, we **strongly recommend** upgrading to KubeOne 1.4.8 and rotating those MachineDeployments **BEFORE** upgrading to KubeOne 1.5. **If not done, the Canal CNI update might break the cluster networking when upgrading to KubeOne 1.5.**

**Which issue(s) this PR fixes**:
xref #2325

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Update machine-controller to v1.43.7. This update fixes several issues for RHEL clusters on Azure. If you have RHEL-based MachineDeployments on Azure, we **strongly recommend** upgrading to KubeOne 1.4.8 and rotating those MachineDeployments **BEFORE** upgrading to KubeOne 1.5. **If not done, the Canal CNI update might break the cluster networking when upgrading to KubeOne 1.5.**
```

**Documentation**:
```documentation
NONE
```