### PR TITLE
Use vmware-system-csi namespace when generating certs for the vSphere CSI webhooks

### DIFF
--- a/pkg/addons/applier.go
+++ b/pkg/addons/applier.go
@@ -282,7 +282,7 @@ func csiWebhookCerts(s *state.State, data *templateData, csiMigration bool, kube
 		if err := webhookCerts(data.Certificates,
 			webhookCertsCSI,
 			resources.GenericCSIWebhookName,
-			resources.GenericCSIWebhookNamespace,
+			resources.VsphereCSIWebhookNamespace,
 			s.Cluster.ClusterNetwork.ServiceDomainName,
 			kubeCAPrivateKey,
 			kubeCACert,
@@ -293,7 +293,7 @@ func csiWebhookCerts(s *state.State, data *templateData, csiMigration bool, kube
 			if err := webhookCerts(data.Certificates,
 				"CSIMigration",
 				resources.VsphereCSIWebhookName,
-				resources.GenericCSIWebhookNamespace,
+				resources.VsphereCSIWebhookNamespace,
 				s.Cluster.ClusterNetwork.ServiceDomainName,
 				kubeCAPrivateKey,
 				kubeCACert,
@@ -317,7 +317,7 @@ func csiWebhookCerts(s *state.State, data *templateData, csiMigration bool, kube
 	return nil
 }
 
-func webhookCerts(certs map[string]string, prefix, webhookName, webhookNamespace, serviceDomainName string, kubeCAPrivateKey *rsa.PrivateKey, kubeCACert *x509.Certificate) error { //nolint:unparam
+func webhookCerts(certs map[string]string, prefix, webhookName, webhookNamespace, serviceDomainName string, kubeCAPrivateKey *rsa.PrivateKey, kubeCACert *x509.Certificate) error {
 	certsMap, err := certificate.NewSignedTLSCert(
 		webhookName,
 		webhookNamespace,

--- a/pkg/templates/resources/resources.go
+++ b/pkg/templates/resources/resources.go
@@ -95,6 +95,7 @@ const (
 	MetricsServerNamespace = metav1.NamespaceSystem
 
 	VsphereCSIWebhookName      = "vsphere-webhook-svc"
+	VsphereCSIWebhookNamespace = "vmware-system-csi"
 	NutanixCSIWebhookName      = "csi-snapshot-webhook"
 	GenericCSIWebhookName      = "snapshot-validation-service"
 	GenericCSIWebhookNamespace = metav1.NamespaceSystem


### PR DESCRIPTION
**What this PR does / why we need it**:

We moved the vSphere CSI driver from `kube-system` namespace to `vmware-system-csi` namespace in #2292. Unfortunately, we forgot to provide the new namespace to certificates used by CSI webhooks. This breaks communication with the CSI driver as described in #2350.

**Which issue(s) this PR fixes**:
Fixes #2350 

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Use `vmware-system-csi` namespace when generating certs for the vSphere CSI webhooks
```

**Documentation**:
```documentation
https://...
```