### PR TITLE
Rename generate-internal-groups Make target to update-codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ download-gocache:
 	@# Prevent this from getting executed multiple times
 	@touch download-gocache
 
-.PHONY: generate-internal-groups
-generate-internal-groups: GOFLAGS = -mod=readonly
-generate-internal-groups: vendor
+.PHONY: update-codegen
+update-codegen: GOFLAGS = -mod=readonly
+update-codegen: vendor
 	./hack/update-codegen.sh
 
 .PHONY: test


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR renames `generate-internal-groups` Make target to `update-codegen`. The script itself is called `update-codegen.sh` and `generate-internal-groups` is not really intuitive and easy to remember, so we decided to rename the Make target.

**What type of PR is this?**

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Rename `generate-internal-groups` Make target to `update-codegen`
```

**Documentation**:
```documentation
NONE
```