### PR TITLE
Use November's Kubernetes patch releases in the CI

### DIFF
--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -6,14 +6,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_22_15
+      - TestAwsAmznInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -29,485 +29,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: true
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-gce: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_22_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_23_13
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_23_13
+      - TestAwsCentosInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -523,14 +52,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_23_13
+      - TestAwsDefaultInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -546,14 +75,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_23_13
+      - TestAwsFlatcarInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -569,14 +98,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_23_13
+      - TestAwsRhelInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -592,14 +121,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_23_13
+      - TestAwsRockylinuxInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -615,14 +144,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_23_13
+      - TestAzureDefaultInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -640,14 +169,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_23_13
+      - TestAzureCentosInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -665,14 +194,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_23_13
+      - TestAzureFlatcarInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -691,14 +220,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_23_13
+      - TestAzureRhelInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -716,14 +245,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_23_13
+      - TestAzureRockylinuxInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -741,14 +270,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_23_13
+      - TestGceDefaultInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: gce
@@ -764,14 +293,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_23_13
+      - TestOpenstackDefaultInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -787,14 +316,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_23_13
+      - TestOpenstackCentosInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -810,14 +339,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_23_13
+      - TestOpenstackRockylinuxInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -833,14 +362,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_23_13
+      - TestOpenstackRhelInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -856,14 +385,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_23_13
+      - TestOpenstackFlatcarInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -879,14 +408,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_23_13
+      - TestVsphereDefaultInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -902,14 +431,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_23_13
+      - TestVsphereCentosInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -925,14 +454,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_23_13
+      - TestVsphereFlatcarInstallContainerdV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -948,14 +477,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_24_7
+      - TestAwsAmznInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -971,14 +500,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_24_7
+      - TestAwsCentosInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -994,14 +523,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_24_7
+      - TestAwsDefaultInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -1017,14 +546,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_24_7
+      - TestAwsFlatcarInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -1040,14 +569,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_24_7
+      - TestAwsRhelInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -1063,14 +592,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_24_7
+      - TestAwsRockylinuxInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -1086,14 +615,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_24_7
+      - TestAzureDefaultInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -1111,14 +640,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_24_7
+      - TestAzureCentosInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -1136,14 +665,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_24_7
+      - TestAzureFlatcarInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -1162,14 +691,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_24_7
+      - TestAzureRhelInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -1187,14 +716,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_24_7
+      - TestAzureRockylinuxInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -1212,14 +741,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_24_7
+      - TestGceDefaultInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: gce
@@ -1235,14 +764,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_24_7
+      - TestOpenstackDefaultInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -1258,14 +787,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_24_7
+      - TestOpenstackCentosInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -1281,14 +810,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_24_7
+      - TestOpenstackRockylinuxInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -1304,14 +833,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_24_7
+      - TestOpenstackRhelInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -1327,14 +856,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_24_7
+      - TestOpenstackFlatcarInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -1350,14 +879,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_24_7
+      - TestVsphereDefaultInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -1373,14 +902,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_24_7
+      - TestVsphereCentosInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -1396,14 +925,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.7
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_24_7
+      - TestVsphereFlatcarInstallContainerdV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -1419,14 +948,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_25_3
+      - TestAwsAmznInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -1442,14 +971,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_25_3
+      - TestAwsCentosInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -1465,14 +994,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_25_3
+      - TestAwsDefaultInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -1488,14 +1017,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_25_3
+      - TestAwsFlatcarInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -1511,14 +1040,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_25_3
+      - TestAwsRhelInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -1534,14 +1063,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_25_3
+      - TestAwsRockylinuxInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -1557,14 +1086,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_25_3
+      - TestAzureDefaultInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -1582,14 +1111,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_25_3
+      - TestAzureCentosInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -1607,14 +1136,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_25_3
+      - TestAzureFlatcarInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -1633,14 +1162,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_25_3
+      - TestAzureRhelInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -1658,14 +1187,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_25_3
+      - TestAzureRockylinuxInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -1683,14 +1212,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_25_3
+      - TestGceDefaultInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: gce
@@ -1706,14 +1235,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_25_3
+      - TestOpenstackDefaultInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -1729,14 +1258,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_25_3
+      - TestOpenstackCentosInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -1752,14 +1281,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_25_3
+      - TestOpenstackRockylinuxInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -1775,14 +1304,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_25_3
+      - TestOpenstackRhelInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -1798,14 +1327,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_25_3
+      - TestOpenstackFlatcarInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -1821,14 +1350,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_25_3
+      - TestVsphereDefaultInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -1844,14 +1373,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_25_3
+      - TestVsphereCentosInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -1867,14 +1396,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_25_3
+      - TestVsphereFlatcarInstallContainerdV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -1890,14 +1419,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerV1_22_15
+      - TestAwsAmznInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -1913,14 +1442,37 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerV1_22_15
+      - TestAwsCentosInstallContainerdV1_25_4
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: true
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.25.4
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -1936,14 +1488,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerV1_22_15
+      - TestAwsFlatcarInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -1959,14 +1511,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerV1_22_15
+      - TestAwsRhelInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -1982,37 +1534,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerV1_22_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.22.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerV1_22_15
+      - TestAwsRockylinuxInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -2028,14 +1557,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerV1_22_15
+      - TestAzureDefaultInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -2053,14 +1582,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerV1_22_15
+      - TestAzureCentosInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -2078,14 +1607,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerV1_22_15
+      - TestAzureFlatcarInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -2104,14 +1633,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerV1_22_15
+      - TestAzureRhelInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -2129,14 +1658,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerV1_22_15
+      - TestAzureRockylinuxInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -2154,14 +1683,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-docker-v1.22.15
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallDockerV1_22_15
+      - TestGceDefaultInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: gce
@@ -2177,14 +1706,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerV1_22_15
+      - TestOpenstackDefaultInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -2200,14 +1729,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerV1_22_15
+      - TestOpenstackCentosInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -2223,14 +1752,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerV1_22_15
+      - TestOpenstackRockylinuxInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -2246,14 +1775,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerV1_22_15
+      - TestOpenstackRhelInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -2269,14 +1798,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerV1_22_15
+      - TestOpenstackFlatcarInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -2292,14 +1821,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerV1_22_15
+      - TestVsphereDefaultInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -2315,14 +1844,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerV1_22_15
+      - TestVsphereCentosInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -2338,14 +1867,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerV1_22_15
+      - TestVsphereFlatcarInstallContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -2361,14 +1890,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerV1_23_13
+      - TestAwsAmznInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -2384,14 +1913,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerV1_23_13
+      - TestAwsCentosInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -2407,14 +1936,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-default-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerV1_23_13
+      - TestAwsDefaultInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -2430,14 +1959,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerV1_23_13
+      - TestAwsFlatcarInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -2453,14 +1982,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerV1_23_13
+      - TestAwsRhelInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -2476,14 +2005,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerV1_23_13
+      - TestAwsRockylinuxInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -2499,14 +2028,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-default-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerV1_23_13
+      - TestAzureDefaultInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -2524,14 +2053,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerV1_23_13
+      - TestAzureCentosInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -2549,14 +2078,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerV1_23_13
+      - TestAzureFlatcarInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -2575,14 +2104,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerV1_23_13
+      - TestAzureRhelInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -2600,14 +2129,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerV1_23_13
+      - TestAzureRockylinuxInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -2625,14 +2154,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.13
+  name: pull-kubeone-e2e-gce-default-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallDockerV1_23_13
+      - TestGceDefaultInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: gce
@@ -2648,14 +2177,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerV1_23_13
+      - TestOpenstackDefaultInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2671,14 +2200,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerV1_23_13
+      - TestOpenstackCentosInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2694,14 +2223,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerV1_23_13
+      - TestOpenstackRockylinuxInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2717,14 +2246,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerV1_23_13
+      - TestOpenstackRhelInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2740,14 +2269,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerV1_23_13
+      - TestOpenstackFlatcarInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2763,14 +2292,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerV1_23_13
+      - TestVsphereDefaultInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -2786,14 +2315,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerV1_23_13
+      - TestVsphereCentosInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -2809,14 +2338,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerV1_23_13
+      - TestVsphereFlatcarInstallDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -2829,22 +2358,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsAmznInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -2857,22 +2381,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsCentosInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -2885,22 +2404,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsDefaultInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -2913,22 +2427,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsFlatcarInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -2941,22 +2450,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsRhelInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -2969,22 +2473,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAwsRockylinuxInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -2997,22 +2496,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureDefaultInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -3027,22 +2521,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureCentosInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -3057,22 +2546,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureFlatcarInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -3087,23 +2571,18 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureRhelInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -3118,22 +2597,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestAzureRockylinuxInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -3148,22 +2622,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestGceDefaultInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: gce
@@ -3176,22 +2645,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestOpenstackDefaultInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -3204,22 +2668,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestOpenstackCentosInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -3232,22 +2691,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestOpenstackRockylinuxInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -3260,22 +2714,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestOpenstackRhelInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -3288,22 +2737,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestOpenstackFlatcarInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -3316,22 +2760,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestVsphereDefaultInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -3344,22 +2783,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestVsphereCentosInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -3372,22 +2806,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3
+      - TestVsphereFlatcarInstallDockerV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -3408,14 +2837,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsAmznStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -3436,14 +2865,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -3464,14 +2893,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -3492,14 +2921,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -3520,14 +2949,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -3548,14 +2977,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -3576,14 +3005,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -3606,14 +3035,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -3636,14 +3065,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -3667,14 +3096,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -3697,14 +3126,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -3727,14 +3156,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestGceDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: gce
@@ -3755,14 +3184,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -3783,14 +3212,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -3811,14 +3240,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -3839,14 +3268,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -3867,14 +3296,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -3895,14 +3324,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -3923,14 +3352,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestVsphereCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -3951,14 +3380,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -3979,14 +3408,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsAmznStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -4007,14 +3436,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -4035,14 +3464,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -4063,14 +3492,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -4091,14 +3520,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -4119,14 +3548,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -4147,14 +3576,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -4177,14 +3606,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -4207,14 +3636,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -4238,14 +3667,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -4268,14 +3697,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -4298,14 +3727,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestGceDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: gce
@@ -4326,14 +3755,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -4354,14 +3783,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -4382,14 +3811,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -4410,14 +3839,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -4438,14 +3867,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -4466,14 +3895,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -4494,14 +3923,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestVsphereCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -4522,14 +3951,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -4550,14 +3979,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsAmznStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -4578,14 +4007,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsCentosStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -4606,14 +4035,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -4634,14 +4063,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -4662,14 +4091,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsRhelStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -4690,14 +4119,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -4718,14 +4147,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -4748,14 +4177,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureCentosStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -4778,14 +4207,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -4809,14 +4238,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureRhelStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -4839,14 +4268,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -4869,14 +4298,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestGceDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: gce
@@ -4897,14 +4326,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -4925,14 +4354,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -4953,14 +4382,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -4981,14 +4410,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -5009,14 +4438,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -5037,14 +4466,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -5065,14 +4494,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestVsphereCentosStableUpgradeContainerdFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -5093,14 +4522,585 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: gce
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosStableUpgradeDockerFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeDockerFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -5116,14 +5116,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoContainerdV1_25_3
+      - TestAwsAmznCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -5139,14 +5139,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdV1_25_3
+      - TestAwsCentosCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -5162,14 +5162,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoContainerdV1_25_3
+      - TestAwsDefaultCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -5185,14 +5185,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoContainerdV1_25_3
+      - TestAwsFlatcarCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -5208,14 +5208,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoContainerdV1_25_3
+      - TestAwsRhelCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -5231,14 +5231,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoContainerdV1_25_3
+      - TestAwsRockylinuxCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -5254,14 +5254,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoContainerdV1_25_3
+      - TestAzureDefaultCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -5279,14 +5279,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdV1_25_3
+      - TestAzureCentosCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -5304,14 +5304,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoContainerdV1_25_3
+      - TestAzureFlatcarCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -5330,14 +5330,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoContainerdV1_25_3
+      - TestAzureRhelCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -5355,14 +5355,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoContainerdV1_25_3
+      - TestAzureRockylinuxCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -5380,14 +5380,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoContainerdV1_25_3
+      - TestGceDefaultCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: gce
@@ -5403,14 +5403,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoContainerdV1_25_3
+      - TestOpenstackDefaultCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -5426,14 +5426,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdV1_25_3
+      - TestOpenstackCentosCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -5449,14 +5449,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoContainerdV1_25_3
+      - TestOpenstackRockylinuxCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -5472,14 +5472,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoContainerdV1_25_3
+      - TestOpenstackRhelCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -5495,14 +5495,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoContainerdV1_25_3
+      - TestOpenstackFlatcarCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -5518,14 +5518,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoContainerdV1_25_3
+      - TestVsphereDefaultCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -5541,14 +5541,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoContainerdV1_25_3
+      - TestVsphereCentosCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -5564,14 +5564,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoContainerdV1_25_3
+      - TestVsphereFlatcarCalicoContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -5587,14 +5587,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoDockerV1_22_15
+      - TestAwsAmznCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -5610,14 +5610,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoDockerV1_22_15
+      - TestAwsCentosCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -5633,14 +5633,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-default-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoDockerV1_22_15
+      - TestAwsDefaultCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -5656,14 +5656,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-flatcar-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoDockerV1_22_15
+      - TestAwsFlatcarCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -5679,14 +5679,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rhel-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoDockerV1_22_15
+      - TestAwsRhelCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -5702,14 +5702,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rockylinux-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoDockerV1_22_15
+      - TestAwsRockylinuxCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -5725,14 +5725,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-default-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoDockerV1_22_15
+      - TestAzureDefaultCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -5750,14 +5750,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoDockerV1_22_15
+      - TestAzureCentosCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -5775,14 +5775,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoDockerV1_22_15
+      - TestAzureFlatcarCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -5801,14 +5801,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoDockerV1_22_15
+      - TestAzureRhelCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -5826,14 +5826,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoDockerV1_22_15
+      - TestAzureRockylinuxCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -5851,14 +5851,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-gce-default-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoDockerV1_22_15
+      - TestGceDefaultCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: gce
@@ -5874,14 +5874,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoDockerV1_22_15
+      - TestOpenstackDefaultCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -5897,14 +5897,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoDockerV1_22_15
+      - TestOpenstackCentosCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -5920,14 +5920,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoDockerV1_22_15
+      - TestOpenstackRockylinuxCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -5943,14 +5943,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoDockerV1_22_15
+      - TestOpenstackRhelCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -5966,14 +5966,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoDockerV1_22_15
+      - TestOpenstackFlatcarCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -5989,14 +5989,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoDockerV1_22_15
+      - TestVsphereDefaultCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -6012,14 +6012,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoDockerV1_22_15
+      - TestVsphereCentosCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -6035,14 +6035,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoDockerV1_22_15
+      - TestVsphereFlatcarCalicoDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -6058,14 +6058,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveContainerdV1_25_3
+      - TestAwsAmznWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -6081,14 +6081,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveContainerdV1_25_3
+      - TestAwsCentosWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -6104,14 +6104,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveContainerdV1_25_3
+      - TestAwsDefaultWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -6127,14 +6127,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveContainerdV1_25_3
+      - TestAwsFlatcarWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -6150,14 +6150,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveContainerdV1_25_3
+      - TestAwsRhelWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -6173,14 +6173,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveContainerdV1_25_3
+      - TestAwsRockylinuxWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -6196,14 +6196,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveContainerdV1_25_3
+      - TestAzureDefaultWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -6221,14 +6221,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveContainerdV1_25_3
+      - TestAzureCentosWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -6246,14 +6246,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveContainerdV1_25_3
+      - TestAzureFlatcarWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -6272,14 +6272,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveContainerdV1_25_3
+      - TestAzureRhelWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -6297,14 +6297,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveContainerdV1_25_3
+      - TestAzureRockylinuxWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -6322,14 +6322,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveContainerdV1_25_3
+      - TestGceDefaultWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: gce
@@ -6345,14 +6345,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveContainerdV1_25_3
+      - TestOpenstackDefaultWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -6368,14 +6368,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveContainerdV1_25_3
+      - TestOpenstackCentosWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -6391,14 +6391,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveContainerdV1_25_3
+      - TestOpenstackRockylinuxWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -6414,14 +6414,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveContainerdV1_25_3
+      - TestOpenstackRhelWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -6437,14 +6437,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveContainerdV1_25_3
+      - TestOpenstackFlatcarWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -6460,14 +6460,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveContainerdV1_25_3
+      - TestVsphereDefaultWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -6483,14 +6483,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosWeaveContainerdV1_25_3
+      - TestVsphereCentosWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -6506,14 +6506,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveContainerdV1_25_3
+      - TestVsphereFlatcarWeaveContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -6529,14 +6529,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveDockerV1_22_15
+      - TestAwsAmznWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -6552,14 +6552,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveDockerV1_22_15
+      - TestAwsCentosWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -6575,14 +6575,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-default-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveDockerV1_22_15
+      - TestAwsDefaultWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -6598,14 +6598,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-flatcar-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveDockerV1_22_15
+      - TestAwsFlatcarWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -6621,14 +6621,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rhel-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveDockerV1_22_15
+      - TestAwsRhelWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -6644,14 +6644,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rockylinux-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveDockerV1_22_15
+      - TestAwsRockylinuxWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -6667,14 +6667,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-default-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveDockerV1_22_15
+      - TestAzureDefaultWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -6692,14 +6692,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveDockerV1_22_15
+      - TestAzureCentosWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -6717,14 +6717,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveDockerV1_22_15
+      - TestAzureFlatcarWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -6743,14 +6743,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveDockerV1_22_15
+      - TestAzureRhelWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -6768,14 +6768,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveDockerV1_22_15
+      - TestAzureRockylinuxWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -6793,14 +6793,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-gce-default-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveDockerV1_22_15
+      - TestGceDefaultWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: gce
@@ -6816,14 +6816,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveDockerV1_22_15
+      - TestOpenstackDefaultWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -6839,14 +6839,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveDockerV1_22_15
+      - TestOpenstackCentosWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -6862,14 +6862,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveDockerV1_22_15
+      - TestOpenstackRockylinuxWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -6885,14 +6885,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveDockerV1_22_15
+      - TestOpenstackRhelWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -6908,14 +6908,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveDockerV1_22_15
+      - TestOpenstackFlatcarWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -6931,14 +6931,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveDockerV1_22_15
+      - TestVsphereDefaultWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -6954,14 +6954,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosWeaveDockerV1_22_15
+      - TestVsphereCentosWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -6977,14 +6977,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveDockerV1_22_15
+      - TestVsphereFlatcarWeaveDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -7000,14 +7000,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumContainerdV1_25_3
+      - TestAwsAmznCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -7023,14 +7023,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdV1_25_3
+      - TestAwsCentosCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -7046,14 +7046,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumContainerdV1_25_3
+      - TestAwsDefaultCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -7069,14 +7069,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumContainerdV1_25_3
+      - TestAwsFlatcarCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -7092,14 +7092,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumContainerdV1_25_3
+      - TestAwsRhelCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -7115,14 +7115,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumContainerdV1_25_3
+      - TestAwsRockylinuxCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -7138,14 +7138,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumContainerdV1_25_3
+      - TestAzureDefaultCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -7163,14 +7163,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdV1_25_3
+      - TestAzureCentosCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -7188,14 +7188,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumContainerdV1_25_3
+      - TestAzureFlatcarCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -7214,14 +7214,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumContainerdV1_25_3
+      - TestAzureRhelCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -7239,14 +7239,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumContainerdV1_25_3
+      - TestAzureRockylinuxCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -7264,14 +7264,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumContainerdV1_25_3
+      - TestGceDefaultCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: gce
@@ -7287,14 +7287,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumContainerdV1_25_3
+      - TestOpenstackDefaultCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -7310,14 +7310,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdV1_25_3
+      - TestOpenstackCentosCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -7333,14 +7333,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumContainerdV1_25_3
+      - TestOpenstackRockylinuxCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -7356,14 +7356,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumContainerdV1_25_3
+      - TestOpenstackRhelCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -7379,14 +7379,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumContainerdV1_25_3
+      - TestOpenstackFlatcarCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -7402,14 +7402,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumContainerdV1_25_3
+      - TestVsphereDefaultCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -7425,14 +7425,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumContainerdV1_25_3
+      - TestVsphereCentosCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -7448,14 +7448,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumContainerdV1_25_3
+      - TestVsphereFlatcarCiliumContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -7471,14 +7471,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumDockerV1_22_15
+      - TestAwsAmznCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -7494,14 +7494,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumDockerV1_22_15
+      - TestAwsCentosCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -7517,14 +7517,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-default-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumDockerV1_22_15
+      - TestAwsDefaultCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -7540,14 +7540,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-flatcar-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumDockerV1_22_15
+      - TestAwsFlatcarCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -7563,14 +7563,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rhel-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumDockerV1_22_15
+      - TestAwsRhelCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -7586,14 +7586,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumDockerV1_22_15
+      - TestAwsRockylinuxCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -7609,14 +7609,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-default-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumDockerV1_22_15
+      - TestAzureDefaultCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -7634,14 +7634,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumDockerV1_22_15
+      - TestAzureCentosCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -7659,14 +7659,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumDockerV1_22_15
+      - TestAzureFlatcarCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -7685,14 +7685,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumDockerV1_22_15
+      - TestAzureRhelCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -7710,14 +7710,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumDockerV1_22_15
+      - TestAzureRockylinuxCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -7735,14 +7735,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-gce-default-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumDockerV1_22_15
+      - TestGceDefaultCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: gce
@@ -7758,14 +7758,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumDockerV1_22_15
+      - TestOpenstackDefaultCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -7781,14 +7781,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumDockerV1_22_15
+      - TestOpenstackCentosCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -7804,14 +7804,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumDockerV1_22_15
+      - TestOpenstackRockylinuxCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -7827,14 +7827,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumDockerV1_22_15
+      - TestOpenstackRhelCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -7850,14 +7850,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumDockerV1_22_15
+      - TestOpenstackFlatcarCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -7873,14 +7873,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumDockerV1_22_15
+      - TestVsphereDefaultCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -7896,14 +7896,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumDockerV1_22_15
+      - TestVsphereCentosCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -7919,14 +7919,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumDockerV1_22_15
+      - TestVsphereFlatcarCiliumDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -7942,14 +7942,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.22.15
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_22_15
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -7967,14 +7967,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_13
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -7992,14 +7992,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_7
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -8017,14 +8017,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_25_3
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -8042,14 +8042,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_15
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -8067,14 +8067,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_13
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -8092,14 +8092,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_7
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -8117,14 +8117,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_3
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -8142,14 +8142,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.25.3
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_25_3
+      - TestAwsDefaultKubeProxyIpvsV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -8165,14 +8165,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_22_15
+      - TestAwsAmznLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -8188,14 +8188,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_22_15
+      - TestAwsCentosLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -8211,14 +8211,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_22_15
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -8234,14 +8234,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_15
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -8257,14 +8257,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_22_15
+      - TestAwsRhelLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -8280,14 +8280,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_15
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -8303,14 +8303,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_22_15
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -8328,14 +8328,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_22_15
+      - TestAzureCentosLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -8353,14 +8353,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_22_15
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -8379,14 +8379,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_22_15
+      - TestAzureRhelLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -8404,14 +8404,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_15
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -8429,14 +8429,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_22_15
+      - TestGceDefaultLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: gce
@@ -8452,14 +8452,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_15
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -8475,14 +8475,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_22_15
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -8498,14 +8498,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_15
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -8521,14 +8521,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_22_15
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -8544,14 +8544,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_15
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -8567,14 +8567,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_22_15
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -8590,14 +8590,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_22_15
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -8613,14 +8613,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_15
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -8636,14 +8636,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_23_13
+      - TestAwsAmznLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -8659,14 +8659,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_23_13
+      - TestAwsCentosLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -8682,14 +8682,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_13
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -8705,14 +8705,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_13
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -8728,14 +8728,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_23_13
+      - TestAwsRhelLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -8751,14 +8751,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_13
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -8774,14 +8774,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_13
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -8799,14 +8799,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_23_13
+      - TestAzureCentosLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -8824,14 +8824,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_13
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -8850,14 +8850,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_23_13
+      - TestAzureRhelLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -8875,14 +8875,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_13
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -8900,14 +8900,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_23_13
+      - TestGceDefaultLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: gce
@@ -8923,14 +8923,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_13
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -8946,14 +8946,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_13
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -8969,14 +8969,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_13
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -8992,14 +8992,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_13
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -9015,14 +9015,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_13
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -9038,14 +9038,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_13
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -9061,14 +9061,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_23_13
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -9084,14 +9084,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_13
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -9107,14 +9107,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_24_7
+      - TestAwsAmznLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -9130,14 +9130,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_24_7
+      - TestAwsCentosLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -9153,14 +9153,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_7
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -9176,14 +9176,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_7
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -9199,14 +9199,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_24_7
+      - TestAwsRhelLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -9222,14 +9222,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_7
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -9245,14 +9245,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_7
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -9270,14 +9270,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_24_7
+      - TestAzureCentosLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -9295,14 +9295,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_7
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -9321,14 +9321,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_24_7
+      - TestAzureRhelLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -9346,14 +9346,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_7
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -9371,14 +9371,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_24_7
+      - TestGceDefaultLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: gce
@@ -9394,14 +9394,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_7
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -9417,14 +9417,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_7
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -9440,14 +9440,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_7
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -9463,14 +9463,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_7
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -9486,14 +9486,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_7
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -9509,14 +9509,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_7
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -9532,14 +9532,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_7
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -9555,14 +9555,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.7
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_7
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -9578,14 +9578,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_25_3
+      - TestAwsAmznLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -9601,14 +9601,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_25_3
+      - TestAwsCentosLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -9624,14 +9624,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_25_3
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -9647,14 +9647,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_25_3
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -9670,14 +9670,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_25_3
+      - TestAwsRhelLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -9693,14 +9693,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_3
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -9716,14 +9716,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_25_3
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -9741,14 +9741,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_25_3
+      - TestAzureCentosLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -9766,14 +9766,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_25_3
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -9792,14 +9792,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_25_3
+      - TestAzureRhelLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -9817,14 +9817,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_3
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -9842,14 +9842,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_25_3
+      - TestGceDefaultLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: gce
@@ -9865,14 +9865,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_3
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -9888,14 +9888,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_25_3
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -9911,14 +9911,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_3
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -9934,14 +9934,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_25_3
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -9957,14 +9957,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_3
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -9980,14 +9980,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_25_3
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -10003,14 +10003,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_25_3
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -10026,14 +10026,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_3
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -10049,14 +10049,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerDockerV1_22_15
+      - TestAwsAmznLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -10072,14 +10072,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerDockerV1_22_15
+      - TestAwsCentosLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -10095,14 +10095,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerDockerV1_22_15
+      - TestAwsDefaultLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -10118,14 +10118,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerDockerV1_22_15
+      - TestAwsFlatcarLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -10141,14 +10141,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerDockerV1_22_15
+      - TestAwsRhelLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -10164,14 +10164,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerDockerV1_22_15
+      - TestAwsRockylinuxLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -10187,14 +10187,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerDockerV1_22_15
+      - TestAzureDefaultLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -10212,14 +10212,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerDockerV1_22_15
+      - TestAzureCentosLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -10237,14 +10237,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerDockerV1_22_15
+      - TestAzureFlatcarLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -10263,14 +10263,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerDockerV1_22_15
+      - TestAzureRhelLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -10288,14 +10288,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerDockerV1_22_15
+      - TestAzureRockylinuxLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -10313,14 +10313,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerDockerV1_22_15
+      - TestGceDefaultLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: gce
@@ -10336,14 +10336,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerDockerV1_22_15
+      - TestOpenstackDefaultLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10359,14 +10359,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerDockerV1_22_15
+      - TestOpenstackCentosLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10382,14 +10382,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_15
+      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10405,14 +10405,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerDockerV1_22_15
+      - TestOpenstackRhelLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10428,14 +10428,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_15
+      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10451,14 +10451,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerDockerV1_22_15
+      - TestVsphereDefaultLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -10474,14 +10474,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerDockerV1_22_15
+      - TestVsphereCentosLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -10497,14 +10497,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerDockerV1_22_15
+      - TestVsphereFlatcarLegacyMachineControllerDockerV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -10520,14 +10520,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerDockerV1_23_13
+      - TestAwsAmznLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -10543,14 +10543,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerDockerV1_23_13
+      - TestAwsCentosLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -10566,14 +10566,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerDockerV1_23_13
+      - TestAwsDefaultLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -10589,14 +10589,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_13
+      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -10612,14 +10612,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerDockerV1_23_13
+      - TestAwsRhelLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -10635,14 +10635,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_13
+      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -10658,14 +10658,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerDockerV1_23_13
+      - TestAzureDefaultLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -10683,14 +10683,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerDockerV1_23_13
+      - TestAzureCentosLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -10708,14 +10708,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_13
+      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -10734,14 +10734,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerDockerV1_23_13
+      - TestAzureRhelLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -10759,14 +10759,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_13
+      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -10784,14 +10784,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerDockerV1_23_13
+      - TestGceDefaultLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: gce
@@ -10807,14 +10807,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_13
+      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -10830,14 +10830,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_13
+      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -10853,14 +10853,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_13
+      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -10876,14 +10876,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_13
+      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -10899,14 +10899,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_13
+      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -10922,14 +10922,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_13
+      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -10945,14 +10945,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerDockerV1_23_13
+      - TestVsphereCentosLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -10968,14 +10968,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_13
+      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -10991,14 +10991,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_22_15
+      - TestAwsDefaultCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -11014,14 +11014,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_22_15
+      - TestOpenstackDefaultCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -11037,14 +11037,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_22_15
+      - TestOpenstackCentosCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -11060,14 +11060,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_22_15
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -11083,14 +11083,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_22_15
+      - TestOpenstackRhelCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -11106,14 +11106,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_22_15
+      - TestOpenstackFlatcarCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -11129,14 +11129,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_22_15
+      - TestAzureDefaultCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -11154,14 +11154,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_22_15
+      - TestAzureCentosCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -11179,14 +11179,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_22_15
+      - TestAzureFlatcarCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -11205,14 +11205,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_22_15
+      - TestAzureRhelCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -11230,14 +11230,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_22_15
+      - TestAzureRockylinuxCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -11255,14 +11255,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_22_15
+      - TestVsphereDefaultCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -11278,14 +11278,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_22_15
+      - TestVsphereCentosCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -11301,14 +11301,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_22_15
+      - TestVsphereFlatcarCsiCcmMigrationV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -11324,14 +11324,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_23_13
+      - TestAwsDefaultCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -11347,14 +11347,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_23_13
+      - TestOpenstackDefaultCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -11370,14 +11370,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_23_13
+      - TestOpenstackCentosCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -11393,14 +11393,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_13
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -11416,14 +11416,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_23_13
+      - TestOpenstackRhelCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -11439,14 +11439,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_23_13
+      - TestOpenstackFlatcarCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -11462,14 +11462,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_23_13
+      - TestAzureDefaultCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -11487,14 +11487,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_23_13
+      - TestAzureCentosCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -11512,14 +11512,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_23_13
+      - TestAzureFlatcarCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -11538,14 +11538,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_23_13
+      - TestAzureRhelCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -11563,14 +11563,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_23_13
+      - TestAzureRockylinuxCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -11588,14 +11588,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_23_13
+      - TestVsphereDefaultCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -11611,14 +11611,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_23_13
+      - TestVsphereCentosCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -11634,14 +11634,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_23_13
+      - TestVsphereFlatcarCsiCcmMigrationV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -11657,14 +11657,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_24_7
+      - TestAwsDefaultCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -11680,14 +11680,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_24_7
+      - TestOpenstackDefaultCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -11703,14 +11703,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_24_7
+      - TestOpenstackCentosCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -11726,14 +11726,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_7
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -11749,14 +11749,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_24_7
+      - TestOpenstackRhelCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -11772,14 +11772,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_24_7
+      - TestOpenstackFlatcarCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -11795,14 +11795,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_24_7
+      - TestAzureDefaultCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -11820,14 +11820,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_24_7
+      - TestAzureCentosCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -11845,14 +11845,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_24_7
+      - TestAzureFlatcarCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -11871,14 +11871,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_24_7
+      - TestAzureRhelCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -11896,14 +11896,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_24_7
+      - TestAzureRockylinuxCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -11921,14 +11921,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_24_7
+      - TestVsphereDefaultCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -11944,14 +11944,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_24_7
+      - TestVsphereCentosCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -11967,14 +11967,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.7
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_24_7
+      - TestVsphereFlatcarCsiCcmMigrationV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -11990,14 +11990,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_25_3
+      - TestAwsDefaultCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -12013,14 +12013,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_25_3
+      - TestOpenstackDefaultCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -12036,14 +12036,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_25_3
+      - TestOpenstackCentosCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -12059,14 +12059,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_25_3
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -12082,14 +12082,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_25_3
+      - TestOpenstackRhelCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -12105,14 +12105,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_25_3
+      - TestOpenstackFlatcarCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -12128,14 +12128,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_25_3
+      - TestAzureDefaultCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -12153,14 +12153,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_25_3
+      - TestAzureCentosCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -12178,14 +12178,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_25_3
+      - TestAzureFlatcarCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -12204,14 +12204,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_25_3
+      - TestAzureRhelCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -12229,14 +12229,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_25_3
+      - TestAzureRockylinuxCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -12254,14 +12254,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_25_3
+      - TestVsphereDefaultCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -12277,14 +12277,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_25_3
+      - TestVsphereCentosCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -12300,14 +12300,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_25_3
+      - TestVsphereFlatcarCsiCcmMigrationV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -12323,14 +12323,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_22_15
+      - TestAwsAmznInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -12346,14 +12346,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_22_15
+      - TestAwsCentosInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -12369,14 +12369,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_22_15
+      - TestAwsDefaultInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -12392,14 +12392,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_22_15
+      - TestAwsFlatcarInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -12415,14 +12415,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_22_15
+      - TestAwsRhelInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -12438,14 +12438,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_22_15
+      - TestAwsRockylinuxInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -12461,14 +12461,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_22_15
+      - TestAzureDefaultInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -12486,14 +12486,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_22_15
+      - TestAzureCentosInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -12511,14 +12511,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_22_15
+      - TestAzureFlatcarInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -12537,14 +12537,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_22_15
+      - TestAzureRhelInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -12562,14 +12562,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_22_15
+      - TestAzureRockylinuxInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -12587,14 +12587,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_22_15
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -12610,14 +12610,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_22_15
+      - TestDigitaloceanCentosInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -12633,14 +12633,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_15
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -12656,14 +12656,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_22_15
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12679,14 +12679,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_22_15
+      - TestEquinixmetalCentosInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12702,14 +12702,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_15
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12725,14 +12725,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_22_15
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12748,14 +12748,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_22_15
+      - TestHetznerDefaultInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -12771,14 +12771,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_22_15
+      - TestHetznerCentosInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -12794,14 +12794,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_22_15
+      - TestHetznerRockylinuxInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -12817,14 +12817,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_22_15
+      - TestOpenstackDefaultInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -12840,14 +12840,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_22_15
+      - TestOpenstackCentosInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -12863,14 +12863,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_22_15
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -12886,14 +12886,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_22_15
+      - TestOpenstackRhelInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -12909,14 +12909,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_22_15
+      - TestOpenstackFlatcarInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -12932,14 +12932,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_22_15
+      - TestVsphereDefaultInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -12955,14 +12955,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_22_15
+      - TestVsphereCentosInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -12978,14 +12978,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_22_15
+      - TestVsphereFlatcarInstallContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -13001,14 +13001,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_23_13
+      - TestAwsAmznInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -13024,14 +13024,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_23_13
+      - TestAwsCentosInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -13047,14 +13047,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_23_13
+      - TestAwsDefaultInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -13070,14 +13070,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_23_13
+      - TestAwsFlatcarInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -13093,14 +13093,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_23_13
+      - TestAwsRhelInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -13116,14 +13116,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_23_13
+      - TestAwsRockylinuxInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -13139,14 +13139,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_23_13
+      - TestAzureDefaultInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -13164,14 +13164,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_23_13
+      - TestAzureCentosInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -13189,14 +13189,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_23_13
+      - TestAzureFlatcarInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -13215,14 +13215,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_23_13
+      - TestAzureRhelInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -13240,14 +13240,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_23_13
+      - TestAzureRockylinuxInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -13265,14 +13265,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_13
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13288,14 +13288,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_23_13
+      - TestDigitaloceanCentosInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13311,14 +13311,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_13
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13334,14 +13334,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_13
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13357,14 +13357,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_23_13
+      - TestEquinixmetalCentosInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13380,14 +13380,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_13
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13403,14 +13403,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_13
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13426,14 +13426,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_23_13
+      - TestHetznerDefaultInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -13449,14 +13449,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_23_13
+      - TestHetznerCentosInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -13472,14 +13472,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_23_13
+      - TestHetznerRockylinuxInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -13495,14 +13495,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_23_13
+      - TestOpenstackDefaultInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -13518,14 +13518,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_23_13
+      - TestOpenstackCentosInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -13541,14 +13541,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_13
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -13564,14 +13564,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_23_13
+      - TestOpenstackRhelInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -13587,14 +13587,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_23_13
+      - TestOpenstackFlatcarInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -13610,14 +13610,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_23_13
+      - TestVsphereDefaultInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -13633,14 +13633,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_23_13
+      - TestVsphereCentosInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -13656,14 +13656,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_23_13
+      - TestVsphereFlatcarInstallContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -13679,14 +13679,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_24_7
+      - TestAwsAmznInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -13702,14 +13702,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_24_7
+      - TestAwsCentosInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -13725,14 +13725,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_24_7
+      - TestAwsDefaultInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -13748,14 +13748,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_24_7
+      - TestAwsFlatcarInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -13771,14 +13771,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_24_7
+      - TestAwsRhelInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -13794,14 +13794,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_24_7
+      - TestAwsRockylinuxInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -13817,14 +13817,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_24_7
+      - TestAzureDefaultInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -13842,14 +13842,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_24_7
+      - TestAzureCentosInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -13867,14 +13867,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_24_7
+      - TestAzureFlatcarInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -13893,14 +13893,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_24_7
+      - TestAzureRhelInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -13918,14 +13918,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_24_7
+      - TestAzureRockylinuxInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -13943,14 +13943,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_7
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13966,14 +13966,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_24_7
+      - TestDigitaloceanCentosInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13989,14 +13989,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_7
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14012,14 +14012,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_7
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14035,14 +14035,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_24_7
+      - TestEquinixmetalCentosInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14058,14 +14058,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_7
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14081,14 +14081,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_7
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14104,14 +14104,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_24_7
+      - TestHetznerDefaultInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: hetzner
@@ -14127,14 +14127,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_24_7
+      - TestHetznerCentosInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: hetzner
@@ -14150,14 +14150,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_24_7
+      - TestHetznerRockylinuxInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: hetzner
@@ -14173,14 +14173,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_24_7
+      - TestOpenstackDefaultInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -14196,14 +14196,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_24_7
+      - TestOpenstackCentosInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -14219,14 +14219,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_7
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -14242,14 +14242,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_24_7
+      - TestOpenstackRhelInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -14265,14 +14265,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_24_7
+      - TestOpenstackFlatcarInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -14288,14 +14288,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_24_7
+      - TestVsphereDefaultInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -14311,14 +14311,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_24_7
+      - TestVsphereCentosInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -14334,14 +14334,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_24_7
+      - TestVsphereFlatcarInstallContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -14357,14 +14357,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_25_3
+      - TestAwsAmznInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -14380,14 +14380,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_25_3
+      - TestAwsCentosInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -14403,14 +14403,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_25_3
+      - TestAwsDefaultInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -14426,14 +14426,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_25_3
+      - TestAwsFlatcarInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -14449,14 +14449,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_25_3
+      - TestAwsRhelInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -14472,14 +14472,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_25_3
+      - TestAwsRockylinuxInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -14495,14 +14495,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_25_3
+      - TestAzureDefaultInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -14520,14 +14520,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_25_3
+      - TestAzureCentosInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -14545,14 +14545,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_25_3
+      - TestAzureFlatcarInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -14571,14 +14571,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_25_3
+      - TestAzureRhelInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -14596,14 +14596,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_25_3
+      - TestAzureRockylinuxInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -14621,14 +14621,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_25_3
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14644,14 +14644,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_25_3
+      - TestDigitaloceanCentosInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14667,14 +14667,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_3
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14690,14 +14690,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_25_3
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14713,14 +14713,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_25_3
+      - TestEquinixmetalCentosInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14736,14 +14736,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_3
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14759,14 +14759,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_25_3
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14782,14 +14782,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_25_3
+      - TestHetznerDefaultInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: hetzner
@@ -14805,14 +14805,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_25_3
+      - TestHetznerCentosInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: hetzner
@@ -14828,14 +14828,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_25_3
+      - TestHetznerRockylinuxInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: hetzner
@@ -14851,14 +14851,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_25_3
+      - TestOpenstackDefaultInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -14874,14 +14874,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_25_3
+      - TestOpenstackCentosInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -14897,14 +14897,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_25_3
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -14920,14 +14920,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_25_3
+      - TestOpenstackRhelInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -14943,14 +14943,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_25_3
+      - TestOpenstackFlatcarInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -14966,14 +14966,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_25_3
+      - TestVsphereDefaultInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -14989,14 +14989,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_25_3
+      - TestVsphereCentosInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -15012,14 +15012,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_25_3
+      - TestVsphereFlatcarInstallContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -15035,14 +15035,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerExternalV1_22_15
+      - TestAwsAmznInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -15058,14 +15058,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerExternalV1_22_15
+      - TestAwsCentosInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -15081,14 +15081,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerExternalV1_22_15
+      - TestAwsDefaultInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -15104,14 +15104,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerExternalV1_22_15
+      - TestAwsFlatcarInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -15127,14 +15127,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerExternalV1_22_15
+      - TestAwsRhelInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -15150,14 +15150,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerExternalV1_22_15
+      - TestAwsRockylinuxInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -15173,14 +15173,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerExternalV1_22_15
+      - TestAzureDefaultInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -15198,14 +15198,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerExternalV1_22_15
+      - TestAzureCentosInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -15223,14 +15223,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerExternalV1_22_15
+      - TestAzureFlatcarInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -15249,14 +15249,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerExternalV1_22_15
+      - TestAzureRhelInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -15274,14 +15274,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerExternalV1_22_15
+      - TestAzureRockylinuxInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -15299,14 +15299,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallDockerExternalV1_22_15
+      - TestDigitaloceanDefaultInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -15322,14 +15322,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallDockerExternalV1_22_15
+      - TestDigitaloceanCentosInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -15345,14 +15345,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallDockerExternalV1_22_15
+      - TestDigitaloceanRockylinuxInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -15368,14 +15368,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallDockerExternalV1_22_15
+      - TestEquinixmetalDefaultInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15391,14 +15391,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallDockerExternalV1_22_15
+      - TestEquinixmetalCentosInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15414,14 +15414,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallDockerExternalV1_22_15
+      - TestEquinixmetalRockylinuxInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15437,14 +15437,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallDockerExternalV1_22_15
+      - TestEquinixmetalFlatcarInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15460,14 +15460,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallDockerExternalV1_22_15
+      - TestHetznerDefaultInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -15483,14 +15483,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallDockerExternalV1_22_15
+      - TestHetznerCentosInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -15506,14 +15506,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallDockerExternalV1_22_15
+      - TestHetznerRockylinuxInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -15529,14 +15529,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerExternalV1_22_15
+      - TestOpenstackDefaultInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -15552,14 +15552,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerExternalV1_22_15
+      - TestOpenstackCentosInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -15575,14 +15575,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerExternalV1_22_15
+      - TestOpenstackRockylinuxInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -15598,14 +15598,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerExternalV1_22_15
+      - TestOpenstackRhelInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -15621,14 +15621,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerExternalV1_22_15
+      - TestOpenstackFlatcarInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -15644,14 +15644,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerExternalV1_22_15
+      - TestVsphereDefaultInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -15667,14 +15667,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerExternalV1_22_15
+      - TestVsphereCentosInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -15690,14 +15690,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerExternalV1_22_15
+      - TestVsphereFlatcarInstallDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -15713,14 +15713,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerExternalV1_23_13
+      - TestAwsAmznInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -15736,14 +15736,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerExternalV1_23_13
+      - TestAwsCentosInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -15759,14 +15759,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerExternalV1_23_13
+      - TestAwsDefaultInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -15782,14 +15782,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerExternalV1_23_13
+      - TestAwsFlatcarInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -15805,14 +15805,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerExternalV1_23_13
+      - TestAwsRhelInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -15828,14 +15828,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerExternalV1_23_13
+      - TestAwsRockylinuxInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -15851,14 +15851,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerExternalV1_23_13
+      - TestAzureDefaultInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -15876,14 +15876,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerExternalV1_23_13
+      - TestAzureCentosInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -15901,14 +15901,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerExternalV1_23_13
+      - TestAzureFlatcarInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -15927,14 +15927,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerExternalV1_23_13
+      - TestAzureRhelInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -15952,14 +15952,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerExternalV1_23_13
+      - TestAzureRockylinuxInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -15977,14 +15977,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallDockerExternalV1_23_13
+      - TestDigitaloceanDefaultInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16000,14 +16000,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallDockerExternalV1_23_13
+      - TestDigitaloceanCentosInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16023,14 +16023,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_13
+      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16046,14 +16046,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallDockerExternalV1_23_13
+      - TestEquinixmetalDefaultInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16069,14 +16069,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallDockerExternalV1_23_13
+      - TestEquinixmetalCentosInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16092,14 +16092,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_13
+      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16115,14 +16115,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_13
+      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16138,14 +16138,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallDockerExternalV1_23_13
+      - TestHetznerDefaultInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -16161,14 +16161,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallDockerExternalV1_23_13
+      - TestHetznerCentosInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -16184,14 +16184,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallDockerExternalV1_23_13
+      - TestHetznerRockylinuxInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -16207,14 +16207,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerExternalV1_23_13
+      - TestOpenstackDefaultInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -16230,14 +16230,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerExternalV1_23_13
+      - TestOpenstackCentosInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -16253,14 +16253,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerExternalV1_23_13
+      - TestOpenstackRockylinuxInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -16276,14 +16276,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerExternalV1_23_13
+      - TestOpenstackRhelInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -16299,14 +16299,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerExternalV1_23_13
+      - TestOpenstackFlatcarInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -16322,14 +16322,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerExternalV1_23_13
+      - TestVsphereDefaultInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -16345,14 +16345,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerExternalV1_23_13
+      - TestVsphereCentosInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -16368,14 +16368,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerExternalV1_23_13
+      - TestVsphereFlatcarInstallDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -16396,14 +16396,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -16424,14 +16424,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -16452,14 +16452,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -16480,14 +16480,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -16508,14 +16508,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -16536,14 +16536,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -16564,14 +16564,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -16594,14 +16594,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -16624,837 +16624,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.22.15-to-v1.23.13
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -17478,14 +16655,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -17508,14 +16685,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -17538,14 +16715,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -17566,14 +16743,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -17594,14 +16771,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -17622,14 +16799,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17650,14 +16827,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17678,14 +16855,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17706,14 +16883,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17734,14 +16911,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -17762,14 +16939,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -17790,14 +16967,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -17818,14 +16995,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -17846,14 +17023,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -17874,14 +17051,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -17902,14 +17079,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -17930,14 +17107,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -17958,14 +17135,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -17986,14 +17163,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -18014,14 +17191,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.23.13-to-v1.24.7
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.22.16-to-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -18042,14 +17219,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -18070,14 +17247,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -18098,14 +17275,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -18126,14 +17303,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -18154,14 +17331,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -18182,14 +17359,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -18210,14 +17387,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -18240,14 +17417,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -18270,14 +17447,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -18301,14 +17478,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -18331,14 +17508,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -18361,14 +17538,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18389,14 +17566,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18417,14 +17594,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18445,14 +17622,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18473,14 +17650,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18501,14 +17678,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18529,14 +17706,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18557,14 +17734,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: hetzner
@@ -18585,14 +17762,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: hetzner
@@ -18613,14 +17790,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: hetzner
@@ -18641,14 +17818,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -18669,14 +17846,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -18697,14 +17874,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -18725,14 +17902,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -18753,14 +17930,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -18781,14 +17958,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -18809,14 +17986,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -18837,14 +18014,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.24.7-to-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -18865,14 +18042,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -18893,14 +18070,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -18921,14 +18098,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -18949,14 +18126,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -18977,14 +18154,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -19005,14 +18182,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -19033,14 +18210,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -19063,14 +18240,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -19093,14 +18270,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -19124,14 +18301,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -19154,14 +18331,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -19184,14 +18361,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19212,14 +18389,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19240,14 +18417,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19268,14 +18445,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19296,14 +18473,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19324,14 +18501,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19352,14 +18529,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19380,14 +18557,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: hetzner
@@ -19408,14 +18585,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: hetzner
@@ -19436,14 +18613,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: hetzner
@@ -19464,14 +18641,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -19492,14 +18669,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -19520,14 +18697,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -19548,14 +18725,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -19576,14 +18753,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -19604,14 +18781,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -19632,14 +18809,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -19660,14 +18837,837 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-external-from-v1.22.15-to-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-external-from-v1.22.16-to-v1.23.14
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -19683,14 +19683,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -19706,14 +19706,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -19729,14 +19729,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -19752,14 +19752,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -19775,14 +19775,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -19798,14 +19798,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: aws
@@ -19821,14 +19821,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -19846,14 +19846,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -19871,14 +19871,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -19897,14 +19897,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -19922,14 +19922,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: azure
@@ -19947,14 +19947,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_15
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19970,14 +19970,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_15
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19993,14 +19993,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20016,14 +20016,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_15
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20039,14 +20039,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_15
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20062,14 +20062,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20085,14 +20085,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_15
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20108,14 +20108,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_15
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -20131,14 +20131,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_15
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -20154,14 +20154,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -20177,14 +20177,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_15
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20200,14 +20200,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_15
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20223,14 +20223,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_15
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20246,14 +20246,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_15
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20269,14 +20269,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_15
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20292,14 +20292,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_15
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -20315,14 +20315,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_15
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -20338,14 +20338,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.22.15
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_15
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -20361,14 +20361,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -20384,14 +20384,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -20407,14 +20407,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -20430,14 +20430,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -20453,14 +20453,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -20476,14 +20476,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: aws
@@ -20499,14 +20499,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -20524,14 +20524,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -20549,14 +20549,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -20575,14 +20575,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -20600,14 +20600,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: azure
@@ -20625,14 +20625,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_13
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20648,14 +20648,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_13
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20671,14 +20671,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20694,14 +20694,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_13
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20717,14 +20717,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_13
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20740,14 +20740,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20763,14 +20763,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_13
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20786,14 +20786,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_13
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -20809,14 +20809,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_13
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -20832,14 +20832,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -20855,14 +20855,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_13
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -20878,14 +20878,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_13
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -20901,14 +20901,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_13
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -20924,14 +20924,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_13
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -20947,14 +20947,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_13
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: openstack
@@ -20970,14 +20970,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_13
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -20993,14 +20993,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_13
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -21016,14 +21016,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.13
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_13
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_14
       env:
       - name: PROVIDER
         value: vsphere
