### PR TITLE
kubeone init: generate KubeOneCluster and optional terraform configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
   - exhaustive
   - exportloopref
   - forcetypeassert
-  - goconst
   - gocritic
   - gocyclo
   - gofmt

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GITCOMMIT=$(shell git log -1 --pretty=format:"%H")
 GITTAG=$(shell git describe --tags --always)
 DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.24.txt)
 GOLDFLAGS?=-s -w -extldflags=-zrelro -extldflags=-znow \
-	-X k8c.io/kubeone/pkg/cmd.defaultInitVersion=$(DEFAULT_STABLE) \
+	-X k8c.io/kubeone/pkg/cmd.defaultKubeVersion=$(DEFAULT_STABLE) \
 	-X k8c.io/kubeone/pkg/cmd.version=$(GITTAG) \
 	-X k8c.io/kubeone/pkg/cmd.commit=$(GITCOMMIT) \
 	-X k8c.io/kubeone/pkg/cmd.date=$(BUILD_DATE)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export GOFLAGS?=-mod=readonly -trimpath
 BUILD_DATE=$(shell if hash gdate 2>/dev/null; then gdate --rfc-3339=seconds | sed 's/ /T/'; else date --rfc-3339=seconds | sed 's/ /T/'; fi)
 GITCOMMIT=$(shell git log -1 --pretty=format:"%H")
 GITTAG=$(shell git describe --tags --always)
-DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable.txt)
+DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.24.txt)
 GOLDFLAGS?=-s -w -extldflags=-zrelro -extldflags=-znow \
 	-X k8c.io/kubeone/pkg/cmd.defaultInitVersion=$(DEFAULT_STABLE) \
 	-X k8c.io/kubeone/pkg/cmd.version=$(GITTAG) \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ export GOFLAGS?=-mod=readonly -trimpath
 BUILD_DATE=$(shell if hash gdate 2>/dev/null; then gdate --rfc-3339=seconds | sed 's/ /T/'; else date --rfc-3339=seconds | sed 's/ /T/'; fi)
 GITCOMMIT=$(shell git log -1 --pretty=format:"%H")
 GITTAG=$(shell git describe --tags --always)
+DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable.txt)
 GOLDFLAGS?=-s -w -extldflags=-zrelro -extldflags=-znow \
+	-X k8c.io/kubeone/pkg/cmd.defaultInitVersion=$(DEFAULT_STABLE) \
 	-X k8c.io/kubeone/pkg/cmd.version=$(GITTAG) \
 	-X k8c.io/kubeone/pkg/cmd.commit=$(GITCOMMIT) \
 	-X k8c.io/kubeone/pkg/cmd.date=$(BUILD_DATE)

--- a/examples/embed.go
+++ b/examples/embed.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package examples
+
+import "embed"
+
+//go:embed terraform/*
+var TerraformFS embed.FS

