### PR TITLE
Machine Controller Addon: add metrics port 8080

### DIFF
--- a/addons/machinecontroller/deployment-controller.yaml
+++ b/addons/machinecontroller/deployment-controller.yaml
@@ -84,6 +84,9 @@ spec:
 {{ end }}
           ports:
             - containerPort: 8085
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /readyz


### PR DESCRIPTION
Add metrics port (8080/TCP) to Machine Controller addon, so Prometheus ServiceMonitor can be used

Signed-off-by: sphr2k <mail@janwerner.de>

**What this PR does / why we need it**:

Expose machine-controller metrics port (8080/TCP), so Prometheus ServiceMonitor can be used for scraping

```release-note
Expose machine-controller metrics port (8080/TCP), so Prometheus ServiceMonitor can be used for scraping
```

```documentation
NONE
```