@@ -21039,14 +21039,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -21062,14 +21062,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -21085,14 +21085,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -21108,14 +21108,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -21131,14 +21131,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -21154,14 +21154,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: aws
@@ -21177,14 +21177,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -21202,14 +21202,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -21227,14 +21227,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -21253,14 +21253,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -21278,14 +21278,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: azure
@@ -21303,14 +21303,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_7
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: digitalocean
@@ -21326,14 +21326,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_7
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: digitalocean
@@ -21349,14 +21349,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: digitalocean
@@ -21372,14 +21372,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_7
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21395,14 +21395,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_7
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21418,14 +21418,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21441,14 +21441,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_7
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21464,14 +21464,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_7
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: hetzner
@@ -21487,14 +21487,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_7
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: hetzner
@@ -21510,14 +21510,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: hetzner
@@ -21533,14 +21533,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_7
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -21556,14 +21556,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_7
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -21579,14 +21579,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_7
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -21602,14 +21602,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_7
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -21625,14 +21625,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_7
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: openstack
@@ -21648,14 +21648,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_7
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -21671,14 +21671,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_7
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -21694,14 +21694,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.7
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.8
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_7
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_8
       env:
       - name: PROVIDER
         value: vsphere
@@ -21717,14 +21717,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -21740,14 +21740,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -21763,14 +21763,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -21786,14 +21786,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -21809,14 +21809,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -21832,14 +21832,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: aws
@@ -21855,14 +21855,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -21880,14 +21880,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -21905,14 +21905,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -21931,14 +21931,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -21956,14 +21956,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: azure
@@ -21981,14 +21981,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: digitalocean
@@ -22004,14 +22004,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_3
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: digitalocean
@@ -22027,14 +22027,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: digitalocean
@@ -22050,14 +22050,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22073,14 +22073,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_3
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22096,14 +22096,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22119,14 +22119,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_3
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22142,14 +22142,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: hetzner
@@ -22165,14 +22165,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_3
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: hetzner
@@ -22188,14 +22188,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: hetzner
@@ -22211,14 +22211,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -22234,14 +22234,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_3
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -22257,14 +22257,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_3
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -22280,14 +22280,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_3
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -22303,14 +22303,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_3
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: openstack
@@ -22326,14 +22326,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_3
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -22349,14 +22349,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_3
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -22372,14 +22372,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.25.3
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.25.4
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_3
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_4
       env:
       - name: PROVIDER
         value: vsphere
