### PR TITLE
Recreate SSH connection if case of errors with session

### DIFF
--- a/pkg/ssh/connection.go
+++ b/pkg/ssh/connection.go
@@ -274,6 +274,8 @@ func (c *connection) Close() error {
 func (c *connection) POpen(cmd string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (int, error) {
 	sess, err := c.session()
 	if err != nil {
+		c.Close()
+
 		return 0, err
 	}
 	defer sess.Close()

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -676,7 +676,7 @@ func systemdUnitExecStartPath(conn executor.Interface, unitName string) (string,
 func systemdStatus(conn executor.Interface, service string) (uint64, error) {
 	out, _, _, err := conn.Exec(fmt.Sprintf(systemdShowStatusCMD, service))
 	if err != nil {
-		return 0, fail.Runtime(err, "ckecking %q systemd service status", service)
+		return 0, fail.Runtime(err, "checking %q systemd service status", service)
 	}
 
 	out = strings.ReplaceAll(out, "=", ": ")


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to recycle a broken SSH connection we have to close it on error.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #2319

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Recreate SSH connection if case of errors with session
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
