### PR TITLE
[release/v1.5] Update OpenStack CCM and CSI to v1.24.5 and v1.22.2

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -300,19 +300,19 @@ func optionalResources() map[Resource]map[string]string {
 
 		// OpenStack CCM
 		OpenstackCCM: {
-			"1.22.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.0",
+			"1.22.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.22.2",
 			"1.23.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.4",
-			">= 1.24.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.2",
+			">= 1.24.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.5",
 		},
 
 		// OpenStack CSI
 		OpenstackCSI: {
-			"1.22.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
+			"1.22.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.2",
 			"1.23.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.4",
-			">= 1.24.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.24.2",
+			">= 1.24.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.24.5",
 		},
-		OpenstackCSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
-		OpenstackCSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.6.0"},
+		OpenstackCSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
+		OpenstackCSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.7.0"},
 		OpenstackCSIAttacher:           {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
 		OpenstackCSIProvisioner:        {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"},
 		OpenstackCSIResizer:            {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a partial cherry-pick of #2427 to update the OpenStack CCM and CSI to v1.24.5 and v1.22.2. This cherry-pick doesn't include updating snapshot-controller because it's a larger change (it includes updating CRDs, RBAC,...).

**Which issue(s) this PR fixes**:
Fixes #2412 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update OpenStack CCM and CSI to v1.24.5 and v1.22.2
```

**Documentation**:
```documentation
NONE
```