### PR TITLE
Allow overriding image repository for CoreDNS

### DIFF
--- a/docs/api_reference/v1beta2.en.md
+++ b/docs/api_reference/v1beta2.en.md
@@ -1,6 +1,6 @@
 +++
 title = "v1beta2 API Reference"
-date = 2022-09-29T16:34:01+03:00
+date = 2022-10-05T12:04:49+02:00
 weight = 11
 +++
 ## v1beta2
@@ -290,6 +290,7 @@ ControlPlaneConfig defines control plane nodes
 | ----- | ----------- | ------ | -------- |
 | replicas |  | *int32 | false |
 | deployPodDisruptionBudget |  | *bool | false |
+| imageRepository | ImageRepository allows users to specify the image registry to be used for CoreDNS. Kubeadm automatically appends `/coredns` at the end, so it's not necessary to specify it. By default it's empty, which means it'll be defaulted based on kubeadm defaults and if overwriteRegistry feature is used. ImageRepository has the highest priority, meaning that it'll override overwriteRegistry if specified. | string | false |
 
 [Back to Group](#v1beta2)
 

--- a/pkg/apis/kubeone/types.go
+++ b/pkg/apis/kubeone/types.go
@@ -738,6 +738,15 @@ type NodeLocalDNS struct {
 type CoreDNS struct {
 	Replicas                  *int32 `json:"replicas,omitempty"`
 	DeployPodDisruptionBudget *bool  `json:"deployPodDisruptionBudget,omitempty"`
+
+	// ImageRepository allows users to specify the image registry to be used
+	// for CoreDNS. Kubeadm automatically appends `/coredns` at the end, so it's
+	// not necessary to specify it.
+	// By default it's empty, which means it'll be defaulted based on kubeadm
+	// defaults and if overwriteRegistry feature is used.
+	// ImageRepository has the highest priority, meaning that it'll override
+	// overwriteRegistry if specified.
+	ImageRepository string `json:"imageRepository,omitempty"`
 }
 
 // PodNodeSelector feature flag

--- a/pkg/apis/kubeone/v1beta2/types.go
+++ b/pkg/apis/kubeone/v1beta2/types.go
@@ -673,6 +673,15 @@ type NodeLocalDNS struct {
 type CoreDNS struct {
 	Replicas                  *int32 `json:"replicas,omitempty"`
 	DeployPodDisruptionBudget *bool  `json:"deployPodDisruptionBudget,omitempty"`
+
+	// ImageRepository allows users to specify the image registry to be used
+	// for CoreDNS. Kubeadm automatically appends `/coredns` at the end, so it's
+	// not necessary to specify it.
+	// By default it's empty, which means it'll be defaulted based on kubeadm
+	// defaults and if overwriteRegistry feature is used.
+	// ImageRepository has the highest priority, meaning that it'll override
+	// overwriteRegistry if specified.
+	ImageRepository string `json:"imageRepository,omitempty"`
 }
 
 // PodNodeSelector feature flag

--- a/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/kubeone/v1beta2/zz_generated.conversion.go
@@ -1082,6 +1082,7 @@ func Convert_kubeone_ControlPlaneConfig_To_v1beta2_ControlPlaneConfig(in *kubeon
 func autoConvert_v1beta2_CoreDNS_To_kubeone_CoreDNS(in *CoreDNS, out *kubeone.CoreDNS, s conversion.Scope) error {
 	out.Replicas = (*int32)(unsafe.Pointer(in.Replicas))
 	out.DeployPodDisruptionBudget = (*bool)(unsafe.Pointer(in.DeployPodDisruptionBudget))
+	out.ImageRepository = in.ImageRepository
 	return nil
 }
 
@@ -1093,6 +1094,7 @@ func Convert_v1beta2_CoreDNS_To_kubeone_CoreDNS(in *CoreDNS, out *kubeone.CoreDN
 func autoConvert_kubeone_CoreDNS_To_v1beta2_CoreDNS(in *kubeone.CoreDNS, out *CoreDNS, s conversion.Scope) error {
 	out.Replicas = (*int32)(unsafe.Pointer(in.Replicas))
 	out.DeployPodDisruptionBudget = (*bool)(unsafe.Pointer(in.DeployPodDisruptionBudget))
+	out.ImageRepository = in.ImageRepository
 	return nil
 }
 

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -649,6 +649,14 @@ features:
   coreDNS:
     replicas: 2
     deployPodDisruptionBudget: true
+    # imageRepository allows users to specify the image registry to be used
+    # for CoreDNS. Kubeadm automatically appends /coredns at the end, so it's
+    # not necessary to specify it.
+    # By default it's empty, which means it'll be defaulted based on kubeadm
+    # defaults and if overwriteRegistry feature is used.
+    # imageRepository has the highest priority, meaning that it'll override
+    # overwriteRegistry if specified.
+    imageRepository: ""
 
   # nodeLocalDNS allows disabling deployment of node local DNS
   nodeLocalDNS:


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now, we have the overwriteRegistry mechanism that can be used to overwrite image registries for all images used by KubeOne and kubeadm. However, due to architecture decisions in kubeadm, overwriteRegistry doesn't work well for the CoreDNS image.

By default, the CoreDNS image is `registry.k8s.io/coredns/coredns:<version>` (or `k8s.gcr.io` for Kubernetes 1.24 and older). When we overwrite the image (via kubeadm's `dns.imageRepository`), we end up with `my.corp/coredns:<version>`. Note that we have only `/coredns` instead of `/coredns/coredns` when overwriting the CoreDNS image.

This is making the overwriteRegistry feature useless depending on the registry type that you use (e.g. it might be a problem for pull through registries). In the v1beta1 API, we had the AssetConfiguration API that allowed overriding the CoreDNS image explicitly, but we removed that API in v1beta2.

To address this issue, we're introducing a new field (`.features.coreDNS.imageRepository`) in the v1beta2 API that can be used to override the CoreDNS image repository. It remains impossible to override the image tag, it's only possible to override the repository. This field is decoupled from the overwriteRegistry feature, i.e. it can be used even if overwriteRegistry is not used.

Example configuration:

```yaml
apiVersion: kubeone.k8c.io/v1beta2
kind: KubeOneCluster
versions:
  kubernetes: 1.24.6
cloudProvider:
  aws: {}
  external: false
registryConfiguration:
  overwriteRegistry: "localhost:8080"
features:
  coreDNS:
    imageRepository: "localhost:8080/coredns" # results in localhost:8080/coredns/coredns being used
```

**Which issue(s) this PR fixes**:
Fixes #2023 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Allow overriding image repository for CoreDNS via `.features.coreDNS.imageRepository` field.
```

**Documentation**:
```documentation
TBD
```

/assign @kron4eg 
/hold
for discussion