### PR TITLE
install.sh: change VERSION regex to match only stable releases

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ set -eu
 # What OS is used
 OS="$(uname | tr '[:upper:]' '[:lower:]')"
 # Find out what's the latest version
-VERSION="$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/kubermatic/kubeone/releases | sed -n -E 's/^[[:space:]]*"tag_name": "v([^"]*)",$/\1/p' | sort -V | tail -1)"
+VERSION="$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/kubermatic/kubeone/releases | sed -n -E 's/^[[:space:]]*"tag_name": "v(([0-9])*\.([0-9])*\.([0-9])*)",$/\1/p' | sort -V | tail -1)"
 # Download URL for the latest version
 URL="https://github.com/kubermatic/kubeone/releases/download/v${VERSION}/kubeone_${VERSION}_${OS}_amd64.zip"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The installation script right now uses the following regex to match the KubeOne version: `v([^"]*)`. This matches everything, including prereleases. Because of this, the installation script downloads KubeOne v1.5.0-rc.0 instead of v1.5.0.

This PR changes the regex to `v(([0-9])*\.([0-9])*\.([0-9])*)` so that only stable releases are matched by the script.

**Which issue(s) this PR fixes**:
xref https://github.com/kubermatic/kubeone/issues/2352#issuecomment-1252114838

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The installation script (`install.sh`) has been modified to match only the stable releases
```

**Documentation**:
```documentation
NONE
```