### PR TITLE
Revert using spot instances for AWS E2E tests

### DIFF
--- a/test/e2e/testdata/aws.tfvars
+++ b/test/e2e/testdata/aws.tfvars
@@ -2,10 +2,9 @@ disable_kubeapi_loadbalancer = true
 subnets_cidr                 = 27
 
 # Use smaller instances in Ireland for E2E tests
-aws_region                                        = "eu-west-1"
-control_plane_type                                = "t3a.small"
-control_plane_volume_size                         = 25
-worker_type                                       = "t3a.small"
-worker_volume_size                                = 25
-bastion_type                                      = "t3a.nano"
-initial_machinedeployment_spotinstances_max_price = 0.0204
+aws_region                = "eu-west-1"
+control_plane_type        = "t3a.small"
+control_plane_volume_size = 25
+worker_type               = "t3a.small"
+worker_volume_size        = 25
+bastion_type              = "t3a.nano"

--- a/test/e2e/testdata/aws_stable.tfvars
+++ b/test/e2e/testdata/aws_stable.tfvars
@@ -2,9 +2,8 @@ disable_kubeapi_loadbalancer = true
 subnets_cidr                 = 27
 
 # Use smaller instances in Ireland for E2E tests
-aws_region                                        = "eu-west-1"
-control_plane_type                                = "t3a.small"
-control_plane_volume_size                         = 25
-worker_type                                       = "t3a.small"
-bastion_type                                      = "t3a.nano"
-initial_machinedeployment_spotinstances_max_price = 0.0204
+aws_region                = "eu-west-1"
+control_plane_type        = "t3a.small"
+control_plane_volume_size = 25
+worker_type               = "t3a.small"
+bastion_type              = "t3a.nano"


### PR DESCRIPTION
**What this PR does / why we need it**:

The AWS E2E tests are unstable as of recently. Many tests are:

- timeout-ing after 20 minutes because worker nodes are not joining a cluster
- failing because Sonobuoy randomly stops working

We started using spot instances in the CI with #2415, but this PR reverts that until we don't stabilize our tests.

**What type of PR is this?**

/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```