### PR TITLE
Initialize OperatingSystemManager even if v1beta1 API is used

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -207,7 +207,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 		DeployCSIAddon:                      deployCSI,
 		MachineControllerCredentialsEnvVars: string(credsEnvVarsMC),
 		MachineControllerCredentialsHash:    mcCredsHash,
-		OperatingSystemManagerEnabled:       s.Cluster.OperatingSystemManagerEnabled(),
+		OperatingSystemManagerEnabled:       s.Cluster.OperatingSystemManager.Deploy,
 		RegistryCredentials:                 containerdRegistryCredentials(s.Cluster.ContainerRuntime.Containerd),
 		InternalImages: &internalImages{
 			pauseImage: s.PauseImage,
@@ -222,7 +222,7 @@ func newAddonsApplier(s *state.State) (*applier, error) {
 	}
 
 	// Certs for operating-system-manager-webhook
-	if s.Cluster.OperatingSystemManagerEnabled() {
+	if s.Cluster.OperatingSystemManager.Deploy {
 		if err := webhookCerts(data.Certificates,
 			"OSM",
 			resources.OperatingSystemManagerWebhookName,

--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -128,7 +128,7 @@ func collectAddons(s *state.State) (addonsToDeploy []addonAction) {
 		})
 	}
 
-	if s.Cluster.OperatingSystemManagerEnabled() {
+	if s.Cluster.OperatingSystemManager.Deploy {
 		addonsToDeploy = append(addonsToDeploy, addonAction{
 			name: resources.AddonOperatingSystemManager,
 		})

--- a/pkg/apis/kubeone/config/config.go
+++ b/pkg/apis/kubeone/config/config.go
@@ -268,6 +268,14 @@ func SetKubeOneClusterDynamicDefaults(cluster *kubeoneapi.KubeOneCluster, creden
 		}
 	}
 
+	// this can be nil if v1beta1 API was used as a source to convert into the internal API, since v1beta1 lacks the
+	// OperatingSystemManager field at all.
+	if cluster.OperatingSystemManager == nil {
+		cluster.OperatingSystemManager = &kubeoneapi.OperatingSystemManagerConfig{
+			Deploy: cluster.MachineController.Deploy,
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -119,10 +119,6 @@ func (h *HostConfig) SetLeader(leader bool) {
 	h.IsLeader = leader
 }
 
-func (c KubeOneCluster) OperatingSystemManagerEnabled() bool {
-	return c.OperatingSystemManager != nil && c.OperatingSystemManager.Deploy
-}
-
 func (crc ContainerRuntimeConfig) MachineControllerFlags() []string {
 	var mcFlags []string
 	switch {

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -67,7 +67,7 @@ func ValidateKubeOneCluster(c kubeoneapi.KubeOneCluster) field.ErrorList {
 			"machine-controller deployment is disabled, but the configuration still contains dynamic workers"))
 	}
 
-	if c.OperatingSystemManagerEnabled() {
+	if c.OperatingSystemManager.Deploy {
 		allErrs = append(allErrs, ValidateOperatingSystemManager(c.MachineController, field.NewPath("operatingSystemManager"))...)
 	}
 

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -67,6 +67,9 @@ func TestValidateKubeOneCluster(t *testing.T) {
 				MachineController: &kubeoneapi.MachineControllerConfig{
 					Deploy: true,
 				},
+				OperatingSystemManager: &kubeoneapi.OperatingSystemManagerConfig{
+					Deploy: true,
+				},
 				DynamicWorkers: []kubeoneapi.DynamicWorkerConfig{
 					{
 						Name:     "test-1",
@@ -115,6 +118,9 @@ func TestValidateKubeOneCluster(t *testing.T) {
 					Kubernetes: "1.22.1",
 				},
 				MachineController: &kubeoneapi.MachineControllerConfig{
+					Deploy: false,
+				},
+				OperatingSystemManager: &kubeoneapi.OperatingSystemManagerConfig{
 					Deploy: false,
 				},
 				DynamicWorkers: []kubeoneapi.DynamicWorkerConfig{
@@ -167,6 +173,9 @@ func TestValidateKubeOneCluster(t *testing.T) {
 				MachineController: &kubeoneapi.MachineControllerConfig{
 					Deploy: true,
 				},
+				OperatingSystemManager: &kubeoneapi.OperatingSystemManagerConfig{
+					Deploy: true,
+				},
 				DynamicWorkers: []kubeoneapi.DynamicWorkerConfig{
 					{
 						Name:     "test-1",
@@ -215,6 +224,9 @@ func TestValidateKubeOneCluster(t *testing.T) {
 					Kubernetes: "1.22.1",
 				},
 				MachineController: &kubeoneapi.MachineControllerConfig{
+					Deploy: true,
+				},
+				OperatingSystemManager: &kubeoneapi.OperatingSystemManagerConfig{
 					Deploy: true,
 				},
 				DynamicWorkers: []kubeoneapi.DynamicWorkerConfig{

--- a/pkg/credentials/secret.go
+++ b/pkg/credentials/secret.go
@@ -71,7 +71,7 @@ func Ensure(s *state.State) error {
 	}
 
 	// Ensure that we remove credentials secret for OSM if it's queued for deletion
-	if !s.Cluster.OperatingSystemManagerEnabled() {
+	if !s.Cluster.OperatingSystemManager.Deploy {
 		osmSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      SecretNameOSM,
@@ -97,7 +97,7 @@ func Ensure(s *state.State) error {
 		}
 	}
 
-	if s.Cluster.OperatingSystemManagerEnabled() {
+	if s.Cluster.OperatingSystemManager.Deploy {
 		osmCreds, err := ProviderCredentials(s.Cluster.CloudProvider, s.CredentialsFilePath, TypeOSM)
 		if err != nil {
 			return err

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -294,7 +294,7 @@ func WithResources(t Tasks) Tasks {
 			{
 				Fn:        operatingsystemmanager.WaitReady,
 				Operation: "waiting for operating-system-manager",
-				Predicate: func(s *state.State) bool { return s.Cluster.OperatingSystemManagerEnabled() },
+				Predicate: func(s *state.State) bool { return s.Cluster.OperatingSystemManager.Deploy },
 			},
 		}...,
 	)

--- a/pkg/templates/operatingsystemmanager/helper.go
+++ b/pkg/templates/operatingsystemmanager/helper.go
@@ -34,7 +34,7 @@ const appLabelKey = "app"
 
 // WaitReady waits for operating-system-manager and its webhook to become ready
 func WaitReady(s *state.State) error {
-	if !s.Cluster.OperatingSystemManagerEnabled() {
+	if !s.Cluster.OperatingSystemManager.Deploy {
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When v1beta1 API is used, internal Cluster doesn't get `.OperatingSystemManager` defaulted, since it's defaulted only for v1beta2 and later converted to internal Cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
This is an addition to #2344
regarding #2343

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed NPE regarding OSM for the v1beta1 API in use
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
