### PR TITLE
testv2: Use previous Terraform configs and KubeOne v1.5 in upgrade tests

### DIFF
--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -2692,21 +2692,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsAmznStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -2720,21 +2720,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -2748,21 +2748,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -2776,21 +2776,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -2804,21 +2804,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -2832,21 +2832,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -2860,21 +2860,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -2890,21 +2890,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -2920,21 +2920,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -2950,7 +2950,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -2958,14 +2958,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -2981,21 +2981,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -3011,21 +3011,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestGceDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: gce
@@ -3039,21 +3039,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
@@ -3067,21 +3067,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
@@ -3095,7 +3095,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3123,21 +3123,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
@@ -3151,21 +3151,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
@@ -3179,21 +3179,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
@@ -3207,21 +3207,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
@@ -3235,21 +3235,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsAmznStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -3263,21 +3263,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -3291,21 +3291,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -3319,21 +3319,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -3347,21 +3347,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -3375,21 +3375,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -3403,21 +3403,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -3433,21 +3433,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -3463,21 +3463,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -3493,7 +3493,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3501,14 +3501,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -3524,21 +3524,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -3554,21 +3554,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestGceDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: gce
@@ -3582,21 +3582,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
@@ -3610,21 +3610,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
@@ -3638,7 +3638,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -3666,21 +3666,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
@@ -3694,21 +3694,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
@@ -3722,21 +3722,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
@@ -3750,21 +3750,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
@@ -3778,21 +3778,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsAmznStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -3806,21 +3806,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -3834,21 +3834,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -3862,21 +3862,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -3890,21 +3890,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -3918,21 +3918,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -3946,21 +3946,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -3976,21 +3976,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -4006,21 +4006,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -4036,7 +4036,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -4044,14 +4044,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -4067,21 +4067,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -4097,21 +4097,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestGceDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: gce
@@ -4125,21 +4125,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -4153,21 +4153,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -4181,7 +4181,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -4209,21 +4209,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -4237,21 +4237,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -4265,21 +4265,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
@@ -4293,21 +4293,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
@@ -4321,21 +4321,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsAmznStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -4349,21 +4349,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -4377,21 +4377,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -4405,21 +4405,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -4433,21 +4433,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -4461,21 +4461,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsRockylinuxStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -4489,21 +4489,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -4519,21 +4519,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -4549,21 +4549,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -4579,7 +4579,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -4587,14 +4587,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -4610,21 +4610,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureRockylinuxStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -4640,21 +4640,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestGceDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: gce
@@ -4668,21 +4668,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestOpenstackDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -4696,21 +4696,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestOpenstackCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -4724,7 +4724,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -4752,21 +4752,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestOpenstackRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -4780,21 +4780,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestOpenstackFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -4808,21 +4808,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestVsphereDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
@@ -4836,21 +4836,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestVsphereFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
@@ -15633,21 +15633,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -15661,21 +15661,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -15689,21 +15689,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -15717,21 +15717,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -15745,21 +15745,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -15773,21 +15773,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -15801,21 +15801,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -15831,21 +15831,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -15861,21 +15861,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -15891,7 +15891,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -15899,14 +15899,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -15922,21 +15922,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -15952,21 +15952,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
@@ -15980,21 +15980,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16008,21 +16008,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16036,21 +16036,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16064,21 +16064,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16092,21 +16092,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16120,21 +16120,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16148,21 +16148,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
@@ -16176,21 +16176,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
@@ -16204,21 +16204,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
@@ -16232,21 +16232,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -16260,21 +16260,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -16288,7 +16288,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -16316,21 +16316,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -16344,21 +16344,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -16372,21 +16372,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
@@ -16400,21 +16400,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
@@ -16428,21 +16428,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -16456,21 +16456,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -16484,21 +16484,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -16512,21 +16512,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -16540,21 +16540,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -16568,21 +16568,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
@@ -16596,21 +16596,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -16626,21 +16626,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -16656,21 +16656,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -16686,7 +16686,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -16694,14 +16694,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -16717,21 +16717,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
@@ -16747,21 +16747,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16775,21 +16775,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16803,21 +16803,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16831,21 +16831,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16859,21 +16859,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16887,21 +16887,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16915,21 +16915,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16943,21 +16943,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
@@ -16971,21 +16971,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
@@ -16999,21 +16999,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
@@ -17027,21 +17027,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
@@ -17055,21 +17055,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
@@ -17083,7 +17083,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -17111,21 +17111,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
@@ -17139,21 +17139,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
@@ -17167,21 +17167,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
@@ -17195,21 +17195,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
@@ -17223,21 +17223,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -17251,21 +17251,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -17279,21 +17279,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -17307,21 +17307,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -17335,21 +17335,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -17363,21 +17363,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
@@ -17391,21 +17391,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -17421,21 +17421,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -17451,21 +17451,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -17481,7 +17481,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -17489,14 +17489,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -17512,21 +17512,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
@@ -17542,21 +17542,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
@@ -17570,21 +17570,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
@@ -17598,21 +17598,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
@@ -17626,21 +17626,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17654,21 +17654,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17682,21 +17682,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17710,21 +17710,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17738,21 +17738,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
@@ -17766,21 +17766,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
@@ -17794,21 +17794,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
@@ -17822,21 +17822,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
@@ -17850,21 +17850,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
@@ -17878,7 +17878,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -17906,21 +17906,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
@@ -17934,21 +17934,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
@@ -17962,21 +17962,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
@@ -17990,21 +17990,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
@@ -18018,21 +18018,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsAmznStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -18046,21 +18046,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -18074,21 +18074,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -18102,21 +18102,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -18130,21 +18130,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -18158,21 +18158,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
@@ -18186,21 +18186,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -18216,21 +18216,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -18246,21 +18246,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -18276,7 +18276,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -18284,14 +18284,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -18307,21 +18307,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
@@ -18337,21 +18337,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18365,21 +18365,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18393,21 +18393,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18421,21 +18421,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18449,21 +18449,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18477,21 +18477,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18505,21 +18505,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18533,21 +18533,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
@@ -18561,21 +18561,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestHetznerCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
@@ -18589,21 +18589,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
@@ -18617,21 +18617,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -18645,21 +18645,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -18673,7 +18673,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -18701,21 +18701,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -18729,21 +18729,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
@@ -18757,21 +18757,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
@@ -18785,21 +18785,21 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.4
+  - base_ref: release/v1.5
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere

--- a/test/e2e/scenario_upgrade.go
+++ b/test/e2e/scenario_upgrade.go
@@ -36,8 +36,8 @@ import (
 )
 
 const (
-	kubeoneStableVersion = "1.4.7" //nolint:deadcode,varcheck
-	kubeoneStableBaseRef = "release/v1.4"
+	kubeoneStableVersion = "1.5.1" //nolint:deadcode,varcheck
+	kubeoneStableBaseRef = "release/v1.5"
 )
 
 type scenarioUpgrade struct {

--- a/test/e2e/tests_definitions.go
+++ b/test/e2e/tests_definitions.go
@@ -44,6 +44,23 @@ var (
 				},
 			},
 		},
+		"aws_default_stable": {
+			name: "aws_default_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-aws":     "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "aws",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/aws",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"subnets_cidr=27",
+				},
+			},
+		},
 		"aws_centos": {
 			name: "aws_centos",
 			environ: map[string]string{
@@ -55,6 +72,24 @@ var (
 			},
 			terraform: terraformBin{
 				path: "../../examples/terraform/aws",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"subnets_cidr=27",
+					"os=centos",
+				},
+			},
+		},
+		"aws_centos_stable": {
+			name: "aws_centos_stable",
+			environ: map[string]string{
+				"PROVIDER": "aws",
+			},
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-aws":     "true",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/aws",
 				vars: []string{
 					"disable_kubeapi_loadbalancer=true",
 					"subnets_cidr=27",
@@ -81,6 +116,25 @@ var (
 				},
 			},
 		},
