### PR TITLE
[release/v1.4] Cherry-pick Canal/Calico iptables backend and Azure CCM changes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,4 +97,4 @@ issues:
     text: "cyclomatic complexity 36 of func `openstackValidationFunc` is high"
 
   - path: pkg/addons
-    text: "cyclomatic complexity 41 of func `newAddonsApplier` is high"
+    text: "cyclomatic complexity 44 of func `newAddonsApplier` is high"

--- a/addons/calico-vxlan/calico-vxlan.yaml
+++ b/addons/calico-vxlan/calico-vxlan.yaml
@@ -4353,6 +4353,8 @@ spec:
               value: "false"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            - name: FELIX_IPTABLESBACKEND
+              value: "{{ default .CalicoIptablesBackend .Params.iptablesBackend }}"
           securityContext:
             privileged: true
           resources:

--- a/addons/ccm-azure/ccm-azure.yaml
+++ b/addons/ccm-azure/ccm-azure.yaml
@@ -202,6 +202,9 @@ spec:
             - name: etc-pki
               mountPath: /etc/pki
               readOnly: true
+            - name: usr-share-ca-certs
+              mountPath: /usr/share/ca-certificates
+              readOnly: true
             - name: msi
               mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
@@ -215,6 +218,9 @@ spec:
         - name: etc-pki
           hostPath:
             path: /etc/pki
+        - name: usr-share-ca-certs
+          hostPath:
+            path: /usr/share/ca-certificates
         - name: msi
           hostPath:
             path: /var/lib/waagent/ManagedIdentity-Settings

--- a/addons/cni-canal/canal.yaml
+++ b/addons/cni-canal/canal.yaml
@@ -4361,6 +4361,8 @@ spec:
               value: "false"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            - name: FELIX_IPTABLESBACKEND
+              value: "{{ default .CalicoIptablesBackend .Params.iptablesBackend }}"
           securityContext:
             privileged: true
           resources:

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -225,7 +225,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 
 	calicoIptablesBackend := "Auto"
 	for _, cp := range s.LiveCluster.ControlPlane {
-		if cp.Config.OperatingSystem == kubeoneapi.OperatingSystemNameFlatcar {
+		if cp.Config.OperatingSystem == kubeoneapi.OperatingSystemNameFlatcar || cp.Config.OperatingSystem == kubeoneapi.OperatingSystemNameRHEL {
 			calicoIptablesBackend = "NFT"
 
 			break

--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -70,6 +70,7 @@ type templateData struct {
 	CCMClusterName                           string
 	CSIMigration                             bool
 	CSIMigrationFeatureGates                 string
+	CalicoIptablesBackend                    string
 	MachineControllerCredentialsEnvVars      string
 	MachineControllerCredentialsHash         string
 	OperatingSystemManagerEnabled            bool
@@ -222,6 +223,15 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 		}
 	}
 
+	calicoIptablesBackend := "Auto"
+	for _, cp := range s.LiveCluster.ControlPlane {
+		if cp.Config.OperatingSystem == kubeoneapi.OperatingSystemNameFlatcar {
+			calicoIptablesBackend = "NFT"
+
+			break
+		}
+	}
+
 	data := templateData{
 		Config: s.Cluster,
 		Certificates: map[string]string{
@@ -237,6 +247,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 		CCMClusterName:                        s.LiveCluster.CCMClusterName,
 		CSIMigration:                          csiMigration,
 		CSIMigrationFeatureGates:              csiMigrationFeatureGates,
+		CalicoIptablesBackend:                 calicoIptablesBackend,
 		MachineControllerCredentialsEnvVars:   string(credsEnvVarsMC),
 		MachineControllerCredentialsHash:      mcCredsHash,
 		OperatingSystemManagerEnabled:         s.Cluster.OperatingSystemManagerEnabled(),

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -673,17 +673,17 @@ func detectCCMMigrationStatus(s *state.State) (*state.CCMStatus, error) {
 // backwards compatibility.
 //
 // The function works in the following way:
-//   * if the cluster is not provisioned, or if the cluster is not an OpenStack
+//   - if the cluster is not provisioned, or if the cluster is not an OpenStack
 //     cluster, return the KubeOne cluster name
-//   * if it's an existing OpenStack cluster:
-//      * if cluster is running in-tree cloud provider: return the KubeOne
-//        cluster name because the in-tree provider already has the
-//        --cluster-name flag set
-//      * if cluster is running external cloud provider: check if there is
-//        `--cluster-name` flag on the OpenStack CCM. If there is, read the
-//        value and return it, otherwise don't set the OpenStack cluster name,
-//        in which case it defaults to `kubernetes`
-//   * if cluster is migrated to external CCM, return the KubeOne cluster name
+//   - if it's an existing OpenStack cluster:
+//   - if cluster is running in-tree cloud provider: return the KubeOne
+//     cluster name because the in-tree provider already has the
+//     --cluster-name flag set
+//   - if cluster is running external cloud provider: check if there is
+//     `--cluster-name` flag on the OpenStack CCM. If there is, read the
+//     value and return it, otherwise don't set the OpenStack cluster name,
+//     in which case it defaults to `kubernetes`
+//   - if cluster is migrated to external CCM, return the KubeOne cluster name
 //
 // If an operator wants to change the --cluster-name flag on OpenStack external
 // CCM, they need to edit the CCM DaemonSet manually. KubeOne will

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -80,8 +80,8 @@ func WithBinariesOnly(t Tasks) Tasks {
 }
 
 // WithHostnameOS will prepend passed tasks with 2 basic tasks:
-//  * detect OS on all cluster hosts
-//  * detect hostnames  on all cluster hosts
+//   - detect OS on all cluster hosts
+//   - detect hostnames  on all cluster hosts
 func WithHostnameOS(t Tasks) Tasks {
 	return t.prepend(
 		Task{Fn: determineHostname, ErrMsg: "failed to detect hostname"},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR cherry-picks several fixes from the master to the release/v1.4 branch:

- Mount /usr/share/ca-certificates in the Azure CCM (part of #2331)
- Set iptables backend to NFT for Canal and Calico VXLAN on Flatcar clusters (#2301)
- Enforce NFT iptables backend for Canal on RHEL (part of #2331)

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Mount `/usr/share/ca-certificates` to the Azure CCM container to fix CrashLoopBackoff on clusters running Flatcar
- Enforce the NFT iptables backend for Canal and Calico VXLAN on RHEL
- Set iptables backend (`FELIX_IPTABLESBACKEND`) to `NFT` for Canal and Calico VXLAN on clusters running Flatcar Linux. For non Flatcar clusters, iptables backend is set to Auto, which is the default value and results in Calico determining the iptables backend automatically. The value can be overridden by setting the `iptablesBackend` addon parameter (see the PR description for an example).
```

**Documentation**:
```documentation
NONE
```