### PR TITLE
Initial support for Kubernetes 1.25

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes-support.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes-support.md
@@ -10,17 +10,18 @@ Update default admission controllers if needed:
 To find out what admission controllers are enabled by default, you can run
 kube-apiserver --help and search for the --enable-admission-plugins flag.
 The easiest way to run kube-apiserver is using Docker such as:
-docker run --rm k8s.gcr.io/kube-apiserver:v1.2x.0 kube-apiserver -h
+docker run --rm registry.k8s.io/kube-apiserver:v1.2x.0 kube-apiserver -h
 -->
 
 This is a collector issue for Kubernetes 1.2x support in KubeOne. The following tasks should be taken care of:
 
 * [ ] Check the Kubernetes changelog to ensure there are no breaking changes and removals
-* [ ] Update [the `kubeone-e2e` image](https://github.com/kubermatic/kubeone/tree/main/hack/images/kubeone-e2e) to add the needed Kubernetes test binaries <!-- link to the PR -->
+* [ ] Update [the `kubeone-e2e` image](https://github.com/kubermatic/kubeone/tree/main/hack/images/kubeone-e2e) to update Sonobuoy (and other dependencies if needed) <!-- link to the PR -->
+* [ ] Update the latest supported Kubernetes version in [the API validation](https://github.com/kubermatic/kubeone/blob/main/pkg/apis/kubeone/validation/validation.go#L40-L41)
 * [ ] Update [default admission controllers](https://github.com/kubermatic/kubeone/blob/main/pkg/kubeflags/data.go) if needed <!-- link to the PR -->
 * [ ] Add E2E tests <!-- link to the PR -->
 * [ ] Update daily periodics to use the latest Kubernetes release
-* [ ] Update [the Compatibility Matrix](https://docs.kubermatic.com/kubeone/main/architecture/compatibility/) <!-- link to the PR -->
+* [ ] Update [the Compatibility Matrix](https://docs.kubermatic.com/kubeone/main/architecture/compatibility/supported-versions/) <!-- link to the PR -->
 * [ ] Create an issue to track updating [images](https://github.com/kubermatic/kubeone/blob/main/pkg/templates/images/images.go) <!-- link to the issue -->
 * [ ] Run the full conformance tests suite using [Sonobuoy](https://github.com/vmware-tanzu/sonobuoy)
 

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -38,7 +38,7 @@ const (
 	// lowerVersionConstraint defines a semver constraint that validates Kubernetes versions against a lower bound
 	lowerVersionConstraint = ">= 1.22"
 	// upperVersionConstraint defines a semver constraint that validates Kubernetes versions against an upper bound
-	upperVersionConstraint = "<= 1.24"
+	upperVersionConstraint = "<= 1.25"
 )
 
 var (

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "kubermatic/kubeone-e2e:v0.1.25"
+	prowImage             = "kubermatic/kubeone-e2e:v0.1.26"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -6,18 +6,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_22_12
+      - TestAwsAmznInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -29,466 +29,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_22_12
+      - TestAwsCentosInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: true
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-gce: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -500,18 +52,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_23_9
+      - TestAwsDefaultInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -523,18 +75,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_23_9
+      - TestAwsFlatcarInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -546,18 +98,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_23_9
+      - TestAwsRhelInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -569,18 +121,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_23_9
+      - TestAwsRockylinuxInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -592,20 +144,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_23_9
+      - TestAzureDefaultInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -617,20 +169,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_23_9
+      - TestAzureCentosInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -642,20 +194,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_23_9
+      - TestAzureFlatcarInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -668,20 +220,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_23_9
+      - TestAzureRhelInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -693,20 +245,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_23_9
+      - TestAzureRockylinuxInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -718,18 +270,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_23_9
+      - TestGceDefaultInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -741,18 +293,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_23_9
+      - TestOpenstackDefaultInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -764,18 +316,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_23_9
+      - TestOpenstackCentosInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -787,18 +339,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_23_9
+      - TestOpenstackRockylinuxInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -810,18 +362,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_23_9
+      - TestOpenstackRhelInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -833,18 +385,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_23_9
+      - TestOpenstackFlatcarInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -856,18 +408,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_23_9
+      - TestVsphereDefaultInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -879,18 +431,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_23_9
+      - TestVsphereFlatcarInstallContainerdV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -902,18 +454,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_24_3
+      - TestAwsAmznInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -925,18 +477,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_24_3
+      - TestAwsCentosInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -948,18 +500,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_24_3
+      - TestAwsDefaultInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -971,18 +523,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_24_3
+      - TestAwsFlatcarInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -994,18 +546,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_24_3
+      - TestAwsRhelInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1017,18 +569,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_24_3
+      - TestAwsRockylinuxInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1040,20 +592,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_24_3
+      - TestAzureDefaultInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1065,20 +617,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_24_3
+      - TestAzureCentosInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1090,20 +642,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_24_3
+      - TestAzureFlatcarInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1116,20 +668,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_24_3
+      - TestAzureRhelInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1141,20 +693,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_24_3
+      - TestAzureRockylinuxInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1166,18 +718,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_24_3
+      - TestGceDefaultInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1189,18 +741,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_24_3
+      - TestOpenstackDefaultInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1212,18 +764,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_24_3
+      - TestOpenstackCentosInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1235,18 +787,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_24_3
+      - TestOpenstackRockylinuxInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1258,18 +810,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_24_3
+      - TestOpenstackRhelInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1281,18 +833,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_24_3
+      - TestOpenstackFlatcarInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1304,18 +856,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_24_3
+      - TestVsphereDefaultInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1327,18 +879,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_24_3
+      - TestVsphereFlatcarInstallContainerdV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1350,18 +902,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerV1_22_12
+      - TestAwsAmznInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1373,18 +925,41 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerV1_22_12
+      - TestAwsCentosInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: true
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.7
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallContainerdV1_24_7
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1396,18 +971,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerV1_22_12
+      - TestAwsFlatcarInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1419,18 +994,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerV1_22_12
+      - TestAwsRhelInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1442,41 +1017,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerV1_22_12
+      - TestAwsRockylinuxInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1488,20 +1040,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerV1_22_12
+      - TestAzureDefaultInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1513,20 +1065,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerV1_22_12
+      - TestAzureCentosInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1538,20 +1090,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerV1_22_12
+      - TestAzureFlatcarInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1564,20 +1116,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerV1_22_12
+      - TestAzureRhelInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1589,20 +1141,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerV1_22_12
+      - TestAzureRockylinuxInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1614,18 +1166,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallDockerV1_22_12
+      - TestGceDefaultInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1637,18 +1189,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerV1_22_12
+      - TestOpenstackDefaultInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1660,18 +1212,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerV1_22_12
+      - TestOpenstackCentosInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1683,18 +1235,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerV1_22_12
+      - TestOpenstackRockylinuxInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1706,18 +1258,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerV1_22_12
+      - TestOpenstackRhelInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1729,18 +1281,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerV1_22_12
+      - TestOpenstackFlatcarInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1752,18 +1304,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerV1_22_12
+      - TestVsphereDefaultInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1775,18 +1327,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerV1_22_12
+      - TestVsphereFlatcarInstallContainerdV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1798,18 +1350,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerV1_23_9
+      - TestAwsAmznInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1821,18 +1373,41 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerV1_23_9
+      - TestAwsCentosInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: true
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallContainerdV1_25_3
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1844,18 +1419,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerV1_23_9
+      - TestAwsFlatcarInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1867,18 +1442,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerV1_23_9
+      - TestAwsRhelInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1890,41 +1465,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerV1_23_9
+      - TestAwsRockylinuxInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1936,20 +1488,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerV1_23_9
+      - TestAzureDefaultInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1961,20 +1513,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerV1_23_9
+      - TestAzureCentosInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1986,20 +1538,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerV1_23_9
+      - TestAzureFlatcarInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2012,20 +1564,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerV1_23_9
+      - TestAzureRhelInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2037,20 +1589,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerV1_23_9
+      - TestAzureRockylinuxInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2062,18 +1614,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallDockerV1_23_9
+      - TestGceDefaultInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2085,18 +1637,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerV1_23_9
+      - TestOpenstackDefaultInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2108,18 +1660,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerV1_23_9
+      - TestOpenstackCentosInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2131,18 +1683,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerV1_23_9
+      - TestOpenstackRockylinuxInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2154,18 +1706,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerV1_23_9
+      - TestOpenstackRhelInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2177,18 +1729,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerV1_23_9
+      - TestOpenstackFlatcarInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2200,18 +1752,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerV1_23_9
+      - TestVsphereDefaultInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2223,18 +1775,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerV1_23_9
+      - TestVsphereFlatcarInstallContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2243,26 +1795,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsAmznInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2271,26 +1818,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsCentosInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2299,26 +1841,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-default-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsDefaultInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2327,26 +1864,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsFlatcarInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2355,26 +1887,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsRhelInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2383,26 +1910,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsRockylinuxInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2411,28 +1933,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-default-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureDefaultInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2441,28 +1958,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureCentosInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2471,28 +1983,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureFlatcarInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2501,29 +2008,24 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureRhelInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2532,28 +2034,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureRockylinuxInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2562,26 +2059,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-gce-default-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestGceDefaultInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2590,26 +2082,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackDefaultInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2618,26 +2105,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackCentosInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2646,26 +2128,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackRockylinuxInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2674,26 +2151,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackRhelInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2702,26 +2174,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackFlatcarInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2730,26 +2197,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestVsphereDefaultInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2758,26 +2220,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestVsphereFlatcarInstallDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2786,26 +2243,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsAmznInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2814,26 +2266,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsCentosInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2842,26 +2289,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsDefaultInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2870,26 +2312,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsFlatcarInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2898,26 +2335,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsRhelInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2926,26 +2358,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsRockylinuxInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2954,28 +2381,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureDefaultInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2984,28 +2406,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureCentosInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3014,28 +2431,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureFlatcarInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3044,29 +2456,24 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureRhelInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3075,28 +2482,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureRockylinuxInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3105,26 +2507,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestGceDefaultInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3133,26 +2530,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackDefaultInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3161,26 +2553,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackCentosInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3189,26 +2576,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackRockylinuxInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3217,26 +2599,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackRhelInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3245,26 +2622,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackFlatcarInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3273,26 +2645,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestVsphereDefaultInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3301,26 +2668,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestVsphereFlatcarInstallDockerV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3337,18 +2699,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsAmznUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3365,18 +2727,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsCentosUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3393,18 +2755,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3421,18 +2783,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3449,18 +2811,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsRhelUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3477,18 +2839,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3505,20 +2867,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3535,20 +2897,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureCentosUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3565,20 +2927,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3596,20 +2958,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureRhelUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3626,20 +2988,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3656,18 +3018,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestGceDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3684,18 +3046,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3712,18 +3074,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackCentosUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3740,18 +3102,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3768,18 +3130,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackRhelUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3796,18 +3158,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3824,18 +3186,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestVsphereDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3852,18 +3214,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestVsphereFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3880,18 +3242,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsAmznUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3908,18 +3270,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsCentosUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3936,18 +3298,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3964,18 +3326,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3992,18 +3354,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsRhelUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4020,18 +3382,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4048,20 +3410,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4078,20 +3440,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureCentosUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4108,20 +3470,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4139,20 +3501,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureRhelUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4169,20 +3531,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4199,18 +3561,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestGceDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4227,18 +3589,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4255,18 +3617,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackCentosUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4283,18 +3645,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4311,18 +3673,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackRhelUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4339,18 +3701,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4367,18 +3729,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestVsphereDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4395,18 +3757,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestVsphereFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4423,18 +3785,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsAmznUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4451,18 +3813,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsCentosUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4479,18 +3841,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4507,18 +3869,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4535,18 +3897,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsRhelUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4563,18 +3925,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4591,20 +3953,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4621,20 +3983,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureCentosUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4651,20 +4013,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4682,20 +4044,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureRhelUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4712,20 +4074,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4742,18 +4104,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-gce-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestGceDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4770,18 +4132,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4798,18 +4160,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackCentosUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4826,18 +4188,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4854,18 +4216,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackRhelUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4882,18 +4244,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4910,18 +4272,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestVsphereDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4938,18 +4300,561 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestVsphereFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: gce
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-default-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4961,18 +4866,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoContainerdV1_22_12
+      - TestAwsAmznCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4984,18 +4889,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdV1_22_12
+      - TestAwsCentosCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5007,18 +4912,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoContainerdV1_22_12
+      - TestAwsDefaultCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5030,18 +4935,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoContainerdV1_22_12
+      - TestAwsFlatcarCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5053,18 +4958,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoContainerdV1_22_12
+      - TestAwsRhelCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5076,18 +4981,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoContainerdV1_22_12
+      - TestAwsRockylinuxCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5099,20 +5004,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoContainerdV1_22_12
+      - TestAzureDefaultCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5124,20 +5029,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdV1_22_12
+      - TestAzureCentosCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5149,20 +5054,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoContainerdV1_22_12
+      - TestAzureFlatcarCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5175,20 +5080,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoContainerdV1_22_12
+      - TestAzureRhelCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5200,20 +5105,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoContainerdV1_22_12
+      - TestAzureRockylinuxCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5225,18 +5130,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoContainerdV1_22_12
+      - TestGceDefaultCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5248,18 +5153,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoContainerdV1_22_12
+      - TestOpenstackDefaultCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5271,18 +5176,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdV1_22_12
+      - TestOpenstackCentosCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5294,18 +5199,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoContainerdV1_22_12
+      - TestOpenstackRockylinuxCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5317,18 +5222,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoContainerdV1_22_12
+      - TestOpenstackRhelCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5340,18 +5245,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoContainerdV1_22_12
+      - TestOpenstackFlatcarCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5363,18 +5268,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoContainerdV1_22_12
+      - TestVsphereDefaultCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5386,18 +5291,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoContainerdV1_22_12
+      - TestVsphereFlatcarCalicoContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5409,18 +5314,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoDockerV1_22_12
+      - TestAwsAmznCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5432,18 +5337,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoDockerV1_22_12
+      - TestAwsCentosCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5455,18 +5360,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-default-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoDockerV1_22_12
+      - TestAwsDefaultCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5478,18 +5383,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoDockerV1_22_12
+      - TestAwsFlatcarCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5501,18 +5406,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoDockerV1_22_12
+      - TestAwsRhelCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5524,18 +5429,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoDockerV1_22_12
+      - TestAwsRockylinuxCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5547,20 +5452,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoDockerV1_22_12
+      - TestAzureDefaultCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5572,20 +5477,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoDockerV1_22_12
+      - TestAzureCentosCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5597,20 +5502,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoDockerV1_22_12
+      - TestAzureFlatcarCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5623,20 +5528,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoDockerV1_22_12
+      - TestAzureRhelCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5648,20 +5553,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoDockerV1_22_12
+      - TestAzureRockylinuxCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5673,18 +5578,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoDockerV1_22_12
+      - TestGceDefaultCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5696,18 +5601,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoDockerV1_22_12
+      - TestOpenstackDefaultCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5719,18 +5624,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoDockerV1_22_12
+      - TestOpenstackCentosCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5742,18 +5647,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoDockerV1_22_12
+      - TestOpenstackRockylinuxCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5765,18 +5670,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoDockerV1_22_12
+      - TestOpenstackRhelCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5788,18 +5693,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoDockerV1_22_12
+      - TestOpenstackFlatcarCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5811,18 +5716,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoDockerV1_22_12
+      - TestVsphereDefaultCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5834,18 +5739,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoDockerV1_22_12
+      - TestVsphereFlatcarCalicoDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5857,18 +5762,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveContainerdV1_22_12
+      - TestAwsAmznWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5880,18 +5785,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveContainerdV1_22_12
+      - TestAwsCentosWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5903,18 +5808,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveContainerdV1_22_12
+      - TestAwsDefaultWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5926,18 +5831,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveContainerdV1_22_12
+      - TestAwsFlatcarWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5949,18 +5854,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveContainerdV1_22_12
+      - TestAwsRhelWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5972,18 +5877,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveContainerdV1_22_12
+      - TestAwsRockylinuxWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5995,20 +5900,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveContainerdV1_22_12
+      - TestAzureDefaultWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6020,20 +5925,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveContainerdV1_22_12
+      - TestAzureCentosWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6045,20 +5950,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveContainerdV1_22_12
+      - TestAzureFlatcarWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6071,20 +5976,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveContainerdV1_22_12
+      - TestAzureRhelWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6096,20 +6001,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveContainerdV1_22_12
+      - TestAzureRockylinuxWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6121,18 +6026,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveContainerdV1_22_12
+      - TestGceDefaultWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6144,18 +6049,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveContainerdV1_22_12
+      - TestOpenstackDefaultWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6167,18 +6072,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveContainerdV1_22_12
+      - TestOpenstackCentosWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6190,18 +6095,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveContainerdV1_22_12
+      - TestOpenstackRockylinuxWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6213,18 +6118,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveContainerdV1_22_12
+      - TestOpenstackRhelWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6236,18 +6141,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveContainerdV1_22_12
+      - TestOpenstackFlatcarWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6259,18 +6164,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveContainerdV1_22_12
+      - TestVsphereDefaultWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6282,18 +6187,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveContainerdV1_22_12
+      - TestVsphereFlatcarWeaveContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6305,18 +6210,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveDockerV1_22_12
+      - TestAwsAmznWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6328,18 +6233,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveDockerV1_22_12
+      - TestAwsCentosWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6351,18 +6256,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-default-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveDockerV1_22_12
+      - TestAwsDefaultWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6374,18 +6279,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveDockerV1_22_12
+      - TestAwsFlatcarWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6397,18 +6302,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveDockerV1_22_12
+      - TestAwsRhelWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6420,18 +6325,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveDockerV1_22_12
+      - TestAwsRockylinuxWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6443,20 +6348,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveDockerV1_22_12
+      - TestAzureDefaultWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6468,20 +6373,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveDockerV1_22_12
+      - TestAzureCentosWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6493,20 +6398,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveDockerV1_22_12
+      - TestAzureFlatcarWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6519,20 +6424,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveDockerV1_22_12
+      - TestAzureRhelWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6544,20 +6449,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveDockerV1_22_12
+      - TestAzureRockylinuxWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6569,18 +6474,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveDockerV1_22_12
+      - TestGceDefaultWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6592,18 +6497,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveDockerV1_22_12
+      - TestOpenstackDefaultWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6615,18 +6520,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveDockerV1_22_12
+      - TestOpenstackCentosWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6638,18 +6543,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveDockerV1_22_12
+      - TestOpenstackRockylinuxWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6661,18 +6566,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveDockerV1_22_12
+      - TestOpenstackRhelWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6684,18 +6589,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveDockerV1_22_12
+      - TestOpenstackFlatcarWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6707,18 +6612,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveDockerV1_22_12
+      - TestVsphereDefaultWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6730,18 +6635,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveDockerV1_22_12
+      - TestVsphereFlatcarWeaveDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6753,18 +6658,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumContainerdV1_22_12
+      - TestAwsAmznCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6776,18 +6681,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdV1_22_12
+      - TestAwsCentosCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6799,18 +6704,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumContainerdV1_22_12
+      - TestAwsDefaultCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6822,18 +6727,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumContainerdV1_22_12
+      - TestAwsFlatcarCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6845,18 +6750,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumContainerdV1_22_12
+      - TestAwsRhelCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6868,18 +6773,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumContainerdV1_22_12
+      - TestAwsRockylinuxCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6891,20 +6796,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumContainerdV1_22_12
+      - TestAzureDefaultCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6916,20 +6821,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdV1_22_12
+      - TestAzureCentosCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6941,20 +6846,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumContainerdV1_22_12
+      - TestAzureFlatcarCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6967,20 +6872,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumContainerdV1_22_12
+      - TestAzureRhelCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6992,20 +6897,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumContainerdV1_22_12
+      - TestAzureRockylinuxCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7017,18 +6922,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumContainerdV1_22_12
+      - TestGceDefaultCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7040,18 +6945,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumContainerdV1_22_12
+      - TestOpenstackDefaultCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7063,18 +6968,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdV1_22_12
+      - TestOpenstackCentosCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7086,18 +6991,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumContainerdV1_22_12
+      - TestOpenstackRockylinuxCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7109,18 +7014,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumContainerdV1_22_12
+      - TestOpenstackRhelCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7132,18 +7037,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumContainerdV1_22_12
+      - TestOpenstackFlatcarCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7155,18 +7060,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumContainerdV1_22_12
+      - TestVsphereDefaultCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7178,18 +7083,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumContainerdV1_22_12
+      - TestVsphereFlatcarCiliumContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7201,18 +7106,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumDockerV1_22_12
+      - TestAwsAmznCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7224,18 +7129,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumDockerV1_22_12
+      - TestAwsCentosCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7247,18 +7152,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-default-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumDockerV1_22_12
+      - TestAwsDefaultCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7270,18 +7175,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumDockerV1_22_12
+      - TestAwsFlatcarCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7293,18 +7198,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumDockerV1_22_12
+      - TestAwsRhelCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7316,18 +7221,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumDockerV1_22_12
+      - TestAwsRockylinuxCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7339,20 +7244,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumDockerV1_22_12
+      - TestAzureDefaultCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7364,20 +7269,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumDockerV1_22_12
+      - TestAzureCentosCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7389,20 +7294,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumDockerV1_22_12
+      - TestAzureFlatcarCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7415,20 +7320,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumDockerV1_22_12
+      - TestAzureRhelCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7440,20 +7345,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumDockerV1_22_12
+      - TestAzureRockylinuxCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7465,18 +7370,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumDockerV1_22_12
+      - TestGceDefaultCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7488,18 +7393,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumDockerV1_22_12
+      - TestOpenstackDefaultCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7511,18 +7416,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumDockerV1_22_12
+      - TestOpenstackCentosCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7534,18 +7439,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumDockerV1_22_12
+      - TestOpenstackRockylinuxCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7557,18 +7462,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumDockerV1_22_12
+      - TestOpenstackRhelCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7580,18 +7485,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumDockerV1_22_12
+      - TestOpenstackFlatcarCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7603,18 +7508,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumDockerV1_22_12
+      - TestVsphereDefaultCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7626,18 +7531,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumDockerV1_22_12
+      - TestVsphereFlatcarCiliumDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7649,20 +7554,20 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_22_12
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7674,20 +7579,20 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_9
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7699,20 +7604,20 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_3
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7724,20 +7629,20 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_12
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7749,20 +7654,20 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_9
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7774,20 +7679,20 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_3
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7799,18 +7704,20 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.22.12
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_22_12
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7822,18 +7729,20 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.23.9
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_23_9
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7845,18 +7754,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_22_12
+      - TestAwsDefaultKubeProxyIpvsV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7868,18 +7777,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_22_12
+      - TestAwsAmznLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7891,18 +7800,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestAwsCentosLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7914,18 +7823,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_12
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7937,18 +7846,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_22_12
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7960,18 +7869,41 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_12
+      - TestAwsRhelLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.22.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_15
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7983,20 +7915,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8008,20 +7940,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_22_12
+      - TestAzureCentosLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8033,20 +7965,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_22_12
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8059,20 +7991,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_22_12
+      - TestAzureRhelLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8084,20 +8016,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_12
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8109,18 +8041,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestGceDefaultLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8132,18 +8064,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8155,18 +8087,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8178,18 +8110,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8201,18 +8133,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8224,18 +8156,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8247,18 +8179,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8270,18 +8202,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_12
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8293,18 +8225,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_23_9
+      - TestAwsAmznLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8316,18 +8248,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_23_9
+      - TestAwsCentosLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8339,18 +8271,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8362,18 +8294,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_9
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8385,18 +8317,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_23_9
+      - TestAwsRhelLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8408,18 +8340,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_9
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8431,20 +8363,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8456,20 +8388,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_23_9
+      - TestAzureCentosLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8481,20 +8413,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_9
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8507,20 +8439,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_23_9
+      - TestAzureRhelLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8532,20 +8464,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_9
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8557,18 +8489,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestGceDefaultLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8580,18 +8512,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8603,18 +8535,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8626,18 +8558,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8649,18 +8581,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8672,18 +8604,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8695,18 +8627,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8718,18 +8650,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_9
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8741,18 +8673,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_24_3
+      - TestAwsAmznLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8764,18 +8696,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_24_3
+      - TestAwsCentosLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8787,18 +8719,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8810,18 +8742,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_3
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8833,18 +8765,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_24_3
+      - TestAwsRhelLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8856,18 +8788,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_3
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8879,20 +8811,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8904,20 +8836,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_24_3
+      - TestAzureCentosLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8929,20 +8861,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_3
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8955,20 +8887,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_24_3
+      - TestAzureRhelLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8980,20 +8912,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_3
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9005,18 +8937,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestGceDefaultLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9028,18 +8960,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9051,18 +8983,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9074,18 +9006,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9097,18 +9029,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9120,18 +9052,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9143,18 +9075,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9166,18 +9098,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_3
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9189,18 +9121,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerDockerV1_22_12
+      - TestAwsAmznLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9212,18 +9144,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerDockerV1_22_12
+      - TestAwsCentosLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9235,18 +9167,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerDockerV1_22_12
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9258,18 +9190,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerDockerV1_22_12
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9281,18 +9213,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerDockerV1_22_12
+      - TestAwsRhelLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9304,18 +9236,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerDockerV1_22_12
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9327,20 +9259,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerDockerV1_22_12
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9352,20 +9284,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerDockerV1_22_12
+      - TestAzureCentosLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9377,20 +9309,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerDockerV1_22_12
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9403,20 +9335,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerDockerV1_22_12
+      - TestAzureRhelLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9428,20 +9360,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerDockerV1_22_12
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9453,18 +9385,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerDockerV1_22_12
+      - TestGceDefaultLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9476,18 +9408,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9499,18 +9431,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9522,18 +9454,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9545,18 +9477,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9568,18 +9500,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9591,18 +9523,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerDockerV1_22_12
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9614,18 +9546,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerDockerV1_22_12
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9637,18 +9569,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerDockerV1_23_9
+      - TestAwsAmznLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9660,18 +9592,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerDockerV1_23_9
+      - TestAwsCentosLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9683,18 +9615,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerDockerV1_23_9
+      - TestAwsDefaultLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9706,18 +9638,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_9
+      - TestAwsFlatcarLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9729,18 +9661,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerDockerV1_23_9
+      - TestAwsRhelLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9752,18 +9684,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_9
+      - TestAwsRockylinuxLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9775,20 +9707,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerDockerV1_23_9
+      - TestAzureDefaultLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9800,20 +9732,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerDockerV1_23_9
+      - TestAzureCentosLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9825,20 +9757,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_9
+      - TestAzureFlatcarLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9851,20 +9783,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerDockerV1_23_9
+      - TestAzureRhelLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9876,20 +9808,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_9
+      - TestAzureRockylinuxLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9901,18 +9833,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerDockerV1_23_9
+      - TestGceDefaultLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9924,18 +9856,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackDefaultLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9947,18 +9879,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackCentosLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9970,18 +9902,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9993,18 +9925,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackRhelLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10016,18 +9948,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10039,18 +9971,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_9
+      - TestVsphereDefaultLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10062,18 +9994,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_9
+      - TestVsphereFlatcarLegacyMachineControllerDockerV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10085,18 +10017,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_24_3
+      - TestAwsAmznLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10108,18 +10040,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_22_12
+      - TestAwsCentosLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10129,20 +10061,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
+    preset-aws: "true"
     preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_22_12
+      - TestAwsDefaultLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10152,20 +10084,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
+    preset-aws: "true"
     preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_22_12
+      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10175,20 +10107,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
+    preset-aws: "true"
     preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_22_12
+      - TestAwsRhelLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10198,43 +10130,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
+    preset-aws: "true"
     preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_22_12
+      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10246,20 +10155,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_22_12
+      - TestAzureDefaultLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10271,20 +10180,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_22_12
+      - TestAzureCentosLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10296,20 +10205,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_22_12
+      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10322,20 +10231,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_22_12
+      - TestAzureRhelLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10347,20 +10256,158 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_22_12
+      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultLegacyMachineControllerDockerV1_23_13
+      env:
+      - name: PROVIDER
+        value: gce
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10372,18 +10419,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_22_12
+      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10395,18 +10442,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_22_12
+      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10418,18 +10465,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_23_9
+      - TestAwsDefaultCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10441,18 +10488,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_23_9
+      - TestOpenstackDefaultCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10464,18 +10511,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_23_9
+      - TestOpenstackCentosCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10487,18 +10534,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_9
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10510,18 +10557,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_23_9
+      - TestOpenstackRhelCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10533,18 +10580,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_23_9
+      - TestOpenstackFlatcarCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10556,20 +10603,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_23_9
+      - TestAzureDefaultCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10581,20 +10628,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_23_9
+      - TestAzureCentosCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10606,20 +10653,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_23_9
+      - TestAzureFlatcarCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10632,20 +10679,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_23_9
+      - TestAzureRhelCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10657,20 +10704,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_23_9
+      - TestAzureRockylinuxCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10682,18 +10729,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_23_9
+      - TestVsphereDefaultCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10705,18 +10752,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_23_9
+      - TestVsphereFlatcarCsiCcmMigrationV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10728,18 +10775,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_24_3
+      - TestAwsDefaultCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10751,18 +10798,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_24_3
+      - TestOpenstackDefaultCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10774,18 +10821,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_24_3
+      - TestOpenstackCentosCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10797,18 +10844,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_3
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10820,18 +10867,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_24_3
+      - TestOpenstackRhelCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10843,18 +10890,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_24_3
+      - TestOpenstackFlatcarCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10866,20 +10913,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_24_3
+      - TestAzureDefaultCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10891,20 +10938,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_24_3
+      - TestAzureCentosCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10916,20 +10963,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_24_3
+      - TestAzureFlatcarCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10942,20 +10989,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_24_3
+      - TestAzureRhelCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10967,20 +11014,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_24_3
+      - TestAzureRockylinuxCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10992,18 +11039,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_24_3
+      - TestVsphereDefaultCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11015,18 +11062,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_24_3
+      - TestVsphereFlatcarCsiCcmMigrationV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11038,18 +11085,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_22_12
+      - TestAwsDefaultCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11059,20 +11106,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.22.12
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_22_12
+      - TestOpenstackDefaultCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11082,20 +11129,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.22.12
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_22_12
+      - TestOpenstackCentosCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11105,20 +11152,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.22.12
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_22_12
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11128,20 +11175,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.22.12
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_22_12
+      - TestOpenstackRhelCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11151,20 +11198,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.22.12
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_22_12
+      - TestOpenstackFlatcarCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11176,20 +11223,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_22_12
+      - TestAzureDefaultCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11201,20 +11248,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_22_12
+      - TestAzureCentosCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11226,20 +11273,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_22_12
+      - TestAzureFlatcarCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11252,20 +11299,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_22_12
+      - TestAzureRhelCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11277,365 +11324,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_22_12
+      - TestAzureRockylinuxCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11647,18 +11349,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_22_12
+      - TestVsphereDefaultCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11670,18 +11372,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_22_12
+      - TestVsphereFlatcarCsiCcmMigrationV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11693,18 +11395,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_23_9
+      - TestAwsDefaultCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11714,20 +11416,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.9
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_23_9
+      - TestOpenstackDefaultCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11737,20 +11439,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.9
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_23_9
+      - TestOpenstackCentosCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11760,20 +11462,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.9
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_23_9
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11783,20 +11485,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.9
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_23_9
+      - TestOpenstackRhelCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11806,20 +11508,20 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
-    preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.9
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_23_9
+      - TestOpenstackFlatcarCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
-        value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11831,20 +11533,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_23_9
+      - TestAzureDefaultCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11856,20 +11558,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_23_9
+      - TestAzureCentosCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11881,20 +11583,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_23_9
+      - TestAzureFlatcarCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11907,20 +11609,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_23_9
+      - TestAzureRhelCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11932,365 +11634,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_23_9
+      - TestAzureRockylinuxCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_23_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12302,18 +11659,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_23_9
+      - TestVsphereDefaultCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12325,18 +11682,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_23_9
+      - TestVsphereFlatcarCsiCcmMigrationV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12348,18 +11705,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_24_3
+      - TestAwsAmznInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12371,18 +11728,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_24_3
+      - TestAwsCentosInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12394,18 +11751,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_24_3
+      - TestAwsDefaultInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12417,18 +11774,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_24_3
+      - TestAwsFlatcarInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12440,18 +11797,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_24_3
+      - TestAwsRhelInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12463,18 +11820,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_24_3
+      - TestAwsRockylinuxInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12486,20 +11843,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_24_3
+      - TestAzureDefaultInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12511,20 +11868,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_24_3
+      - TestAzureCentosInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12536,20 +11893,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_24_3
+      - TestAzureFlatcarInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12562,20 +11919,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_24_3
+      - TestAzureRhelInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12587,20 +11944,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_24_3
+      - TestAzureRockylinuxInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12612,18 +11969,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_3
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12635,18 +11992,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_24_3
+      - TestDigitaloceanCentosInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12658,18 +12015,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_3
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12681,18 +12038,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_3
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12704,18 +12061,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_24_3
+      - TestEquinixmetalCentosInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12727,18 +12084,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_3
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12750,18 +12107,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_3
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12773,18 +12130,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_24_3
+      - TestHetznerDefaultInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12796,18 +12153,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_24_3
+      - TestHetznerCentosInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12819,18 +12176,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_24_3
+      - TestHetznerRockylinuxInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12842,18 +12199,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_24_3
+      - TestOpenstackDefaultInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12865,18 +12222,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_24_3
+      - TestOpenstackCentosInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12888,18 +12245,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_3
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12911,18 +12268,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_24_3
+      - TestOpenstackRhelInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12934,18 +12291,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_24_3
+      - TestOpenstackFlatcarInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12957,18 +12314,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_24_3
+      - TestVsphereDefaultInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12980,18 +12337,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_24_3
+      - TestVsphereFlatcarInstallContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13003,18 +12360,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerExternalV1_22_12
+      - TestAwsAmznInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13026,18 +12383,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerExternalV1_22_12
+      - TestAwsCentosInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13049,18 +12406,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerExternalV1_22_12
+      - TestAwsDefaultInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13072,18 +12429,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerExternalV1_22_12
+      - TestAwsFlatcarInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13095,18 +12452,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerExternalV1_22_12
+      - TestAwsRhelInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13118,18 +12475,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerExternalV1_22_12
+      - TestAwsRockylinuxInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13141,20 +12498,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerExternalV1_22_12
+      - TestAzureDefaultInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13166,20 +12523,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerExternalV1_22_12
+      - TestAzureCentosInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13191,20 +12548,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerExternalV1_22_12
+      - TestAzureFlatcarInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13217,20 +12574,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerExternalV1_22_12
+      - TestAzureRhelInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13242,20 +12599,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerExternalV1_22_12
+      - TestAzureRockylinuxInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13267,18 +12624,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallDockerExternalV1_22_12
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13290,18 +12647,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallDockerExternalV1_22_12
+      - TestDigitaloceanCentosInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13313,18 +12670,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallDockerExternalV1_22_12
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13336,18 +12693,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallDockerExternalV1_22_12
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13359,18 +12716,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallDockerExternalV1_22_12
+      - TestEquinixmetalCentosInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13382,18 +12739,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallDockerExternalV1_22_12
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13405,18 +12762,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallDockerExternalV1_22_12
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13428,18 +12785,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallDockerExternalV1_22_12
+      - TestHetznerDefaultInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13451,18 +12808,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallDockerExternalV1_22_12
+      - TestHetznerCentosInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13474,18 +12831,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallDockerExternalV1_22_12
+      - TestHetznerRockylinuxInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13497,18 +12854,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerExternalV1_22_12
+      - TestOpenstackDefaultInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13520,18 +12877,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerExternalV1_22_12
+      - TestOpenstackCentosInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13543,18 +12900,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerExternalV1_22_12
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13566,18 +12923,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerExternalV1_22_12
+      - TestOpenstackRhelInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13589,18 +12946,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerExternalV1_22_12
+      - TestOpenstackFlatcarInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13612,18 +12969,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerExternalV1_22_12
+      - TestVsphereDefaultInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13635,18 +12992,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerExternalV1_22_12
+      - TestVsphereFlatcarInstallContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13658,18 +13015,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerExternalV1_23_9
+      - TestAwsAmznInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13681,18 +13038,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerExternalV1_23_9
+      - TestAwsCentosInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13704,18 +13061,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerExternalV1_23_9
+      - TestAwsDefaultInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13727,18 +13084,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerExternalV1_23_9
+      - TestAwsFlatcarInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13750,18 +13107,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerExternalV1_23_9
+      - TestAwsRhelInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13773,18 +13130,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerExternalV1_23_9
+      - TestAwsRockylinuxInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13796,20 +13153,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerExternalV1_23_9
+      - TestAzureDefaultInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13821,20 +13178,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerExternalV1_23_9
+      - TestAzureCentosInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13846,20 +13203,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerExternalV1_23_9
+      - TestAzureFlatcarInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13872,20 +13229,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerExternalV1_23_9
+      - TestAzureRhelInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13897,20 +13254,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerExternalV1_23_9
+      - TestAzureRockylinuxInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13922,18 +13279,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallDockerExternalV1_23_9
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13945,18 +13302,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallDockerExternalV1_23_9
+      - TestDigitaloceanCentosInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13968,18 +13325,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_9
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13991,18 +13348,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallDockerExternalV1_23_9
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14014,18 +13371,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallDockerExternalV1_23_9
+      - TestEquinixmetalCentosInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14037,18 +13394,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_9
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14060,18 +13417,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_9
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14083,18 +13440,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallDockerExternalV1_23_9
+      - TestHetznerDefaultInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14106,18 +13463,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallDockerExternalV1_23_9
+      - TestHetznerCentosInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14129,18 +13486,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallDockerExternalV1_23_9
+      - TestHetznerRockylinuxInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14152,18 +13509,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerExternalV1_23_9
+      - TestOpenstackDefaultInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14175,18 +13532,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerExternalV1_23_9
+      - TestOpenstackCentosInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14198,18 +13555,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerExternalV1_23_9
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14221,18 +13578,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerExternalV1_23_9
+      - TestOpenstackRhelInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14244,18 +13601,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerExternalV1_23_9
+      - TestOpenstackFlatcarInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14267,18 +13624,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerExternalV1_23_9
+      - TestVsphereDefaultInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14290,18 +13647,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerExternalV1_23_9
+      - TestVsphereFlatcarInstallContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14310,26 +13667,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsAmznInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14338,26 +13690,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsCentosInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14366,26 +13713,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsDefaultInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14394,26 +13736,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsFlatcarInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14422,26 +13759,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsRhelInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14450,26 +13782,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsRockylinuxInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14478,28 +13805,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAzureDefaultInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14508,28 +13830,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAzureCentosInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14538,28 +13855,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAzureFlatcarInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14568,29 +13880,24 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAzureRhelInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14599,28 +13906,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAzureRockylinuxInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14629,26 +13931,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14657,26 +13954,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestDigitaloceanCentosInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14685,26 +13977,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14713,26 +14000,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14741,26 +14023,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalCentosInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14769,26 +14046,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14797,26 +14069,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14825,26 +14092,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestHetznerDefaultInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14853,26 +14115,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestHetznerCentosInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14881,26 +14138,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestHetznerRockylinuxInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14909,26 +14161,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackDefaultInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14937,26 +14184,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackCentosInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14965,26 +14207,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14993,26 +14230,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackRhelInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15021,26 +14253,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackFlatcarInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15049,26 +14276,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestVsphereDefaultInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15077,26 +14299,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestVsphereFlatcarInstallContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15105,26 +14322,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAwsAmznInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15133,26 +14345,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAwsCentosInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15161,26 +14368,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAwsDefaultInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15189,26 +14391,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAwsFlatcarInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15217,26 +14414,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAwsRhelInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15245,26 +14437,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAwsRockylinuxInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15273,28 +14460,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAzureDefaultInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15303,28 +14485,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAzureCentosInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15333,28 +14510,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAzureFlatcarInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15363,29 +14535,24 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAzureRhelInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15394,28 +14561,23 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAzureRockylinuxInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15424,26 +14586,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanDefaultInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15452,26 +14609,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanCentosInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15480,26 +14632,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanRockylinuxInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15508,26 +14655,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalDefaultInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15536,26 +14678,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalCentosInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15564,26 +14701,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalRockylinuxInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15592,26 +14724,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalFlatcarInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15620,26 +14747,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerDefaultInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15648,26 +14770,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerCentosInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15676,26 +14793,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerRockylinuxInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15704,26 +14816,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackDefaultInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15732,26 +14839,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackCentosInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15760,26 +14862,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackRockylinuxInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15788,26 +14885,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackRhelInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15816,26 +14908,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackFlatcarInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15844,26 +14931,21 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestVsphereDefaultInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15872,26 +14954,676 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestVsphereFlatcarInstallDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarInstallDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15908,18 +15640,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsAmznUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15936,18 +15668,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15964,18 +15696,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15992,18 +15724,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16020,18 +15752,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16048,18 +15780,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16076,20 +15808,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16106,20 +15838,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16136,20 +15868,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16167,20 +15899,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16197,20 +15929,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16227,18 +15959,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16255,18 +15987,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestDigitaloceanCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16283,18 +16015,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16311,18 +16043,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16339,18 +16071,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestEquinixmetalCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16367,18 +16099,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16395,18 +16127,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16423,18 +16155,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestHetznerDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16451,18 +16183,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestHetznerCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16479,18 +16211,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestHetznerRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16507,18 +16239,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16535,18 +16267,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16563,18 +16295,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16591,18 +16323,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16619,18 +16351,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16647,18 +16379,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestVsphereDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16675,18 +16407,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestVsphereFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16703,18 +16435,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsAmznUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16731,18 +16463,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16759,18 +16491,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16787,18 +16519,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16815,18 +16547,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16843,18 +16575,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16871,20 +16603,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16901,20 +16633,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16931,20 +16663,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16962,20 +16694,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16992,20 +16724,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17022,18 +16754,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17050,18 +16782,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestDigitaloceanCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17078,18 +16810,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17106,18 +16838,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17134,18 +16866,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17162,18 +16894,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17190,18 +16922,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17218,18 +16950,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestHetznerDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17246,18 +16978,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestHetznerCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17274,18 +17006,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestHetznerRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17302,18 +17034,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17330,18 +17062,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17358,18 +17090,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17386,18 +17118,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17414,18 +17146,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17442,18 +17174,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestVsphereDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17470,18 +17202,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestVsphereFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17498,18 +17230,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsAmznUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17526,18 +17258,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17554,18 +17286,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17582,18 +17314,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17610,18 +17342,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17638,18 +17370,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17666,20 +17398,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17696,20 +17428,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17726,20 +17458,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17757,20 +17489,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17787,20 +17519,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17817,18 +17549,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17845,18 +17577,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17873,18 +17605,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17901,18 +17633,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17929,18 +17661,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17957,18 +17689,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17985,18 +17717,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18013,18 +17745,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18041,18 +17773,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18069,18 +17801,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18097,18 +17829,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18125,18 +17857,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18153,18 +17885,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18181,18 +17913,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18209,18 +17941,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18237,18 +17969,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestVsphereDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18265,18 +17997,813 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestVsphereFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-default-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18288,18 +18815,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18311,18 +18838,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18334,18 +18861,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18357,18 +18884,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18380,18 +18907,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18403,18 +18930,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18426,20 +18953,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18451,20 +18978,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18476,20 +19003,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18502,20 +19029,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18527,20 +19054,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18552,18 +19079,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18575,18 +19102,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18598,18 +19125,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18621,18 +19148,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18644,18 +19171,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18667,18 +19194,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18690,18 +19217,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_12
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18713,18 +19240,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18736,18 +19263,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18759,18 +19286,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18782,18 +19309,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18805,18 +19332,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18828,18 +19355,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18851,18 +19378,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18874,18 +19401,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18897,18 +19424,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18920,18 +19447,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_12
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_15
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18943,18 +19470,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18966,18 +19493,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18989,18 +19516,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19012,18 +19539,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19035,18 +19562,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19058,18 +19585,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19081,20 +19608,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19106,20 +19633,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19131,20 +19658,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19157,20 +19684,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19182,20 +19709,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19207,18 +19734,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19230,18 +19757,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19253,18 +19780,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19276,18 +19803,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19299,18 +19826,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19322,18 +19849,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19345,18 +19872,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_9
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19368,18 +19895,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19391,18 +19918,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19414,18 +19941,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19437,18 +19964,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19460,18 +19987,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19483,18 +20010,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19506,18 +20033,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19529,18 +20056,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19552,18 +20079,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19575,18 +20102,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.13
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_9
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_13
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19598,18 +20125,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19621,18 +20148,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19644,18 +20171,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19667,18 +20194,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19690,18 +20217,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19713,18 +20240,18 @@ presubmits:
   labels:
     preset-aws: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19736,20 +20263,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19761,20 +20288,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19786,20 +20313,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19812,20 +20339,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19837,20 +20364,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19862,18 +20389,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19885,18 +20412,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19908,18 +20435,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19931,18 +20458,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19954,18 +20481,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19977,18 +20504,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20000,18 +20527,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20023,18 +20550,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20046,18 +20573,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20069,18 +20596,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20092,18 +20619,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20115,18 +20642,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20138,18 +20665,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20161,18 +20688,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20184,18 +20711,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20207,18 +20734,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20230,18 +20757,282 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.7
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_7
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: aws
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20253,18 +21044,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_12
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20276,18 +21067,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_12
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20299,18 +21090,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_12
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20322,18 +21113,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_12
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20345,18 +21136,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_12
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20368,18 +21159,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_12
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20391,18 +21182,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_12
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20414,18 +21205,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_12
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20437,18 +21228,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_12
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20460,18 +21251,179 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_12
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.25.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_3
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20483,18 +21435,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_9
+      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20506,18 +21458,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_9
+      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20529,18 +21481,18 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_9
+      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20552,18 +21504,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_9
+      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20575,18 +21527,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_9
+      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20598,18 +21550,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_9
+      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20621,18 +21573,18 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_9
+      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20644,18 +21596,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_9
+      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20667,18 +21619,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_9
+      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20690,18 +21642,248 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.22.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_9
+      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_15
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: kubermatic/kubeone-e2e:v0.1.26
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.13
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_13
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -10,7481 +10,8021 @@ import (
 func TestStub(t *testing.T) {
 	t.Skip("stub is skipped")
 }
-func TestAwsAmznInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_23_9(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_24_3(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerV1_22_12(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestGceDefaultInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["gce_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarInstallContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsAmznInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerV1_22_12(t *testing.T) {
+func TestAwsCentosInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerV1_22_12(t *testing.T) {
+func TestAwsRhelInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerV1_22_12(t *testing.T) {
+func TestAzureCentosInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerV1_22_12(t *testing.T) {
+func TestAzureRhelInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestGceDefaultInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarInstallDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerV1_23_9(t *testing.T) {
+func TestAwsAmznInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerV1_23_9(t *testing.T) {
+func TestAwsCentosInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestAwsDefaultInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerV1_23_9(t *testing.T) {
+func TestAwsFlatcarInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerV1_23_9(t *testing.T) {
+func TestAwsRhelInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerV1_23_9(t *testing.T) {
+func TestAwsRockylinuxInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestAzureDefaultInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerV1_23_9(t *testing.T) {
+func TestAzureCentosInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerV1_23_9(t *testing.T) {
+func TestAzureFlatcarInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerV1_23_9(t *testing.T) {
+func TestAzureRhelInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerV1_23_9(t *testing.T) {
+func TestAzureRockylinuxInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestGceDefaultInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackDefaultInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackCentosInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackRhelInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestVsphereDefaultInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerV1_23_9(t *testing.T) {
+func TestVsphereFlatcarInstallDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsAmznUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsCentosUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsRhelUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureCentosUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureRhelUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestGceDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackCentosUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackRhelUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestVsphereDefaultUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestVsphereFlatcarUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsAmznUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsCentosUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRhelUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureCentosUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRhelUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestGceDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackCentosUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRhelUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereDefaultUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereFlatcarUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsAmznUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsCentosUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRhelUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureCentosUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRhelUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestGceDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackCentosUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRhelUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereDefaultUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereFlatcarUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsAmznUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsCentosUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRhelUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureCentosUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRhelUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestGceDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackCentosUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRhelUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereDefaultUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereFlatcarUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsDefaultUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsFlatcarUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsRhelUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureDefaultUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureCentosUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureFlatcarUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureRhelUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestGceDefaultUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["gce_default"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackDefaultUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rockylinux"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackRhelUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackFlatcarUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestVsphereDefaultUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestVsphereFlatcarUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
-	scenario := Scenarios["upgrade_docker"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsAmznCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCalicoContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsAmznCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsCentosCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsRhelCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureCentosCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureRhelCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestGceDefaultCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCalicoDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarWeaveContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsAmznWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsCentosWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsRhelWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureCentosWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureRhelWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestGceDefaultWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarWeaveDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCiliumContainerdV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsAmznCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsCentosCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsRhelCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureCentosCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureRhelCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestGceDefaultCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCiliumDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_22_12(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_9(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_3(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_long_timeout_default"]
+	scenario := Scenarios["conformance_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_22_12(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_long_timeout_default"]
+	scenario := Scenarios["conformance_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultKubeProxyIpvsV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
-	scenario := Scenarios["kube_proxy_ipvs"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsAmznLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestGceDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["gce_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsAmznLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerDockerV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_24_3(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
-	scenario := Scenarios["kube_proxy_ipvs"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsDefaultCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarCsiCcmMigrationV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsAmznInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsAmznInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsCentosInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsDefaultInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsRhelInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureDefaultInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureCentosInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureRhelInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerDefaultInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerCentosInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackDefaultInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackCentosInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackRhelInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestVsphereDefaultInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestVsphereFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsAmznInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsCentosInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsDefaultInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsRhelInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureDefaultInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureCentosInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureRhelInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerDefaultInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerCentosInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackDefaultInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackCentosInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackRhelInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestVsphereDefaultInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestVsphereFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsAmznUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackCentosUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRhelUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereDefaultUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereFlatcarUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsAmznUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestHetznerDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestHetznerCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackCentosUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRhelUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereDefaultUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereFlatcarUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.23.13", "v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsAmznUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestDigitaloceanDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestDigitaloceanCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestDigitaloceanRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestEquinixmetalDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestEquinixmetalCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestEquinixmetalRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestEquinixmetalFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestHetznerDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestHetznerCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestHetznerRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackCentosUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackRhelUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestVsphereDefaultUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestVsphereFlatcarUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.24.7", "v1.25.3")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsAmznUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackCentosUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRhelUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereDefaultUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereFlatcarUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.22.15", "v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_amzn"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_centos"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_default"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_flatcar"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsRhelUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rhel"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["aws_rockylinux"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_default"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_centos"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_flatcar"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureRhelUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rhel"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAzureRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["azure_rockylinux"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestDigitaloceanDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_default"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestDigitaloceanCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_centos"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestDigitaloceanRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["digitalocean_rockylinux"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_default"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_centos"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_rockylinux"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestEquinixmetalFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["equinixmetal_flatcar"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestHetznerDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_default"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestHetznerCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_centos"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestHetznerRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["hetzner_rockylinux"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_default"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackCentosUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_centos"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rockylinux"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackRhelUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_rhel"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestOpenstackFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["openstack_flatcar"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestVsphereDefaultUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_default"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestVsphereFlatcarUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
-	ctx := NewSignalContext()
-	infra := Infrastructures["vsphere_flatcar"]
-	scenario := Scenarios["upgrade_docker_external"]
-	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
-	scenario.Run(ctx, t)
-}
-
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.7")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.3")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.13")
 	scenario.Run(ctx, t)
 }

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -1,5 +1,5 @@
 - scenario: install_containerd
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -23,7 +23,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -47,7 +47,31 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.24.3
+  initVersion: v1.24.7
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+      alwaysRun: true
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: gce_default
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_flatcar
+
+- scenario: install_containerd
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -71,7 +95,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -94,7 +118,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -117,8 +141,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd
-  initVersion: v1.23.9
-  upgradedVersion: v1.24.3
+  initVersion: v1.24.7
+  upgradedVersion: v1.25.3
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -141,8 +165,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd
-  initVersion: v1.22.12
-  upgradedVersion: v1.23.9
+  initVersion: v1.23.13
+  upgradedVersion: v1.24.7
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -165,8 +189,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd
-  initVersion: v1.21.14
-  upgradedVersion: v1.22.12
+  initVersion: v1.22.15
+  upgradedVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -189,32 +213,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_docker
-  initVersion: v1.22.12
-  upgradedVersion: v1.23.9
-  infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: gce_default
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
-
-- scenario: upgrade_docker
-  initVersion: v1.21.14
-  upgradedVersion: v1.22.12
+  initVersion: v1.22.15
+  upgradedVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -237,7 +237,7 @@
     - name: vsphere_flatcar
 
 - scenario: calico_containerd
-  initVersion: v1.22.12
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -260,7 +260,7 @@
     - name: vsphere_flatcar
 
 - scenario: calico_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -283,7 +283,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_containerd
-  initVersion: v1.22.12
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -306,7 +306,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -329,7 +329,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_containerd
-  initVersion: v1.22.12
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -352,7 +352,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -375,47 +375,52 @@
     - name: vsphere_flatcar
 
 - scenario: conformance_containerd
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.24.3
+  initVersion: v1.24.7
+  infrastructures:
+    - name: aws_long_timeout_default
+
+- scenario: conformance_containerd
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.24.3
+  initVersion: v1.24.7
+  infrastructures:
+    - name: aws_long_timeout_default
+
+- scenario: conformance_containerd_external
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.22.12
-  infrastructures:
-    - name: aws_default
-
-- scenario: kube_proxy_ipvs
-  initVersion: v1.23.9
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_default
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -438,7 +443,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -461,7 +466,30 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.24.3
+  initVersion: v1.24.7
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: gce_default
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_flatcar
+
+- scenario: legacy_machine_controller_containerd
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -484,7 +512,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -507,7 +535,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -529,15 +557,44 @@
     - name: vsphere_default
     - name: vsphere_flatcar
 
-- scenario: kube_proxy_ipvs
-  initVersion: v1.24.3
+- scenario: csi_ccm_migration
+  initVersion: v1.22.15
+  infrastructures:
+    - name: aws_default  
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: vsphere_default
+    - name: vsphere_flatcar
+
+- scenario: csi_ccm_migration
+  initVersion: v1.23.13
+  infrastructures:
+    - name: aws_default  
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: vsphere_default
+    - name: vsphere_flatcar
+
+- scenario: csi_ccm_migration
+  initVersion: v1.24.7
   infrastructures:
     - name: aws_default
-
-- scenario: csi_ccm_migration
-  initVersion: v1.22.12
-  infrastructures:
-    - name: aws_default  
     - name: openstack_default
     - name: openstack_centos
     - name: openstack_rockylinux
@@ -552,24 +609,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.23.9
-  infrastructures:
-    - name: aws_default  
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: vsphere_default
-    - name: vsphere_flatcar
-
-- scenario: csi_ccm_migration
-  initVersion: v1.24.3
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -586,7 +626,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -618,7 +658,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -650,7 +690,39 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.24.3
+  initVersion: v1.24.7
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: digitalocean_default
+    - name: digitalocean_centos
+    - name: digitalocean_rockylinux
+    - name: equinixmetal_default
+    - name: equinixmetal_centos
+    - name: equinixmetal_rockylinux
+    - name: equinixmetal_flatcar
+    - name: hetzner_default
+    - name: hetzner_centos
+    - name: hetzner_rockylinux
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_flatcar
+
+- scenario: install_containerd_external
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -682,7 +754,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -714,7 +786,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -746,8 +818,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.21.14
-  upgradedVersion: v1.22.12
+  initVersion: v1.22.15
+  upgradedVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -779,8 +851,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.22.12
-  upgradedVersion: v1.23.9
+  initVersion: v1.23.13
+  upgradedVersion: v1.24.7
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -812,8 +884,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.23.9
-  upgradedVersion: v1.24.3
+  initVersion: v1.24.7
+  upgradedVersion: v1.25.3
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -845,41 +917,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_docker_external
-  initVersion: v1.21.14
-  upgradedVersion: v1.22.12
-  infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: digitalocean_default
-    - name: digitalocean_centos
-    - name: digitalocean_rockylinux
-    - name: equinixmetal_default
-    - name: equinixmetal_centos
-    - name: equinixmetal_rockylinux
-    - name: equinixmetal_flatcar
-    - name: hetzner_default
-    - name: hetzner_centos
-    - name: hetzner_rockylinux
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_flatcar
-
-- scenario: upgrade_docker_external
-  initVersion: v1.22.12
-  upgradedVersion: v1.23.9
+  initVersion: v1.22.15
+  upgradedVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -911,7 +950,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -943,7 +982,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -975,7 +1014,39 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.24.3
+  initVersion: v1.24.7
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: digitalocean_default
+    - name: digitalocean_centos
+    - name: digitalocean_rockylinux
+    - name: equinixmetal_default
+    - name: equinixmetal_centos
+    - name: equinixmetal_rockylinux
+    - name: equinixmetal_flatcar
+    - name: hetzner_default
+    - name: hetzner_centos
+    - name: hetzner_rockylinux
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_flatcar
+
+- scenario: legacy_machine_controller_containerd_external
+  initVersion: v1.25.3
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -1007,7 +1078,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker_external
-  initVersion: v1.22.12
+  initVersion: v1.22.15
   infrastructures:
     - name: digitalocean_default
     - name: digitalocean_centos
@@ -1021,7 +1092,7 @@
     - name: hetzner_rockylinux
 
 - scenario: legacy_machine_controller_docker_external
-  initVersion: v1.23.9
+  initVersion: v1.23.13
   infrastructures:
     - name: digitalocean_default
     - name: digitalocean_centos


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR provides initial support for Kubernetes 1.25.

- Change the latest supported Kubernetes version in the API validation to 1.25
- Add E2E tests for Kubernetes 1.25.3
- Remove E2E tests based on Kubernetes 1.21
- Update all other tests to the latest Kubernetes patch release
- Update the E2E image to `kubeone-e2e:v.0.1.26`
- Update the Kubernetes support issue template

**Which issue(s) this PR fixes**:
xref #2307

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add support for Kubernetes 1.25
```

**Documentation**:
```documentation
TBD
```