--- a/examples/embed.go
+++ b/examples/embed.go
@@ -42,10 +42,10 @@ func CopyTo(dst, src string) error {
 
 		dstFullPath := filepath.Join(dst, dstPartPath)
 		if de.IsDir() {
-			return os.MkdirAll(dstFullPath, de.Type().Perm())
+			return os.MkdirAll(dstFullPath, 0755)
 		}
 
-		fh, err := os.OpenFile(dstFullPath, os.O_CREATE|os.O_WRONLY, 0600)
+		fh, err := os.Create(dstFullPath)
 		if err != nil {
 			return err
 		}

--- a/pkg/apis/kubeone/v1beta2/helpers.go
+++ b/pkg/apis/kubeone/v1beta2/helpers.go
@@ -57,6 +57,35 @@ func SetCloudProvider(cp *CloudProviderSpec, name string) error {
 	return nil
 }
 
+func (cps *CloudProviderSpec) Name() string {
+	switch {
+	case cps.AWS != nil:
+		return "aws"
+	case cps.Azure != nil:
+		return "azure"
+	case cps.DigitalOcean != nil:
+		return "digitalocean"
+	case cps.GCE != nil:
+		return "gce"
+	case cps.Hetzner != nil:
+		return "hetzner"
+	case cps.Nutanix != nil:
+		return "nutanix"
+	case cps.Openstack != nil:
+		return "openstack"
+	case cps.EquinixMetal != nil:
+		return "equinixmetal"
+	case cps.VMwareCloudDirector != nil:
+		return "vmwareCloudDirector"
+	case cps.Vsphere != nil:
+		return "vsphere"
+	case cps.None != nil:
+		return "none"
+	}
+
+	return "unknown"
+}
+
 // NewKubeOneCluster initialize KubeOneCluster with correct typeMeta
 func NewKubeOneCluster() *KubeOneCluster {
 	return &KubeOneCluster{

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	yamlv2 "gopkg.in/yaml.v2"
 
 	"k8c.io/kubeone/examples"
@@ -191,7 +190,7 @@ type initOpts struct {
 	Path      string    `longflag:"path"`
 }
 
-func initCmd(rootFlags *pflag.FlagSet) *cobra.Command {
+func initCmd() *cobra.Command {
 	opts := &initOpts{
 		Provider: oneOfFlag{
 			validSet:     sets.StringKeySet(validProviders),

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -273,13 +273,19 @@ func initCmd() *cobra.Command {
 }
 
 func runInit(opts *initOpts) error {
+	providerName := opts.Provider.String()
+	clusterName := opts.ClusterName
+
+	if opts.Terraform && providerName != "none" {
+		clusterName = ""
+	}
+
 	ybuf, err := genKubeOneClusterYAML(&genKubeOneClusterYAMLParams{
-		providerName:      opts.Provider.String(),
-		clusterName:       opts.ClusterName,
+		providerName:      providerName,
+		clusterName:       clusterName,
 		kubernetesVersion: opts.KubernetesVersion,
 		validProviders:    validProviders,
 	})
-
 	if err != nil {
 		return fail.Runtime(err, "generating KubeOneCluster")
 	}
@@ -333,7 +339,9 @@ var (
 	manifestTemplateSource = heredoc.Doc(`
 		apiVersion: {{ .APIVersion }}
 		kind: {{ .Kind }}
-		name: {{ .Name }}
+		{{- with .Name}}
+		name: {{ . }}
+		{{- end }}
 
 		cloudProvider:
 		  {{ .CloudProvider.Name }}: {}

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -46,8 +46,7 @@ type initProvider struct {
 }
 
 var (
-	defaultInitVersion = "x.y.z"
-	validProviders     = map[string]initProvider{
+	validProviders = map[string]initProvider{
 		"aws": {
 			terraformPath: "terraform/aws",
 		},
@@ -221,7 +220,7 @@ func initCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&opts.Terraform, longFlagName(opts, "Terraform"), true, "generate terraform config")
 	cmd.Flags().StringVar(&opts.ClusterName, longFlagName(opts, "ClusterName"), "example", "name of the cluster")
-	cmd.Flags().StringVar(&opts.KubernetesVersion, longFlagName(opts, "KubernetesVersion"), defaultInitVersion, "kubernetes version")
+	cmd.Flags().StringVar(&opts.KubernetesVersion, longFlagName(opts, "KubernetesVersion"), defaultKubeVersion, "kubernetes version")
 	cmd.Flags().StringVar(&opts.Path, longFlagName(opts, "Path"), ".", "path where to write files")
 	cmd.Flags().Var(&opts.Provider, longFlagName(opts, "Provider"), providerUsageText)
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -40,7 +40,7 @@ import (
 
 type initProvider struct {
 	terraformPath string
-	inTree        bool
+	external      bool
 	cloudConfig   string
 	csiConfig     string
 }
@@ -49,9 +49,11 @@ var (
 	validProviders = map[string]initProvider{
 		"aws": {
 			terraformPath: "terraform/aws",
+			external:      true,
 		},
 		"azure": {
 			terraformPath: "terraform/azure",
+			external:      true,
 			cloudConfig: heredoc.Doc(`
 				{
 				    "tenantId": "{{ .Credentials.AZURE_TENANT_ID }}",
@@ -73,26 +75,28 @@ var (
 		},
 		"digitalocean": {
 			terraformPath: "terraform/digitalocean",
+			external:      true,
 		},
 		"equinixmetal": {
 			terraformPath: "terraform/equinixmetal",
+			external:      true,
 		},
 		"gce": {
 			terraformPath: "terraform/gce",
-			inTree:        true,
 		},
 		"hetzner": {
 			terraformPath: "terraform/hetzner",
+			external:      true,
 		},
 		"none": {
 			terraformPath: "",
-			inTree:        true,
 		},
 		"nutanix": {
 			terraformPath: "terraform/nutanix",
 		},
 		"openstack": {
 			terraformPath: "terraform/openstack",
+			external:      true,
 			cloudConfig: heredoc.Doc(`
 				[Global]
 				auth-url=<KEYSTONE-URL>
@@ -108,10 +112,10 @@ var (
 		},
 		"vmware-cloud-director": {
 			terraformPath: "terraform/vmware-cloud-director",
-			inTree:        true,
 		},
 		"vsphere": {
 			terraformPath: "terraform/vsphere",
+			external:      true,
 			cloudConfig: heredoc.Doc(`
 				[Global]
 				secret-name = "vsphere-ccm-credentials"
@@ -149,6 +153,7 @@ var (
 		},
 		"vsphere/flatcar": {
 			terraformPath: "terraform/vsphere_flatcar",
+			external:      true,
 			cloudConfig: heredoc.Doc(`
 				[Global]
 				secret-name = "vsphere-ccm-credentials"
@@ -278,7 +283,7 @@ func genKubeOneClusterYAML(opts *initOpts) ([]byte, error) {
 		},
 		Name: opts.ClusterName,
 		CloudProvider: kubeonev1beta2.CloudProviderSpec{
-			External:    !prov.inTree,
+			External:    prov.external,
 			CloudConfig: prov.cloudConfig,
 			CSIConfig:   prov.csiConfig,
 		},

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	yamlv2 "gopkg.in/yaml.v2"
+
+	kubeonev1beta2 "k8c.io/kubeone/pkg/apis/kubeone/v1beta2"
+	"k8c.io/kubeone/pkg/yamled"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+)
+
+type initProvider struct {
+	terraformPath string
+	inTree        bool
+	cloudConfig   string
+	csiConfig     string
+}
+
+var (
+	validProviders = map[string]initProvider{
+		"aws": {
+			terraformPath: "terraform/aws",
+		},
+		"azure": {
+			terraformPath: "terraform/azure",
+			cloudConfig: heredoc.Doc(`
+				{
+				    "tenantId": "{{ .Credentials.AZURE_TENANT_ID }}",
+				    "subscriptionId": "{{ .Credentials.AZURE_SUBSCRIPTION_ID }}",
+				    "aadClientId": "{{ .Credentials.AZURE_CLIENT_ID }}",
+				    "aadClientSecret": "{{ .Credentials.AZURE_CLIENT_SECRET }}",
+				    "resourceGroup": "<RESOURCE-GROUP>",
+				    "location": "<LOCATION>",
+				    "subnetName": "<SUBNET>",
+				    "routeTableName": "",
+				    "securityGroupName": "<SECURITY-GROUP>",
+				    "vnetName": "<VPC-NAME>",
+				    "primaryAvailabilitySetName": "<AVAILABILITY-SET-NAME>",
+				    "useInstanceMetadata": true,
+				    "useManagedIdentityExtension": false,
+				    "userAssignedIdentityID": ""
+				}
+			`),
+		},
+		"digitalocean": {
+			terraformPath: "terraform/digitalocean",
+		},
+		"equinixmetal": {
+			terraformPath: "terraform/equinixmetal",
+		},
+		"gce": {
+			terraformPath: "terraform/gce",
+		},
+		"hetzner": {
+			terraformPath: "terraform/hetzner",
+		},
+		"none": {
+			terraformPath: "",
+			inTree:        true,
+		},
+		"openstack": {
+			terraformPath: "terraform/openstack",
+			cloudConfig: heredoc.Doc(`
+				[Global]
+				auth-url=<KEYSTONE-URL>
+				username=<USER>
+				password=<PASSWORD>
+				tenant-id=<TENANT-ID>
+				domain-name=DEFAULT
+				region=<REGION>
+
+				[LoadBalancer]
+				[BlockStorage]
+			`),
+		},
+		"vmware-cloud-director": {
+			terraformPath: "terraform/vmware-cloud-director",
+		},
+		"vsphere": {
+			terraformPath: "terraform/vsphere",
+			cloudConfig: heredoc.Doc(`
+				[Global]
+				secret-name = "vsphere-ccm-credentials"
+				secret-namespace = "kube-system"
+				port = "443"
+				insecure-flag = "0"
+
+				[VirtualCenter "<VCENTER-ADDRESS>"]
+
+				[Workspace]
+				server = "<VCENTER-ADDRESS>"
+				datacenter = "<DATACENTER>"
+				default-datastore="<DATASTORE>"
+				resourcepool-path=""
+				folder = ""
+
+				[Disk]
+				scsicontrollertype = pvscsi
+
+				[Network]
+				public-network = "<VM-NETWORK>"
+			`),
+			csiConfig: heredoc.Doc(`
+				[Global]
+				cluster-id = "<CLUSTER-ID>"
+				cluster-distribution = "<CLUSTER-DISTRIBUTION>"
+
+				[VirtualCenter "<VCENTER-ADDRESS>"]
+				insecure-flag = "false"
+				user = "<USERNAME>"
+				password = "<PASSWORD>"
+				port = "<PORT>"
+				datacenters = "<DATACENTER>"
+			`),
+		},
+		"vsphere/flatcar": {
+			terraformPath: "terraform/vsphere_flatcar",
+			cloudConfig: heredoc.Doc(`
+				[Global]
+				secret-name = "vsphere-ccm-credentials"
+				secret-namespace = "kube-system"
+				port = "443"
+				insecure-flag = "0"
+
+				[VirtualCenter "<VCENTER-ADDRESS>"]
+
+				[Workspace]
+				server = "<VCENTER-ADDRESS>"
+				datacenter = "<DATACENTER>"
+				default-datastore="<DATASTORE>"
+				resourcepool-path=""
+				folder = ""
+
+				[Disk]
+				scsicontrollertype = pvscsi
+
+				[Network]
+				public-network = "<VM-NETWORK>"
+			`),
+			csiConfig: heredoc.Doc(`
+				[Global]
+				cluster-id = "<CLUSTER-ID>"
+				cluster-distribution = "<CLUSTER-DISTRIBUTION>"
+
+				[VirtualCenter "<VCENTER-ADDRESS>"]
+				insecure-flag = "false"
+				user = "<USERNAME>"
+				password = "<PASSWORD>"
+				port = "<PORT>"
+				datacenters = "<DATACENTER>"
+			`),
+		},
+	}
+)
+
+type initOpts struct {
+	Provider  oneOfFlag `longflag:"provider"`
+	Name      string    `longflag:"name"`
+	Version   string    `longflag:"version"`
+	Terraform bool      `longflag:"terraform"`
+	Path      string    `longflag:"path"`
+}
+
+func initCmd(rootFlags *pflag.FlagSet) *cobra.Command {
+	opts := &initOpts{
+		Provider: oneOfFlag{
+			validSet:     sets.StringKeySet(validProviders),
+			defaultValue: "none",
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "init new kubeone cluster configuration",
+		Long: heredoc.Doc(`
+			Initialize new KubeOne + terraform configuration for chosen provider.
+		`),
+		SilenceErrors: true,
+		Example:       `kubeone init --provider aws`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runInit(opts)
+		},
+	}
+
+	providerUsageText := fmt.Sprintf("provider to initialize, possible values: %s", strings.Join(opts.Provider.PossibleValues(), ", "))
+
+	cmd.Flags().BoolVar(&opts.Terraform, longFlagName(opts, "Terraform"), false, "generate terraform config")
+	cmd.Flags().StringVar(&opts.Name, longFlagName(opts, "Name"), "example", "name of the cluster")
+	cmd.Flags().StringVar(&opts.Version, longFlagName(opts, "version"), "v1.24.5", "kubernetes version")
+	cmd.Flags().StringVar(&opts.Path, longFlagName(opts, "Path"), ".", "path where to write files")
+	cmd.Flags().Var(&opts.Provider, longFlagName(opts, "Provider"), providerUsageText)
+
+	return cmd
+}
+
+func runInit(opts *initOpts) error {
+	ybuf, err := genKubeOneClusterYAML(opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s", ybuf)
+
+	return nil
+}
+
+func genKubeOneClusterYAML(opts *initOpts) ([]byte, error) {
+	providerName := opts.Provider.String()
+	prov := validProviders[providerName]
+
+	cluster := kubeonev1beta2.KubeOneCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeOneCluster",
+			APIVersion: kubeonev1beta2.SchemeGroupVersion.Identifier(),
+		},
+		Name: opts.Name,
+		CloudProvider: kubeonev1beta2.CloudProviderSpec{
+			External:    !prov.inTree,
+			CloudConfig: prov.cloudConfig,
+			CSIConfig:   prov.csiConfig,
+		},
+		ContainerRuntime: kubeonev1beta2.ContainerRuntimeConfig{
+			Containerd: &kubeonev1beta2.ContainerRuntimeContainerd{},
+		},
+		Versions: kubeonev1beta2.VersionConfig{
+			Kubernetes: opts.Version,
+		},
+		Addons: &kubeonev1beta2.Addons{
+			Enable: true,
+			Addons: []kubeonev1beta2.Addon{
+				{
+					Name: "default-storage-class",
+				},
+			},
+		},
+	}
+
+	switch strings.Split(providerName, "/")[0] {
+	case "aws":
+		cluster.CloudProvider.AWS = &kubeonev1beta2.AWSSpec{}
+	case "azure":
+		cluster.CloudProvider.Azure = &kubeonev1beta2.AzureSpec{}
+	case "digitalocean":
+		cluster.CloudProvider.DigitalOcean = &kubeonev1beta2.DigitalOceanSpec{}
+	case "equinixmetal":
+		cluster.CloudProvider.DigitalOcean = &kubeonev1beta2.DigitalOceanSpec{}
+	case "gce":
+		cluster.CloudProvider.GCE = &kubeonev1beta2.GCESpec{}
+	case "hetzner":
+		cluster.CloudProvider.Hetzner = &kubeonev1beta2.HetznerSpec{}
+	case "none":
+		cluster.CloudProvider.None = &kubeonev1beta2.NoneSpec{}
+	case "openstack":
+		cluster.CloudProvider.Openstack = &kubeonev1beta2.OpenstackSpec{}
+	case "vmware-cloud-director":
+		cluster.CloudProvider.VMwareCloudDirector = &kubeonev1beta2.VMwareCloudDirectorSpec{}
+	case "vsphere":
+		cluster.CloudProvider.Vsphere = &kubeonev1beta2.VsphereSpec{}
+	default:
+		return nil, fmt.Errorf("unknown provider")
+	}
+
+	buf, err := yaml.Marshal(&cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := yamled.Load(bytes.NewBuffer(buf))
+	if err != nil {
+		return nil, err
+	}
+
+	toremove := []string{
+		"apiEndpoint",
+		"clusterNetwork",
+		"controlPlane",
+		"hosts",
+		"features",
+		"loggingConfig",
+		"proxy",
+		"staticWorkers",
+	}
+	for _, yamlPath := range toremove {
+		doc.Remove(yamled.Path{yamlPath})
+	}
+
+	return yamlv2.Marshal(doc)
+}

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"flag"
+	"sort"
+	"testing"
+
+	"k8c.io/kubeone/pkg/testhelper"
+)
+
+var updateFlag = flag.Bool("update", false, "update testdata files")
+
+func Test_genKubeOneClusterYAML(t *testing.T) {
+	type testArgs struct {
+		providerName string
+		err          error
+	}
+
+	validProvidersNames := []string{}
+	for provName := range validProviders {
+		validProvidersNames = append(validProvidersNames, provName)
+	}
+	sort.Strings(validProvidersNames)
+	tests := []testArgs{}
+
+	for _, provName := range validProvidersNames {
+		tests = append(tests, testArgs{
+			providerName: provName,
+		})
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.providerName, func(t *testing.T) {
+			params := &genKubeOneClusterYAMLParams{
+				providerName:      tt.providerName,
+				clusterName:       "example",
+				kubernetesVersion: "v1.24.4",
+				validProviders:    validProviders,
+			}
+
+			got, err := genKubeOneClusterYAML(params)
+			if !errors.Is(err, tt.err) {
+				t.Errorf("genKubeOneClusterYAML() unexpected error: %v, expected err %v", err, tt.err)
+
+				return
+			}
+
+			testhelper.DiffOutput(t, testhelper.FSGoldenName(t), string(got), *updateFlag)
+		})
+	}
+}

--- a/pkg/cmd/local.go
+++ b/pkg/cmd/local.go
@@ -155,7 +155,7 @@ func localCmd(rootFlags *pflag.FlagSet) *cobra.Command {
 	cmd.Flags().StringVar(
 		&opts.KubernetesVersion,
 		longFlagName(opts, "KubernetesVersion"),
-		"1.24.2",
+		defaultKubeVersion,
 		"kubernetes version to install when there is no manifest")
 
 	cmd.Flags().StringVar(

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -127,7 +127,7 @@ func newRoot() *cobra.Command {
 		completionCmd(rootCmd),
 		configCmd(fs),
 		documentCmd(rootCmd),
-		initCmd(fs),
+		initCmd(),
 		installCmd(fs),
 		kubeconfigCmd(fs),
 		localCmd(fs),

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -122,14 +122,15 @@ func newRoot() *cobra.Command {
 		"format for logging")
 
 	rootCmd.AddCommand(
-		applyCmd(fs),
-		localCmd(fs),
 		addonsCmd(fs),
+		applyCmd(fs),
 		completionCmd(rootCmd),
 		configCmd(fs),
 		documentCmd(rootCmd),
+		initCmd(fs),
 		installCmd(fs),
 		kubeconfigCmd(fs),
+		localCmd(fs),
 		migrateCmd(fs),
 		proxyCmd(fs),
 		resetCmd(fs),

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -36,6 +36,8 @@ import (
 	"k8c.io/kubeone/pkg/credentials"
 	"k8c.io/kubeone/pkg/fail"
 	"k8c.io/kubeone/pkg/state"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const yes = "yes"
@@ -250,4 +252,37 @@ func defaultBackupPath(backupPath, manifestPath, clusterName string) string {
 	}
 
 	return backupPath
+}
+
+type oneOfFlag struct {
+	validSet     sets.String
+	defaultValue string
+	value        string
+	valid        bool
+}
+
+func (oof *oneOfFlag) String() string {
+	if oof.valid {
+		return oof.value
+	}
+
+	return oof.defaultValue
+}
+
+func (oof *oneOfFlag) Set(val string) error {
+	if !oof.validSet.Has(val) {
+		return fmt.Errorf("unknown provider")
+	}
+	oof.value = val
+	oof.valid = true
+
+	return nil
+}
+
+func (*oneOfFlag) Type() string {
+	return "string"
+}
+
+func (oof *oneOfFlag) PossibleValues() []string {
+	return oof.validSet.List()
 }

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -275,7 +275,7 @@ func (oof *oneOfFlag) String() string {
 
 func (oof *oneOfFlag) Set(val string) error {
 	if !oof.validSet.Has(val) {
-		return fmt.Errorf("unknown provider")
+		return fmt.Errorf("unknown value")
 	}
 	oof.value = val
 	oof.valid = true

--- a/pkg/cmd/shared.go
+++ b/pkg/cmd/shared.go
@@ -40,6 +40,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+var (
+	defaultKubeVersion = ""
+)
+
 const yes = "yes"
 
 type globalOptions struct {

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-aws.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-aws.golden
@@ -1,0 +1,18 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  aws: {}
+  external: true
+
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-azure.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-azure.golden
@@ -1,0 +1,36 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  azure: {}
+  external: true
+
+  cloudConfig: |
+    {
+        "tenantId": "{{ .Credentials.AZURE_TENANT_ID }}",
+        "subscriptionId": "{{ .Credentials.AZURE_SUBSCRIPTION_ID }}",
+        "aadClientId": "{{ .Credentials.AZURE_CLIENT_ID }}",
+        "aadClientSecret": "{{ .Credentials.AZURE_CLIENT_SECRET }}",
+        "resourceGroup": "<RESOURCE-GROUP>",
+        "location": "<LOCATION>",
+        "subnetName": "<SUBNET>",
+        "routeTableName": "",
+        "securityGroupName": "<SECURITY-GROUP>",
+        "vnetName": "<VPC-NAME>",
+        "primaryAvailabilitySetName": "<AVAILABILITY-SET-NAME>",
+        "useInstanceMetadata": true,
+        "useManagedIdentityExtension": false,
+        "userAssignedIdentityID": ""
+    }
+    
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-digitalocean.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-digitalocean.golden
@@ -1,0 +1,18 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  digitalocean: {}
+  external: true
+
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-equinixmetal.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-equinixmetal.golden
@@ -1,0 +1,18 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  equinixmetal: {}
+  external: true
+
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-gce.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-gce.golden
@@ -1,0 +1,16 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  gce: {}
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-hetzner.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-hetzner.golden
@@ -1,0 +1,18 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  hetzner: {}
+  external: true
+
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-none.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-none.golden
@@ -1,0 +1,17 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  none: {}
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+machineController:
+  deploy: false
+
+operatingSystemManager:
+  deploy: false

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-nutanix.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-nutanix.golden
@@ -1,0 +1,16 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  nutanix: {}
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-openstack.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-openstack.golden
@@ -1,0 +1,30 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  openstack: {}
+  external: true
+
+  cloudConfig: |
+    [Global]
+    auth-url=<KEYSTONE-URL>
+    username=<USER>
+    password=<PASSWORD>
+    tenant-id=<TENANT-ID>
+    domain-name=DEFAULT
+    region=<REGION>
+    
+    [LoadBalancer]
+    [BlockStorage]
+    
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-vmware-cloud-director.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-vmware-cloud-director.golden
@@ -1,0 +1,16 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  vmwareCloudDirector: {}
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-vsphere-flatcar.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-vsphere-flatcar.golden
@@ -1,0 +1,52 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  vsphere: {}
+  external: true
+
+  cloudConfig: |
+    [Global]
+    secret-name = "vsphere-ccm-credentials"
+    secret-namespace = "kube-system"
+    port = "443"
+    insecure-flag = "0"
+    
+    [VirtualCenter "<VCENTER-ADDRESS>"]
+    
+    [Workspace]
+    server = "<VCENTER-ADDRESS>"
+    datacenter = "<DATACENTER>"
+    default-datastore="<DATASTORE>"
+    resourcepool-path=""
+    folder = ""
+    
+    [Disk]
+    scsicontrollertype = pvscsi
+    
+    [Network]
+    public-network = "<VM-NETWORK>"
+    
+  csiConfig: |
+    [Global]
+    cluster-id = "<CLUSTER-ID>"
+    cluster-distribution = "<CLUSTER-DISTRIBUTION>"
+    
+    [VirtualCenter "<VCENTER-ADDRESS>"]
+    insecure-flag = "false"
+    user = "<USERNAME>"
+    password = "<PASSWORD>"
+    port = "<PORT>"
+    datacenters = "<DATACENTER>"
+    
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class

--- a/pkg/cmd/testdata/Test_genKubeOneClusterYAML-vsphere.golden
+++ b/pkg/cmd/testdata/Test_genKubeOneClusterYAML-vsphere.golden
@@ -1,0 +1,52 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: example
+
+cloudProvider:
+  vsphere: {}
+  external: true
+
+  cloudConfig: |
+    [Global]
+    secret-name = "vsphere-ccm-credentials"
+    secret-namespace = "kube-system"
+    port = "443"
+    insecure-flag = "0"
+    
+    [VirtualCenter "<VCENTER-ADDRESS>"]
+    
+    [Workspace]
+    server = "<VCENTER-ADDRESS>"
+    datacenter = "<DATACENTER>"
+    default-datastore="<DATASTORE>"
+    resourcepool-path=""
+    folder = ""
+    
+    [Disk]
+    scsicontrollertype = pvscsi
+    
+    [Network]
+    public-network = "<VM-NETWORK>"
+    
+  csiConfig: |
+    [Global]
+    cluster-id = "<CLUSTER-ID>"
+    cluster-distribution = "<CLUSTER-DISTRIBUTION>"
+    
+    [VirtualCenter "<VCENTER-ADDRESS>"]
+    insecure-flag = "false"
+    user = "<USERNAME>"
+    password = "<PASSWORD>"
+    port = "<PORT>"
+    datacenters = "<DATACENTER>"
+    
+containerRuntime:
+  containerd: {}
+
+versions:
+  kubernetes: v1.24.4
+
+addons:
+  enable: true
+  addons:
+    - name: default-storage-class


### PR DESCRIPTION
**What this PR does / why we need it**:
To make it easier to start with kubeone, and to have correct (corresponding version of terarfomr to kubeone) terraform configuration.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1063

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Implement a new `kubeone init` command used to generate the KubeOneCluster manifest and example Terraform configurations
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
