### PR TITLE
[release/v1.4] Update Golang to v1.18.8 and use quay.io/kubermatic/kubeone-e2e image

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.17.5
+        - image: golang:1.18.8
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.17.5
+        - image: golang:1.18.8
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.17.5
+        - image: golang:1.18.8
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.17.5
+        - image: golang:1.18.8
           command:
             - make
           args:
@@ -148,7 +148,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -177,7 +177,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -214,7 +214,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -241,7 +241,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -266,7 +266,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -293,7 +293,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -320,7 +320,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -352,7 +352,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -377,7 +377,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -402,7 +402,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -429,7 +429,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -459,7 +459,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -484,7 +484,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -509,7 +509,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -536,7 +536,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -566,7 +566,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -593,7 +593,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -620,7 +620,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -649,7 +649,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -681,7 +681,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -706,7 +706,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -731,7 +731,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -758,7 +758,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -788,7 +788,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -813,7 +813,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -838,7 +838,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -865,7 +865,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -895,7 +895,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -925,7 +925,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -953,7 +953,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -983,7 +983,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1016,7 +1016,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1042,7 +1042,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1070,7 +1070,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1101,7 +1101,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1127,7 +1127,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1155,7 +1155,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1186,7 +1186,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1214,7 +1214,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1244,7 +1244,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1277,7 +1277,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1303,7 +1303,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1331,7 +1331,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1362,7 +1362,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1388,7 +1388,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1416,7 +1416,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: kubermatic/kubeone-e2e:v0.1.20
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1449,7 +1449,7 @@ postsubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-4
+        - image: quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-2
           command:
             - /bin/bash
             - -c
@@ -1475,7 +1475,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-4
+        - image: quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-2
           command:
             - ./hack/ci/upload-gocache.sh
           resources:

--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,7 +14,7 @@
 
 # building image
 
-FROM golang:1.17.5 as builder
+FROM golang:1.18.8 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip
@@ -23,21 +23,13 @@ ENV TERRAFORM_VERSION "1.1.0"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform
 RUN chmod +x /usr/local/bin/terraform
 
-ENV KUBETEST_COMMIT "eb1a87c9083a31f9a9dda7822cb674f9f8d99439"
-ENV KUBETESTS_ROOT "/opt/kube-test"
-ENV GO111MODULE=on
-
-# Install the kubetest binary
-RUN go get -v k8s.io/test-infra/kubetest@${KUBETEST_COMMIT} && \
-    go clean -modcache -cache
-
 COPY install-kube-tests-binaries.sh /opt/install-kube-tests-binaries.sh
 RUN /opt/install-kube-tests-binaries.sh
 
 # resulting image
 
 
-FROM golang:1.17.5
+FROM golang:1.18.8
 
 ARG version
 
@@ -51,5 +43,4 @@ ENV GO111MODULE on
 ENV USER root
 
 COPY --from=builder /usr/local/bin/terraform /usr/local/bin/terraform
-COPY --from=builder /go/bin/kubetest /usr/local/bin/kubetest
 COPY --from=builder ${KUBETESTS_ROOT} ${KUBETESTS_ROOT}

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -17,10 +17,10 @@
 set -euox pipefail
 
 declare -A full_versions
-full_versions["1.20"]="v1.20.13"
-full_versions["1.21"]="v1.21.7"
-full_versions["1.22"]="v1.22.4"
-full_versions["1.23"]="v1.23.0"
+full_versions["1.20"]="v1.20.15"
+full_versions["1.21"]="v1.21.14"
+full_versions["1.22"]="v1.22.15"
+full_versions["1.23"]="v1.23.13"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.20
+TAG=v0.1.27-go-1.18
 
-docker build --build-arg version=${TAG} --pull -t kubermatic/kubeone-e2e:${TAG} .
-docker push kubermatic/kubeone-e2e:${TAG}
+docker build --build-arg version=${TAG} --pull -t quay.io/kubermatic/kubeone-e2e:${TAG} .
+docker push quay.io/kubermatic/kubeone-e2e:${TAG}

--- a/test/e2e/testutil/testutil.go
+++ b/test/e2e/testutil/testutil.go
@@ -69,9 +69,5 @@ func ValidateCommon() error {
 		return errors.New("the terraform client is not available, please install")
 	}
 
-	if ok := IsCommandAvailable("kubetest"); !ok {
-		return errors.New("the kubetest is not available, please install: 'go get -u k8s.io/test-infra/kubetest'")
-	}
-
 	return nil
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -143,7 +143,7 @@ func TestClusterUpgrade(t *testing.T) { //nolint:gocyclo
 			// Create KubeOne target
 			target := NewKubeone(testPath, tc.initialConfigPath)
 
-			// Ensure terraform, kubetest and all needed prerequisites are in place before running test
+			// Ensure terraform, and all needed prerequisites are in place before running test
 			t.Log("Validating prerequisites...")
 
 			err = testutil.ValidateCommon()


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update the Go version to v1.18.8 on the `release/v1.4` branch
- Manually cherry-pick #2463 to the `release/v1.4` branch

**What type of PR is this?**

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- KubeOne is now built using Go 1.18.8
- The `kubeone-e2e` image is moved from Docker Hub to Quay (`quay.io/kubermatic/kubeone-e2e`)
```

**Documentation**:
```documentation
NONE
```