### PR TITLE
Update NodeLocalDNS to v1.22.13

### DIFF
--- a/addons/nodelocaldns/nodelocaldns.yaml
+++ b/addons/nodelocaldns/nodelocaldns.yaml
@@ -134,9 +134,10 @@ spec:
           requests:
             cpu: 25m
             memory: 5Mi
-        args: [ "-localip", "__PILLAR__LOCAL__DNS__,__PILLAR__DNS__SERVER__", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
         securityContext:
-          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
         ports:
         - containerPort: 53
           name: dns

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -213,7 +213,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoCNI:              {"*": "quay.io/calico/cni:v3.23.3"},
 		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.23.3"},
 		CalicoNode:             {"*": "quay.io/calico/node:v3.23.3"},
-		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.21.1"},
+		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.13"},
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.55.0"},
 		MetricsServer:          {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.6.1"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Update NodeLocalDNSCache to v1.22.13.

**Which issue(s) this PR fixes**:
xref #2406 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update NodeLocalDNSCache to v1.22.13
```

**Documentation**:
```documentation
NONE
```