@@ -22395,14 +22395,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_15
+      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -22418,14 +22418,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_15
+      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -22441,14 +22441,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_15
+      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -22464,14 +22464,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_15
+      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22487,14 +22487,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_15
+      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22510,14 +22510,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_15
+      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22533,14 +22533,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_15
+      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22556,14 +22556,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_15
+      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -22579,14 +22579,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_15
+      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -22602,14 +22602,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.22.15
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.22.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_15
+      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -22625,14 +22625,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_13
+      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -22648,14 +22648,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_13
+      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -22671,14 +22671,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_13
+      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: digitalocean
@@ -22694,14 +22694,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_13
+      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22717,14 +22717,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_13
+      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22740,14 +22740,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_13
+      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22763,14 +22763,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_13
+      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -22786,14 +22786,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_13
+      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -22809,14 +22809,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_13
+      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner
@@ -22832,14 +22832,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.13
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.14
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_13
+      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_14
       env:
       - name: PROVIDER
         value: hetzner

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -10,8381 +10,8381 @@ import (
 func TestStub(t *testing.T) {
 	t.Skip("stub is skipped")
 }
-func TestAwsAmznInstallContainerdV1_22_15(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_22_15(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_22_15(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_22_15(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_22_15(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_22_15(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_22_15(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_22_15(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_22_15(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_22_15(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_22_15(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_22_15(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_22_15(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_22_15(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_22_15(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_22_15(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_22_15(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_22_15(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_23_13(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_23_13(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_23_13(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_23_13(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_23_13(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_23_13(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_23_13(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_23_13(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_23_13(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_23_13(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_23_13(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_23_13(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_23_13(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_23_13(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_23_13(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_23_13(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_23_13(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_23_13(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_24_7(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_24_7(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_24_7(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_24_7(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_24_7(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_24_7(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_24_7(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_24_7(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_24_7(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_24_7(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_24_7(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_24_7(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_24_7(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_24_7(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_24_7(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_24_7(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_24_7(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_24_7(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_24_7(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_24_7(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_25_3(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_25_3(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_25_3(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_25_3(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_25_3(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_25_3(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_25_3(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_25_3(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_25_3(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_25_3(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_25_3(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_25_3(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_25_3(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_25_3(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_25_3(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_25_3(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_25_3(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerV1_22_15(t *testing.T) {
+func TestAwsAmznInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerV1_22_15(t *testing.T) {
+func TestAwsCentosInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerV1_22_15(t *testing.T) {
+func TestAwsDefaultInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerV1_22_15(t *testing.T) {
+func TestAwsFlatcarInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerV1_22_15(t *testing.T) {
+func TestAwsRhelInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerV1_22_15(t *testing.T) {
+func TestAwsRockylinuxInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerV1_22_15(t *testing.T) {
+func TestAzureDefaultInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerV1_22_15(t *testing.T) {
+func TestAzureCentosInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerV1_22_15(t *testing.T) {
+func TestAzureFlatcarInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerV1_22_15(t *testing.T) {
+func TestAzureRhelInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerV1_22_15(t *testing.T) {
+func TestAzureRockylinuxInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallDockerV1_22_15(t *testing.T) {
+func TestGceDefaultInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerV1_22_15(t *testing.T) {
+func TestOpenstackDefaultInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerV1_22_15(t *testing.T) {
+func TestOpenstackCentosInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerV1_22_15(t *testing.T) {
+func TestOpenstackRhelInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerV1_22_15(t *testing.T) {
+func TestVsphereDefaultInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerV1_22_15(t *testing.T) {
+func TestVsphereCentosInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerV1_22_15(t *testing.T) {
+func TestVsphereFlatcarInstallDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerV1_23_13(t *testing.T) {
+func TestAwsAmznInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerV1_23_13(t *testing.T) {
+func TestAwsCentosInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerV1_23_13(t *testing.T) {
+func TestAwsDefaultInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerV1_23_13(t *testing.T) {
+func TestAwsFlatcarInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerV1_23_13(t *testing.T) {
+func TestAwsRhelInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerV1_23_13(t *testing.T) {
+func TestAwsRockylinuxInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerV1_23_13(t *testing.T) {
+func TestAzureDefaultInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerV1_23_13(t *testing.T) {
+func TestAzureCentosInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerV1_23_13(t *testing.T) {
+func TestAzureFlatcarInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerV1_23_13(t *testing.T) {
+func TestAzureRhelInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerV1_23_13(t *testing.T) {
+func TestAzureRockylinuxInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallDockerV1_23_13(t *testing.T) {
+func TestGceDefaultInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerV1_23_13(t *testing.T) {
+func TestOpenstackDefaultInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerV1_23_13(t *testing.T) {
+func TestOpenstackCentosInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerV1_23_13(t *testing.T) {
+func TestOpenstackRhelInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerV1_23_13(t *testing.T) {
+func TestVsphereDefaultInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerV1_23_13(t *testing.T) {
+func TestVsphereCentosInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerV1_23_13(t *testing.T) {
+func TestVsphereFlatcarInstallDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestGceDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereCentosStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeDockerFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCalicoContainerdV1_25_3(t *testing.T) {
+func TestAwsAmznCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoContainerdV1_25_3(t *testing.T) {
+func TestAwsCentosCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoContainerdV1_25_3(t *testing.T) {
+func TestAwsDefaultCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoContainerdV1_25_3(t *testing.T) {
+func TestAwsFlatcarCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoContainerdV1_25_3(t *testing.T) {
+func TestAwsRhelCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoContainerdV1_25_3(t *testing.T) {
+func TestAwsRockylinuxCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoContainerdV1_25_3(t *testing.T) {
+func TestAzureDefaultCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdV1_25_3(t *testing.T) {
+func TestAzureCentosCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoContainerdV1_25_3(t *testing.T) {
+func TestAzureFlatcarCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoContainerdV1_25_3(t *testing.T) {
+func TestAzureRhelCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoContainerdV1_25_3(t *testing.T) {
+func TestAzureRockylinuxCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoContainerdV1_25_3(t *testing.T) {
+func TestGceDefaultCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoContainerdV1_25_3(t *testing.T) {
+func TestOpenstackDefaultCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoContainerdV1_25_3(t *testing.T) {
+func TestOpenstackCentosCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRhelCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoContainerdV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoContainerdV1_25_3(t *testing.T) {
+func TestVsphereDefaultCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoContainerdV1_25_3(t *testing.T) {
+func TestVsphereCentosCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoContainerdV1_25_3(t *testing.T) {
+func TestVsphereFlatcarCalicoContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCalicoDockerV1_22_15(t *testing.T) {
+func TestAwsAmznCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoDockerV1_22_15(t *testing.T) {
+func TestAwsCentosCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoDockerV1_22_15(t *testing.T) {
+func TestAwsDefaultCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoDockerV1_22_15(t *testing.T) {
+func TestAwsFlatcarCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoDockerV1_22_15(t *testing.T) {
+func TestAwsRhelCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoDockerV1_22_15(t *testing.T) {
+func TestAwsRockylinuxCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoDockerV1_22_15(t *testing.T) {
+func TestAzureDefaultCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoDockerV1_22_15(t *testing.T) {
+func TestAzureCentosCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoDockerV1_22_15(t *testing.T) {
+func TestAzureFlatcarCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoDockerV1_22_15(t *testing.T) {
+func TestAzureRhelCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoDockerV1_22_15(t *testing.T) {
+func TestAzureRockylinuxCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoDockerV1_22_15(t *testing.T) {
+func TestGceDefaultCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoDockerV1_22_15(t *testing.T) {
+func TestOpenstackDefaultCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoDockerV1_22_15(t *testing.T) {
+func TestOpenstackCentosCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoDockerV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoDockerV1_22_15(t *testing.T) {
+func TestOpenstackRhelCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoDockerV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoDockerV1_22_15(t *testing.T) {
+func TestVsphereDefaultCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoDockerV1_22_15(t *testing.T) {
+func TestVsphereCentosCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoDockerV1_22_15(t *testing.T) {
+func TestVsphereFlatcarCalicoDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveContainerdV1_25_3(t *testing.T) {
+func TestAwsAmznWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveContainerdV1_25_3(t *testing.T) {
+func TestAwsCentosWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveContainerdV1_25_3(t *testing.T) {
+func TestAwsDefaultWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveContainerdV1_25_3(t *testing.T) {
+func TestAwsFlatcarWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveContainerdV1_25_3(t *testing.T) {
+func TestAwsRhelWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveContainerdV1_25_3(t *testing.T) {
+func TestAwsRockylinuxWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveContainerdV1_25_3(t *testing.T) {
+func TestAzureDefaultWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveContainerdV1_25_3(t *testing.T) {
+func TestAzureCentosWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveContainerdV1_25_3(t *testing.T) {
+func TestAzureFlatcarWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveContainerdV1_25_3(t *testing.T) {
+func TestAzureRhelWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveContainerdV1_25_3(t *testing.T) {
+func TestAzureRockylinuxWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveContainerdV1_25_3(t *testing.T) {
+func TestGceDefaultWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveContainerdV1_25_3(t *testing.T) {
+func TestOpenstackDefaultWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveContainerdV1_25_3(t *testing.T) {
+func TestOpenstackCentosWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRhelWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveContainerdV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveContainerdV1_25_3(t *testing.T) {
+func TestVsphereDefaultWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosWeaveContainerdV1_25_3(t *testing.T) {
+func TestVsphereCentosWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveContainerdV1_25_3(t *testing.T) {
+func TestVsphereFlatcarWeaveContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveDockerV1_22_15(t *testing.T) {
+func TestAwsAmznWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveDockerV1_22_15(t *testing.T) {
+func TestAwsCentosWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveDockerV1_22_15(t *testing.T) {
+func TestAwsDefaultWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveDockerV1_22_15(t *testing.T) {
+func TestAwsFlatcarWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveDockerV1_22_15(t *testing.T) {
+func TestAwsRhelWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveDockerV1_22_15(t *testing.T) {
+func TestAwsRockylinuxWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveDockerV1_22_15(t *testing.T) {
+func TestAzureDefaultWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveDockerV1_22_15(t *testing.T) {
+func TestAzureCentosWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveDockerV1_22_15(t *testing.T) {
+func TestAzureFlatcarWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveDockerV1_22_15(t *testing.T) {
+func TestAzureRhelWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveDockerV1_22_15(t *testing.T) {
+func TestAzureRockylinuxWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveDockerV1_22_15(t *testing.T) {
+func TestGceDefaultWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveDockerV1_22_15(t *testing.T) {
+func TestOpenstackDefaultWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveDockerV1_22_15(t *testing.T) {
+func TestOpenstackCentosWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveDockerV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveDockerV1_22_15(t *testing.T) {
+func TestOpenstackRhelWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveDockerV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveDockerV1_22_15(t *testing.T) {
+func TestVsphereDefaultWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosWeaveDockerV1_22_15(t *testing.T) {
+func TestVsphereCentosWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveDockerV1_22_15(t *testing.T) {
+func TestVsphereFlatcarWeaveDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumContainerdV1_25_3(t *testing.T) {
+func TestAwsAmznCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumContainerdV1_25_3(t *testing.T) {
+func TestAwsCentosCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumContainerdV1_25_3(t *testing.T) {
+func TestAwsDefaultCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumContainerdV1_25_3(t *testing.T) {
+func TestAwsFlatcarCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumContainerdV1_25_3(t *testing.T) {
+func TestAwsRhelCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumContainerdV1_25_3(t *testing.T) {
+func TestAwsRockylinuxCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumContainerdV1_25_3(t *testing.T) {
+func TestAzureDefaultCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdV1_25_3(t *testing.T) {
+func TestAzureCentosCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumContainerdV1_25_3(t *testing.T) {
+func TestAzureFlatcarCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumContainerdV1_25_3(t *testing.T) {
+func TestAzureRhelCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumContainerdV1_25_3(t *testing.T) {
+func TestAzureRockylinuxCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumContainerdV1_25_3(t *testing.T) {
+func TestGceDefaultCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumContainerdV1_25_3(t *testing.T) {
+func TestOpenstackDefaultCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumContainerdV1_25_3(t *testing.T) {
+func TestOpenstackCentosCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRhelCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumContainerdV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumContainerdV1_25_3(t *testing.T) {
+func TestVsphereDefaultCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumContainerdV1_25_3(t *testing.T) {
+func TestVsphereCentosCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumContainerdV1_25_3(t *testing.T) {
+func TestVsphereFlatcarCiliumContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumDockerV1_22_15(t *testing.T) {
+func TestAwsAmznCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumDockerV1_22_15(t *testing.T) {
+func TestAwsCentosCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumDockerV1_22_15(t *testing.T) {
+func TestAwsDefaultCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumDockerV1_22_15(t *testing.T) {
+func TestAwsFlatcarCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumDockerV1_22_15(t *testing.T) {
+func TestAwsRhelCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumDockerV1_22_15(t *testing.T) {
+func TestAwsRockylinuxCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumDockerV1_22_15(t *testing.T) {
+func TestAzureDefaultCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumDockerV1_22_15(t *testing.T) {
+func TestAzureCentosCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumDockerV1_22_15(t *testing.T) {
+func TestAzureFlatcarCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumDockerV1_22_15(t *testing.T) {
+func TestAzureRhelCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumDockerV1_22_15(t *testing.T) {
+func TestAzureRockylinuxCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumDockerV1_22_15(t *testing.T) {
+func TestGceDefaultCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumDockerV1_22_15(t *testing.T) {
+func TestOpenstackDefaultCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumDockerV1_22_15(t *testing.T) {
+func TestOpenstackCentosCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumDockerV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumDockerV1_22_15(t *testing.T) {
+func TestOpenstackRhelCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumDockerV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumDockerV1_22_15(t *testing.T) {
+func TestVsphereDefaultCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumDockerV1_22_15(t *testing.T) {
+func TestVsphereCentosCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumDockerV1_22_15(t *testing.T) {
+func TestVsphereFlatcarCiliumDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_22_15(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_13(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_7(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_25_3(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_25_3(t *testing.T) {
+func TestAwsDefaultKubeProxyIpvsV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_15(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_13(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_7(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_3(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerDockerV1_22_15(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerDockerV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_13(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_22_15(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_23_13(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_24_7(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_25_3(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_22_15(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_23_13(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_24_7(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_25_3(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAwsAmznInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAwsCentosInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAwsDefaultInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAwsFlatcarInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAwsRhelInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAwsRockylinuxInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAzureDefaultInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAzureCentosInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAzureFlatcarInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAzureRhelInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
+func TestAzureRockylinuxInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallDockerExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanDefaultInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallDockerExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanCentosInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallDockerExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalDefaultInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallDockerExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalCentosInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalFlatcarInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallDockerExternalV1_22_15(t *testing.T) {
+func TestHetznerDefaultInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallDockerExternalV1_22_15(t *testing.T) {
+func TestHetznerCentosInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
+func TestHetznerRockylinuxInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerExternalV1_22_15(t *testing.T) {
+func TestOpenstackDefaultInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerExternalV1_22_15(t *testing.T) {
+func TestOpenstackCentosInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerExternalV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerExternalV1_22_15(t *testing.T) {
+func TestOpenstackRhelInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerExternalV1_22_15(t *testing.T) {
+func TestVsphereDefaultInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerExternalV1_22_15(t *testing.T) {
+func TestVsphereCentosInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerExternalV1_22_15(t *testing.T) {
+func TestVsphereFlatcarInstallDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAwsAmznInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAwsCentosInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAwsDefaultInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAwsFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAwsRhelInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAwsRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAzureDefaultInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAzureCentosInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAzureFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAzureRhelInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
+func TestAzureRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallDockerExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanDefaultInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallDockerExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanCentosInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallDockerExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalDefaultInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallDockerExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalCentosInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallDockerExternalV1_23_13(t *testing.T) {
+func TestHetznerDefaultInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallDockerExternalV1_23_13(t *testing.T) {
+func TestHetznerCentosInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
+func TestHetznerRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerExternalV1_23_13(t *testing.T) {
+func TestOpenstackDefaultInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerExternalV1_23_13(t *testing.T) {
+func TestOpenstackCentosInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerExternalV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerExternalV1_23_13(t *testing.T) {
+func TestOpenstackRhelInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerExternalV1_23_13(t *testing.T) {
+func TestVsphereDefaultInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerExternalV1_23_13(t *testing.T) {
+func TestVsphereCentosInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerExternalV1_23_13(t *testing.T) {
+func TestVsphereFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_13_ToV1_24_7(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13", "v1.24.7")
+	scenario.SetVersions("v1.23.14", "v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_7_ToV1_25_3(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7", "v1.25.3")
+	scenario.SetVersions("v1.24.8", "v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereCentosStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_15_ToV1_23_13(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_16_ToV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15", "v1.23.13")
+	scenario.SetVersions("v1.22.16", "v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_15(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_13(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_7(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.7")
+	scenario.SetVersions("v1.24.8")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_3(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.3")
+	scenario.SetVersions("v1.25.4")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_15(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.15")
+	scenario.SetVersions("v1.22.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_13(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.13")
+	scenario.SetVersions("v1.23.14")
 	scenario.Run(ctx, t)
 }

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -1,5 +1,5 @@
 - scenario: install_containerd
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -24,7 +24,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -49,7 +49,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.24.7
+  initVersion: v1.24.8
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -74,7 +74,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -99,7 +99,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -123,7 +123,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -147,8 +147,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd
-  initVersion: v1.24.7
-  upgradedVersion: v1.25.3
+  initVersion: v1.24.8
+  upgradedVersion: v1.25.4
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -172,8 +172,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd
-  initVersion: v1.23.13
-  upgradedVersion: v1.24.7
+  initVersion: v1.23.14
+  upgradedVersion: v1.24.8
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -197,8 +197,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd
-  initVersion: v1.22.15
-  upgradedVersion: v1.23.13
+  initVersion: v1.22.16
+  upgradedVersion: v1.23.14
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -222,8 +222,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_docker
-  initVersion: v1.22.15
-  upgradedVersion: v1.23.13
+  initVersion: v1.22.16
+  upgradedVersion: v1.23.14
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -247,7 +247,7 @@
     - name: vsphere_flatcar_stable
 
 - scenario: calico_containerd
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -271,7 +271,7 @@
     - name: vsphere_flatcar
 
 - scenario: calico_docker
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -295,7 +295,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_containerd
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -319,7 +319,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_docker
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -343,7 +343,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_containerd
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -367,7 +367,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_docker
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -391,52 +391,52 @@
     - name: vsphere_flatcar
 
 - scenario: conformance_containerd
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.24.7
+  initVersion: v1.24.8
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.24.7
+  initVersion: v1.24.8
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_default
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -460,7 +460,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -484,7 +484,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.24.7
+  initVersion: v1.24.8
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -508,7 +508,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -532,7 +532,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -556,7 +556,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -580,7 +580,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_default  
     - name: openstack_default
@@ -598,7 +598,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_default  
     - name: openstack_default
@@ -616,7 +616,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.24.7
+  initVersion: v1.24.8
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -634,7 +634,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -652,40 +652,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.22.15
-  infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: digitalocean_default
-    - name: digitalocean_centos
-    - name: digitalocean_rockylinux
-    - name: equinixmetal_default
-    - name: equinixmetal_centos
-    - name: equinixmetal_rockylinux
-    - name: equinixmetal_flatcar
-    - name: hetzner_default
-    - name: hetzner_centos
-    - name: hetzner_rockylinux
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_centos
-    - name: vsphere_flatcar
-
-- scenario: install_containerd_external
-  initVersion: v1.23.13
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -718,7 +685,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.24.7
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -751,7 +718,40 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.25.3
+  initVersion: v1.24.8
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: digitalocean_default
+    - name: digitalocean_centos
+    - name: digitalocean_rockylinux
+    - name: equinixmetal_default
+    - name: equinixmetal_centos
+    - name: equinixmetal_rockylinux
+    - name: equinixmetal_flatcar
+    - name: hetzner_default
+    - name: hetzner_centos
+    - name: hetzner_rockylinux
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_centos
+    - name: vsphere_flatcar
+
+- scenario: install_containerd_external
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -784,7 +784,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -817,7 +817,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -850,8 +850,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.22.15
-  upgradedVersion: v1.23.13
+  initVersion: v1.22.16
+  upgradedVersion: v1.23.14
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -884,8 +884,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.23.13
-  upgradedVersion: v1.24.7
+  initVersion: v1.23.14
+  upgradedVersion: v1.24.8
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -918,8 +918,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.24.7
-  upgradedVersion: v1.25.3
+  initVersion: v1.24.8
+  upgradedVersion: v1.25.4
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -952,8 +952,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_docker_external
-  initVersion: v1.22.15
-  upgradedVersion: v1.23.13
+  initVersion: v1.22.16
+  upgradedVersion: v1.23.14
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -986,7 +986,7 @@
     - name: vsphere_flatcar_stable
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -1019,7 +1019,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -1052,7 +1052,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.24.7
+  initVersion: v1.24.8
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -1085,7 +1085,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.25.3
+  initVersion: v1.25.4
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -1118,7 +1118,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker_external
-  initVersion: v1.22.15
+  initVersion: v1.22.16
   infrastructures:
     - name: digitalocean_default
     - name: digitalocean_centos
@@ -1132,7 +1132,7 @@
     - name: hetzner_rockylinux
 
 - scenario: legacy_machine_controller_docker_external
-  initVersion: v1.23.13
+  initVersion: v1.23.14
   infrastructures:
     - name: digitalocean_default
     - name: digitalocean_centos


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates our E2E tests to use November's Kubernetes patch releases.

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add support for Kubernetes 1.25.4, 1.24.8, and 1.23.14. Those Kubernetes patch releases fix CVE-2022-3162 and CVE-2022-3294, both in kube-apiserver:
  - [CVE-2022-3162: Unauthorized read of Custom Resources](https://groups.google.com/g/kubernetes-announce/c/oR2PUBiODNA/m/tShPgvpUDQAJ)
  - [CVE-2022-3294: Node address isn't always verified when proxying](https://groups.google.com/g/kubernetes-announce/c/eR0ghAXy2H8/m/sCuQQZlVDQAJ)
We strongly recommend upgrading to those Kubernetes patch releases as soon as possible.
```

**Documentation**:
```documentation
NONE
```