### PR TITLE
[release/v1.5] Make vSphere E2E tests work on the new vSphere infrastructure

### DIFF
--- a/examples/terraform/vsphere/README.md
+++ b/examples/terraform/vsphere/README.md
@@ -61,6 +61,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allow_insecure"></a> [allow\_insecure](#input\_allow\_insecure) | allow insecure https connection to vCenter | `bool` | `false` | no |
 | <a name="input_api_vip"></a> [api\_vip](#input\_api\_vip) | virtual IP address for Kubernetes API | `string` | `""` | no |
 | <a name="input_apiserver_alternative_names"></a> [apiserver\_alternative\_names](#input\_apiserver\_alternative\_names) | subject alternative names for the API Server signing cert. | `list(string)` | `[]` | no |
 | <a name="input_bastion_host"></a> [bastion\_host](#input\_bastion\_host) | ssh jumphost (bastion) hostname | `string` | `""` | no |

--- a/examples/terraform/vsphere/README.md
+++ b/examples/terraform/vsphere/README.md
@@ -1,9 +1,19 @@
-# vSphere Quickstart Terraform configs
+# vSphere Quickstart Terraform configs for Debian-based operating system
 
 The vSphere Quickstart Terraform configs can be used to create the needed
 infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
+
+These Terraform configs are supposed to be used with Debian-based operating
+systems that support vApp (e.g. Ubuntu). For more information on how to prepare
+a template VM to be used with these configs, check out our [Ubuntu Template VM]
+guide.
+
+We also provide Terraform configs for [CentOS-based operating systems](../vsphere_centos)
+and [Flatcar Linux](../vsphere_flatcar).
+
+[Ubuntu Template VM]: https://docs.kubermatic.com/kubeone/main/guides/vsphere-template-vm/ubuntu/
 
 ## Required environment variables
 

--- a/examples/terraform/vsphere/README.md.in
+++ b/examples/terraform/vsphere/README.md.in
@@ -1,9 +1,19 @@
-# vSphere Quickstart Terraform configs
+# vSphere Quickstart Terraform configs for Debian-based operating system
 
 The vSphere Quickstart Terraform configs can be used to create the needed
 infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
+
+These Terraform configs are supposed to be used with Debian-based operating
+systems that support vApp (e.g. Ubuntu). For more information on how to prepare
+a template VM to be used with these configs, check out our [Ubuntu Template VM]
+guide.
+
+We also provide Terraform configs for [CentOS-based operating systems](../vsphere_centos)
+and [Flatcar Linux](../vsphere_flatcar).
+
+[Ubuntu Template VM]: https://docs.kubermatic.com/kubeone/main/guides/vsphere-template-vm/ubuntu/
 
 ## Required environment variables
 

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -77,8 +77,8 @@ output "kubeone_workers" {
         cloudProviderSpec = {
           # provider specific fields:
           # see example under `cloudProviderSpec` section at:
-          # https://github.com/kubermatic/machine-controller/blob/master/examples/vsphere-machinedeployment.yaml
-          allowInsecure = false
+          # https://github.com/kubermatic/machine-controller/blob/main/examples/vsphere-machinedeployment.yaml
+          allowInsecure = var.allow_insecure
           cluster       = var.compute_cluster_name
           cpus          = var.worker_num_cpus
           datacenter    = var.dc_name

--- a/examples/terraform/vsphere/variables.tf
+++ b/examples/terraform/vsphere/variables.tf
@@ -91,6 +91,12 @@ variable "bastion_username" {
 
 # provider specific settings
 
+variable "allow_insecure" {
+  description = "allow insecure https connection to vCenter"
+  default     = false
+  type        = bool
+}
+
 variable "dc_name" {
   default     = "dc-1"
   description = "datacenter name"

--- a/examples/terraform/vsphere_centos/README.md
+++ b/examples/terraform/vsphere_centos/README.md
@@ -1,9 +1,27 @@
-# vSphere Quickstart Terraform configs
+# vSphere Quickstart Terraform configs for CentOS-based operating systems
 
 The vSphere Quickstart Terraform configs can be used to create the needed
 infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
+
+These Terraform configs are supposed to be used with CentOS-based operating
+systems (e.g. CentOS 7 and RHEL). It's required that the template VM support
+using [vSphere `guestinfo` datasource][guestinfo] to be able to use these
+configs. For more information on how to prepare a template VM to be used with
+these configs, check out our [CentOS 7 Template VM] guide.
+
+> **Note**
+> You might have to adjust [`cloud-config-metadata.tftpl`](./cloud-config-metadata.tftpl)
+> file depending on your vSphere environment and setup. This file contains the
+> network configuration for VMs. We configure the network to use IPv4 and DHCP,
+> which might not work for all vSphere environments.
+
+We also provide Terraform configs for [Debian-based operating systems](../vsphere)
+and [Flatcar Linux](../vsphere_flatcar).
+
+[CentOS 7 Template VM]: https://docs.kubermatic.com/kubeone/main/guides/vsphere-template-vm/centos/
+[guestinfo]: https://github.com/vmware-archive/cloud-init-vmware-guestinfo
 
 ## Required environment variables
 

--- a/examples/terraform/vsphere_centos/README.md
+++ b/examples/terraform/vsphere_centos/README.md
@@ -1,0 +1,106 @@
+# vSphere Quickstart Terraform configs
+
+The vSphere Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the following
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
+
+## Required environment variables
+
+* `VSPHERE_USER`
+* `VSPHERE_PASSWORD`
+* `VSPHERE_SERVER`
+* `VSPHERE_ALLOW_UNVERIFIED_SSL`
+
+## How to prepare a template
+
+See <https://github.com/kubermatic/machine-controller/blob/main/docs/vsphere.md>
+
+## Kubernetes API Server Load Balancing
+
+See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
+
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/main/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/main/examples/ha-load-balancing/
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_vsphere"></a> [vsphere](#requirement\_vsphere) | ~> 2.1.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_vsphere"></a> [vsphere](#provider\_vsphere) | ~> 2.1.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.keepalived_config](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_string.keepalived_auth_pass](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [vsphere_compute_cluster_vm_anti_affinity_rule.vm_anti_affinity_rule](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/compute_cluster_vm_anti_affinity_rule) | resource |
+| [vsphere_virtual_machine.control_plane](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/virtual_machine) | resource |
+| [vsphere_compute_cluster.cluster](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/data-sources/compute_cluster) | data source |
+| [vsphere_datacenter.dc](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/data-sources/datacenter) | data source |
+| [vsphere_datastore.datastore](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/data-sources/datastore) | data source |
+| [vsphere_network.network](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/data-sources/network) | data source |
+| [vsphere_resource_pool.pool](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/data-sources/resource_pool) | data source |
+| [vsphere_virtual_machine.template](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/data-sources/virtual_machine) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_insecure"></a> [allow\_insecure](#input\_allow\_insecure) | allow insecure https connection to vCenter | `bool` | `false` | no |
+| <a name="input_api_vip"></a> [api\_vip](#input\_api\_vip) | virtual IP address for Kubernetes API | `string` | `""` | no |
+| <a name="input_apiserver_alternative_names"></a> [apiserver\_alternative\_names](#input\_apiserver\_alternative\_names) | subject alternative names for the API Server signing cert. | `list(string)` | `[]` | no |
+| <a name="input_bastion_host"></a> [bastion\_host](#input\_bastion\_host) | ssh jumphost (bastion) hostname | `string` | `""` | no |
+| <a name="input_bastion_host_key"></a> [bastion\_host\_key](#input\_bastion\_host\_key) | Bastion SSH host public key | `string` | `null` | no |
+| <a name="input_bastion_port"></a> [bastion\_port](#input\_bastion\_port) | ssh jumphost (bastion) port | `number` | `22` | no |
+| <a name="input_bastion_username"></a> [bastion\_username](#input\_bastion\_username) | ssh jumphost (bastion) username | `string` | `""` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
+| <a name="input_compute_cluster_name"></a> [compute\_cluster\_name](#input\_compute\_cluster\_name) | internal vSphere cluster name | `string` | `"cl-1"` | no |
+| <a name="input_control_plane_memory"></a> [control\_plane\_memory](#input\_control\_plane\_memory) | memory size of each control plane node in MB | `number` | `2048` | no |
+| <a name="input_control_plane_num_cpus"></a> [control\_plane\_num\_cpus](#input\_control\_plane\_num\_cpus) | number of cpus of each control plane node | `number` | `2` | no |
+| <a name="input_control_plane_vm_count"></a> [control\_plane\_vm\_count](#input\_control\_plane\_vm\_count) | number of VMs | `number` | `3` | no |
+| <a name="input_datastore_cluster_name"></a> [datastore\_cluster\_name](#input\_datastore\_cluster\_name) | datastore cluster name | `string` | `""` | no |
+| <a name="input_datastore_name"></a> [datastore\_name](#input\_datastore\_name) | datastore name | `string` | `"datastore1"` | no |
+| <a name="input_dc_name"></a> [dc\_name](#input\_dc\_name) | datacenter name | `string` | `"dc-1"` | no |
+| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | disk size | `number` | `50` | no |
+| <a name="input_folder_name"></a> [folder\_name](#input\_folder\_name) | folder name | `string` | `"kubeone"` | no |
+| <a name="input_initial_machinedeployment_operating_system_profile"></a> [initial\_machinedeployment\_operating\_system\_profile](#input\_initial\_machinedeployment\_operating\_system\_profile) | Name of operating system profile for MachineDeployments, only applicable if operating-system-manager addon is enabled.<br>If not specified, the default value will be added by machine-controller addon. | `string` | `""` | no |
+| <a name="input_initial_machinedeployment_replicas"></a> [initial\_machinedeployment\_replicas](#input\_initial\_machinedeployment\_replicas) | Number of replicas per MachineDeployment | `number` | `2` | no |
+| <a name="input_is_vsphere_enterprise_plus_license"></a> [is\_vsphere\_enterprise\_plus\_license](#input\_is\_vsphere\_enterprise\_plus\_license) | toggle on/off based on your vsphere enterprise license | `bool` | `true` | no |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | network name | `string` | `"public"` | no |
+| <a name="input_resource_pool_name"></a> [resource\_pool\_name](#input\_resource\_pool\_name) | cluster resource pool name | `string` | `""` | no |
+| <a name="input_ssh_agent_socket"></a> [ssh\_agent\_socket](#input\_ssh\_agent\_socket) | SSH Agent socket, default to grab from $SSH\_AUTH\_SOCK | `string` | `"env:SSH_AUTH_SOCK"` | no |
+| <a name="input_ssh_hosts_keys"></a> [ssh\_hosts\_keys](#input\_ssh\_hosts\_keys) | A list of SSH hosts public keys to verify | `list(string)` | `null` | no |
+| <a name="input_ssh_port"></a> [ssh\_port](#input\_ssh\_port) | SSH port to be used to provision instances | `number` | `22` | no |
+| <a name="input_ssh_private_key_file"></a> [ssh\_private\_key\_file](#input\_ssh\_private\_key\_file) | SSH private key file used to access instances | `string` | `""` | no |
+| <a name="input_ssh_public_key_file"></a> [ssh\_public\_key\_file](#input\_ssh\_public\_key\_file) | SSH public key file | `string` | `"~/.ssh/id_rsa.pub"` | no |
+| <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | SSH user, used only in output | `string` | `"root"` | no |
+| <a name="input_template_name"></a> [template\_name](#input\_template\_name) | template name | `string` | `"ubuntu-22.04"` | no |
+| <a name="input_vrrp_interface"></a> [vrrp\_interface](#input\_vrrp\_interface) | network interface for API virtual IP | `string` | `"ens192"` | no |
+| <a name="input_vrrp_router_id"></a> [vrrp\_router\_id](#input\_vrrp\_router\_id) | vrrp router id for API virtual IP. Must be unique in used subnet | `number` | `42` | no |
+| <a name="input_worker_disk"></a> [worker\_disk](#input\_worker\_disk) | disk size of each worker node in GB | `number` | `10` | no |
+| <a name="input_worker_memory"></a> [worker\_memory](#input\_worker\_memory) | memory size of each worker node in MB | `number` | `2048` | no |
+| <a name="input_worker_num_cpus"></a> [worker\_num\_cpus](#input\_worker\_num\_cpus) | number of cpus of each workers node | `number` | `2` | no |
+| <a name="input_worker_os"></a> [worker\_os](#input\_worker\_os) | OS to run on worker machines | `string` | `"ubuntu"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_kubeone_api"></a> [kubeone\_api](#output\_kubeone\_api) | kube-apiserver LB endpoint |
+| <a name="output_kubeone_hosts"></a> [kubeone\_hosts](#output\_kubeone\_hosts) | Control plane endpoints to SSH to |
+| <a name="output_kubeone_workers"></a> [kubeone\_workers](#output\_kubeone\_workers) | Workers definitions, that will be transformed into MachineDeployment object |

--- a/examples/terraform/vsphere_centos/README.md.in
+++ b/examples/terraform/vsphere_centos/README.md.in
@@ -1,9 +1,27 @@
-# vSphere Quickstart Terraform configs
+# vSphere Quickstart Terraform configs for CentOS-based operating systems
 
 The vSphere Quickstart Terraform configs can be used to create the needed
 infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
+
+These Terraform configs are supposed to be used with CentOS-based operating
+systems (e.g. CentOS 7 and RHEL). It's required that the template VM support
+using [vSphere `guestinfo` datasource][guestinfo] to be able to use these
+configs. For more information on how to prepare a template VM to be used with
+these configs, check out our [CentOS 7 Template VM] guide.
+
+> **Note**
+> You might have to adjust [`cloud-config-metadata.tftpl`](./cloud-config-metadata.tftpl)
+> file depending on your vSphere environment and setup. This file contains the
+> network configuration for VMs. We configure the network to use IPv4 and DHCP,
+> which might not work for all vSphere environments.
+
+We also provide Terraform configs for [Debian-based operating systems](../vsphere)
+and [Flatcar Linux](../vsphere_flatcar).
+
+[CentOS 7 Template VM]: https://docs.kubermatic.com/kubeone/main/guides/vsphere-template-vm/centos/
+[guestinfo]: https://github.com/vmware-archive/cloud-init-vmware-guestinfo
 
 ## Required environment variables
 

--- a/examples/terraform/vsphere_centos/README.md.in
+++ b/examples/terraform/vsphere_centos/README.md.in
@@ -1,0 +1,25 @@
+# vSphere Quickstart Terraform configs
+
+The vSphere Quickstart Terraform configs can be used to create the needed
+infrastructure for a Kubernetes HA cluster. Check out the following
+[Creating Infrastructure guide][docs-infrastructure] to learn more about how to
+use the configs and how to provision a Kubernetes cluster using KubeOne.
+
+## Required environment variables
+
+* `VSPHERE_USER`
+* `VSPHERE_PASSWORD`
+* `VSPHERE_SERVER`
+* `VSPHERE_ALLOW_UNVERIFIED_SSL`
+
+## How to prepare a template
+
+See <https://github.com/kubermatic/machine-controller/blob/main/docs/vsphere.md>
+
+## Kubernetes API Server Load Balancing
+
+See the [Terraform loadbalancers in examples document][docs-tf-loadbalancer].
+
+[docs-infrastructure]: https://docs.kubermatic.com/kubeone/main/guides/using-terraform-configs/
+[docs-tf-loadbalancer]: https://docs.kubermatic.com/kubeone/main/examples/ha-load-balancing/
+

--- a/examples/terraform/vsphere_centos/cloud-config-metadata.tftpl
+++ b/examples/terraform/vsphere_centos/cloud-config-metadata.tftpl
@@ -1,0 +1,9 @@
+instance-id: ${machine_name}
+local-hostname: ${machine_name}
+network:
+  version: 2
+  ethernets:
+    nics:
+      match:
+        name: e*
+      dhcp4: yes

--- a/examples/terraform/vsphere_centos/cloud-config-userdata.tftpl
+++ b/examples/terraform/vsphere_centos/cloud-config-userdata.tftpl
@@ -1,0 +1,5 @@
+#cloud-config
+hostname: ${machine_name}
+ssh_pwauth: false
+ssh_authorized_keys:
+  - "${ssh_key}"

--- a/examples/terraform/vsphere_centos/etc_keepalived_check_apiserver_sh.tpl
+++ b/examples/terraform/vsphere_centos/etc_keepalived_check_apiserver_sh.tpl
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+errorExit() {
+    echo "*** $*" 1>&2
+    exit 1
+}
+
+curl --silent --max-time 2 --insecure https://localhost:6443/healthz -o /dev/null || errorExit "Error GET https://localhost:6443/healthz"
+if ip addr | grep -q ${APISERVER_VIP}; then
+    curl --silent --max-time 2 --insecure https://${APISERVER_VIP}:6443/healthz -o /dev/null || errorExit "Error GET https://${APISERVER_VIP}:6443/healthz"
+fi

--- a/examples/terraform/vsphere_centos/etc_keepalived_keepalived_conf.tpl
+++ b/examples/terraform/vsphere_centos/etc_keepalived_keepalived_conf.tpl
@@ -1,0 +1,27 @@
+global_defs {
+    router_id LVS_DEVEL
+}
+vrrp_script check_apiserver {
+  script "/etc/keepalived/check_apiserver.sh"
+  interval 3
+  weight -2
+  fall 10
+  rise 2
+}
+
+vrrp_instance VI_1 {
+    state ${STATE}
+    interface ${INTERFACE}
+    virtual_router_id ${ROUTER_ID}
+    priority ${PRIORITY}
+    authentication {
+        auth_type PASS
+        auth_pass ${AUTH_PASS}
+    }
+    virtual_ipaddress {
+        ${APISERVER_VIP}
+    }
+    track_script {
+        check_apiserver
+    }
+}

--- a/examples/terraform/vsphere_centos/keepalived.sh
+++ b/examples/terraform/vsphere_centos/keepalived.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The KubeOne Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is mostly used in CI
+# It installs dependencies and starts the tests
+
+set -euf -o pipefail
+
+noop() { : "didn't detected package manager, noop"; }
+
+PKG_MANAGER="noop"
+
+[ "$(command -v yum)" ] && PKG_MANAGER=yum
+[ "$(command -v apt-get)" ] && PKG_MANAGER=apt-get
+
+sudo ${PKG_MANAGER} update -y
+sudo ${PKG_MANAGER} install keepalived -y
+
+sudo systemctl enable keepalived.service
+sudo systemctl start keepalived.service

--- a/examples/terraform/vsphere_centos/main.tf
+++ b/examples/terraform/vsphere_centos/main.tf
@@ -1,0 +1,188 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+provider "vsphere" {
+  /*
+  See https://www.terraform.io/docs/providers/vsphere/index.html#argument-reference
+  for config options reference
+  */
+}
+
+locals {
+  resource_pool_id = var.resource_pool_name == "" ? data.vsphere_compute_cluster.cluster.resource_pool_id : data.vsphere_resource_pool.pool[0].id
+  hostnames        = formatlist("${var.cluster_name}-cp-%d", [1, 2, 3])
+}
+
+data "vsphere_datacenter" "dc" {
+  name = var.dc_name
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = var.datastore_name
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = var.compute_cluster_name
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_resource_pool" "pool" {
+  count         = var.resource_pool_name == "" ? 0 : 1
+  name          = var.resource_pool_name
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "network" {
+  name          = var.network_name
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = var.template_name
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+resource "vsphere_virtual_machine" "control_plane" {
+  count = var.control_plane_vm_count
+
+  name             = "${var.cluster_name}-cp-${count.index + 1}"
+  resource_pool_id = local.resource_pool_id
+  folder           = var.folder_name
+  datastore_id     = data.vsphere_datastore.datastore.id
+  num_cpus         = var.control_plane_num_cpus
+  memory           = var.control_plane_memory
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
+  firmware         = data.vsphere_virtual_machine.template.firmware
+
+  network_interface {
+    network_id   = data.vsphere_network.network.id
+    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_size
+    thin_provisioned = data.vsphere_virtual_machine.template.disks[0].thin_provisioned
+    eagerly_scrub    = data.vsphere_virtual_machine.template.disks[0].eagerly_scrub
+  }
+
+  cdrom {
+    client_device = true
+  }
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+  }
+
+  extra_config = {
+    "disk.enableUUID" = "TRUE"
+    "guestinfo.metadata" = base64gzip(templatefile("./cloud-config-metadata.tftpl", {
+      machine_name = "${var.cluster_name}-cp-${count.index + 1}"
+      ssh_key      = file(var.ssh_public_key_file)
+    }))
+    "guestinfo.metadata.encoding" = "gzip+base64"
+    "guestinfo.userdata" = base64gzip(templatefile("./cloud-config-userdata.tftpl", {
+      machine_name = "${var.cluster_name}-cp-${count.index + 1}"
+      ssh_key      = file(var.ssh_public_key_file)
+    }))
+    "guestinfo.userdata.encoding" = "gzip+base64"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      vapp[0].properties,
+      tags,
+    ]
+  }
+
+  connection {
+    type         = "ssh"
+    host         = self.default_ip_address
+    user         = var.ssh_username
+    bastion_host = var.bastion_host
+    bastion_port = var.bastion_port
+    bastion_user = var.bastion_username
+  }
+
+  provisioner "remote-exec" {
+    script = "keepalived.sh"
+  }
+}
+
+resource "random_string" "keepalived_auth_pass" {
+  length  = 8
+  special = false
+}
+
+resource "null_resource" "keepalived_config" {
+  count = var.api_vip != "" ? 3 : 0
+
+  triggers = {
+    cluster_instance_ids = join(",", vsphere_virtual_machine.control_plane.*.id)
+  }
+
+  connection {
+    type         = "ssh"
+    user         = var.ssh_username
+    host         = vsphere_virtual_machine.control_plane[count.index].default_ip_address
+    bastion_host = var.bastion_host
+    bastion_port = var.bastion_port
+    bastion_user = var.bastion_username
+  }
+
+  provisioner "file" {
+    content = templatefile("./etc_keepalived_keepalived_conf.tpl", {
+      STATE         = count.index == 0 ? "MASTER" : "BACKUP",
+      APISERVER_VIP = var.api_vip,
+      INTERFACE     = var.vrrp_interface,
+      ROUTER_ID     = var.vrrp_router_id,
+      PRIORITY      = count.index == 0 ? "101" : "100",
+      AUTH_PASS     = random_string.keepalived_auth_pass.result
+    })
+    destination = "/tmp/keepalived.conf"
+  }
+
+  provisioner "file" {
+    content = templatefile("./etc_keepalived_check_apiserver_sh.tpl", {
+      APISERVER_VIP = var.api_vip
+    })
+    destination = "/tmp/check_apiserver.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /etc/keepalived",
+      "sudo mv /tmp/keepalived.conf /etc/keepalived/keepalived.conf",
+      "sudo mv /tmp/check_apiserver.sh /etc/keepalived/check_apiserver.sh",
+      "sudo chmod +x /etc/keepalived/check_apiserver.sh",
+      "sudo systemctl restart keepalived",
+    ]
+  }
+}
+
+/*
+vSphere DRS requires a vSphere Enterprise Plus license. Toggle variable value off if you don't have it.
+An anti-affinity rule places a control_plane machines across different hosts within a cluster, and is useful for preventing single points of failure.
+*/
+
+resource "vsphere_compute_cluster_vm_anti_affinity_rule" "vm_anti_affinity_rule" {
+  count               = var.is_vsphere_enterprise_plus_license ? 1 : 0
+  name                = "vm-anti-affinity-rule"
+  compute_cluster_id  = data.vsphere_compute_cluster.cluster.id
+  virtual_machine_ids = vsphere_virtual_machine.control_plane.*.id
+}

--- a/examples/terraform/vsphere_centos/outputs.tf
+++ b/examples/terraform/vsphere_centos/outputs.tf
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "kubeone_api" {
+  description = "kube-apiserver LB endpoint"
+
+  value = {
+    endpoint                    = var.api_vip != "" ? var.api_vip : vsphere_virtual_machine.control_plane[0].default_ip_address
+    apiserver_alternative_names = var.apiserver_alternative_names
+  }
+}
+
+output "kubeone_hosts" {
+  description = "Control plane endpoints to SSH to"
+
+  value = {
+    control_plane = {
+      cluster_name         = var.cluster_name
+      cloud_provider       = "vsphere"
+      private_address      = []
+      hostnames            = local.hostnames
+      public_address       = vsphere_virtual_machine.control_plane.*.default_ip_address
+      ssh_agent_socket     = var.ssh_agent_socket
+      ssh_port             = var.ssh_port
+      ssh_private_key_file = var.ssh_private_key_file
+      ssh_user             = var.ssh_username
+      bastion              = var.bastion_host
+      bastion_port         = var.bastion_port
+      bastion_user         = var.bastion_username
+      ssh_hosts_keys       = var.ssh_hosts_keys
+      bastion_host_key     = var.bastion_host_key
+    }
+  }
+}
+
+output "kubeone_workers" {
+  description = "Workers definitions, that will be transformed into MachineDeployment object"
+
+  value = {
+    # following outputs will be parsed by kubeone and automatically merged into
+    # corresponding (by name) worker definition
+    "${var.cluster_name}-pool1" = {
+      replicas = var.initial_machinedeployment_replicas
+      providerSpec = {
+        annotations = {
+          "k8c.io/operating-system-profile" = var.initial_machinedeployment_operating_system_profile
+        }
+        sshPublicKeys   = [file(var.ssh_public_key_file)]
+        operatingSystem = var.worker_os
+        operatingSystemSpec = {
+          distUpgradeOnBoot = false
+        }
+        # nodeAnnotations are applied on resulting Node objects
+        # nodeAnnotations = {
+        #   "key" = "value"
+        # }
+        # machineObjectAnnotations are applied on resulting Machine objects
+        # uncomment to following to set those kubelet parameters. More into at:
+        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+        # machineObjectAnnotations = {
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/SystemReserved" = "cpu=200m,memory=200Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/KubeReserved"   = "cpu=200m,memory=300Mi"
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/EvictionHard"   = ""
+        #   "v1.kubelet-config.machine-controller.kubermatic.io/MaxPods"        = "110"
+        # }
+        cloudProviderSpec = {
+          # provider specific fields:
+          # see example under `cloudProviderSpec` section at:
+          # https://github.com/kubermatic/machine-controller/blob/main/examples/vsphere-machinedeployment.yaml
+          allowInsecure = var.allow_insecure
+          cluster       = var.compute_cluster_name
+          cpus          = var.worker_num_cpus
+          datacenter    = var.dc_name
+          # Either Datastore or DatastoreCluster have to be provided.
+          datastore        = var.datastore_name
+          datastoreCluster = var.datastore_cluster_name
+          # Optional: Resize the root disk to this size. Must be bigger than the existing size
+          # Default is to leave the disk at the same size as the template
+          diskSizeGB     = var.worker_disk
+          memoryMB       = var.worker_memory
+          templateVMName = var.template_name
+          vmNetName      = var.network_name
+          resourcePool   = var.resource_pool_name
+          folder         = var.folder_name
+        }
+      }
+    }
+  }
+}

--- a/examples/terraform/vsphere_centos/variables.tf
+++ b/examples/terraform/vsphere_centos/variables.tf
@@ -1,0 +1,239 @@
+/*
+Copyright 2019 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "cluster_name" {
+  description = "Name of the cluster"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", var.cluster_name))
+    error_message = "Value of cluster_name should be lowercase and can only contain alphanumeric characters and hyphens(-)."
+  }
+}
+
+variable "apiserver_alternative_names" {
+  description = "subject alternative names for the API Server signing cert."
+  default     = []
+  type        = list(string)
+}
+
+variable "worker_os" {
+  description = "OS to run on worker machines"
+
+  # valid choices are:
+  # * ubuntu
+  # * centos
+  # * rockylinux
+  default = "ubuntu"
+  type    = string
+}
+
+variable "ssh_public_key_file" {
+  description = "SSH public key file"
+  default     = "~/.ssh/id_rsa.pub"
+  type        = string
+}
+
+variable "ssh_port" {
+  description = "SSH port to be used to provision instances"
+  default     = 22
+  type        = number
+}
+
+variable "ssh_username" {
+  description = "SSH user, used only in output"
+  default     = "root"
+  type        = string
+}
+
+variable "ssh_private_key_file" {
+  description = "SSH private key file used to access instances"
+  default     = ""
+  type        = string
+}
+
+variable "ssh_agent_socket" {
+  description = "SSH Agent socket, default to grab from $SSH_AUTH_SOCK"
+  default     = "env:SSH_AUTH_SOCK"
+  type        = string
+}
+
+variable "bastion_host" {
+  description = "ssh jumphost (bastion) hostname"
+  default     = ""
+  type        = string
+}
+
+variable "bastion_port" {
+  description = "ssh jumphost (bastion) port"
+  type        = number
+  default     = 22
+}
+
+variable "bastion_username" {
+  description = "ssh jumphost (bastion) username"
+  default     = ""
+  type        = string
+}
+
+variable "ssh_hosts_keys" {
+  default     = null
+  description = "A list of SSH hosts public keys to verify"
+  type        = list(string)
+}
+
+variable "bastion_host_key" {
+  description = "Bastion SSH host public key"
+  default     = null
+  type        = string
+}
+
+# provider specific settings
+
+variable "allow_insecure" {
+  description = "allow insecure https connection to vCenter"
+  default     = false
+  type        = bool
+}
+
+variable "dc_name" {
+  default     = "dc-1"
+  description = "datacenter name"
+  type        = string
+}
+
+variable "datastore_name" {
+  default     = "datastore1"
+  description = "datastore name"
+  type        = string
+}
+
+variable "datastore_cluster_name" {
+  default     = ""
+  description = "datastore cluster name"
+  type        = string
+}
+
+variable "resource_pool_name" {
+  default     = ""
+  description = "cluster resource pool name"
+  type        = string
+}
+
+variable "folder_name" {
+  default     = "kubeone"
+  description = "folder name"
+  type        = string
+}
+
+variable "network_name" {
+  default     = "public"
+  description = "network name"
+  type        = string
+}
+
+variable "compute_cluster_name" {
+  default     = "cl-1"
+  description = "internal vSphere cluster name"
+  type        = string
+}
+
+variable "template_name" {
+  default     = "ubuntu-22.04"
+  description = "template name"
+  type        = string
+}
+
+variable "disk_size" {
+  default     = 50
+  description = "disk size"
+  type        = number
+}
+
+variable "control_plane_vm_count" {
+  default     = 3
+  description = "number of VMs"
+  type        = number
+}
+
+variable "control_plane_memory" {
+  default     = 2048
+  description = "memory size of each control plane node in MB"
+  type        = number
+}
+
+variable "control_plane_num_cpus" {
+  default     = 2
+  description = "number of cpus of each control plane node"
+  type        = number
+}
+
+variable "worker_memory" {
+  default     = 2048
+  description = "memory size of each worker node in MB"
+  type        = number
+}
+
+variable "worker_num_cpus" {
+  default     = 2
+  description = "number of cpus of each workers node"
+  type        = number
+}
+
+variable "worker_disk" {
+  default     = 10
+  description = "disk size of each worker node in GB"
+  type        = number
+}
+
+variable "api_vip" {
+  default     = ""
+  description = "virtual IP address for Kubernetes API"
+  type        = string
+}
+
+variable "vrrp_interface" {
+  default     = "ens192"
+  description = "network interface for API virtual IP"
+  type        = string
+}
+
+variable "vrrp_router_id" {
+  default     = 42
+  description = "vrrp router id for API virtual IP. Must be unique in used subnet"
+  type        = number
+}
+
+variable "initial_machinedeployment_replicas" {
+  description = "Number of replicas per MachineDeployment"
+  default     = 2
+  type        = number
+}
+
+variable "initial_machinedeployment_operating_system_profile" {
+  default     = ""
+  type        = string
+  description = <<EOF
+Name of operating system profile for MachineDeployments, only applicable if operating-system-manager addon is enabled.
+If not specified, the default value will be added by machine-controller addon.
+EOF
+}
+
+variable "is_vsphere_enterprise_plus_license" {
+  description = "toggle on/off based on your vsphere enterprise license"
+  type        = bool
+  default     = true
+}

--- a/examples/terraform/vsphere_centos/versions.tf
+++ b/examples/terraform/vsphere_centos/versions.tf
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The KubeOne Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "~> 2.1.1"
+    }
+  }
+}

--- a/examples/terraform/vsphere_flatcar/README.md
+++ b/examples/terraform/vsphere_flatcar/README.md
@@ -57,6 +57,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allow_insecure"></a> [allow\_insecure](#input\_allow\_insecure) | allow insecure https connection to vCenter | `bool` | `false` | no |
 | <a name="input_api_vip"></a> [api\_vip](#input\_api\_vip) | virtual IP address for Kubernetes API | `string` | `""` | no |
 | <a name="input_apiserver_alternative_names"></a> [apiserver\_alternative\_names](#input\_apiserver\_alternative\_names) | subject alternative names for the API Server signing cert. | `list(string)` | `[]` | no |
 | <a name="input_bastion_host"></a> [bastion\_host](#input\_bastion\_host) | ssh jumphost (bastion) hostname | `string` | `""` | no |

--- a/examples/terraform/vsphere_flatcar/README.md
+++ b/examples/terraform/vsphere_flatcar/README.md
@@ -1,9 +1,14 @@
-# vSphere Quickstart Terraform configs
+# vSphere Quickstart Terraform configs for Flatcar Linux
 
 The vSphere Quickstart Terraform configs can be used to create the needed
 infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
+
+These Terraform configs are supposed to be used with Flatcar Linux.
+
+We also provide Terraform configs for [Debian-based operating systems](../vsphere)
+and [CentOS-based operating systems](../vsphere_centos).
 
 ## Required environment variables
 

--- a/examples/terraform/vsphere_flatcar/README.md.in
+++ b/examples/terraform/vsphere_flatcar/README.md.in
@@ -1,9 +1,14 @@
-# vSphere Quickstart Terraform configs
+# vSphere Quickstart Terraform configs for Flatcar Linux
 
 The vSphere Quickstart Terraform configs can be used to create the needed
 infrastructure for a Kubernetes HA cluster. Check out the following
 [Creating Infrastructure guide][docs-infrastructure] to learn more about how to
 use the configs and how to provision a Kubernetes cluster using KubeOne.
+
+These Terraform configs are supposed to be used with Flatcar Linux.
+
+We also provide Terraform configs for [Debian-based operating systems](../vsphere)
+and [CentOS-based operating systems](../vsphere_centos).
 
 ## Required environment variables
 

--- a/examples/terraform/vsphere_flatcar/outputs.tf
+++ b/examples/terraform/vsphere_flatcar/outputs.tf
@@ -77,8 +77,8 @@ output "kubeone_workers" {
         cloudProviderSpec = {
           # provider specific fields:
           # see example under `cloudProviderSpec` section at:
-          # https://github.com/kubermatic/machine-controller/blob/master/examples/vsphere-machinedeployment.yaml
-          allowInsecure = false
+          # https://github.com/kubermatic/machine-controller/blob/main/examples/vsphere-machinedeployment.yaml
+          allowInsecure = var.allow_insecure
           cluster       = var.compute_cluster_name
           cpus          = var.worker_num_cpus
           datacenter    = var.dc_name

--- a/examples/terraform/vsphere_flatcar/variables.tf
+++ b/examples/terraform/vsphere_flatcar/variables.tf
@@ -87,6 +87,12 @@ variable "bastion_username" {
 
 # provider specific settings
 
+variable "allow_insecure" {
+  description = "allow insecure https connection to vCenter"
+  default     = false
+  type        = bool
+}
+
 variable "dc_name" {
   default     = "dc-1"
   description = "datacenter name"

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -430,6 +430,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.22.12
   optional: false
@@ -864,6 +887,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultInstallContainerdV1_23_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.23.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdV1_23_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -1326,6 +1372,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdV1_24_3
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.3
   optional: false
@@ -1774,6 +1843,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallDockerV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.22.12
   optional: false
@@ -2208,6 +2300,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultInstallDockerV1_23_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.23.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallDockerV1_23_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -5385,6 +5500,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosCalicoContainerdV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.22.12
   optional: false
@@ -5819,6 +5957,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultCalicoDockerV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-calico-docker-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosCalicoDockerV1_22_12
       env:
       - name: PROVIDER
         value: vsphere
@@ -6281,6 +6442,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosWeaveContainerdV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.22.12
   optional: false
@@ -6715,6 +6899,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultWeaveDockerV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-weave-docker-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosWeaveDockerV1_22_12
       env:
       - name: PROVIDER
         value: vsphere
@@ -7177,6 +7384,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosCiliumContainerdV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.22.12
   optional: false
@@ -7611,6 +7841,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultCiliumDockerV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-cilium-docker-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosCiliumDockerV1_22_12
       env:
       - name: PROVIDER
         value: vsphere
@@ -8269,6 +8522,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.22.12
   optional: false
@@ -8703,6 +8979,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.23.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_23_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -9165,6 +9464,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_3
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.3
   optional: false
@@ -9599,6 +9921,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultLegacyMachineControllerDockerV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerDockerV1_22_12
       env:
       - name: PROVIDER
         value: vsphere
@@ -10061,6 +10406,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.23.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerDockerV1_23_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.9
   optional: false
@@ -10394,6 +10762,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosCsiCcmMigrationV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.22.12
   optional: false
@@ -10704,6 +11095,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.23.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosCsiCcmMigrationV1_23_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.9
   optional: false
@@ -11000,6 +11414,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultCsiCcmMigrationV1_24_3
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosCsiCcmMigrationV1_24_3
       env:
       - name: PROVIDER
         value: vsphere
@@ -11669,6 +12106,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdExternalV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.22.12
   optional: false
@@ -12310,6 +12770,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultInstallContainerdExternalV1_23_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.23.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdExternalV1_23_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -12979,6 +13462,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdExternalV1_24_3
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.3
   optional: false
@@ -13634,6 +14140,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallDockerExternalV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.22.12
   optional: false
@@ -14275,6 +14804,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultInstallDockerExternalV1_23_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.23.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallDockerExternalV1_23_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -18919,6 +19471,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.22.12
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_12
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
@@ -19574,6 +20149,29 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.23.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
     preset-vsphere-legacy: "true"
   name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
@@ -20215,6 +20813,29 @@ presubmits:
     - command:
       - ./test/go-test-e2e.sh
       - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: kubermatic/kubeone-e2e:v0.1.25
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.3
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_3
       env:
       - name: PROVIDER
         value: vsphere

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -407,7 +407,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -855,7 +855,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -1303,7 +1303,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -1751,7 +1751,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -2199,7 +2199,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -2737,7 +2737,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -3280,7 +3280,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -3823,7 +3823,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -4366,7 +4366,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -4909,7 +4909,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -5362,7 +5362,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -5810,7 +5810,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -6258,7 +6258,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -6706,7 +6706,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -7154,7 +7154,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -7602,7 +7602,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -8246,7 +8246,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -8694,7 +8694,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -9142,7 +9142,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -9590,7 +9590,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -10038,7 +10038,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -10371,7 +10371,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -10681,7 +10681,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -10991,7 +10991,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -11646,7 +11646,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -12301,7 +12301,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -12956,7 +12956,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -13611,7 +13611,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -14266,7 +14266,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -15056,7 +15056,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -15851,7 +15851,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -16646,7 +16646,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone
@@ -17441,7 +17441,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -18236,7 +18236,7 @@ presubmits:
     repo: kubeone
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -18896,7 +18896,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.22.12
   optional: false
   path_alias: k8c.io/kubeone
@@ -19551,7 +19551,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.9
   optional: false
   path_alias: k8c.io/kubeone
@@ -20206,7 +20206,7 @@ presubmits:
   decorate: true
   labels:
     preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
+    preset-vsphere: "true"
   name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.3
   optional: false
   path_alias: k8c.io/kubeone

--- a/test/e2e/testdata/vsphere.tfvars
+++ b/test/e2e/testdata/vsphere.tfvars
@@ -6,4 +6,4 @@ network_name         = "Default Network"
 folder_name          = "kubeone-e2e"
 control_plane_memory = 4096
 worker_memory        = 4096
-disk_size            = 10
+disk_size            = 25

--- a/test/e2e/testdata/vsphere.tfvars
+++ b/test/e2e/testdata/vsphere.tfvars
@@ -1,5 +1,8 @@
-datastore_name       = "HS-FreeNAS"
-network_name         = "VM Network"
+allow_insecure       = true
+dc_name              = "Hamburg"
+datastore_name       = "alpha1"
+compute_cluster_name = "Kubermatic"
+network_name         = "Default Network"
 folder_name          = "kubeone-e2e"
 control_plane_memory = 4096
 worker_memory        = 4096

--- a/test/e2e/tests_definitions.go
+++ b/test/e2e/tests_definitions.go
@@ -985,8 +985,8 @@ var (
 		"vsphere_default": {
 			name: "vsphere_default",
 			labels: map[string]string{
-				"preset-goproxy":        "true",
-				"preset-vsphere-legacy": "true",
+				"preset-goproxy": "true",
+				"preset-vsphere": "true",
 			},
 			environ: map[string]string{
 				"PROVIDER": "vsphere",
@@ -995,7 +995,7 @@ var (
 				path:    "../../examples/terraform/vsphere",
 				varFile: "testdata/vsphere.tfvars",
 				vars: []string{
-					"template_name=kubeone-e2e-ubuntu",
+					"template_name=k1-ubuntu-jammy",
 					"worker_os=ubuntu",
 					"ssh_username=ubuntu",
 				},
@@ -1004,8 +1004,8 @@ var (
 		"vsphere_default_stable": {
 			name: "vsphere_default_stable",
 			labels: map[string]string{
-				"preset-goproxy":        "true",
-				"preset-vsphere-legacy": "true",
+				"preset-goproxy": "true",
+				"preset-vsphere": "true",
 			},
 			environ: map[string]string{
 				"PROVIDER": "vsphere",
@@ -1014,7 +1014,7 @@ var (
 				path:    "../../../kubeone-stable/examples/terraform/vsphere",
 				varFile: "testdata/vsphere.tfvars",
 				vars: []string{
-					"template_name=kubeone-e2e-ubuntu",
+					"template_name=k1-ubuntu-jammy",
 					"worker_os=ubuntu",
 					"ssh_username=ubuntu",
 				},

--- a/test/e2e/tests_definitions.go
+++ b/test/e2e/tests_definitions.go
@@ -1020,6 +1020,25 @@ var (
 				},
 			},
 		},
+		"vsphere_centos": {
+			name: "vsphere_centos",
+			labels: map[string]string{
+				"preset-goproxy": "true",
+				"preset-vsphere": "true",
+			},
+			environ: map[string]string{
+				"PROVIDER": "vsphere",
+			},
+			terraform: terraformBin{
+				path:    "../../examples/terraform/vsphere_centos",
+				varFile: "testdata/vsphere.tfvars",
+				vars: []string{
+					"template_name=k1-centos-7",
+					"worker_os=centos",
+					"ssh_username=centos",
+				},
+			},
+		},
 		"vsphere_flatcar": {
 			name: "vsphere_flatcar",
 			labels: map[string]string{

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -172,6 +172,15 @@ func TestVsphereDefaultInstallContainerdV1_22_12(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosInstallContainerdV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarInstallContainerdV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -337,6 +346,15 @@ func TestOpenstackFlatcarInstallContainerdV1_23_9(t *testing.T) {
 func TestVsphereDefaultInstallContainerdV1_23_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.23.9")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosInstallContainerdV1_23_9(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.9")
@@ -514,6 +532,15 @@ func TestVsphereDefaultInstallContainerdV1_24_3(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosInstallContainerdV1_24_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.24.3")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarInstallContainerdV1_24_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -685,6 +712,15 @@ func TestVsphereDefaultInstallDockerV1_22_12(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosInstallDockerV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["install_docker"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarInstallDockerV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -850,6 +886,15 @@ func TestOpenstackFlatcarInstallDockerV1_23_9(t *testing.T) {
 func TestVsphereDefaultInstallDockerV1_23_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["install_docker"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.23.9")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosInstallDockerV1_23_9(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.9")
@@ -1882,6 +1927,15 @@ func TestVsphereDefaultCalicoContainerdV1_22_12(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosCalicoContainerdV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["calico_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarCalicoContainerdV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -2047,6 +2101,15 @@ func TestOpenstackFlatcarCalicoDockerV1_22_12(t *testing.T) {
 func TestVsphereDefaultCalicoDockerV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["calico_docker"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosCalicoDockerV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.12")
@@ -2224,6 +2287,15 @@ func TestVsphereDefaultWeaveContainerdV1_22_12(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosWeaveContainerdV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["weave_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarWeaveContainerdV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -2389,6 +2461,15 @@ func TestOpenstackFlatcarWeaveDockerV1_22_12(t *testing.T) {
 func TestVsphereDefaultWeaveDockerV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["weave_docker"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosWeaveDockerV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.12")
@@ -2566,6 +2647,15 @@ func TestVsphereDefaultCiliumContainerdV1_22_12(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosCiliumContainerdV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["cilium_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarCiliumContainerdV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -2731,6 +2821,15 @@ func TestOpenstackFlatcarCiliumDockerV1_22_12(t *testing.T) {
 func TestVsphereDefaultCiliumDockerV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["cilium_docker"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosCiliumDockerV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.12")
@@ -2980,6 +3079,15 @@ func TestVsphereDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -3145,6 +3253,15 @@ func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_9(t *testing.T) 
 func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.23.9")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.9")
@@ -3322,6 +3439,15 @@ func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.24.3")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -3487,6 +3613,15 @@ func TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_12(t *testing.T) {
 func TestVsphereDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["legacy_machine_controller_docker"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.22.12")
@@ -3664,6 +3799,15 @@ func TestVsphereDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["legacy_machine_controller_docker"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.23.9")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -3790,6 +3934,15 @@ func TestVsphereDefaultCsiCcmMigrationV1_22_12(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosCsiCcmMigrationV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarCsiCcmMigrationV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -3907,6 +4060,15 @@ func TestVsphereDefaultCsiCcmMigrationV1_23_9(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosCsiCcmMigrationV1_23_9(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.23.9")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarCsiCcmMigrationV1_23_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -4018,6 +4180,15 @@ func TestAzureRockylinuxCsiCcmMigrationV1_24_3(t *testing.T) {
 func TestVsphereDefaultCsiCcmMigrationV1_24_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.24.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosCsiCcmMigrationV1_24_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.3")
@@ -4276,6 +4447,15 @@ func TestVsphereDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -4522,6 +4702,15 @@ func TestOpenstackFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
 func TestVsphereDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.23.9")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.9")
@@ -4780,6 +4969,15 @@ func TestVsphereDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.24.3")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -5032,6 +5230,15 @@ func TestVsphereDefaultInstallDockerExternalV1_22_12(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosInstallDockerExternalV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["install_docker_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -5278,6 +5485,15 @@ func TestOpenstackFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
 func TestVsphereDefaultInstallDockerExternalV1_23_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["install_docker_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.23.9")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosInstallDockerExternalV1_23_9(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.9")
@@ -6796,6 +7012,15 @@ func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *test
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.22.12")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -7048,6 +7273,15 @@ func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testi
 	scenario.Run(ctx, t)
 }
 
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.23.9")
+	scenario.Run(ctx, t)
+}
+
 func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
@@ -7294,6 +7528,15 @@ func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *tes
 func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.24.3")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.24.3")

--- a/test/go-test-e2e.sh
+++ b/test/go-test-e2e.sh
@@ -130,11 +130,10 @@ EOL
     echo "${OS_K1_CREDENTIALS}" > "${CREDENTIALS_FILE_PATH}"
     ;;
   "vsphere")
+    export VSPHERE_ALLOW_UNVERIFIED_SSL=true
     export VSPHERE_SERVER="${VSPHERE_E2E_ADDRESS/http*:\/\//}"
     export VSPHERE_USER=${VSPHERE_E2E_USERNAME}
     export VSPHERE_PASSWORD=${VSPHERE_E2E_PASSWORD}
-    export TF_VAR_bastion_host=${VSPHERE_E2E_TEST_SSH_JUMPHOST}
-    export TF_VAR_bastion_username=${VSPHERE_E2E_TEST_SSH_USERNAME}
     CREDENTIALS_FILE_PATH="${BUILD_DIR}/credentials.yaml"
 
     cat > "${CREDENTIALS_FILE_PATH}" << EOL
@@ -143,28 +142,39 @@ cloudConfig: |
   secret-name = "vsphere-ccm-credentials"
   secret-namespace = "kube-system"
   port = "443"
-  insecure-flag = "0"
+  insecure-flag = "1"
 
   [VirtualCenter "${VSPHERE_SERVER}"]
 
   [Workspace]
   server = "${VSPHERE_SERVER}"
-  datacenter = "dc-1"
-  default-datastore = "HS-FreeNAS"
-  resourcepool-path = ""
+  datacenter = "Hamburg"
+  default-datastore="alpha1"
+  resourcepool-path=""
   folder = "kubeone-e2e"
 
   [Disk]
   scsicontrollertype = pvscsi
 
   [Network]
-  public-network = "VM Network"
+  public-network = "Default Network"
+csiConfig: |
+  [Global]
+  cluster-id = "k1-${BUILD_ID}"
+  user = "${VSPHERE_USER}"
+  password = "${VSPHERE_PASSWORD}"
+  port = "443"
+  insecure-flag = "1"
+  
+  [VirtualCenter "${VSPHERE_SERVER}"]
+  
+  [Workspace]
+  server = "${VSPHERE_SERVER}"
+  datacenter = "Hamburg"
+  default-datastore="alpha1"
+  resourcepool-path=""
+  folder = "kubeone-e2e"
 EOL
-
-    bastion_key="${BUILD_DIR}/bastion_key"
-    echo "${VSPHERE_E2E_TEST_SSH_PRIVATE_KEY}" > "$bastion_key"
-    chmod 600 "${bastion_key}"
-    ssh-add "${bastion_key}"
     ;;
   *)
     echo "unknown provider ${PROVIDER}"

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -20,6 +20,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: install_containerd
@@ -44,6 +45,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: install_containerd
@@ -68,6 +70,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: install_docker
@@ -91,6 +94,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: install_docker
@@ -114,6 +118,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd
@@ -257,6 +262,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: calico_docker
@@ -280,6 +286,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: weave_containerd
@@ -303,6 +310,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: weave_docker
@@ -326,6 +334,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: cilium_containerd
@@ -349,6 +358,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: cilium_docker
@@ -372,6 +382,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: conformance_containerd
@@ -435,6 +446,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
@@ -458,6 +470,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
@@ -481,6 +494,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
@@ -504,6 +518,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
@@ -527,6 +542,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: kube_proxy_ipvs
@@ -549,6 +565,7 @@
     - name: azure_rhel
     - name: azure_rockylinux
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
@@ -566,6 +583,7 @@
     - name: azure_rhel
     - name: azure_rockylinux
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
@@ -583,6 +601,7 @@
     - name: azure_rhel
     - name: azure_rockylinux
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
@@ -615,6 +634,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
@@ -647,6 +667,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
@@ -679,6 +700,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
@@ -711,6 +733,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
@@ -743,6 +766,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd_external
@@ -940,6 +964,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
@@ -972,6 +997,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
@@ -1004,6 +1030,7 @@
     - name: openstack_rhel
     - name: openstack_flatcar
     - name: vsphere_default
+    - name: vsphere_centos
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker_external


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a manual cherry-pick of #2432 to the `release/v1.5` branch.

**What type of PR is this?**

/kind feature
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add `allow_insecure` variable (default `false`) to Terraform configs for vSphere. The value of this variable is propagated to the MachineDeployment template in `output.tf`
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/1237
```