### PR TITLE
Initialize OperatingSystemManager in KubeOneCluster regardless if MachineController enabled or not

### DIFF
--- a/pkg/apis/kubeone/v1beta2/defaults.go
+++ b/pkg/apis/kubeone/v1beta2/defaults.go
@@ -197,10 +197,9 @@ func SetDefaults_MachineController(obj *KubeOneCluster) {
 }
 
 func SetDefaults_OperatingSystemManager(obj *KubeOneCluster) {
-	// OSM can only be used in liaison with machine-controller
-	if obj.OperatingSystemManager == nil && (obj.MachineController != nil && obj.MachineController.Deploy) {
+	if obj.OperatingSystemManager == nil {
 		obj.OperatingSystemManager = &OperatingSystemManagerConfig{
-			Deploy: true,
+			Deploy: obj.MachineController.Deploy,
 		}
 	}
 }

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -70,15 +70,15 @@ func TestValidateKubeOneCluster(t *testing.T) {
 				DynamicWorkers: []kubeoneapi.DynamicWorkerConfig{
 					{
 						Name:     "test-1",
-						Replicas: intPtr(3),
+						Replicas: pointer.Int(3),
 					},
 					{
 						Name:     "test-2",
-						Replicas: intPtr(5),
+						Replicas: pointer.Int(5),
 					},
 					{
 						Name:     "test-3",
-						Replicas: intPtr(0),
+						Replicas: pointer.Int(0),
 					},
 				},
 			},
@@ -120,15 +120,15 @@ func TestValidateKubeOneCluster(t *testing.T) {
 				DynamicWorkers: []kubeoneapi.DynamicWorkerConfig{
 					{
 						Name:     "test-1",
-						Replicas: intPtr(3),
+						Replicas: pointer.Int(3),
 					},
 					{
 						Name:     "test-2",
-						Replicas: intPtr(5),
+						Replicas: pointer.Int(5),
 					},
 					{
 						Name:     "test-3",
-						Replicas: intPtr(0),
+						Replicas: pointer.Int(0),
 					},
 				},
 			},
@@ -170,15 +170,15 @@ func TestValidateKubeOneCluster(t *testing.T) {
 				DynamicWorkers: []kubeoneapi.DynamicWorkerConfig{
 					{
 						Name:     "test-1",
-						Replicas: intPtr(3),
+						Replicas: pointer.Int(3),
 					},
 					{
 						Name:     "test-2",
-						Replicas: intPtr(5),
+						Replicas: pointer.Int(5),
 					},
 					{
 						Name:     "test-3",
-						Replicas: intPtr(0),
+						Replicas: pointer.Int(0),
 					},
 				},
 			},
@@ -220,15 +220,15 @@ func TestValidateKubeOneCluster(t *testing.T) {
 				DynamicWorkers: []kubeoneapi.DynamicWorkerConfig{
 					{
 						Name:     "test-1",
-						Replicas: intPtr(3),
+						Replicas: pointer.Int(3),
 					},
 					{
 						Name:     "test-2",
-						Replicas: intPtr(5),
+						Replicas: pointer.Int(5),
 					},
 					{
 						Name:     "test-3",
-						Replicas: intPtr(0),
+						Replicas: pointer.Int(0),
 					},
 				},
 			},
@@ -1199,15 +1199,15 @@ func TestValidateDynamicWorkerConfig(t *testing.T) {
 			dynamicWorkerConfig: []kubeoneapi.DynamicWorkerConfig{
 				{
 					Name:     "test-1",
-					Replicas: intPtr(3),
+					Replicas: pointer.Int(3),
 				},
 				{
 					Name:     "test-2",
-					Replicas: intPtr(5),
+					Replicas: pointer.Int(5),
 				},
 				{
 					Name:     "test-3",
-					Replicas: intPtr(0),
+					Replicas: pointer.Int(0),
 				},
 			},
 			expectedError: false,
@@ -1222,7 +1222,7 @@ func TestValidateDynamicWorkerConfig(t *testing.T) {
 			dynamicWorkerConfig: []kubeoneapi.DynamicWorkerConfig{
 				{
 					Name:     "test-1",
-					Replicas: intPtr(3),
+					Replicas: pointer.Int(3),
 				},
 				{
 					Name: "test-2",
@@ -1234,7 +1234,7 @@ func TestValidateDynamicWorkerConfig(t *testing.T) {
 			name: "invalid worker config (no name given)",
 			dynamicWorkerConfig: []kubeoneapi.DynamicWorkerConfig{
 				{
-					Replicas: intPtr(3),
+					Replicas: pointer.Int(3),
 				},
 			},
 			expectedError: true,
@@ -1244,7 +1244,7 @@ func TestValidateDynamicWorkerConfig(t *testing.T) {
 			dynamicWorkerConfig: []kubeoneapi.DynamicWorkerConfig{
 				{
 					Name:     "test-1",
-					Replicas: intPtr(3),
+					Replicas: pointer.Int(3),
 					Config: kubeoneapi.ProviderSpec{
 						MachineAnnotations: map[string]string{"test": "test"},
 					},
@@ -1257,7 +1257,7 @@ func TestValidateDynamicWorkerConfig(t *testing.T) {
 			dynamicWorkerConfig: []kubeoneapi.DynamicWorkerConfig{
 				{
 					Name:     "test-1",
-					Replicas: intPtr(3),
+					Replicas: pointer.Int(3),
 					Config: kubeoneapi.ProviderSpec{
 						NodeAnnotations: map[string]string{"test": "test"},
 					},
@@ -1270,7 +1270,7 @@ func TestValidateDynamicWorkerConfig(t *testing.T) {
 			dynamicWorkerConfig: []kubeoneapi.DynamicWorkerConfig{
 				{
 					Name:     "test-1",
-					Replicas: intPtr(3),
+					Replicas: pointer.Int(3),
 					Config: kubeoneapi.ProviderSpec{
 						MachineAnnotations: map[string]string{"test": "test"},
 						NodeAnnotations:    map[string]string{"test": "test"},
@@ -2209,8 +2209,4 @@ func TestValidateAssetConfiguration(t *testing.T) {
 			}
 		})
 	}
-}
-
-func intPtr(i int) *int {
-	return &i
 }

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -23,9 +23,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	"github.com/kubermatic/machine-controller/pkg/jsonutil"
-	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -36,6 +33,10 @@ import (
 	"k8c.io/kubeone/pkg/fail"
 	"k8c.io/kubeone/pkg/kubeconfig"
 	"k8c.io/kubeone/pkg/state"
+
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"github.com/kubermatic/machine-controller/pkg/jsonutil"
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes NPE.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #2343

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
To trigger the issue config should have:
```
machineController:
  deploy: false

# OSM config have to be omitted from the config
# operatingSystemManager:
#   deploy: false
```

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes NPE when machineController deployment is disabled
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