+		"aws_rhel_stable": {
+			name: "aws_rhel_stable",
+			environ: map[string]string{
+				"PROVIDER": "aws",
+			},
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-aws":     "true",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/aws",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"subnets_cidr=27",
+					"os=rhel",
+					"bastion_type=t3.micro",
+				},
+			},
+		},
 		"aws_rockylinux": {
 			name: "aws_rockylinux",
 			environ: map[string]string{
@@ -99,6 +153,24 @@ var (
 				},
 			},
 		},
+		"aws_rockylinux_stable": {
+			name: "aws_rockylinux_stable",
+			environ: map[string]string{
+				"PROVIDER": "aws",
+			},
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-aws":     "true",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/aws",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"subnets_cidr=27",
+					"os=rockylinux",
+				},
+			},
+		},
 		"aws_flatcar": {
 			name: "aws_flatcar",
 			environ: map[string]string{
@@ -110,6 +182,24 @@ var (
 			},
 			terraform: terraformBin{
 				path: "../../examples/terraform/aws",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"subnets_cidr=27",
+					"os=flatcar",
+				},
+			},
+		},
+		"aws_flatcar_stable": {
+			name: "aws_flatcar_stable",
+			environ: map[string]string{
+				"PROVIDER": "aws",
+			},
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-aws":     "true",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/aws",
 				vars: []string{
 					"disable_kubeapi_loadbalancer=true",
 					"subnets_cidr=27",
@@ -138,6 +228,27 @@ var (
 				},
 			},
 		},
+		"aws_flatcar_cloud_init_stable": {
+			name: "aws_flatcar_cloud_init_stable",
+			environ: map[string]string{
+				"PROVIDER": "aws",
+			},
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-aws":     "true",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/aws",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"subnets_cidr=27",
+					"os=flatcar",
+					"ssh_username=core",
+					"bastion_user=core",
+					"worker_deploy_ssh_key=false",
+				},
+			},
+		},
 		"aws_amzn": {
 			name: "aws_amzn",
 			environ: map[string]string{
@@ -149,6 +260,24 @@ var (
 			},
 			terraform: terraformBin{
 				path: "../../examples/terraform/aws",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"subnets_cidr=27",
+					"os=amzn",
+				},
+			},
+		},
+		"aws_amzn_stable": {
+			name: "aws_amzn_stable",
+			environ: map[string]string{
+				"PROVIDER": "aws",
+			},
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-aws":     "true",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/aws",
 				vars: []string{
 					"disable_kubeapi_loadbalancer=true",
 					"subnets_cidr=27",
@@ -190,6 +319,23 @@ var (
 				},
 			},
 		},
+		"azure_default_stable": {
+			name: "azure_default_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-azure":   "true",
+			},
+			environ: map[string]string{
+				"PROVIDER":     "azure",
+				"TEST_TIMEOUT": "120m",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/azure",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+				},
+			},
+		},
 		"azure_centos": {
 			name: "azure_centos",
 			labels: map[string]string{
@@ -208,6 +354,24 @@ var (
 				},
 			},
 		},
+		"azure_centos_stable": {
+			name: "azure_centos_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-azure":   "true",
+			},
+			environ: map[string]string{
+				"PROVIDER":     "azure",
+				"TEST_TIMEOUT": "120m",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/azure",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"os=centos",
+				},
+			},
+		},
 		"azure_flatcar": {
 			name: "azure_flatcar",
 			labels: map[string]string{
@@ -220,6 +384,24 @@ var (
 			},
 			terraform: terraformBin{
 				path: "../../examples/terraform/azure",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"os=flatcar",
+				},
+			},
+		},
+		"azure_flatcar_stable": {
+			name: "azure_flatcar_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-azure":   "true",
+			},
+			environ: map[string]string{
+				"PROVIDER":     "azure",
+				"TEST_TIMEOUT": "120m",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/azure",
 				vars: []string{
 					"disable_kubeapi_loadbalancer=true",
 					"os=flatcar",
@@ -245,6 +427,25 @@ var (
 				},
 			},
 		},
