### PR TITLE
Update Kubernetes support issue templates and version marker for the default Kubernetes version

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes-support.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes-support.md
@@ -1,6 +1,7 @@
 ---
 name: Support Kubernetes 1.2x
 about: Add support for the latest Kubernetes release
+title: Support Kubernetes 1.2x
 labels: sig/cluster-management, kind/feature, Epic
 
 ---
@@ -16,12 +17,13 @@ docker run --rm registry.k8s.io/kube-apiserver:v1.2x.0 kube-apiserver -h
 This is a collector issue for Kubernetes 1.2x support in KubeOne. The following tasks should be taken care of:
 
 * [ ] Check the Kubernetes changelog to ensure there are no breaking changes and removals
-* [ ] Update [the `kubeone-e2e` image](https://github.com/kubermatic/kubeone/tree/main/hack/images/kubeone-e2e) to update Sonobuoy (and other dependencies if needed) <!-- link to the PR -->
-* [ ] Update the latest supported Kubernetes version in [the API validation](https://github.com/kubermatic/kubeone/blob/main/pkg/apis/kubeone/validation/validation.go#L40-L41)
-* [ ] Update [default admission controllers](https://github.com/kubermatic/kubeone/blob/main/pkg/kubeflags/data.go) if needed <!-- link to the PR -->
-* [ ] Add E2E tests <!-- link to the PR -->
+* [ ] Update [the `kubeone-e2e` image](https://github.com/kubermatic/kubeone/tree/main/hack/images/kubeone-e2e) to update Sonobuoy (and other dependencies if needed) <!-- (link to the PR) -->
+* [ ] Update the latest supported Kubernetes version in [the API validation](https://github.com/kubermatic/kubeone/blob/main/pkg/apis/kubeone/validation/validation.go#L40-L41) <!-- (link to the PR) -->
+* [ ] Update [default admission controllers](https://github.com/kubermatic/kubeone/blob/main/pkg/kubeflags/data.go) if needed <!-- (link to the PR) -->
+* [ ] Update [the stable version marker in Makefile](https://github.com/kubermatic/kubeone/blob/5273f9a372736569c6b09b38f2959019d29e4d6a/Makefile#L24) <!-- (link to the PR) -->
+* [ ] Add E2E tests <!-- (link to the PR) -->
 * [ ] Update daily periodics to use the latest Kubernetes release
-* [ ] Update [the Compatibility Matrix](https://docs.kubermatic.com/kubeone/main/architecture/compatibility/supported-versions/) <!-- link to the PR -->
+* [ ] Update [the Compatibility Matrix](https://docs.kubermatic.com/kubeone/main/architecture/compatibility/supported-versions/) <!-- (link to the PR) -->
 * [ ] Create an issue to track updating [images](https://github.com/kubermatic/kubeone/blob/main/pkg/templates/images/images.go) <!-- link to the issue -->
 * [ ] Run the full conformance tests suite using [Sonobuoy](https://github.com/vmware-tanzu/sonobuoy)
 

--- a/.github/ISSUE_TEMPLATE/update-images.md
+++ b/.github/ISSUE_TEMPLATE/update-images.md
@@ -1,6 +1,7 @@
 ---
 name: Update images to support Kubernetes 1.2x
 about: Update components to use versions that support the latest Kubernetes release
+title: Update images to support Kubernetes 1.2x
 labels: sig/cluster-management, kind/feature, Epic
 
 ---
@@ -19,6 +20,17 @@ Action items:
 
 The following components/images should be updated:
 
+### General
+
+- [ ] [Canal CNI](https://github.com/projectcalico/calico) <!-- (PR reference|already the latest) -->
+- [ ] [Calico VXLAN CNI](https://github.com/projectcalico/calico) <!-- (PR reference|already the latest) -->
+- [ ] [Cilium CNI](https://github.com/cilium/cilium) <!-- (PR reference|already the latest) -->
+- [ ] [NodeLocalDNS](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml) <!-- (PR reference|already the latest) -->
+- [ ] [metrics-server](https://github.com/kubernetes-sigs/metrics-server) <!-- (PR reference|already the latest) -->
+- [ ] [Cluster Autoscaler](https://github.com/kubernetes/autoscaler) <!-- (PR reference|already the latest) -->
+
+### Cloud provider components
+
 - [ ] [AWS CCM](https://github.com/kubernetes/cloud-provider-aws) <!-- (PR reference|already the latest) -->
 - [ ] [AWS CSI](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) <!-- (PR reference|already the latest) -->
 - [ ] [Azure CCM](https://github.com/kubernetes-sigs/cloud-provider-azure) <!-- (PR reference|already the latest) -->
@@ -34,6 +46,5 @@ The following components/images should be updated:
 - [ ] [OpenStack CSI](https://github.com/kubernetes/cloud-provider-openstack) <!-- (PR reference|already the latest) -->
 - [ ] [vSphere CCM](https://github.com/kubernetes/cloud-provider-vsphere) <!-- (PR reference|already the latest) -->
 - [ ] [vSphere CSI](https://github.com/kubernetes-sigs/vsphere-csi-driver) <!-- (PR reference|already the latest) -->
-- [ ] [Cluster Autoscaler](https://github.com/kubernetes/autoscaler) <!-- (PR reference|already the latest) -->
 
 Relevant to <!-- epic number -->

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export GOFLAGS?=-mod=readonly -trimpath
 BUILD_DATE=$(shell if hash gdate 2>/dev/null; then gdate --rfc-3339=seconds | sed 's/ /T/'; else date --rfc-3339=seconds | sed 's/ /T/'; fi)
 GITCOMMIT=$(shell git log -1 --pretty=format:"%H")
 GITTAG=$(shell git describe --tags --always)
-DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.24.txt)
+DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.25.txt)
 GOLDFLAGS?=-s -w -extldflags=-zrelro -extldflags=-znow \
 	-X k8c.io/kubeone/pkg/cmd.defaultKubeVersion=$(DEFAULT_STABLE) \
 	-X k8c.io/kubeone/pkg/cmd.version=$(GITTAG) \

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -41,8 +41,6 @@ import (
 )
 
 const (
-	// defaultKubernetesVersion is default Kubernetes version for the example configuration file
-	defaultKubernetesVersion = "1.23.9"
 	// defaultCloudProviderName is cloud provider to build the example configuration file for
 	defaultCloudProviderName = "aws"
 )
@@ -114,7 +112,7 @@ func configPrintCmd() *cobra.Command {
 			configuration manifest, run the print command with --full flag.
 		`),
 		Args:          cobra.ExactArgs(0),
-		Example:       fmt.Sprintf("kubeone config print --provider digitalocean --kubernetes-version %s --cluster-name example", defaultKubernetesVersion),
+		Example:       fmt.Sprintf("kubeone config print --provider digitalocean --kubernetes-version %s --cluster-name example", defaultKubeVersion),
 		SilenceErrors: true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runPrint(opts)
@@ -140,7 +138,7 @@ func configPrintCmd() *cobra.Command {
 		&opts.KubernetesVersion,
 		longFlagName(opts, "KubernetesVersion"),
 		shortFlagName(opts, "KubernetesVersion"),
-		defaultKubernetesVersion,
+		defaultKubeVersion,
 		"Kubernetes version")
 
 	cmd.Flags().StringVarP(


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update the Kubernetes support issue templates
- Update the version marker for the default Kubernetes version to 1.25
- Use the newly-added default Kubernetes version for `kubeone config` (we already use it for `init` and `local`)

**Which issue(s) this PR fixes**:
xref #2307 

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```