### PR TITLE
Move the kubeone-e2e image to Quay

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     branches:
       - ^main$
     labels:
-      preset-docker-push: "true"
+      preset-docker-push-kubermatic: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
@@ -19,7 +19,7 @@ postsubmits:
             - |
               set -euo pipefail
               start-docker.sh
-              docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+              docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
               cd ./hack/images/kubeone-e2e
               ./release.sh
           # docker-in-docker needs privileged mode

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -68,7 +68,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: kubermatic/kubeone-e2e:v0.1.26
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -87,7 +87,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: kubermatic/kubeone-e2e:v0.1.26
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.26
+TAG=v0.1.27
 
-docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
-docker push kubermatic/kubeone-e2e:${TAG}
+docker build --build-arg version=${TAG} --pull -t quay.io/kubermatic/kubeone-e2e:${TAG} .
+docker push quay.io/kubermatic/kubeone-e2e:${TAG}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "kubermatic/kubeone-e2e:v0.1.26"
+	prowImage             = "quay.io/kubermatic/kubeone-e2e:v0.1.27"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -63,7 +63,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -86,7 +86,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -109,7 +109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -132,7 +132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -157,7 +157,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -182,7 +182,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -207,7 +207,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -233,7 +233,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -258,7 +258,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -281,7 +281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -304,7 +304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -327,7 +327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -350,7 +350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -373,7 +373,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -396,7 +396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -419,7 +419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -442,7 +442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -465,7 +465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -488,7 +488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -511,7 +511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -534,7 +534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -557,7 +557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -580,7 +580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -603,7 +603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -628,7 +628,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -653,7 +653,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -678,7 +678,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -704,7 +704,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -729,7 +729,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -752,7 +752,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -775,7 +775,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -798,7 +798,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -821,7 +821,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -844,7 +844,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -867,7 +867,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -890,7 +890,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -913,7 +913,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -936,7 +936,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -959,7 +959,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -982,7 +982,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1005,7 +1005,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1028,7 +1028,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1051,7 +1051,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1074,7 +1074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1099,7 +1099,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1124,7 +1124,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1149,7 +1149,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1175,7 +1175,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1200,7 +1200,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1223,7 +1223,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1246,7 +1246,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1269,7 +1269,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1292,7 +1292,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1315,7 +1315,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1338,7 +1338,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1361,7 +1361,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1384,7 +1384,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1407,7 +1407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1430,7 +1430,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1453,7 +1453,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1476,7 +1476,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1499,7 +1499,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1522,7 +1522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1545,7 +1545,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1570,7 +1570,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1595,7 +1595,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1620,7 +1620,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1646,7 +1646,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1671,7 +1671,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1694,7 +1694,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1717,7 +1717,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1740,7 +1740,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1763,7 +1763,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1786,7 +1786,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1809,7 +1809,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1832,7 +1832,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1855,7 +1855,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1878,7 +1878,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1901,7 +1901,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1924,7 +1924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1947,7 +1947,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1970,7 +1970,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1993,7 +1993,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2016,7 +2016,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2041,7 +2041,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2066,7 +2066,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2091,7 +2091,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2117,7 +2117,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2142,7 +2142,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2165,7 +2165,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2188,7 +2188,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2211,7 +2211,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2234,7 +2234,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2257,7 +2257,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2280,7 +2280,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2303,7 +2303,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2326,7 +2326,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2349,7 +2349,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2372,7 +2372,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2395,7 +2395,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2418,7 +2418,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2441,7 +2441,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2464,7 +2464,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2487,7 +2487,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2512,7 +2512,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2537,7 +2537,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2562,7 +2562,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2588,7 +2588,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2613,7 +2613,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2636,7 +2636,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2659,7 +2659,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2682,7 +2682,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2705,7 +2705,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2728,7 +2728,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2751,7 +2751,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2774,7 +2774,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2797,7 +2797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2820,7 +2820,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2848,7 +2848,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2876,7 +2876,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2904,7 +2904,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2932,7 +2932,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2960,7 +2960,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2988,7 +2988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3018,7 +3018,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3048,7 +3048,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3078,7 +3078,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3109,7 +3109,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3139,7 +3139,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3167,7 +3167,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3195,7 +3195,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3223,7 +3223,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3251,7 +3251,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3279,7 +3279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3307,7 +3307,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3335,7 +3335,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3363,7 +3363,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3391,7 +3391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3419,7 +3419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3447,7 +3447,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3475,7 +3475,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3503,7 +3503,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3531,7 +3531,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3559,7 +3559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3589,7 +3589,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3619,7 +3619,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3649,7 +3649,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3680,7 +3680,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3710,7 +3710,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3738,7 +3738,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3766,7 +3766,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3794,7 +3794,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3822,7 +3822,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3850,7 +3850,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3878,7 +3878,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3906,7 +3906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3934,7 +3934,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3962,7 +3962,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3990,7 +3990,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4018,7 +4018,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4046,7 +4046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4074,7 +4074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4102,7 +4102,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4130,7 +4130,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4160,7 +4160,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4190,7 +4190,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4220,7 +4220,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4251,7 +4251,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4281,7 +4281,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4309,7 +4309,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4337,7 +4337,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4365,7 +4365,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4393,7 +4393,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4421,7 +4421,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4449,7 +4449,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4477,7 +4477,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4505,7 +4505,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4533,7 +4533,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4561,7 +4561,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4589,7 +4589,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4617,7 +4617,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4645,7 +4645,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4673,7 +4673,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4701,7 +4701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4731,7 +4731,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4761,7 +4761,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4791,7 +4791,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4822,7 +4822,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4852,7 +4852,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4880,7 +4880,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4908,7 +4908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4936,7 +4936,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4964,7 +4964,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4992,7 +4992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5020,7 +5020,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5048,7 +5048,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5076,7 +5076,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5104,7 +5104,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5127,7 +5127,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5150,7 +5150,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5173,7 +5173,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5196,7 +5196,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5219,7 +5219,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5242,7 +5242,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5267,7 +5267,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5292,7 +5292,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5317,7 +5317,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5343,7 +5343,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5368,7 +5368,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5391,7 +5391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5414,7 +5414,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5437,7 +5437,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5460,7 +5460,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5483,7 +5483,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5506,7 +5506,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5529,7 +5529,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5552,7 +5552,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5575,7 +5575,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5598,7 +5598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5621,7 +5621,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5644,7 +5644,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5667,7 +5667,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5690,7 +5690,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5713,7 +5713,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5738,7 +5738,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5763,7 +5763,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5788,7 +5788,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5814,7 +5814,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5839,7 +5839,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5862,7 +5862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5885,7 +5885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5908,7 +5908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5931,7 +5931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5954,7 +5954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5977,7 +5977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6000,7 +6000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6023,7 +6023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6046,7 +6046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6069,7 +6069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6092,7 +6092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6115,7 +6115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6138,7 +6138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6161,7 +6161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6184,7 +6184,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6209,7 +6209,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6234,7 +6234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6259,7 +6259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6285,7 +6285,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6310,7 +6310,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6333,7 +6333,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6356,7 +6356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6379,7 +6379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6402,7 +6402,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6425,7 +6425,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6448,7 +6448,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6471,7 +6471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6494,7 +6494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6517,7 +6517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6540,7 +6540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6563,7 +6563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6586,7 +6586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6609,7 +6609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6632,7 +6632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6655,7 +6655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6680,7 +6680,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6705,7 +6705,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6730,7 +6730,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6756,7 +6756,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6781,7 +6781,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6804,7 +6804,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6827,7 +6827,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6850,7 +6850,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6873,7 +6873,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6896,7 +6896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6919,7 +6919,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6942,7 +6942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6965,7 +6965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6988,7 +6988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7011,7 +7011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7034,7 +7034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7057,7 +7057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7080,7 +7080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7103,7 +7103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7126,7 +7126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7151,7 +7151,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7176,7 +7176,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7201,7 +7201,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7227,7 +7227,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7252,7 +7252,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7275,7 +7275,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7298,7 +7298,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7321,7 +7321,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7344,7 +7344,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7367,7 +7367,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7390,7 +7390,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7413,7 +7413,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7436,7 +7436,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7459,7 +7459,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7482,7 +7482,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7505,7 +7505,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7528,7 +7528,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7551,7 +7551,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7574,7 +7574,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7597,7 +7597,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7622,7 +7622,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7647,7 +7647,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7672,7 +7672,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7698,7 +7698,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7723,7 +7723,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7746,7 +7746,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7769,7 +7769,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7792,7 +7792,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7815,7 +7815,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7838,7 +7838,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7861,7 +7861,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7884,7 +7884,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7907,7 +7907,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7930,7 +7930,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7955,7 +7955,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7980,7 +7980,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8005,7 +8005,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8030,7 +8030,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8055,7 +8055,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8080,7 +8080,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8105,7 +8105,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8130,7 +8130,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8153,7 +8153,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8176,7 +8176,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8199,7 +8199,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8222,7 +8222,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8245,7 +8245,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8268,7 +8268,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8291,7 +8291,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8316,7 +8316,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8341,7 +8341,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8366,7 +8366,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8392,7 +8392,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8417,7 +8417,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8440,7 +8440,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8463,7 +8463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8486,7 +8486,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8509,7 +8509,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8532,7 +8532,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8555,7 +8555,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8578,7 +8578,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8601,7 +8601,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8624,7 +8624,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8647,7 +8647,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8670,7 +8670,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8693,7 +8693,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8716,7 +8716,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8739,7 +8739,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8762,7 +8762,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8787,7 +8787,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8812,7 +8812,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8837,7 +8837,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8863,7 +8863,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8888,7 +8888,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8911,7 +8911,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8934,7 +8934,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8957,7 +8957,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8980,7 +8980,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9003,7 +9003,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9026,7 +9026,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9049,7 +9049,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9072,7 +9072,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9095,7 +9095,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9118,7 +9118,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9141,7 +9141,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9164,7 +9164,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9187,7 +9187,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9210,7 +9210,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9233,7 +9233,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9258,7 +9258,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9283,7 +9283,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9308,7 +9308,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9334,7 +9334,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9359,7 +9359,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9382,7 +9382,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9405,7 +9405,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9428,7 +9428,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9451,7 +9451,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9474,7 +9474,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9497,7 +9497,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9520,7 +9520,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9543,7 +9543,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9566,7 +9566,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9589,7 +9589,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9612,7 +9612,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9635,7 +9635,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9658,7 +9658,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9681,7 +9681,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9704,7 +9704,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9729,7 +9729,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9754,7 +9754,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9779,7 +9779,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9805,7 +9805,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9830,7 +9830,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9853,7 +9853,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9876,7 +9876,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9899,7 +9899,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9922,7 +9922,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9945,7 +9945,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9968,7 +9968,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9991,7 +9991,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10014,7 +10014,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10037,7 +10037,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10060,7 +10060,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10083,7 +10083,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10106,7 +10106,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10129,7 +10129,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10152,7 +10152,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10175,7 +10175,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10200,7 +10200,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10225,7 +10225,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10250,7 +10250,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10276,7 +10276,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10301,7 +10301,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10324,7 +10324,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10347,7 +10347,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10370,7 +10370,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10393,7 +10393,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10416,7 +10416,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10439,7 +10439,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10462,7 +10462,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10485,7 +10485,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10508,7 +10508,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10531,7 +10531,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10554,7 +10554,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10577,7 +10577,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10600,7 +10600,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10623,7 +10623,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10646,7 +10646,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10671,7 +10671,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10696,7 +10696,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10721,7 +10721,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10747,7 +10747,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10772,7 +10772,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10795,7 +10795,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10818,7 +10818,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10841,7 +10841,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10864,7 +10864,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10887,7 +10887,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10910,7 +10910,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10933,7 +10933,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10956,7 +10956,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10979,7 +10979,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11002,7 +11002,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11025,7 +11025,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11048,7 +11048,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11071,7 +11071,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11094,7 +11094,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11117,7 +11117,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11142,7 +11142,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11167,7 +11167,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11192,7 +11192,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11218,7 +11218,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11243,7 +11243,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11266,7 +11266,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11289,7 +11289,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11312,7 +11312,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11335,7 +11335,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11358,7 +11358,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11381,7 +11381,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11404,7 +11404,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11427,7 +11427,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11450,7 +11450,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11475,7 +11475,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11500,7 +11500,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11525,7 +11525,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11551,7 +11551,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11576,7 +11576,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11599,7 +11599,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11622,7 +11622,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11645,7 +11645,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11668,7 +11668,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11691,7 +11691,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11714,7 +11714,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11737,7 +11737,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11760,7 +11760,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11783,7 +11783,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11808,7 +11808,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11833,7 +11833,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11858,7 +11858,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11884,7 +11884,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11909,7 +11909,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11932,7 +11932,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11955,7 +11955,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11978,7 +11978,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12001,7 +12001,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12024,7 +12024,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12047,7 +12047,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12070,7 +12070,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12093,7 +12093,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12116,7 +12116,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12141,7 +12141,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12166,7 +12166,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12191,7 +12191,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12217,7 +12217,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12242,7 +12242,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12265,7 +12265,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12288,7 +12288,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12311,7 +12311,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12334,7 +12334,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12357,7 +12357,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12380,7 +12380,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12403,7 +12403,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12426,7 +12426,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12449,7 +12449,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12474,7 +12474,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12499,7 +12499,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12524,7 +12524,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12550,7 +12550,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12575,7 +12575,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12598,7 +12598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12621,7 +12621,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12644,7 +12644,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12667,7 +12667,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12690,7 +12690,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12713,7 +12713,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12736,7 +12736,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12759,7 +12759,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12782,7 +12782,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12805,7 +12805,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12828,7 +12828,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12851,7 +12851,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12874,7 +12874,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12897,7 +12897,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12920,7 +12920,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12943,7 +12943,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12966,7 +12966,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12989,7 +12989,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13012,7 +13012,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13035,7 +13035,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13058,7 +13058,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13081,7 +13081,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13104,7 +13104,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13127,7 +13127,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13152,7 +13152,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13177,7 +13177,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13202,7 +13202,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13228,7 +13228,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13253,7 +13253,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13276,7 +13276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13299,7 +13299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13322,7 +13322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13345,7 +13345,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13368,7 +13368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13391,7 +13391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13414,7 +13414,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13437,7 +13437,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13460,7 +13460,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13483,7 +13483,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13506,7 +13506,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13529,7 +13529,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13552,7 +13552,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13575,7 +13575,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13598,7 +13598,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13621,7 +13621,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13644,7 +13644,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13667,7 +13667,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13690,7 +13690,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13713,7 +13713,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13736,7 +13736,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13759,7 +13759,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13782,7 +13782,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13805,7 +13805,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13830,7 +13830,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13855,7 +13855,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13880,7 +13880,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13906,7 +13906,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13931,7 +13931,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13954,7 +13954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13977,7 +13977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14000,7 +14000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14023,7 +14023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14046,7 +14046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14069,7 +14069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14092,7 +14092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14115,7 +14115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14138,7 +14138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14161,7 +14161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14184,7 +14184,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14207,7 +14207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14230,7 +14230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14253,7 +14253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14276,7 +14276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14299,7 +14299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14322,7 +14322,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14345,7 +14345,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14368,7 +14368,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14391,7 +14391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14414,7 +14414,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14437,7 +14437,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14460,7 +14460,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14483,7 +14483,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14508,7 +14508,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14533,7 +14533,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14558,7 +14558,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14584,7 +14584,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14609,7 +14609,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14632,7 +14632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14655,7 +14655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14678,7 +14678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14701,7 +14701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14724,7 +14724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14747,7 +14747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14770,7 +14770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14793,7 +14793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14816,7 +14816,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14839,7 +14839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14862,7 +14862,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14885,7 +14885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14908,7 +14908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14931,7 +14931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14954,7 +14954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14977,7 +14977,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15000,7 +15000,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15023,7 +15023,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15046,7 +15046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15069,7 +15069,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15092,7 +15092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15115,7 +15115,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15138,7 +15138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15161,7 +15161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15186,7 +15186,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15211,7 +15211,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15236,7 +15236,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15262,7 +15262,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15287,7 +15287,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15310,7 +15310,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15333,7 +15333,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15356,7 +15356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15379,7 +15379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15402,7 +15402,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15425,7 +15425,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15448,7 +15448,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15471,7 +15471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15494,7 +15494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15517,7 +15517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15540,7 +15540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15563,7 +15563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15586,7 +15586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15609,7 +15609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15632,7 +15632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15655,7 +15655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15678,7 +15678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15701,7 +15701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15724,7 +15724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15747,7 +15747,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15770,7 +15770,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15793,7 +15793,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15816,7 +15816,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15839,7 +15839,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15864,7 +15864,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15889,7 +15889,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15914,7 +15914,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15940,7 +15940,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15965,7 +15965,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15988,7 +15988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16011,7 +16011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16034,7 +16034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16057,7 +16057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16080,7 +16080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16103,7 +16103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16126,7 +16126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16149,7 +16149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16172,7 +16172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16195,7 +16195,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16218,7 +16218,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16241,7 +16241,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16264,7 +16264,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16287,7 +16287,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16310,7 +16310,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16333,7 +16333,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16356,7 +16356,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16379,7 +16379,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16407,7 +16407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16435,7 +16435,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16463,7 +16463,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16491,7 +16491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16519,7 +16519,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16547,7 +16547,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16577,7 +16577,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16607,7 +16607,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16637,7 +16637,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16668,7 +16668,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16698,7 +16698,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16726,7 +16726,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16754,7 +16754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16782,7 +16782,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16810,7 +16810,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16838,7 +16838,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16866,7 +16866,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16894,7 +16894,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16922,7 +16922,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16950,7 +16950,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -16978,7 +16978,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17006,7 +17006,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17034,7 +17034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17062,7 +17062,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17090,7 +17090,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17118,7 +17118,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17146,7 +17146,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17174,7 +17174,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17202,7 +17202,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17230,7 +17230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17258,7 +17258,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17286,7 +17286,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17314,7 +17314,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17342,7 +17342,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17370,7 +17370,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17400,7 +17400,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17430,7 +17430,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17460,7 +17460,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17491,7 +17491,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17521,7 +17521,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17549,7 +17549,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17577,7 +17577,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17605,7 +17605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17633,7 +17633,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17661,7 +17661,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17689,7 +17689,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17717,7 +17717,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17745,7 +17745,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17773,7 +17773,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17801,7 +17801,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17829,7 +17829,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17857,7 +17857,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17885,7 +17885,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17913,7 +17913,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17941,7 +17941,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17969,7 +17969,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -17997,7 +17997,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18025,7 +18025,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18053,7 +18053,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18081,7 +18081,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18109,7 +18109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18137,7 +18137,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18165,7 +18165,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18193,7 +18193,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18223,7 +18223,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18253,7 +18253,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18283,7 +18283,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18314,7 +18314,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18344,7 +18344,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18372,7 +18372,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18400,7 +18400,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18428,7 +18428,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18456,7 +18456,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18484,7 +18484,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18512,7 +18512,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18540,7 +18540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18568,7 +18568,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18596,7 +18596,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18624,7 +18624,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18652,7 +18652,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18680,7 +18680,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18708,7 +18708,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18736,7 +18736,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18764,7 +18764,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18792,7 +18792,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18820,7 +18820,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18848,7 +18848,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18876,7 +18876,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18904,7 +18904,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18932,7 +18932,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18960,7 +18960,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -18988,7 +18988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19016,7 +19016,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19046,7 +19046,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19076,7 +19076,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19106,7 +19106,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19137,7 +19137,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19167,7 +19167,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19195,7 +19195,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19223,7 +19223,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19251,7 +19251,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19279,7 +19279,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19307,7 +19307,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19335,7 +19335,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19363,7 +19363,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19391,7 +19391,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19419,7 +19419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19447,7 +19447,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19475,7 +19475,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19503,7 +19503,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19531,7 +19531,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19559,7 +19559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19587,7 +19587,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19615,7 +19615,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19643,7 +19643,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19671,7 +19671,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19694,7 +19694,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19717,7 +19717,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19740,7 +19740,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19763,7 +19763,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19786,7 +19786,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19809,7 +19809,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19834,7 +19834,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19859,7 +19859,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19884,7 +19884,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19910,7 +19910,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19935,7 +19935,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19958,7 +19958,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -19981,7 +19981,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20004,7 +20004,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20027,7 +20027,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20050,7 +20050,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20073,7 +20073,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20096,7 +20096,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20119,7 +20119,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20142,7 +20142,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20165,7 +20165,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20188,7 +20188,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20211,7 +20211,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20234,7 +20234,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20257,7 +20257,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20280,7 +20280,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20303,7 +20303,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20326,7 +20326,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20349,7 +20349,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20372,7 +20372,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20395,7 +20395,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20418,7 +20418,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20441,7 +20441,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20464,7 +20464,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20487,7 +20487,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20512,7 +20512,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20537,7 +20537,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20562,7 +20562,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20588,7 +20588,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20613,7 +20613,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20636,7 +20636,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20659,7 +20659,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20682,7 +20682,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20705,7 +20705,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20728,7 +20728,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20751,7 +20751,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20774,7 +20774,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20797,7 +20797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20820,7 +20820,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20843,7 +20843,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20866,7 +20866,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20889,7 +20889,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20912,7 +20912,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20935,7 +20935,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20958,7 +20958,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -20981,7 +20981,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21004,7 +21004,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21027,7 +21027,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21050,7 +21050,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21073,7 +21073,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21096,7 +21096,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21119,7 +21119,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21142,7 +21142,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21165,7 +21165,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21190,7 +21190,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21215,7 +21215,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21240,7 +21240,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21266,7 +21266,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21291,7 +21291,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21314,7 +21314,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21337,7 +21337,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21360,7 +21360,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21383,7 +21383,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21406,7 +21406,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21429,7 +21429,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21452,7 +21452,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21475,7 +21475,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21498,7 +21498,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21521,7 +21521,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21544,7 +21544,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21567,7 +21567,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21590,7 +21590,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21613,7 +21613,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21636,7 +21636,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21659,7 +21659,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21682,7 +21682,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21705,7 +21705,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21728,7 +21728,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21751,7 +21751,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21774,7 +21774,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21797,7 +21797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21820,7 +21820,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21843,7 +21843,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21868,7 +21868,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21893,7 +21893,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21918,7 +21918,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21944,7 +21944,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21969,7 +21969,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -21992,7 +21992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22015,7 +22015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22038,7 +22038,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22061,7 +22061,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22084,7 +22084,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22107,7 +22107,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22130,7 +22130,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22153,7 +22153,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22176,7 +22176,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22199,7 +22199,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22222,7 +22222,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22245,7 +22245,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22268,7 +22268,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22291,7 +22291,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22314,7 +22314,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22337,7 +22337,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22360,7 +22360,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22383,7 +22383,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22406,7 +22406,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22429,7 +22429,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22452,7 +22452,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22475,7 +22475,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22498,7 +22498,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22521,7 +22521,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22544,7 +22544,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22567,7 +22567,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22590,7 +22590,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22613,7 +22613,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22636,7 +22636,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22659,7 +22659,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22682,7 +22682,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22705,7 +22705,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22728,7 +22728,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22751,7 +22751,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22774,7 +22774,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22797,7 +22797,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22820,7 +22820,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:
@@ -22843,7 +22843,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: kubermatic/kubeone-e2e:v0.1.26
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
       imagePullPolicy: Always
       name: ""
       resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

The `kubeone-e2e` image is the only remaining image on Docker Hub that we have. It's time to move this image to Quay, which is done with this PR. I already pushed the image manually, so all jobs are updated as well.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The `kubeone-e2e` image is moved from Docker Hub to Quay (`quay.io/kubermatic/kubeone-e2e`)
```

**Documentation**:
```documentation
NONE
```