### PR TITLE
[release/v1.4] Add changelog for v1.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# [v1.4.10](https://github.com/kubermatic/kubeone/releases/tag/v1.4.10) - 2022-09-20
+
+## Changelog since v1.4.9
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update `golang.org/x/crypto` dependency to a newer version to fix issues with SSH authentication on instances with newer OpenSSH versions ([#2390](https://github.com/kubermatic/kubeone/pull/2390), [@xmudrii](https://github.com/xmudrii))
+
 # [v1.4.9](https://github.com/kubermatic/kubeone/releases/tag/v1.4.9) - 2022-09-26
 
 ## Changelog since v1.4.8


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry pick changelog for v1.4.10 to the `release/v1.4` branch from #2409.

**What type of PR is this?**

/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```