### PR TITLE
Hard-disable OSM when v1beta1 is used

### DIFF
--- a/pkg/apis/kubeone/config/config.go
+++ b/pkg/apis/kubeone/config/config.go
@@ -167,6 +167,13 @@ func DefaultedV1Beta1KubeOneCluster(versionedCluster *kubeonev1beta1.KubeOneClus
 		return nil, err
 	}
 
+	// this can be nil if v1beta1 API was used as a source to convert into the internal API, since v1beta1 lacks the
+	// OperatingSystemManager field at all.
+	internalCluster.OperatingSystemManager = &kubeoneapi.OperatingSystemManagerConfig{
+		// but we don't want to enable the OSM for older v1beta1 API
+		Deploy: false,
+	}
+
 	// Validate the configuration
 	if err := kubeonevalidation.ValidateKubeOneCluster(*internalCluster).ToAggregate(); err != nil {
 		return nil, fail.ConfigValidation(err)
@@ -265,14 +272,6 @@ func SetKubeOneClusterDynamicDefaults(cluster *kubeoneapi.KubeOneCluster, creden
 		if len(workerset.Config.MachineAnnotations) > 0 && len(workerset.Config.NodeAnnotations) == 0 {
 			cluster.DynamicWorkers[i].Config.NodeAnnotations = cluster.DynamicWorkers[i].Config.MachineAnnotations
 			cluster.DynamicWorkers[i].Config.MachineAnnotations = nil
-		}
-	}
-
-	// this can be nil if v1beta1 API was used as a source to convert into the internal API, since v1beta1 lacks the
-	// OperatingSystemManager field at all.
-	if cluster.OperatingSystemManager == nil {
-		cluster.OperatingSystemManager = &kubeoneapi.OperatingSystemManagerConfig{
-			Deploy: cluster.MachineController.Deploy,
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't want to have OSM when v1beta1 is used, to avoid unpleasant surprises,

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Hard-disable OSM when v1beta1 is used
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
