### PR TITLE
Add cluster-autoscaler v1.25.0

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -394,7 +394,8 @@ func optionalResources() map[Resource]map[string]string {
 		ClusterAutoscaler: {
 			"1.22.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.3",
 			"1.23.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.1",
-			">= 1.24.0": "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.24.0",
+			"1.24.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.24.0",
+			">= 1.25.0": "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.25.0",
 		},
 
 		// CSI Vault Secret Provider


### PR DESCRIPTION
**What this PR does / why we need it**:

Add cluster-autoscaler v1.25.0 for Kubernetes 1.25 clusters.

**Which issue(s) this PR fixes**:
xref #2406 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add cluster-autoscaler v1.25.0 for Kubernetes 1.25 clusters
```

**Documentation**:
```documentation
NONE
```