### PR TITLE
Delete CoreDNS PodDistruptionBudget if the feature is disabled

### DIFF
--- a/pkg/addons/ensure.go
+++ b/pkg/addons/ensure.go
@@ -145,6 +145,16 @@ func collectAddons(s *state.State) (addonsToDeploy []addonAction) {
 	return
 }
 
+func cleanupAddons(s *state.State) error {
+	if !*s.Cluster.Features.CoreDNS.DeployPodDisruptionBudget {
+		if err := DeleteAddonByName(s, resources.AddonCoreDNSPDB); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func Ensure(s *state.State) error {
 	addonsToDeploy := collectAddons(s)
 
@@ -157,6 +167,10 @@ func Ensure(s *state.State) error {
 		if err := EnsureAddonByName(s, add.name); err != nil {
 			return err
 		}
+	}
+
+	if err := cleanupAddons(s); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that we delete the `coredns` PodDisruptionBudget if the feature is disabled.

**Which issue(s) this PR fixes**:
Fixes #2322 

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Automatically delete the CoreDNS PodDistruptionBudget if the feature is disabled
```

**Documentation**:
```documentation
NONE
```