### PR TITLE
Update AWS CCM to v1.25.1, v1.24.2, v1.23.5, v1.22.6 and EBS CSI driver to v1.12.1

### DIFF
--- a/addons/ccm-aws/ccm-aws.yaml
+++ b/addons/ccm-aws/ccm-aws.yaml
@@ -154,6 +154,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
+      dnsPolicy: Default
       priorityClassName: system-node-critical
       serviceAccountName: cloud-controller-manager
       containers:

--- a/addons/csi-aws-ebs/controller.yaml
+++ b/addons/csi-aws-ebs/controller.yaml
@@ -25,6 +25,16 @@ spec:
         node-role.kubernetes.io/control-plane: ""
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+            weight: 1
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
@@ -37,6 +47,11 @@ spec:
         - operator: Exists
           effect: NoExecute
           tolerationSeconds: 300
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
         - name: ebs-plugin
           image: "{{ .InternalImages.Get "AwsEbsCSI" }}"
@@ -76,6 +91,9 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: csi-provisioner
           image: "{{ .InternalImages.Get "AwsEbsCSIProvisioner" }}"
           imagePullPolicy: IfNotPresent
@@ -92,6 +110,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: csi-attacher
           image: "{{ .InternalImages.Get "AwsEbsCSIAttacher" }}"
           imagePullPolicy: IfNotPresent
@@ -105,6 +126,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: csi-snapshotter
           image: "{{ .InternalImages.Get "AwsEbsCSISnapshotter" }}"
           imagePullPolicy: IfNotPresent
@@ -117,6 +141,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: csi-resizer
           image: "{{ .InternalImages.Get "AwsEbsCSIResizer" }}"
           imagePullPolicy: IfNotPresent
@@ -130,6 +157,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: liveness-probe
           image: "{{ .InternalImages.Get "AwsEbsCSILivenessProbe" }}"
           imagePullPolicy: IfNotPresent
@@ -138,6 +168,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/addons/csi-aws-ebs/csidriver.yaml
+++ b/addons/csi-aws-ebs/csidriver.yaml
@@ -9,3 +9,4 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  fsGroupPolicy: File

--- a/addons/csi-aws-ebs/node.yaml
+++ b/addons/csi-aws-ebs/node.yaml
@@ -46,12 +46,13 @@ spec:
           operator: "Exists"
           effect: "NoSchedule"
         - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
+      securityContext:
+        fsGroup: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
       containers:
         - name: ebs-plugin
-          securityContext:
-            privileged: true
           image: "{{ .InternalImages.Get "AwsEbsCSI" }}"
           imagePullPolicy: IfNotPresent
           args:
@@ -86,6 +87,9 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
         - name: node-driver-registrar
           image: "{{ .InternalImages.Get "AwsEbsCSINodeDriverRegistrar" }}"
           imagePullPolicy: IfNotPresent
@@ -103,6 +107,9 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: liveness-probe
           image: "{{ .InternalImages.Get "AwsEbsCSILivenessProbe" }}"
           imagePullPolicy: IfNotPresent
@@ -111,6 +118,9 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: kubelet-dir
           hostPath:

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -251,9 +251,9 @@ func optionalResources() map[Resource]map[string]string {
 		},
 
 		// AWS EBS CSI driver
-		AwsEbsCSI:                    {"*": "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.9.0"},
+		AwsEbsCSI:                    {"*": "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.12.1"},
 		AwsEbsCSIAttacher:            {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
-		AwsEbsCSILivenessProbe:       {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.5.0"},
+		AwsEbsCSILivenessProbe:       {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.6.0"},
 		AwsEbsCSINodeDriverRegistrar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
 		AwsEbsCSIProvisioner:         {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"},
 		AwsEbsCSIResizer:             {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -232,9 +232,10 @@ func optionalResources() map[Resource]map[string]string {
 		CSISnapshotter:        {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0"},
 
 		AwsCCM: {
-			"1.22.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.22.4",
-			"1.23.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.2",
-			">= 1.24.0": "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.24.1",
+			"1.22.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.22.6",
+			"1.23.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.5",
+			"1.24.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.24.2",
+			">= 1.25.0": "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.25.1",
 		},
 
 		// Azure CCM


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update AWS CCM to v1.25.1, v1.24.2, v1.23.5, v1.22.6
- Update AWS EBS CSI driver to v1.12.1

**Which issue(s) this PR fixes**:
xref #2406

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update AWS CCM to v1.25.1, v1.24.2, v1.23.5, v1.22.6
- Update AWS EBS CSI driver to v1.12.1
```

**Documentation**:
```documentation
NONE
```