### PR TITLE
Update Golang to 1.19.3 (part 1)

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-3
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
           command:
             - /bin/bash
             - -c
@@ -44,7 +44,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-3
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
           command:
             - /bin/bash
             - -c

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.2
+        - image: golang:1.19.3
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.2
+        - image: golang:1.19.3
           command:
             - make
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-3
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.2
+        - image: golang:1.19.3
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.2
+        - image: golang:1.19.3
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-3
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
           command:
             - /bin/bash
             - -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.19.2 as builder
+FROM docker.io/golang:1.19.3 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,7 +14,7 @@
 
 # building image
 
-FROM golang:1.19.2 as builder
+FROM golang:1.19.3 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip
@@ -35,7 +35,7 @@ RUN chmod +x kubectl
 
 # resulting image
 
-FROM golang:1.19.2
+FROM golang:1.19.3
 
 ARG version
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the first part of updating Golang to 1.19.3. It includes:

* Updating the `kubeone-e2e` image
* Updating all the jobs that use `quay.io/kubermatic/build` to `go-1.19-node-18-kind-0.17-4`
* Updating all the jobs that use the `golang` image to `1.19.3`
* Updating Dockerfile to 1.19.3

**What type of PR is this?**

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
KubeOne is now built using Go 1.19.3
```

**Documentation**:
```documentation
NONE
```