+		"azure_rhel_stable": {
+			name: "azure_rhel_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-azure":   "true",
+				"preset-rhel":    "true",
+			},
+			environ: map[string]string{
+				"PROVIDER":     "azure",
+				"TEST_TIMEOUT": "120m",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/azure",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"os=rhel",
+				},
+			},
+		},
 		"azure_rockylinux": {
 			name: "azure_rockylinux",
 			labels: map[string]string{
@@ -257,6 +458,24 @@ var (
 			},
 			terraform: terraformBin{
 				path: "../../examples/terraform/azure",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"os=rockylinux",
+				},
+			},
+		},
+		"azure_rockylinux_stable": {
+			name: "azure_rockylinux_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-azure":   "true",
+			},
+			environ: map[string]string{
+				"PROVIDER":     "azure",
+				"TEST_TIMEOUT": "120m",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/azure",
 				vars: []string{
 					"disable_kubeapi_loadbalancer=true",
 					"os=rockylinux",
@@ -279,6 +498,22 @@ var (
 				},
 			},
 		},
+		"digitalocean_default_stable": {
+			name: "digitalocean_default_stable",
+			labels: map[string]string{
+				"preset-goproxy":      "true",
+				"preset-digitalocean": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "digitalocean",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/digitalocean",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+				},
+			},
+		},
 		"digitalocean_centos": {
 			name: "digitalocean_centos",
 			labels: map[string]string{
@@ -290,6 +525,24 @@ var (
 			},
 			terraform: terraformBin{
 				path: "../../examples/terraform/digitalocean",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"control_plane_droplet_image=centos-7-x64",
+					"worker_os=centos",
+				},
+			},
+		},
+		"digitalocean_centos_stable": {
+			name: "digitalocean_centos_stable",
+			labels: map[string]string{
+				"preset-goproxy":      "true",
+				"preset-digitalocean": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "digitalocean",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/digitalocean",
 				vars: []string{
 					"disable_kubeapi_loadbalancer=true",
 					"control_plane_droplet_image=centos-7-x64",
@@ -315,6 +568,24 @@ var (
 				},
 			},
 		},
+		"digitalocean_rockylinux_stable": {
+			name: "digitalocean_rockylinux_stable",
+			labels: map[string]string{
+				"preset-goproxy":      "true",
+				"preset-digitalocean": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "digitalocean",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/digitalocean",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"control_plane_droplet_image=rockylinux-8-x64",
+					"worker_os=rockylinux",
+				},
+			},
+		},
 		"equinixmetal_default": {
 			name: "equinixmetal_default",
 			labels: map[string]string{
@@ -328,6 +599,19 @@ var (
 				path: "../../examples/terraform/equinixmetal",
 			},
 		},
+		"equinixmetal_default_stable": {
+			name: "equinixmetal_default_stable",
+			labels: map[string]string{
+				"preset-goproxy":       "true",
+				"preset-equinix-metal": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "equinixmetal",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/equinixmetal",
+			},
+		},
 		"equinixmetal_centos": {
 			name: "equinixmetal_centos",
 			labels: map[string]string{
@@ -339,6 +623,24 @@ var (
 			},
 			terraform: terraformBin{
 				path: "../../examples/terraform/equinixmetal",
+				vars: []string{
+					"control_plane_operating_system=centos_7",
+					"lb_operating_system=centos_7",
+					"worker_os=centos",
+				},
+			},
+		},
+		"equinixmetal_centos_stable": {
+			name: "equinixmetal_centos_stable",
+			labels: map[string]string{
+				"preset-goproxy":       "true",
+				"preset-equinix-metal": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "equinixmetal",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/equinixmetal",
 				vars: []string{
 					"control_plane_operating_system=centos_7",
 					"lb_operating_system=centos_7",
@@ -364,6 +666,24 @@ var (
 				},
 			},
 		},
+		"equinixmetal_rockylinux_stable": {
+			name: "equinixmetal_rockylinux_stable",
+			labels: map[string]string{
+				"preset-goproxy":       "true",
+				"preset-equinix-metal": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "equinixmetal",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/equinixmetal",
+				vars: []string{
+					"control_plane_operating_system=rocky_8",
+					"lb_operating_system=rocky_8",
+					"worker_os=rockylinux",
+				},
+			},
+		},
 		"equinixmetal_flatcar": {
 			name: "equinixmetal_flatcar",
 			labels: map[string]string{
@@ -375,6 +695,24 @@ var (
 			},
 			terraform: terraformBin{
 				path: "../../examples/terraform/equinixmetal",
+				vars: []string{
+					"control_plane_operating_system=flatcar_stable",
+					"worker_os=flatcar",
+					"ssh_username=core",
+				},
+			},
+		},
+		"equinixmetal_flatcar_stable": {
+			name: "equinixmetal_flatcar_stable",
+			labels: map[string]string{
+				"preset-goproxy":       "true",
+				"preset-equinix-metal": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "equinixmetal",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/equinixmetal",
 				vars: []string{
 					"control_plane_operating_system=flatcar_stable",
 					"worker_os=flatcar",
@@ -398,6 +736,22 @@ var (
 				},
 			},
 		},
+		"gce_default_stable": {
+			name: "gce_default_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-gce":     "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "gce",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/gce",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+				},
+			},
+		},
 		"hetzner_default": {
 			name: "hetzner_default",
 			labels: map[string]string{
@@ -414,6 +768,22 @@ var (
 				},
 			},
 		},
+		"hetzner_default_stable": {
+			name: "hetzner_default_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-hetzner": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "hetzner",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/hetzner",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+				},
+			},
+		},
 		"hetzner_centos": {
 			name: "hetzner_centos",
 			labels: map[string]string{
@@ -425,6 +795,24 @@ var (
 			},
 			terraform: terraformBin{
 				path: "../../examples/terraform/hetzner",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"image=centos-7",
+					"worker_os=centos",
+				},
+			},
+		},
+		"hetzner_centos_stable": {
+			name: "hetzner_centos_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-hetzner": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "hetzner",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/hetzner",
 				vars: []string{
 					"disable_kubeapi_loadbalancer=true",
 					"image=centos-7",
@@ -450,6 +838,24 @@ var (
 				},
 			},
 		},
+		"hetzner_rockylinux_stable": {
+			name: "hetzner_rockylinux_stable",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-hetzner": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "hetzner",
+			},
+			terraform: terraformBin{
+				path: "../../../kubeone-stable/examples/terraform/hetzner",
+				vars: []string{
+					"disable_kubeapi_loadbalancer=true",
+					"image=rocky-8",
+					"worker_os=rockylinux",
+				},
+			},
+		},
 		"openstack_default": {
 			name: "openstack_default",
 			labels: map[string]string{
@@ -461,6 +867,20 @@ var (
 			},
 			terraform: terraformBin{
 				path:    "../../examples/terraform/openstack",
+				varFile: "testdata/openstack_ubuntu.tfvars",
+			},
+		},
+		"openstack_default_stable": {
+			name: "openstack_default_stable",
+			labels: map[string]string{
+				"preset-goproxy":   "true",
+				"preset-openstack": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "openstack",
+			},
+			terraform: terraformBin{
+				path:    "../../../kubeone-stable/examples/terraform/openstack",
 				varFile: "testdata/openstack_ubuntu.tfvars",
 			},
 		},
@@ -478,6 +898,20 @@ var (
 				varFile: "testdata/openstack_centos.tfvars",
 			},
 		},
+		"openstack_centos_stable": {
+			name: "openstack_centos_stable",
+			labels: map[string]string{
+				"preset-goproxy":   "true",
+				"preset-openstack": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "openstack",
+			},
+			terraform: terraformBin{
+				path:    "../../../kubeone-stable/examples/terraform/openstack",
+				varFile: "testdata/openstack_centos.tfvars",
+			},
+		},
 		"openstack_rockylinux": {
 			name: "openstack_rockylinux",
 			labels: map[string]string{
@@ -489,6 +923,20 @@ var (
 			},
 			terraform: terraformBin{
 				path:    "../../examples/terraform/openstack",
+				varFile: "testdata/openstack_rockylinux.tfvars",
+			},
+		},
+		"openstack_rockylinux_stable": {
+			name: "openstack_rockylinux",
+			labels: map[string]string{
+				"preset-goproxy":   "true",
+				"preset-openstack": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "openstack",
+			},
+			terraform: terraformBin{
+				path:    "../../../kubeone-stable/examples/terraform/openstack",
 				varFile: "testdata/openstack_rockylinux.tfvars",
 			},
 		},
@@ -506,6 +954,20 @@ var (
 				varFile: "testdata/openstack_rhel.tfvars",
 			},
 		},
+		"openstack_rhel_stable": {
+			name: "openstack_rhel_stable",
+			labels: map[string]string{
+				"preset-goproxy":   "true",
+				"preset-openstack": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "openstack",
+			},
+			terraform: terraformBin{
+				path:    "../../../kubeone-stable/examples/terraform/openstack",
+				varFile: "testdata/openstack_rhel.tfvars",
+			},
+		},
 		"openstack_flatcar": {
 			name: "openstack_flatcar",
 			labels: map[string]string{
@@ -517,6 +979,20 @@ var (
 			},
 			terraform: terraformBin{
 				path:    "../../examples/terraform/openstack",
+				varFile: "testdata/openstack_flatcar.tfvars",
+			},
+		},
+		"openstack_flatcar_stable": {
+			name: "openstack_flatcar_stable",
+			labels: map[string]string{
+				"preset-goproxy":   "true",
+				"preset-openstack": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "openstack",
+			},
+			terraform: terraformBin{
+				path:    "../../../kubeone-stable/examples/terraform/openstack",
 				varFile: "testdata/openstack_flatcar.tfvars",
 			},
 		},
@@ -552,6 +1028,25 @@ var (
 				},
 			},
 		},
