### PR TITLE
Fix NPE in probes

### DIFF
--- a/pkg/tasks/probes.go
+++ b/pkg/tasks/probes.go
@@ -174,8 +174,13 @@ func safeguardNodeSelectorsAndTolerations(s *state.State) error {
 		return err
 	}
 
+	liveCP := s.LiveCluster.ControlPlane
+	if len(liveCP) == 0 || liveCP[0].Kubelet.Version == nil {
+		return nil
+	}
+
 	// Run safeguard only when upgrading to Kubernetes 1.24.
-	if targetVersion.Minor() == 24 && s.LiveCluster.ControlPlane[0].Kubelet.Version.Minor() == 23 {
+	if targetVersion.Minor() == 24 && liveCP[0].Kubelet.Version.Minor() == 23 {
 		var pods corev1.PodList
 		// List pods in all namespaces
 		if err := s.DynamicClient.List(s.Context, &pods, dynclient.InNamespace("")); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Some newer code in probes assumed that the kubelet on the first node is always there which might not be the case (a bug). This PR introduces some more checks and degrades silently.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #2482

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix NPE in probes
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
