### PR TITLE
Fix path to API docs

### DIFF
--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -43,9 +43,9 @@ find ../docs/api_reference -name '*.en.md' -print0 | while IFS= read -r -d '' do
   apiVersion=$(basename ${docsPath} | awk -F. '{print $1}')
   echodate "Copying ${apiVersion} docs..."
 
-  mkdir -p content/kubeone/"${KUBEONE_VERSION}"/references/kubeone_cluster_"${apiVersion}"
+  mkdir -p content/kubeone/"${KUBEONE_VERSION}"/references/kubeone-cluster-"${apiVersion}"
   cp ../docs/api_reference/"${apiVersion}".en.md \
-    content/kubeone/"${KUBEONE_VERSION}"/references/kubeone_cluster_"${apiVersion}"/_index.en.md
+    content/kubeone/"${KUBEONE_VERSION}"/references/kubeone-cluster-"${apiVersion}"/_index.en.md
 done
 
 # update repo


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a path to the API docs in the `./hack/ci/update-docs.sh` script.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```