+		"vsphere_default_stable": {
+			name: "vsphere_default_stable",
+			labels: map[string]string{
+				"preset-goproxy":        "true",
+				"preset-vsphere-legacy": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "vsphere",
+			},
+			terraform: terraformBin{
+				path:    "../../../kubeone-stable/examples/terraform/vsphere",
+				varFile: "testdata/vsphere.tfvars",
+				vars: []string{
+					"template_name=kubeone-e2e-ubuntu",
+					"worker_os=ubuntu",
+					"ssh_username=ubuntu",
+				},
+			},
+		},
 		"vsphere_flatcar": {
 			name: "vsphere_flatcar",
 			labels: map[string]string{
@@ -563,6 +1058,23 @@ var (
 			},
 			terraform: terraformBin{
 				path:    "../../examples/terraform/vsphere_flatcar",
+				varFile: "testdata/vsphere.tfvars",
+				vars: []string{
+					"template_name=machine-controller-e2e-flatcar",
+				},
+			},
+		},
+		"vsphere_flatcar_stable": {
+			name: "vsphere_flatcar_stable",
+			labels: map[string]string{
+				"preset-goproxy":        "true",
+				"preset-vsphere-legacy": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "vsphere",
+			},
+			terraform: terraformBin{
+				path:    "../../../kubeone-stable/examples/terraform/vsphere_flatcar",
 				varFile: "testdata/vsphere.tfvars",
 				vars: []string{
 					"template_name=machine-controller-e2e-flatcar",

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -1036,126 +1036,126 @@ func TestVsphereFlatcarInstallDockerV1_23_13(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
+	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
+	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
+	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
+	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
+	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
+	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
+	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
+	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
+	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
+	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
+	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["gce_default"]
+	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
+	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
+	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
@@ -1171,162 +1171,162 @@ func TestOpenstackRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T)
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
+	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
+	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
+	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
+	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
+	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
+	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
+	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
+	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
+	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
+	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
+	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
+	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
+	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
+	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
+	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["gce_default"]
+	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
+	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
+	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
@@ -1342,162 +1342,162 @@ func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
+	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
+	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
+	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
+	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
+	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
+	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
+	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
+	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
+	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
+	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
+	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
+	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
+	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
+	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
+	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["gce_default"]
+	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
+	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
+	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
@@ -1513,162 +1513,162 @@ func TestOpenstackRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
+	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
+	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
+	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
+	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
+	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
+	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
+	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
+	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
+	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
+	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
+	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
+	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
+	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
+	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
+	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestGceDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["gce_default"]
+	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
+	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
+	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
@@ -1684,36 +1684,36 @@ func TestOpenstackRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
+	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
+	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
+	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
+	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
@@ -5833,207 +5833,207 @@ func TestVsphereFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
+	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
+	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
+	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
+	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
+	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
+	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
+	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
+	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
+	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
+	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
+	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_default"]
+	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_centos"]
+	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_rockylinux"]
+	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_default"]
+	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_centos"]
+	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_rockylinux"]
+	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_flatcar"]
+	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_default"]
+	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_centos"]
+	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_rockylinux"]
+	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
+	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
+	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
@@ -6049,243 +6049,243 @@ func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
+	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
+	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
+	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
+	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
+	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
+	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
+	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
+	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
+	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
+	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
+	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
+	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
+	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
+	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
+	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_default"]
+	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_centos"]
+	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_rockylinux"]
+	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_default"]
+	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_centos"]
+	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_rockylinux"]
+	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_flatcar"]
+	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_default"]
+	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_centos"]
+	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_rockylinux"]
+	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
+	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
+	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
@@ -6301,243 +6301,243 @@ func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *t
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
+	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
+	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
+	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
+	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
+	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
+	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
+	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
+	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
+	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
+	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
+	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
+	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
+	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
+	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
+	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_default"]
+	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_centos"]
+	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_rockylinux"]
+	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_default"]
+	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_centos"]
+	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_rockylinux"]
+	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_flatcar"]
+	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_default"]
+	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_centos"]
+	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_rockylinux"]
+	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
+	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
+	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
@@ -6553,243 +6553,243 @@ func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *te
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
+	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
+	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
+	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
+	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
+	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
+	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
+	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
+	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
+	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
+	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
+	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
+	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
+	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
+	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
+	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_default"]
+	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_centos"]
+	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_rockylinux"]
+	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_default"]
+	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_centos"]
+	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_rockylinux"]
+	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_flatcar"]
+	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_default"]
+	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_centos"]
+	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_rockylinux"]
+	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
+	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
+	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
@@ -6805,36 +6805,36 @@ func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *test
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
+	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
+	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
+	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
+	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.15", "v1.23.13")

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -144,97 +144,97 @@
   initVersion: v1.24.7
   upgradedVersion: v1.25.3
   infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: gce_default
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: gce_default_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd
   initVersion: v1.23.13
   upgradedVersion: v1.24.7
   infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: gce_default
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: gce_default_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd
   initVersion: v1.22.15
   upgradedVersion: v1.23.13
   infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: gce_default
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: gce_default_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_flatcar_stable
 
 - scenario: upgrade_docker
   initVersion: v1.22.15
   upgradedVersion: v1.23.13
   infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: gce_default
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: gce_default_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_flatcar_stable
 
 - scenario: calico_containerd
   initVersion: v1.25.3
@@ -821,133 +821,133 @@
   initVersion: v1.22.15
   upgradedVersion: v1.23.13
   infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: digitalocean_default
-    - name: digitalocean_centos
-    - name: digitalocean_rockylinux
-    - name: equinixmetal_default
-    - name: equinixmetal_centos
-    - name: equinixmetal_rockylinux
-    - name: equinixmetal_flatcar
-    - name: hetzner_default
-    - name: hetzner_centos
-    - name: hetzner_rockylinux
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: digitalocean_default_stable
+    - name: digitalocean_centos_stable
+    - name: digitalocean_rockylinux_stable
+    - name: equinixmetal_default_stable
+    - name: equinixmetal_centos_stable
+    - name: equinixmetal_rockylinux_stable
+    - name: equinixmetal_flatcar_stable
+    - name: hetzner_default_stable
+    - name: hetzner_centos_stable
+    - name: hetzner_rockylinux_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd_external
   initVersion: v1.23.13
   upgradedVersion: v1.24.7
   infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: digitalocean_default
-    - name: digitalocean_centos
-    - name: digitalocean_rockylinux
-    - name: equinixmetal_default
-    - name: equinixmetal_centos
-    - name: equinixmetal_rockylinux
-    - name: equinixmetal_flatcar
-    - name: hetzner_default
-    - name: hetzner_centos
-    - name: hetzner_rockylinux
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: digitalocean_default_stable
+    - name: digitalocean_centos_stable
+    - name: digitalocean_rockylinux_stable
+    - name: equinixmetal_default_stable
+    - name: equinixmetal_centos_stable
+    - name: equinixmetal_rockylinux_stable
+    - name: equinixmetal_flatcar_stable
+    - name: hetzner_default_stable
+    - name: hetzner_centos_stable
+    - name: hetzner_rockylinux_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd_external
   initVersion: v1.24.7
   upgradedVersion: v1.25.3
   infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: digitalocean_default
-    - name: digitalocean_centos
-    - name: digitalocean_rockylinux
-    - name: equinixmetal_default
-    - name: equinixmetal_centos
-    - name: equinixmetal_rockylinux
-    - name: equinixmetal_flatcar
-    - name: hetzner_default
-    - name: hetzner_centos
-    - name: hetzner_rockylinux
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: digitalocean_default_stable
+    - name: digitalocean_centos_stable
+    - name: digitalocean_rockylinux_stable
+    - name: equinixmetal_default_stable
+    - name: equinixmetal_centos_stable
+    - name: equinixmetal_rockylinux_stable
+    - name: equinixmetal_flatcar_stable
+    - name: hetzner_default_stable
+    - name: hetzner_centos_stable
+    - name: hetzner_rockylinux_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_flatcar_stable
 
 - scenario: upgrade_docker_external
   initVersion: v1.22.15
   upgradedVersion: v1.23.13
   infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: digitalocean_default
-    - name: digitalocean_centos
-    - name: digitalocean_rockylinux
-    - name: equinixmetal_default
-    - name: equinixmetal_centos
-    - name: equinixmetal_rockylinux
-    - name: equinixmetal_flatcar
-    - name: hetzner_default
-    - name: hetzner_centos
-    - name: hetzner_rockylinux
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: digitalocean_default_stable
+    - name: digitalocean_centos_stable
+    - name: digitalocean_rockylinux_stable
+    - name: equinixmetal_default_stable
+    - name: equinixmetal_centos_stable
+    - name: equinixmetal_rockylinux_stable
+    - name: equinixmetal_flatcar_stable
+    - name: hetzner_default_stable
+    - name: hetzner_centos_stable
+    - name: hetzner_rockylinux_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_flatcar_stable
 
 - scenario: legacy_machine_controller_containerd_external
   initVersion: v1.22.15


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces two important changes to the upgrade tests:

- We're now using KubeOne v1.5 (instead of v1.4) as a previous stable version for initially provisioning the cluster
- We're now using previous stable Terraform configs for creating the infra
  - We had two problems with using the latest Terraform configs for creating the infra. The first one is that the previous stable KubeOne version might not be able to read the latest Terraform output (e.g. this time we added support for SSH host keys). The second problem is that the latest stable Terraform configs might create a setup unsupported by the previous stable version (e.g. use a newer OS version that's not supported by the previous version). Both problems are solved by using the previous stable Terraform configs to create the infra.

**What type of PR is this?**

/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```