### PR TITLE
Update Go to 1.19.2

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-3
           command:
             - /bin/bash
             - -c
@@ -44,7 +44,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-3
           command:
             - /bin/bash
             - -c
@@ -68,7 +68,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: kubermatic/kubeone-e2e:v0.1.25
+        - image: kubermatic/kubeone-e2e:v0.1.26
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -87,7 +87,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: kubermatic/kubeone-e2e:v0.1.25
+        - image: kubermatic/kubeone-e2e:v0.1.26
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.0
+        - image: golang:1.19.2
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.0
+        - image: golang:1.19.2
           command:
             - make
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-3
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.0
+        - image: golang:1.19.2
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.0
+        - image: golang:1.19.2
           command:
             - make
           args:
@@ -125,7 +125,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golangci/golangci-lint:v1.49.0
+        - image: golangci/golangci-lint:v1.50.1
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-3
           command:
             - /bin/bash
             - -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.19.0 as builder
+FROM docker.io/golang:1.19.2 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY


### PR DESCRIPTION
**What this PR does / why we need it**:

Update Go to 1.19.2.

`kubeone-e2e` image has been already updated as part of #2404

**What type of PR is this?**

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
KubeOne is now built using Go 1.19.2
```

**Documentation**:
```documentation
NONE
```