### PR TITLE
[release/v1.5] Update Golang to 1.19.3

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
           command:
             - /bin/bash
             - -c
@@ -44,7 +44,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
           command:
             - /bin/bash
             - -c
@@ -68,7 +68,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: kubermatic/kubeone-e2e:v0.1.25
+        - image: kubermatic/kubeone-e2e:v0.1.26
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -87,7 +87,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: kubermatic/kubeone-e2e:v0.1.25
+        - image: kubermatic/kubeone-e2e:v0.1.26
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.0
+        - image: golang:1.19.3
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.0
+        - image: golang:1.19.3
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.0
+        - image: golang:1.19.3
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.0
+        - image: golang:1.19.3
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
           command:
             - /bin/bash
             - -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.19.0 as builder
+FROM docker.io/golang:1.19.3 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "kubermatic/kubeone-e2e:v0.1.25"
+	prowImage             = "kubermatic/kubeone-e2e:v0.1.26"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -63,7 +63,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -86,7 +86,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -109,7 +109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -132,7 +132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -157,7 +157,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -182,7 +182,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -207,7 +207,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -233,7 +233,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -258,7 +258,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -281,7 +281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -304,7 +304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -327,7 +327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -350,7 +350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -373,7 +373,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -396,7 +396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -419,7 +419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -442,7 +442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -465,7 +465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -488,7 +488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -511,7 +511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -534,7 +534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -557,7 +557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -580,7 +580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -603,7 +603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -628,7 +628,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -653,7 +653,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -678,7 +678,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -704,7 +704,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -729,7 +729,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -752,7 +752,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -775,7 +775,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -798,7 +798,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -821,7 +821,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -844,7 +844,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -867,7 +867,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -890,7 +890,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -913,7 +913,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -936,7 +936,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -959,7 +959,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -982,7 +982,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1005,7 +1005,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1028,7 +1028,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1051,7 +1051,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1074,7 +1074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1099,7 +1099,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1124,7 +1124,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1149,7 +1149,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1175,7 +1175,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1200,7 +1200,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1223,7 +1223,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1246,7 +1246,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1269,7 +1269,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1292,7 +1292,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1315,7 +1315,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1338,7 +1338,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1361,7 +1361,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1384,7 +1384,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1407,7 +1407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1430,7 +1430,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1453,7 +1453,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1476,7 +1476,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1499,7 +1499,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1522,7 +1522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1545,7 +1545,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1570,7 +1570,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1595,7 +1595,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1620,7 +1620,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1646,7 +1646,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1671,7 +1671,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1694,7 +1694,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1717,7 +1717,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1740,7 +1740,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1763,7 +1763,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1786,7 +1786,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1809,7 +1809,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1832,7 +1832,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1855,7 +1855,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1878,7 +1878,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1901,7 +1901,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1924,7 +1924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1947,7 +1947,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1970,7 +1970,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1993,7 +1993,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2016,7 +2016,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2041,7 +2041,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2066,7 +2066,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2091,7 +2091,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2117,7 +2117,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2142,7 +2142,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2165,7 +2165,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2188,7 +2188,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2211,7 +2211,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2234,7 +2234,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2257,7 +2257,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2280,7 +2280,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2303,7 +2303,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2326,7 +2326,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2349,7 +2349,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2377,7 +2377,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2405,7 +2405,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2433,7 +2433,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2461,7 +2461,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2489,7 +2489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2517,7 +2517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2547,7 +2547,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2577,7 +2577,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2607,7 +2607,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2638,7 +2638,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2668,7 +2668,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2696,7 +2696,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2724,7 +2724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2752,7 +2752,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2780,7 +2780,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2808,7 +2808,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2836,7 +2836,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2864,7 +2864,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2892,7 +2892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2920,7 +2920,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2948,7 +2948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2976,7 +2976,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3004,7 +3004,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3032,7 +3032,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3060,7 +3060,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3090,7 +3090,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3120,7 +3120,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3150,7 +3150,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3181,7 +3181,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3211,7 +3211,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3239,7 +3239,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3267,7 +3267,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3295,7 +3295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3323,7 +3323,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3351,7 +3351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3379,7 +3379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3407,7 +3407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3435,7 +3435,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3463,7 +3463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3491,7 +3491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3519,7 +3519,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3547,7 +3547,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3575,7 +3575,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3603,7 +3603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3633,7 +3633,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3663,7 +3663,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3693,7 +3693,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3724,7 +3724,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3754,7 +3754,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3782,7 +3782,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3810,7 +3810,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3838,7 +3838,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3866,7 +3866,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3894,7 +3894,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3922,7 +3922,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3950,7 +3950,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3978,7 +3978,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4006,7 +4006,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4034,7 +4034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4062,7 +4062,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4090,7 +4090,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4118,7 +4118,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4146,7 +4146,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4176,7 +4176,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4206,7 +4206,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4236,7 +4236,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4267,7 +4267,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4297,7 +4297,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4325,7 +4325,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4353,7 +4353,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4381,7 +4381,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4409,7 +4409,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4437,7 +4437,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4465,7 +4465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4493,7 +4493,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4521,7 +4521,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4549,7 +4549,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4577,7 +4577,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4605,7 +4605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4633,7 +4633,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4661,7 +4661,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4689,7 +4689,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4719,7 +4719,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4749,7 +4749,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4779,7 +4779,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4810,7 +4810,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4840,7 +4840,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4868,7 +4868,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4896,7 +4896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4924,7 +4924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4952,7 +4952,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4980,7 +4980,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5008,7 +5008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5036,7 +5036,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5064,7 +5064,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5087,7 +5087,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5110,7 +5110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5133,7 +5133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5156,7 +5156,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5179,7 +5179,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5202,7 +5202,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5227,7 +5227,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5252,7 +5252,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5277,7 +5277,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5303,7 +5303,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5328,7 +5328,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5351,7 +5351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5374,7 +5374,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5397,7 +5397,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5420,7 +5420,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5443,7 +5443,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5466,7 +5466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5489,7 +5489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5512,7 +5512,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5535,7 +5535,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5558,7 +5558,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5581,7 +5581,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5604,7 +5604,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5627,7 +5627,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5650,7 +5650,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5673,7 +5673,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5698,7 +5698,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5723,7 +5723,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5748,7 +5748,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5774,7 +5774,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5799,7 +5799,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5822,7 +5822,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5845,7 +5845,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5868,7 +5868,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5891,7 +5891,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5914,7 +5914,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5937,7 +5937,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5960,7 +5960,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5983,7 +5983,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6006,7 +6006,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6029,7 +6029,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6052,7 +6052,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6075,7 +6075,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6098,7 +6098,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6121,7 +6121,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6144,7 +6144,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6169,7 +6169,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6194,7 +6194,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6219,7 +6219,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6245,7 +6245,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6270,7 +6270,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6293,7 +6293,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6316,7 +6316,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6339,7 +6339,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6362,7 +6362,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6385,7 +6385,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6408,7 +6408,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6431,7 +6431,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6454,7 +6454,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6477,7 +6477,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6500,7 +6500,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6523,7 +6523,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6546,7 +6546,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6569,7 +6569,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6592,7 +6592,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6615,7 +6615,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6640,7 +6640,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6665,7 +6665,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6690,7 +6690,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6716,7 +6716,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6741,7 +6741,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6764,7 +6764,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6787,7 +6787,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6810,7 +6810,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6833,7 +6833,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6856,7 +6856,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6879,7 +6879,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6902,7 +6902,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6925,7 +6925,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6948,7 +6948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6971,7 +6971,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6994,7 +6994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7017,7 +7017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7040,7 +7040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7063,7 +7063,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7086,7 +7086,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7111,7 +7111,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7136,7 +7136,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7161,7 +7161,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7187,7 +7187,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7212,7 +7212,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7235,7 +7235,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7258,7 +7258,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7281,7 +7281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7304,7 +7304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7327,7 +7327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7350,7 +7350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7373,7 +7373,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7396,7 +7396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7419,7 +7419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7442,7 +7442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7465,7 +7465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7488,7 +7488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7511,7 +7511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7534,7 +7534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7557,7 +7557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7582,7 +7582,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7607,7 +7607,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7632,7 +7632,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7658,7 +7658,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7683,7 +7683,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7706,7 +7706,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7729,7 +7729,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7752,7 +7752,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7775,7 +7775,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7798,7 +7798,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7821,7 +7821,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7844,7 +7844,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7867,7 +7867,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7890,7 +7890,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7915,7 +7915,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7940,7 +7940,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7965,7 +7965,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7990,7 +7990,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8015,7 +8015,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8040,7 +8040,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8063,7 +8063,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8086,7 +8086,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8109,7 +8109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8132,7 +8132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8155,7 +8155,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8178,7 +8178,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8201,7 +8201,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8224,7 +8224,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8249,7 +8249,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8274,7 +8274,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8299,7 +8299,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8325,7 +8325,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8350,7 +8350,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8373,7 +8373,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8396,7 +8396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8419,7 +8419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8442,7 +8442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8465,7 +8465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8488,7 +8488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8511,7 +8511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8534,7 +8534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8557,7 +8557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8580,7 +8580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8603,7 +8603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8626,7 +8626,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8649,7 +8649,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8672,7 +8672,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8695,7 +8695,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8720,7 +8720,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8745,7 +8745,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8770,7 +8770,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8796,7 +8796,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8821,7 +8821,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8844,7 +8844,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8867,7 +8867,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8890,7 +8890,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8913,7 +8913,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8936,7 +8936,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8959,7 +8959,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8982,7 +8982,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9005,7 +9005,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9028,7 +9028,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9051,7 +9051,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9074,7 +9074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9097,7 +9097,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9120,7 +9120,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9143,7 +9143,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9166,7 +9166,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9191,7 +9191,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9216,7 +9216,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9241,7 +9241,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9267,7 +9267,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9292,7 +9292,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9315,7 +9315,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9338,7 +9338,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9361,7 +9361,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9384,7 +9384,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9407,7 +9407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9430,7 +9430,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9453,7 +9453,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9476,7 +9476,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9499,7 +9499,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9522,7 +9522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9545,7 +9545,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9568,7 +9568,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9591,7 +9591,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9614,7 +9614,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9637,7 +9637,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9662,7 +9662,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9687,7 +9687,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9712,7 +9712,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9738,7 +9738,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9763,7 +9763,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9786,7 +9786,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9809,7 +9809,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9832,7 +9832,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9855,7 +9855,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9878,7 +9878,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9901,7 +9901,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9924,7 +9924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9947,7 +9947,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9970,7 +9970,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9993,7 +9993,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10016,7 +10016,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10039,7 +10039,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10062,7 +10062,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10085,7 +10085,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10108,7 +10108,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10133,7 +10133,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10158,7 +10158,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10183,7 +10183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10209,7 +10209,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10234,7 +10234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10257,7 +10257,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10280,7 +10280,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10303,7 +10303,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10326,7 +10326,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10349,7 +10349,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10372,7 +10372,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10395,7 +10395,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10418,7 +10418,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10441,7 +10441,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10464,7 +10464,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10487,7 +10487,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10510,7 +10510,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10533,7 +10533,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10556,7 +10556,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10579,7 +10579,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10602,7 +10602,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10627,7 +10627,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10652,7 +10652,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10677,7 +10677,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10703,7 +10703,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10728,7 +10728,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10751,7 +10751,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10774,7 +10774,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10797,7 +10797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10820,7 +10820,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10843,7 +10843,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10866,7 +10866,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10889,7 +10889,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10912,7 +10912,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10935,7 +10935,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10960,7 +10960,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10985,7 +10985,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11010,7 +11010,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11036,7 +11036,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11061,7 +11061,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11084,7 +11084,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11107,7 +11107,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11130,7 +11130,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11153,7 +11153,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11176,7 +11176,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11199,7 +11199,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11222,7 +11222,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11245,7 +11245,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11268,7 +11268,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11293,7 +11293,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11318,7 +11318,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11343,7 +11343,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11369,7 +11369,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11394,7 +11394,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11417,7 +11417,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11440,7 +11440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11463,7 +11463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11486,7 +11486,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11509,7 +11509,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11532,7 +11532,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11555,7 +11555,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11578,7 +11578,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11601,7 +11601,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11626,7 +11626,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11651,7 +11651,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11676,7 +11676,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11702,7 +11702,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11727,7 +11727,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11750,7 +11750,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11773,7 +11773,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11796,7 +11796,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11819,7 +11819,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11842,7 +11842,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11865,7 +11865,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11888,7 +11888,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11911,7 +11911,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11934,7 +11934,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11957,7 +11957,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11980,7 +11980,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12003,7 +12003,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12026,7 +12026,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12049,7 +12049,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12072,7 +12072,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12095,7 +12095,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12118,7 +12118,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12141,7 +12141,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12164,7 +12164,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12187,7 +12187,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12210,7 +12210,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12233,7 +12233,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12256,7 +12256,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12279,7 +12279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12304,7 +12304,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12329,7 +12329,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12354,7 +12354,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12380,7 +12380,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12405,7 +12405,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12428,7 +12428,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12451,7 +12451,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12474,7 +12474,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12497,7 +12497,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12520,7 +12520,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12543,7 +12543,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12566,7 +12566,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12589,7 +12589,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12612,7 +12612,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12635,7 +12635,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12658,7 +12658,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12681,7 +12681,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12704,7 +12704,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12727,7 +12727,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12750,7 +12750,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12773,7 +12773,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12796,7 +12796,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12819,7 +12819,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12842,7 +12842,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12865,7 +12865,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12888,7 +12888,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12911,7 +12911,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12934,7 +12934,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12957,7 +12957,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12982,7 +12982,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13007,7 +13007,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13032,7 +13032,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13058,7 +13058,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13083,7 +13083,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13106,7 +13106,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13129,7 +13129,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13152,7 +13152,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13175,7 +13175,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13198,7 +13198,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13221,7 +13221,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13244,7 +13244,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13267,7 +13267,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13290,7 +13290,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13313,7 +13313,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13336,7 +13336,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13359,7 +13359,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13382,7 +13382,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13405,7 +13405,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13428,7 +13428,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13451,7 +13451,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13474,7 +13474,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13497,7 +13497,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13520,7 +13520,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13543,7 +13543,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13566,7 +13566,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13589,7 +13589,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13612,7 +13612,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13635,7 +13635,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13660,7 +13660,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13685,7 +13685,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13710,7 +13710,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13736,7 +13736,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13761,7 +13761,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13784,7 +13784,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13807,7 +13807,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13830,7 +13830,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13853,7 +13853,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13876,7 +13876,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13899,7 +13899,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13922,7 +13922,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13945,7 +13945,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13968,7 +13968,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13991,7 +13991,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14014,7 +14014,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14037,7 +14037,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14060,7 +14060,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14083,7 +14083,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14106,7 +14106,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14129,7 +14129,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14152,7 +14152,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14175,7 +14175,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14198,7 +14198,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14221,7 +14221,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14244,7 +14244,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14267,7 +14267,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14290,7 +14290,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14313,7 +14313,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14338,7 +14338,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14363,7 +14363,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14388,7 +14388,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14414,7 +14414,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14439,7 +14439,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14462,7 +14462,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14485,7 +14485,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14508,7 +14508,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14531,7 +14531,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14554,7 +14554,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14577,7 +14577,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14600,7 +14600,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14623,7 +14623,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14646,7 +14646,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14669,7 +14669,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14692,7 +14692,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14715,7 +14715,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14738,7 +14738,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14761,7 +14761,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14784,7 +14784,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14807,7 +14807,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14830,7 +14830,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14853,7 +14853,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14881,7 +14881,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14909,7 +14909,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14937,7 +14937,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14965,7 +14965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14993,7 +14993,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15021,7 +15021,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15051,7 +15051,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15081,7 +15081,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15111,7 +15111,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15142,7 +15142,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15172,7 +15172,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15200,7 +15200,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15228,7 +15228,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15256,7 +15256,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15284,7 +15284,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15312,7 +15312,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15340,7 +15340,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15368,7 +15368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15396,7 +15396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15424,7 +15424,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15452,7 +15452,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15480,7 +15480,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15508,7 +15508,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15536,7 +15536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15564,7 +15564,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15592,7 +15592,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15620,7 +15620,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15648,7 +15648,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15676,7 +15676,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15704,7 +15704,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15732,7 +15732,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15760,7 +15760,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15788,7 +15788,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15816,7 +15816,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15846,7 +15846,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15876,7 +15876,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15906,7 +15906,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15937,7 +15937,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15967,7 +15967,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15995,7 +15995,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16023,7 +16023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16051,7 +16051,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16079,7 +16079,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16107,7 +16107,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16135,7 +16135,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16163,7 +16163,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16191,7 +16191,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16219,7 +16219,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16247,7 +16247,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16275,7 +16275,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16303,7 +16303,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16331,7 +16331,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16359,7 +16359,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16387,7 +16387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16415,7 +16415,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16443,7 +16443,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16471,7 +16471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16499,7 +16499,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16527,7 +16527,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16555,7 +16555,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16583,7 +16583,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16611,7 +16611,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16641,7 +16641,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16671,7 +16671,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16701,7 +16701,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16732,7 +16732,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16762,7 +16762,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16790,7 +16790,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16818,7 +16818,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16846,7 +16846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16874,7 +16874,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16902,7 +16902,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16930,7 +16930,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16958,7 +16958,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16986,7 +16986,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17014,7 +17014,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17042,7 +17042,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17070,7 +17070,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17098,7 +17098,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17126,7 +17126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17154,7 +17154,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17182,7 +17182,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17210,7 +17210,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17238,7 +17238,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17266,7 +17266,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17294,7 +17294,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17322,7 +17322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17350,7 +17350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17378,7 +17378,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17406,7 +17406,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17436,7 +17436,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17466,7 +17466,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17496,7 +17496,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17527,7 +17527,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17557,7 +17557,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17585,7 +17585,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17613,7 +17613,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17641,7 +17641,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17669,7 +17669,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17697,7 +17697,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17725,7 +17725,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17753,7 +17753,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17781,7 +17781,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17809,7 +17809,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17837,7 +17837,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17865,7 +17865,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17893,7 +17893,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17921,7 +17921,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17949,7 +17949,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17977,7 +17977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18005,7 +18005,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18033,7 +18033,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18061,7 +18061,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18089,7 +18089,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18117,7 +18117,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18145,7 +18145,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18173,7 +18173,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18201,7 +18201,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18231,7 +18231,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18261,7 +18261,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18291,7 +18291,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18322,7 +18322,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18352,7 +18352,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18380,7 +18380,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18408,7 +18408,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18436,7 +18436,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18464,7 +18464,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18492,7 +18492,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18520,7 +18520,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18548,7 +18548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18576,7 +18576,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18604,7 +18604,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18632,7 +18632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18660,7 +18660,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18688,7 +18688,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18716,7 +18716,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18744,7 +18744,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18772,7 +18772,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18800,7 +18800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18828,7 +18828,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18851,7 +18851,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18874,7 +18874,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18897,7 +18897,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18920,7 +18920,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18943,7 +18943,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18966,7 +18966,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18991,7 +18991,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19016,7 +19016,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19041,7 +19041,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19067,7 +19067,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19092,7 +19092,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19115,7 +19115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19138,7 +19138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19161,7 +19161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19184,7 +19184,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19207,7 +19207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19230,7 +19230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19253,7 +19253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19276,7 +19276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19299,7 +19299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19322,7 +19322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19345,7 +19345,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19368,7 +19368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19391,7 +19391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19414,7 +19414,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19437,7 +19437,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19460,7 +19460,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19483,7 +19483,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19506,7 +19506,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19529,7 +19529,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19552,7 +19552,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19575,7 +19575,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19598,7 +19598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19621,7 +19621,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19644,7 +19644,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19669,7 +19669,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19694,7 +19694,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19719,7 +19719,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19745,7 +19745,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19770,7 +19770,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19793,7 +19793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19816,7 +19816,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19839,7 +19839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19862,7 +19862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19885,7 +19885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19908,7 +19908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19931,7 +19931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19954,7 +19954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19977,7 +19977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20000,7 +20000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20023,7 +20023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20046,7 +20046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20069,7 +20069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20092,7 +20092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20115,7 +20115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20138,7 +20138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20161,7 +20161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20184,7 +20184,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20207,7 +20207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20230,7 +20230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20253,7 +20253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20276,7 +20276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20299,7 +20299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20322,7 +20322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20347,7 +20347,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20372,7 +20372,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20397,7 +20397,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20423,7 +20423,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20448,7 +20448,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20471,7 +20471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20494,7 +20494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20517,7 +20517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20540,7 +20540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20563,7 +20563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20586,7 +20586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20609,7 +20609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20632,7 +20632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20655,7 +20655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20678,7 +20678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20701,7 +20701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20724,7 +20724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20747,7 +20747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20770,7 +20770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20793,7 +20793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20816,7 +20816,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20839,7 +20839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20862,7 +20862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20885,7 +20885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20908,7 +20908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20931,7 +20931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20954,7 +20954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20977,7 +20977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21000,7 +21000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21023,7 +21023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21046,7 +21046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21069,7 +21069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21092,7 +21092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21115,7 +21115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21138,7 +21138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21161,7 +21161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21184,7 +21184,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21207,7 +21207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21230,7 +21230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21253,7 +21253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21276,7 +21276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21299,7 +21299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21322,7 +21322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.25
+      image: kubermatic/kubeone-e2e:v0.1.26
       imagePullPolicy: Always
       name: ""
       resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates Go to 1.19.3 on the `release/v1.5` branch. It includes:

* Updating all the jobs that use the `kubeone-e2e` image to `v0.1.26`
* Updating all the jobs that use `quay.io/kubermatic/build` to `go-1.19-node-18-kind-0.17-4`
* Updating all the jobs that use the `golang` image to `1.19.3`
* Updating Dockerfile to 1.19.3

**What type of PR is this?**

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
KubeOne is now built using Go 1.19.3
```

**Documentation**:
```documentation
NONE
```