### PR TITLE
[release/v1.4] Update kubernetes-cni to 1.1.1

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultKubernetesCNIVersion = "0.8.7"
+	defaultKubernetesCNIVersion = "1.1.1"
 	defaultCriToolsVersion      = "1.21.0"
 )
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -96,7 +96,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -127,7 +127,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -129,7 +129,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -94,7 +94,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -128,7 +128,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -91,7 +91,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -127,7 +127,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -130,7 +130,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -127,7 +127,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -127,7 +127,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -127,7 +127,7 @@ sudo yum install -y \
 	kubelet-1.16.1 \
 	kubeadm-1.16.1 \
 	kubectl-1.16.1 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -131,7 +131,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -133,7 +133,7 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -72,7 +72,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="0.8.7*"
+cni_ver="1.1.1*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -69,7 +69,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="0.8.7*"
+cni_ver="1.1.1*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="0.8.7*"
+cni_ver="1.1.1*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="0.8.7*"
+cni_ver="1.1.1*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="0.8.7*"
+cni_ver="1.1.1*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="0.8.7*"
+cni_ver="1.1.1*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="0.8.7*"
+cni_ver="1.1.1*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -55,7 +55,7 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -55,7 +55,7 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -55,7 +55,7 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -55,7 +55,7 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -61,7 +61,7 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -55,7 +55,7 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -126,7 +126,7 @@ sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
 
 sudo yum install -y \
 	kubeadm-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="0.8.7*"
+cni_ver="1.1.1*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -50,7 +50,7 @@ sudo systemctl restart docker
 
 
 sudo mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-${HOST_ARCH}-v0.8.7.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -127,7 +127,7 @@ sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
 sudo yum install -y \
 	kubelet-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-0.8.7
+	kubernetes-cni-1.1.1
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="0.8.7*"
+cni_ver="1.1.1*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a manual cherry-pick of #2353 to the `release/v1.4` branch. This PR is needed to support the latest Kubernetes patch releases.

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update the kubernetes-cni package from 0.8.7 to 1.1.1 to support the latest Kubernetes patch releases
```

**Documentation**:
```documentation
NONE
```