### PR TITLE
Fix NPE when determining if it is safe to repair a cluster

### DIFF
--- a/pkg/state/cluster.go
+++ b/pkg/state/cluster.go
@@ -243,7 +243,7 @@ func (c *Cluster) SafeToRepair(targetVersion string) (bool, string) {
 
 	var highestVer *semver.Version
 	for _, host := range c.ControlPlane {
-		if !host.IsInCluster {
+		if !host.IsInCluster || host.Kubelet.Version == nil {
 			continue
 		}
 		if highestVer == nil || host.Kubelet.Version.GreaterThan(highestVer) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an NPE when determining if it is safe to repair a cluster. We wrongly assumed that we'll always be able to determine the kubelet version when running the `SafeToRepair` function. With this, we'll skip a node if we can't determine its kubelet version instead of throwing an NPE.

This is similar to #2483 but in a different place.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix a panic (NPE) when determining if it is safe to repair a cluster when there's no kubelet or kubelet systemd unit on the node
```

**Documentation**:
```documentation
NONE
```