### PR TITLE
Add changelogs for October 2022 patch releases

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -1,3 +1,13 @@
+# [v1.4.10](https://github.com/kubermatic/kubeone/releases/tag/v1.4.10) - 2022-09-20
+
+## Changelog since v1.4.9
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update `golang.org/x/crypto` dependency to a newer version to fix issues with SSH authentication on instances with newer OpenSSH versions ([#2390](https://github.com/kubermatic/kubeone/pull/2390), [@xmudrii](https://github.com/xmudrii))
+
 # [v1.4.9](https://github.com/kubermatic/kubeone/releases/tag/v1.4.9) - 2022-09-26
 
 ## Changelog since v1.4.8

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -1,3 +1,19 @@
+# [v1.5.2](https://github.com/kubermatic/kubeone/releases/tag/v1.5.2) - 2022-10-20
+
+## Changelog since v1.5.1
+
+## Changes by Kind
+
+### Feature
+
+- Add support for Ubuntu 22.04 ([#2383](https://github.com/kubermatic/kubeone/pull/2383), [@ahmedwaleedmalik](https://github.com/ahmedwaleedmalik))
+
+### Updates
+
+- Update containerd to 1.6. This change affects control plane nodes, static worker nodes, and nodes managed by machine-controller/OSM ([#2388](https://github.com/kubermatic/kubeone/pull/2388), [@ahmedwaleedmalik](https://github.com/ahmedwaleedmalik))
+- Update to machine-controller v1.54.1 ([#2383](https://github.com/kubermatic/kubeone/pull/2383), [@ahmedwaleedmalik](https://github.com/ahmedwaleedmalik))
+- Update Operating System Manager (OSM) to 1.1.1 ([#2388](https://github.com/kubermatic/kubeone/pull/2388), [@ahmedwaleedmalik](https://github.com/ahmedwaleedmalik))
+
 # [v1.5.1](https://github.com/kubermatic/kubeone/releases/tag/v1.5.1) - 2022-09-26
 
 ## Changelog since v1.5.0


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds changelogs for the October 2022 patch releases: 1.5.2 and 1.4.10.

**What type of PR is this?**

/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```