### PR TITLE
Update etcd to 3.5.6 and enable compact hash checks

### DIFF
--- a/pkg/templates/kubeadm/v1beta3/kubeadm_test.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm_test.go
@@ -25,8 +25,9 @@ import (
 
 func TestEtcdVersionCorruptCheckExtraArgs(t *testing.T) {
 	etcdExtraArgs := map[string]string{
-		"experimental-initial-corrupt-check": "true",
-		"experimental-corrupt-check-time":    "240m",
+		"experimental-compact-hash-check-enabled": "true",
+		"experimental-initial-corrupt-check":      "true",
+		"experimental-corrupt-check-time":         "240m",
 	}
 
 	tests := []struct {
@@ -55,26 +56,32 @@ func TestEtcdVersionCorruptCheckExtraArgs(t *testing.T) {
 			expectedEtcdArgs:     etcdExtraArgs,
 		},
 		{
+			name:                 "unfixed 1.26",
+			kubeVersion:          semver.MustParse("1.26.0"),
+			expectedEtcdImageTag: fixedEtcdVersion,
+			expectedEtcdArgs:     etcdExtraArgs,
+		},
+		{
 			name:                 "fixed 1.23",
-			kubeVersion:          semver.MustParse("1.23.14"),
+			kubeVersion:          semver.MustParse("1.23.99"),
 			expectedEtcdImageTag: "",
 			expectedEtcdArgs:     etcdExtraArgs,
 		},
 		{
 			name:                 "fixed 1.24",
-			kubeVersion:          semver.MustParse("1.24.8"),
+			kubeVersion:          semver.MustParse("1.24.99"),
 			expectedEtcdImageTag: "",
 			expectedEtcdArgs:     etcdExtraArgs,
 		},
 		{
 			name:                 "fixed 1.25",
-			kubeVersion:          semver.MustParse("1.25.4"),
+			kubeVersion:          semver.MustParse("1.25.99"),
 			expectedEtcdImageTag: "",
 			expectedEtcdArgs:     etcdExtraArgs,
 		},
 		{
 			name:                 "fixed 1.26",
-			kubeVersion:          semver.MustParse("1.26.0"),
+			kubeVersion:          semver.MustParse("1.26.99"),
 			expectedEtcdImageTag: "",
 			expectedEtcdArgs:     etcdExtraArgs,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update etcd to 3.5.6 which includes a fix for [the recently reported data inconsistency issue for a case when etcd crashes during processing defragmentation operation](https://groups.google.com/a/kubernetes.io/g/dev/c/sEVopPxKPDo/m/9ME3CzicBwAJ)
- Enable compact hash checks as per [the recommendations from etcd for detecting data corruption](https://etcd.io/docs/v3.5/op-guide/data_corruption/#enabling-data-corruption-detection)

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

- There's no `registry.k8s.io/etcd:3.5.6-0` image available yet, so I'll leave this PR as a draft until then.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update etcd to 3.5.6 which includes a fix for [the recently reported data inconsistency issue for a case when etcd crashes during processing defragmentation operation](https://groups.google.com/a/kubernetes.io/g/dev/c/sEVopPxKPDo/m/9ME3CzicBwAJ)
- Enable compact hash checks as per [the recommendations from etcd for detecting data corruption](https://etcd.io/docs/v3.5/op-guide/data_corruption/#enabling-data-corruption-detection)
```

**Documentation**:
```documentation
NONE
```