### PR TITLE
Allow disabling IPv6 for Hubble UI

### DIFF
--- a/addons/cni-cilium/README.md
+++ b/addons/cni-cilium/README.md
@@ -1,0 +1,14 @@
+# Cilium CNI addon
+
+This addon is used to deploy [Cilium CNI](https://cilium.io/).
+
+## Available parameters
+
+This section what [addon parameters][params] can be used with this addon.
+
+[params]: https://docs.kubermatic.com/kubeone/main/guides/addons/#parameters
+
+* `HubbleUI` - used to enable/disable Hubble UI listening on an IPv6 interface
+  * `true` (default): enable listening on IPv6
+  * `false`: disable listening on IPv6
+  * Note: enabling this parameter requires having IPv6 support enabled in kernel

--- a/addons/cni-cilium/cilium.yaml
+++ b/addons/cni-cilium/cilium.yaml
@@ -7,7 +7,7 @@
 #   - templated cluster-pool-ipv4-cidr
 #   - templated kube-proxy-replacement parts
 #   - added seccomp profile to cilium-operator
-
+{{ $hubble_ipv6 := default "true" .Params.HubbleIPv6 }}
 ---
 # Source: cilium/templates/cilium-agent/serviceaccount.yaml
 apiVersion: v1
@@ -250,7 +250,13 @@ metadata:
   name: hubble-ui-nginx
   namespace: kube-system
 data:
+# The only difference between those two configs is that non-IPv6 config
+# doesn't have `listen       [::]:8081;`
+{{ if eq $hubble_ipv6 "true" }}
   nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n\n        location / {\n            try_files $uri $uri/ /index.html;\n        }\n    }\n}"
+{{ else }}
+  nginx.conf: "server {\n    listen       8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n\n        location / {\n            try_files $uri $uri/ /index.html;\n        }\n    }\n}"
+{{ end }}
 ---
 {{ end }}
 # Source: cilium/templates/cilium-agent/clusterrole.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a new parameter for the Cilium addon called `HubbleIPv6`. This parameter is used to enable/disable Hubble UI listening on an IPv6 interface. By default, the value of this parameter is `true` which means that Hubble UI is listening on an IPv6 interface, and it can be set to `false` to disable listening on IPv6.

Example:

```yaml
...
addons:
  enable: true
  addons:
    - name: cni-cilium
      params:
        HubbleIPv6: "true"
```

**Which issue(s) this PR fixes**:
Fixes #2446 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add a new addon parameter called `HubbleIPv6` (`true`/`false`, default: `true`) for Cilium CNI used to enable/disable Hubble UI listening on an IPv6 interface
```

**Documentation**:
```documentation
NONE
```