### PR TITLE
Add MachineControllerEnabled() helper function for better robustness 

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -367,7 +367,7 @@ func containerdRegistryCredentials(containerdConfig *kubeoneapi.ContainerRuntime
 func mcCredentialsEnvVars(s *state.State) ([]byte, error) {
 	var credsEnvVarsMC []byte
 
-	if s.Cluster.MachineController.Deploy {
+	if s.Cluster.MachineControllerEnabled() {
 		credsMC, err := credentials.ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, credentials.TypeMC)
 		if err != nil {
 			return nil, err

--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -122,7 +122,7 @@ func collectAddons(s *state.State) (addonsToDeploy []addonAction) {
 		name: resources.AddonNodeLocalDNS,
 	})
 
-	if s.Cluster.MachineController.Deploy {
+	if s.Cluster.MachineControllerEnabled() {
 		addonsToDeploy = append(addonsToDeploy, addonAction{
 			name: resources.AddonMachineController,
 		})

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -123,6 +123,10 @@ func (c KubeOneCluster) OperatingSystemManagerEnabled() bool {
 	return c.OperatingSystemManager != nil && c.OperatingSystemManager.Deploy
 }
 
+func (c KubeOneCluster) MachineControllerEnabled() bool {
+	return c.MachineController != nil && c.MachineController.Deploy
+}
+
 func (crc ContainerRuntimeConfig) MachineControllerFlags() []string {
 	var mcFlags []string
 	switch {

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -60,7 +60,7 @@ func ValidateKubeOneCluster(c kubeoneapi.KubeOneCluster) field.ErrorList {
 	allErrs = append(allErrs, ValidateClusterNetworkConfig(c.ClusterNetwork, field.NewPath("clusterNetwork"))...)
 	allErrs = append(allErrs, ValidateStaticWorkersConfig(c.StaticWorkers, field.NewPath("staticWorkers"))...)
 
-	if c.MachineController != nil && c.MachineController.Deploy {
+	if c.MachineControllerEnabled() {
 		allErrs = append(allErrs, ValidateDynamicWorkerConfig(c.DynamicWorkers, field.NewPath("dynamicWorkers"))...)
 	} else if len(c.DynamicWorkers) > 0 {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("dynamicWorkers"),

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -200,7 +200,7 @@ func validateCredentials(s *state.State, credentialsFile string) error {
 	_, universalErr := credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.TypeUniversal)
 
 	var mcErr error
-	if s.Cluster.MachineController.Deploy {
+	if s.Cluster.MachineControllerEnabled() {
 		_, mcErr = credentials.ProviderCredentials(s.Cluster.CloudProvider, credentialsFile, credentials.TypeMC)
 	}
 

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -83,7 +83,7 @@ func Ensure(s *state.State) error {
 		}
 	}
 
-	if s.Cluster.MachineController.Deploy {
+	if s.Cluster.MachineControllerEnabled() {
 		s.Logger.Infoln("Creating machine-controller credentials secret...")
 
 		providerCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, TypeMC)

--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -234,7 +234,7 @@ func safeguardNodeSelectorsAndTolerations(s *state.State) error {
 // This safeguard only warns user about the problem, it doesn't block kubeone apply
 // from reconciling the cluster.
 func safeguardFlatcarMachineDeployments(s *state.State) error {
-	if !s.Cluster.OperatingSystemManager.Deploy || !s.Cluster.MachineController.Deploy {
+	if !s.Cluster.OperatingSystemManagerEnabled() || !s.Cluster.MachineControllerEnabled() {
 		return nil
 	}
 

--- a/pkg/templates/machinecontroller/helper.go
+++ b/pkg/templates/machinecontroller/helper.go
@@ -41,7 +41,7 @@ const appLabelKey = "app"
 
 // WaitReady waits for machine-controller and its webhook to become ready
 func WaitReady(s *state.State) error {
-	if !s.Cluster.MachineController.Deploy {
+	if !s.Cluster.MachineControllerEnabled() {
 		return nil
 	}
 
@@ -76,7 +76,7 @@ func waitForCRDs(s *state.State) error {
 
 // DestroyWorkers destroys all MachineDeployment, MachineSet and Machine objects
 func DestroyWorkers(s *state.State) error {
-	if !s.Cluster.MachineController.Deploy {
+	if !s.Cluster.MachineControllerEnabled() {
 		s.Logger.Info("Skipping deleting workers because machine-controller is disabled in configuration.")
 
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a new helper function to detect whether machine controller is enabled or not, as a panic was encountered when disabling machine controller explicitly in the kubeone yaml file as reported below: 

```shell
INFO[21:23:26 CEST] Running cluster probes...                    
E0913 21:23:26.324467   26761 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2707280?, 0x3c2c270})
	k8s.io/apimachinery@v0.24.2/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x1?})
	k8s.io/apimachinery@v0.24.2/pkg/util/runtime/runtime.go:49 +0x75
panic({0x2707280, 0x3c2c270})
	runtime/panic.go:884 +0x212
k8c.io/kubeone/pkg/tasks.safeguardFlatcarMachineDeployments(0xc00065a1e0?)
	k8c.io/kubeone/pkg/tasks/probes.go:236 +0x33
k8c.io/kubeone/pkg/tasks.safeguard(0xc00065a1e0)
	k8c.io/kubeone/pkg/tasks/probes.go:154 +0x59c
k8c.io/kubeone/pkg/tasks.(*Task).Run.func1()
	k8c.io/kubeone/pkg/tasks/task.go:60 +0x94
k8s.io/apimachinery/pkg/util/wait.ConditionFunc.WithContext.func1({0x277f9c0, 0x1})
	k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:220 +0x1b
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext({0x2dbece8?, 0xc0001b4010?}, 0xc000130380?)
	k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:233 +0x57
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0x280bfa0?)
	k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:226 +0x39
k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff({0x2540be400, 0x3ff6666666666666, 0x0, 0xa, 0x0}, 0x3c5d760?)
	k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:421 +0x5f
k8c.io/kubeone/pkg/tasks.(*Task).Run(0xc00036e840, 0xc00065a1e0)
	k8c.io/kubeone/pkg/tasks/task.go:55 +0x11c
k8c.io/kubeone/pkg/tasks.Tasks.Run({0xc000130380, 0x4, 0x0?}, 0xc0005b1978?)
	k8c.io/kubeone/pkg/tasks/tasks.go:40 +0xfd
k8c.io/kubeone/pkg/cmd.runApply(0xc00065a1e0, 0xc0002790a0)
	k8c.io/kubeone/pkg/cmd/apply.go:160 +0x1e7
k8c.io/kubeone/pkg/cmd.applyCmd.func1(0xc0004e7400?, {0x2992b6d?, 0x3?, 0x3?})
	k8c.io/kubeone/pkg/cmd/apply.go:93 +0xa8
github.com/spf13/cobra.(*Command).execute(0xc0004e7400, {0xc00068e2d0, 0x3, 0x3})
	github.com/spf13/cobra@v1.4.0/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc0004e7180)
	github.com/spf13/cobra@v1.4.0/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.4.0/command.go:902
k8c.io/kubeone/pkg/cmd.Execute()
	k8c.io/kubeone/pkg/cmd/root.go:55 +0x89
main.main()
	k8c.io/kubeone/main.go:24 +0x17
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x241e293]
```
 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
