### PR TITLE
Refactor validation for csiConfig

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,4 +91,4 @@ issues:
     text: "cyclomatic complexity 36 of func `openstackValidationFunc` is high"
 
   - path: pkg/apis/kubeone
-    text: "cyclomatic complexity 31 of func `ValidateCloudProviderSpec` is high"
+    text: "cyclomatic complexity 32 of func `ValidateCloudProviderSpec` is high"

--- a/pkg/apis/kubeone/config/config.go
+++ b/pkg/apis/kubeone/config/config.go
@@ -349,4 +349,8 @@ func checkClusterFeatures(c kubeoneapi.KubeOneCluster, logger logrus.FieldLogger
 	if c.ContainerRuntime.Docker != nil {
 		logger.Warnf("Support for docker will be removed with Kubernetes 1.24 release. It is recommended to switch to containerd as container runtime using `kubeone migrate to-containerd`")
 	}
+
+	if c.CloudProvider.Vsphere != nil && !c.CloudProvider.External && len(c.CloudProvider.CSIConfig) > 0 {
+		logger.Warnf(".cloudProvider.csiConfig is provided, but is ignored when used with the in-tree cloud provider")
+	}
 }

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -244,6 +244,9 @@ func ValidateCloudProviderSpec(p kubeoneapi.CloudProviderSpec, fldPath *field.Pa
 		if len(p.CloudConfig) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("cloudConfig"), ".cloudProvider.cloudConfig is required for vSphere provider"))
 		}
+		if p.External && len(p.CSIConfig) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("csiConfig"), ".cloudProvider.csiConfig is required for vSphere provider"))
+		}
 		providerFound = true
 	}
 	if p.None != nil {
@@ -257,13 +260,8 @@ func ValidateCloudProviderSpec(p kubeoneapi.CloudProviderSpec, fldPath *field.Pa
 		allErrs = append(allErrs, field.Invalid(fldPath, "", "provider must be specified"))
 	}
 
-	if len(p.CSIConfig) > 0 {
-		if p.Vsphere == nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("csiConfig"), "", ".cloudProvider.csiConfig is currently supported only for vsphere clusters"))
-		}
-		if !p.External {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("csiConfig"), "", ".cloudProvider.csiConfig is supported only for clusters using external cloud provider (.cloudProvider.external)"))
-		}
+	if p.Vsphere == nil && len(p.CSIConfig) > 0 {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("csiConfig"), ".cloudProvider.csiConfig is currently supported only for vsphere clusters"))
 	}
 
 	return allErrs

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -667,12 +667,21 @@ func TestValidateCloudProviderSpec(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "vSphere provider config without csiConfig",
+			name: "vSphere provider config without csiConfig (external disabled)",
 			providerConfig: kubeoneapi.CloudProviderSpec{
 				Vsphere:     &kubeoneapi.VsphereSpec{},
 				CloudConfig: "test",
 			},
 			expectedError: false,
+		},
+		{
+			name: "vSphere provider config without csiConfig (external enabled)",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Vsphere:     &kubeoneapi.VsphereSpec{},
+				External:    true,
+				CloudConfig: "test",
+			},
+			expectedError: true,
 		},
 		{
 			name: "vSphere provider config with csiConfig",
@@ -692,7 +701,7 @@ func TestValidateCloudProviderSpec(t *testing.T) {
 				CloudConfig: "test",
 				CSIConfig:   "test",
 			},
-			expectedError: true,
+			expectedError: false,
 		},
 		{
 			name: "OpenStack provider config without csiConfig",


### PR DESCRIPTION
**What this PR does / why we need it**:

After discussing internally with @kron4eg, we decided to make it possible to provide `.cloudProvider.csiConfig` even if the in-tree provider is used. This needed to make implementing E2E tests easier/possible, as well as, to make it easier to test vSphere integration manually (e.g. you don't need to delete/comment `csiConfig` each time you want to test something).

In such cases when CSIConfig is used with the in-tree provider, the CSIConfig is ignored and a warning about this is printed.

Additionally, CSIConfig is now a mandatory field for vSphere if external is enabled. This wasn't the case before, however, if you don't provide CSIConfig, vSphere CSI will crashloop, resulting in a non-functional cluster.

**What type of PR is this?**

/kind api-change

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- `.cloudProvider.csiConfig` is now a mandatory field for vSphere clusters using the external cloud provider (`.cloudProvider.external: true`)
- `.cloudProvider.csiConfig` can be specified even if the in-tree provider is used, but the provided CSIConfig is ignored in such cases (a warning about this is printed)
```

**Documentation**:
```documentation
NONE
```