### PR TITLE
[release/v1.5] Use `registry.k8s.io` instead of `k8s.gcr.io` for Kubernetes upstream images

### DIFF
--- a/addons/csi-vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi-vmware-cloud-director/csi-controller.yaml
@@ -108,7 +108,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          image: {{ .InternalImages.Get "VMwareCloudDirectorCSIAttacher" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -121,7 +121,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: {{ .InternalImages.Get "VMwareCloudDirectorCSIProvisioner" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)

--- a/addons/csi-vmware-cloud-director/csi-node.yaml
+++ b/addons/csi-vmware-cloud-director/csi-node.yaml
@@ -47,7 +47,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: {{ .InternalImages.Get "VMwareCloudDirectorCSINodeDriverRegistrar" }}
           imagePullPolicy: "IfNotPresent"
           args:
             - "--v=5"

--- a/hack/image-loader.sh
+++ b/hack/image-loader.sh
@@ -109,20 +109,12 @@ k1images=$(kubeone config images list --filter=base --kubernetes-version="$KUBER
 optionalimages=$(kubeone config images list --filter=optional --kubernetes-version="$KUBERNETES_VERSION")
 
 for IMAGE in $k8simages; do
-  # The CoreDNS image has a different override semantics in Kubernetes 1.21 and
-  # in other Kubernetes minor releases (due to a bug).
-  # The image will be overridden in the following way depending on the
-  # Kubernetes version:
-  #   * 1.21: k8s.gcr.io/coredns/coredns -> custom-registry/coredns/coredns
-  #   * all other releases: k8s.gcr.io/coredns/coredns -> custom-registry/coredns
-  if [[ "$IMAGE" == "k8s.gcr.io/coredns/coredns:"* ]]; then
+  # The CoreDNS image has a different override semantics than other images.
+  # The image will be overridden in the following way:
+  #   registry.k8s.io/coredns/coredns -> custom-registry/coredns
+  if [[ "$IMAGE" == "registry.k8s.io/coredns/coredns:"* ]]; then
     corednsVersion=$(cut -d ':' -f 2 <<< "${IMAGE}")
-    kubernetesMinor=$(cut -d '.' -f 2 <<< "${KUBERNETES_VERSION}")
-    if [ "${kubernetesMinor}" -eq "21" ]; then
-      retag "k8s.gcr.io/coredns/coredns:${corednsVersion}" "coredns/coredns"
-    else
-      retag "k8s.gcr.io/coredns/coredns:${corednsVersion}" "coredns"
-    fi
+    retag "registry.k8s.io/coredns/coredns:${corednsVersion}" "coredns"
   else
     retag "${IMAGE}"
   fi

--- a/pkg/addons/manifest_test.go
+++ b/pkg/addons/manifest_test.go
@@ -122,7 +122,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: {{ Registry "k8s.gcr.io" }}/kube-apiserver:v1.19.3
+  - image: {{ Registry "registry.k8s.io" }}/kube-apiserver:v1.19.3
 `
 
 	testManifest1WithImageParsed = `apiVersion: v1
@@ -136,7 +136,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: k8s.gcr.io/kube-apiserver:v1.19.3
+  - image: registry.k8s.io/kube-apiserver:v1.19.3
 `
 
 	testManifest1WithCustomImageParsed = `apiVersion: v1

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -132,8 +132,8 @@ func (crc ContainerRuntimeConfig) MachineControllerFlags() []string {
 		// example output:
 		// -node-containerd-registry-mirrors=docker.io=custom.tld
 		// -node-containerd-registry-mirrors=docker.io=https://secure-custom.tld
-		// -node-containerd-registry-mirrors=k8s.gcr.io=http://somewhere
-		// -node-insecure-registries=docker.io,k8s.gcr.io
+		// -node-containerd-registry-mirrors=registry.k8s.io=http://somewhere
+		// -node-insecure-registries=docker.io,registry.k8s.io
 		var (
 			registryNames                 []string
 			insecureSet                   = map[string]struct{}{}

--- a/pkg/apis/kubeone/helpers_test.go
+++ b/pkg/apis/kubeone/helpers_test.go
@@ -118,7 +118,7 @@ func TestContainerRuntimeConfig_MachineControllerFlags(t *testing.T) {
 								"registry3",
 							},
 						},
-						"k8s.gcr.io": {
+						"registry.k8s.io": {
 							Mirrors: []string{
 								"https://insecure.registry",
 							},
@@ -133,8 +133,8 @@ func TestContainerRuntimeConfig_MachineControllerFlags(t *testing.T) {
 				"-node-containerd-registry-mirrors=docker.io=http://registry1",
 				"-node-containerd-registry-mirrors=docker.io=https://registry2",
 				"-node-containerd-registry-mirrors=docker.io=registry3",
-				"-node-containerd-registry-mirrors=k8s.gcr.io=https://insecure.registry",
-				"-node-insecure-registries=k8s.gcr.io",
+				"-node-containerd-registry-mirrors=registry.k8s.io=https://insecure.registry",
+				"-node-insecure-registries=registry.k8s.io",
 			},
 		},
 	}

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -622,7 +622,7 @@ containerRuntime:
   # Default for 1.21+ Kubernetes clusters.
   # containerd:
   #   registries:
-  #     k8s.gcr.io:
+  #     registry.k8s.io:
   #       mirrors:
   #       - https://self-signed.pull-through.cache.tld
   #       tlsConfig:

--- a/pkg/containerruntime/containerd_config_test.go
+++ b/pkg/containerruntime/containerd_config_test.go
@@ -55,7 +55,7 @@ func Test_marshalContainerdConfig(t *testing.T) {
 		{
 			name: "multi registry mirrors",
 			cluster: genCluster(withContainerdRegistry(map[string]kubeoneapi.ContainerdRegistry{
-				"k8s.gcr.io": {
+				"registry.k8s.io": {
 					Mirrors: []string{"https://some"},
 				},
 				"*": {

--- a/pkg/containerruntime/testdata/Test_marshalContainerdConfig-multi_registry_mirrors.golden
+++ b/pkg/containerruntime/testdata/Test_marshalContainerdConfig-multi_registry_mirrors.golden
@@ -15,7 +15,7 @@ SystemdCgroup = true
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."*"]
 endpoint = ["https://custom.insecure.registry"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
 endpoint = ["https://some"]
 [plugins."io.containerd.grpc.v1.cri".registry.configs]
 [plugins."io.containerd.grpc.v1.cri".registry.configs."*"]

--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -66,8 +66,8 @@ var (
 	`)
 
 	kubeadmPauseImageVersionScriptTemplate = heredoc.Doc(`
-		sudo kubeadm config images list --kubernetes-version={{ .KUBERNETES_VERSION }} |
-			grep "k8s.gcr.io/pause" |
+		sudo kubeadm config images list --image-repository=registry.k8s.io --kubernetes-version={{ .KUBERNETES_VERSION }} |
+			grep "registry.k8s.io/pause" |
 			cut -d ":" -f2
 	`)
 )

--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -81,7 +81,7 @@ func withInsecureRegistry(registry string) genClusterOpts {
 func withDefaultAssetConfiguration(cls *kubeoneapi.KubeOneCluster) {
 	cls.AssetConfiguration = kubeoneapi.AssetConfiguration{
 		Kubernetes: kubeoneapi.ImageAsset{
-			ImageRepository: "k8s.gcr.io",
+			ImageRepository: "registry.k8s.io",
 		},
 		CNI: kubeoneapi.BinaryAsset{
 			URL: "http://127.0.0.1/cni.tar.gz",

--- a/pkg/tasks/kubeadm_config.go
+++ b/pkg/tasks/kubeadm_config.go
@@ -48,7 +48,7 @@ func determinePauseImageExecutor(s *state.State, node *kubeoneapi.HostConfig, co
 		return fail.SSH(err, "getting kubeadm PauseImage version")
 	}
 
-	s.PauseImage = s.Cluster.RegistryConfiguration.ImageRegistry("k8s.gcr.io") + "/pause:" + out
+	s.PauseImage = s.Cluster.RegistryConfiguration.ImageRegistry("registry.k8s.io") + "/pause:" + out
 
 	return nil
 }

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -219,7 +219,7 @@ func baseResources() map[Resource]map[string]string {
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.21.1"},
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.54.2"},
-		MetricsServer:          {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.6.1"},
+		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.1"},
 		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.1.1"},
 	}
 }
@@ -227,17 +227,17 @@ func baseResources() map[Resource]map[string]string {
 func optionalResources() map[Resource]map[string]string {
 	return map[Resource]map[string]string{
 		// General CSI images (could be used for all providers)
-		CSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"},
-		CSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.4.0"},
-		CSIAttacher:           {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"},
-		CSIProvisioner:        {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"},
-		CSIResizer:            {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"},
-		CSISnapshotter:        {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0"},
+		CSINodeDriverRegistar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0"},
+		CSILivenessProbe:      {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.4.0"},
+		CSIAttacher:           {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.3.0"},
+		CSIProvisioner:        {"*": "registry.k8s.io/sig-storage/csi-provisioner:v2.2.2"},
+		CSIResizer:            {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.3.0"},
+		CSISnapshotter:        {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v4.2.0"},
 
 		AwsCCM: {
-			"1.22.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.22.4",
-			"1.23.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.2",
-			">= 1.24.0": "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.24.1",
+			"1.22.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.22.4",
+			"1.23.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.2",
+			">= 1.24.0": "registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.1",
 		},
 
 		// Azure CCM
@@ -254,13 +254,13 @@ func optionalResources() map[Resource]map[string]string {
 
 		// AWS EBS CSI driver
 		AwsEbsCSI:                    {"*": "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.9.0"},
-		AwsEbsCSIAttacher:            {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
-		AwsEbsCSILivenessProbe:       {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.5.0"},
-		AwsEbsCSINodeDriverRegistrar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
-		AwsEbsCSIProvisioner:         {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"},
-		AwsEbsCSIResizer:             {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},
-		AwsEbsCSISnapshotter:         {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1"},
-		AwsEbsCSISnapshotController:  {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v6.0.1"},
+		AwsEbsCSIAttacher:            {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"},
+		AwsEbsCSILivenessProbe:       {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.5.0"},
+		AwsEbsCSINodeDriverRegistrar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
+		AwsEbsCSIProvisioner:         {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"},
+		AwsEbsCSIResizer:             {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"},
+		AwsEbsCSISnapshotter:         {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1"},
+		AwsEbsCSISnapshotController:  {"*": "registry.k8s.io/sig-storage/snapshot-controller:v6.0.1"},
 
 		// AzureFile CSI driver
 		AzureFileCSI:                      {"*": "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.20.0"},
@@ -287,13 +287,13 @@ func optionalResources() map[Resource]map[string]string {
 
 		DigitalOceanCSI:                          {"*": "docker.io/digitalocean/do-csi-plugin:v4.2.0"},
 		DigitalOceanCSIAlpine:                    {"*": "docker.io/alpine:3"},
-		DigitalOceanCSIAttacher:                  {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.5.0"},
-		DigitalOceanCSINodeDriverRegistar:        {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
-		DigitalOceanCSIProvisioner:               {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1"},
-		DigitalOceanCSIResizer:                   {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.5.0"},
-		DigitalOceanCSISnapshotController:        {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v6.0.1"},
-		DigitalOceanCSISnapshotValidationWebhook: {"*": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.0.1"},
-		DigitalOceanCSISnapshotter:               {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1"},
+		DigitalOceanCSIAttacher:                  {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.5.0"},
+		DigitalOceanCSINodeDriverRegistar:        {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
+		DigitalOceanCSIProvisioner:               {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.2.1"},
+		DigitalOceanCSIResizer:                   {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.5.0"},
+		DigitalOceanCSISnapshotController:        {"*": "registry.k8s.io/sig-storage/snapshot-controller:v6.0.1"},
+		DigitalOceanCSISnapshotValidationWebhook: {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1"},
+		DigitalOceanCSISnapshotter:               {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1"},
 
 		// Hetzner CCM
 		HetznerCCM: {"*": "docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.12.1"},
@@ -314,14 +314,14 @@ func optionalResources() map[Resource]map[string]string {
 			"1.23.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.4",
 			">= 1.24.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.24.5",
 		},
-		OpenstackCSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
-		OpenstackCSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.7.0"},
-		OpenstackCSIAttacher:           {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
-		OpenstackCSIProvisioner:        {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"},
-		OpenstackCSIResizer:            {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},
-		OpenstackCSISnapshotter:        {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1"},
-		OpenstackCSISnapshotController: {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v5.0.1"},
-		OpenstackCSISnapshotWebhook:    {"*": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v5.0.1"},
+		OpenstackCSINodeDriverRegistar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
+		OpenstackCSILivenessProbe:      {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.7.0"},
+		OpenstackCSIAttacher:           {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"},
+		OpenstackCSIProvisioner:        {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"},
+		OpenstackCSIResizer:            {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"},
+		OpenstackCSISnapshotter:        {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1"},
+		OpenstackCSISnapshotController: {"*": "registry.k8s.io/sig-storage/snapshot-controller:v5.0.1"},
+		OpenstackCSISnapshotWebhook:    {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.1"},
 
 		// Equinix Metal CCM
 		EquinixMetalCCM: {"*": "docker.io/equinix/cloud-provider-equinix-metal:v3.4.3"},
@@ -335,41 +335,41 @@ func optionalResources() map[Resource]map[string]string {
 
 		// VMware Cloud Director CSI
 		VMwareCloudDirectorCSI:                    {"*": "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.2.0.latest"},
-		VMwareCloudDirectorCSIAttacher:            {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.2.1"},
-		VMwareCloudDirectorCSIProvisioner:         {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"},
-		VMwareCloudDirectorCSINodeDriverRegistrar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"},
+		VMwareCloudDirectorCSIAttacher:            {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.2.1"},
+		VMwareCloudDirectorCSIProvisioner:         {"*": "registry.k8s.io/sig-storage/csi-provisioner:v2.2.2"},
+		VMwareCloudDirectorCSINodeDriverRegistrar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0"},
 
 		// vSphere CSI
 		VsphereCSIDriver:                    {"*": "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.0"},
 		VsphereCSISyncer:                    {"*": "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.6.0"},
-		VsphereCSIAttacher:                  {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
-		VsphereCSILivenessProbe:             {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.7.0"},
-		VsphereCSINodeDriverRegistar:        {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
-		VsphereCSIProvisioner:               {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1"},
-		VsphereCSIResizer:                   {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},
-		VsphereCSISnapshotter:               {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1"},
-		VsphereCSISnapshotController:        {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v5.0.1"},
-		VsphereCSISnapshotValidationWebhook: {"*": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v5.0.1"},
+		VsphereCSIAttacher:                  {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"},
+		VsphereCSILivenessProbe:             {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.7.0"},
+		VsphereCSINodeDriverRegistar:        {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
+		VsphereCSIProvisioner:               {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.2.1"},
+		VsphereCSIResizer:                   {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"},
+		VsphereCSISnapshotter:               {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1"},
+		VsphereCSISnapshotController:        {"*": "registry.k8s.io/sig-storage/snapshot-controller:v5.0.1"},
+		VsphereCSISnapshotValidationWebhook: {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.1"},
 
 		// Nutanix CSI
 		NutanixCSI:                          {"*": "quay.io/karbon/ntnx-csi:v2.5.1"},
-		NutanixCSILivenessProbe:             {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.7.0"},
-		NutanixCSIProvisioner:               {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.2.0"},
-		NutanixCSIRegistrar:                 {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
-		NutanixCSIResizer:                   {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.5.0"},
-		NutanixCSISnapshotter:               {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1"},
-		NutanixCSISnapshotController:        {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v6.0.1"},
-		NutanixCSISnapshotValidationWebhook: {"*": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.0.1"},
+		NutanixCSILivenessProbe:             {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.7.0"},
+		NutanixCSIProvisioner:               {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.2.0"},
+		NutanixCSIRegistrar:                 {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
+		NutanixCSIResizer:                   {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.5.0"},
+		NutanixCSISnapshotter:               {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1"},
+		NutanixCSISnapshotController:        {"*": "registry.k8s.io/sig-storage/snapshot-controller:v6.0.1"},
+		NutanixCSISnapshotValidationWebhook: {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1"},
 
 		// GCP Compute Persistent Disk CSI
-		GCPComputeCSIDriver:                    {"*": "k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.7.2"},
-		GCPComputeCSIProvisioner:               {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"},
-		GCPComputeCSIAttacher:                  {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
-		GCPComputeCSIResizer:                   {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},
-		GCPComputeCSISnapshotter:               {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.1"},
-		GCPComputeCSISnapshotController:        {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v4.0.1"},
-		GCPComputeCSISnapshotValidationWebhook: {"*": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.0.1"},
-		GCPComputeCSINodeDriverRegistrar:       {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
+		GCPComputeCSIDriver:                    {"*": "registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.7.2"},
+		GCPComputeCSIProvisioner:               {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"},
+		GCPComputeCSIAttacher:                  {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"},
+		GCPComputeCSIResizer:                   {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"},
+		GCPComputeCSISnapshotter:               {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v4.0.1"},
+		GCPComputeCSISnapshotController:        {"*": "registry.k8s.io/sig-storage/snapshot-controller:v4.0.1"},
+		GCPComputeCSISnapshotValidationWebhook: {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v4.0.1"},
+		GCPComputeCSINodeDriverRegistrar:       {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
 
 		// WeaveNet CNI plugin
 		WeaveNetCNIKube: {"*": "docker.io/weaveworks/weave-kube:2.8.1"},
@@ -392,19 +392,19 @@ func optionalResources() map[Resource]map[string]string {
 
 		// Cluster-autoscaler addon
 		ClusterAutoscaler: {
-			"1.22.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.3",
-			"1.23.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.1",
-			">= 1.24.0": "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.24.0",
+			"1.22.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.3",
+			"1.23.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.1",
+			">= 1.24.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.0",
 		},
 
 		// CSI Vault Secret Provider
 		CSIVaultSecretProvider: {"*": "docker.io/hashicorp/vault-csi-provider:1.1.0"},
 
 		// CSI Secrets Driver
-		SecretStoreCSIDriverNodeRegistrar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
-		SecretStoreCSIDriver:              {"*": "k8s.gcr.io/csi-secrets-store/driver:v1.2.1"},
-		SecretStoreCSIDriverLivenessProbe: {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.7.0"},
-		SecretStoreCSIDriverCRDs:          {"*": "k8s.gcr.io/csi-secrets-store/driver-crds:v1.2.1"},
+		SecretStoreCSIDriverNodeRegistrar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
+		SecretStoreCSIDriver:              {"*": "registry.k8s.io/csi-secrets-store/driver:v1.2.1"},
+		SecretStoreCSIDriverLivenessProbe: {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.7.0"},
+		SecretStoreCSIDriverCRDs:          {"*": "registry.k8s.io/csi-secrets-store/driver-crds:v1.2.1"},
 	}
 }
 

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -169,6 +169,9 @@ const (
 
 	// VMwareCloud Director CSI
 	VMwareCloudDirectorCSI
+	VMwareCloudDirectorCSIAttacher
+	VMwareCloudDirectorCSIProvisioner
+	VMwareCloudDirectorCSINodeDriverRegistrar
 
 	// vSphere CSI
 	VsphereCSIDriver
@@ -331,7 +334,10 @@ func optionalResources() map[Resource]map[string]string {
 		},
 
 		// VMware Cloud Director CSI
-		VMwareCloudDirectorCSI: {"*": "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.2.0.latest"},
+		VMwareCloudDirectorCSI:                    {"*": "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.2.0.latest"},
+		VMwareCloudDirectorCSIAttacher:            {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.2.1"},
+		VMwareCloudDirectorCSIProvisioner:         {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"},
+		VMwareCloudDirectorCSINodeDriverRegistrar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"},
 
 		// vSphere CSI
 		VsphereCSIDriver:                    {"*": "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.0"},

--- a/pkg/templates/images/resource_string.go
+++ b/pkg/templates/images/resource_string.go
@@ -96,32 +96,35 @@ func _() {
 	_ = x[SecretStoreCSIDriverLivenessProbe-86]
 	_ = x[SecretStoreCSIDriverCRDs-87]
 	_ = x[VMwareCloudDirectorCSI-88]
-	_ = x[VsphereCSIDriver-89]
-	_ = x[VsphereCSISyncer-90]
-	_ = x[VsphereCSIAttacher-91]
-	_ = x[VsphereCSILivenessProbe-92]
-	_ = x[VsphereCSINodeDriverRegistar-93]
-	_ = x[VsphereCSIProvisioner-94]
-	_ = x[VsphereCSIResizer-95]
-	_ = x[VsphereCSISnapshotter-96]
-	_ = x[VsphereCSISnapshotController-97]
-	_ = x[VsphereCSISnapshotValidationWebhook-98]
-	_ = x[GCPComputeCSIDriver-99]
-	_ = x[GCPComputeCSIProvisioner-100]
-	_ = x[GCPComputeCSIAttacher-101]
-	_ = x[GCPComputeCSIResizer-102]
-	_ = x[GCPComputeCSISnapshotter-103]
-	_ = x[GCPComputeCSISnapshotController-104]
-	_ = x[GCPComputeCSISnapshotValidationWebhook-105]
-	_ = x[GCPComputeCSINodeDriverRegistrar-106]
-	_ = x[CalicoVXLANCNI-107]
-	_ = x[CalicoVXLANController-108]
-	_ = x[CalicoVXLANNode-109]
+	_ = x[VMwareCloudDirectorCSIAttacher-89]
+	_ = x[VMwareCloudDirectorCSIProvisioner-90]
+	_ = x[VMwareCloudDirectorCSINodeDriverRegistrar-91]
+	_ = x[VsphereCSIDriver-92]
+	_ = x[VsphereCSISyncer-93]
+	_ = x[VsphereCSIAttacher-94]
+	_ = x[VsphereCSILivenessProbe-95]
+	_ = x[VsphereCSINodeDriverRegistar-96]
+	_ = x[VsphereCSIProvisioner-97]
+	_ = x[VsphereCSIResizer-98]
+	_ = x[VsphereCSISnapshotter-99]
+	_ = x[VsphereCSISnapshotController-100]
+	_ = x[VsphereCSISnapshotValidationWebhook-101]
+	_ = x[GCPComputeCSIDriver-102]
+	_ = x[GCPComputeCSIProvisioner-103]
+	_ = x[GCPComputeCSIAttacher-104]
+	_ = x[GCPComputeCSIResizer-105]
+	_ = x[GCPComputeCSISnapshotter-106]
+	_ = x[GCPComputeCSISnapshotController-107]
+	_ = x[GCPComputeCSISnapshotValidationWebhook-108]
+	_ = x[GCPComputeCSINodeDriverRegistrar-109]
+	_ = x[CalicoVXLANCNI-110]
+	_ = x[CalicoVXLANController-111]
+	_ = x[CalicoVXLANNode-112]
 }
 
-const _Resource_name = "CalicoCNICalicoControllerCalicoNodeFlannelCiliumCiliumOperatorHubbleRelayHubbleUIHubbleUIBackendCiliumCertGenWeaveNetCNIKubeWeaveNetCNINPCDNSNodeCacheMachineControllerMetricsServerOperatingSystemManagerClusterAutoscalerCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeAwsCCMAzureCCMAzureCNMAwsEbsCSIAwsEbsCSIAttacherAwsEbsCSILivenessProbeAwsEbsCSINodeDriverRegistrarAwsEbsCSIProvisionerAwsEbsCSIResizerAwsEbsCSISnapshotterAwsEbsCSISnapshotControllerAzureFileCSIAzureFileCSIAttacherAzureFileCSILivenessProbeAzureFileCSINodeDriverRegistarAzureFileCSIProvisionerAzureFileCSIResizerAzureFileCSISnapshotterAzureFileCSISnapshotterControllerAzureDiskCSIAzureDiskCSIAttacherAzureDiskCSILivenessProbeAzureDiskCSINodeDriverRegistarAzureDiskCSIProvisionerAzureDiskCSIResizerAzureDiskCSISnapshotterAzureDiskCSISnapshotterControllerNutanixCSILivenessProbeNutanixCSINutanixCSIProvisionerNutanixCSIRegistrarNutanixCSIResizerNutanixCSISnapshotterNutanixCSISnapshotControllerNutanixCSISnapshotValidationWebhookDigitalOceanCSIDigitalOceanCSIAlpineDigitalOceanCSIAttacherDigitalOceanCSINodeDriverRegistarDigitalOceanCSIProvisionerDigitalOceanCSIResizerDigitalOceanCSISnapshotControllerDigitalOceanCSISnapshotValidationWebhookDigitalOceanCSISnapshotterOpenstackCSIOpenstackCSINodeDriverRegistarOpenstackCSILivenessProbeOpenstackCSIAttacherOpenstackCSIProvisionerOpenstackCSIResizerOpenstackCSISnapshotterOpenstackCSISnapshotControllerOpenstackCSISnapshotWebhookDigitaloceanCCMHetznerCCMHetznerCSIOpenstackCCMEquinixMetalCCMVsphereCCMCSIVaultSecretProviderSecretStoreCSIDriverNodeRegistrarSecretStoreCSIDriverSecretStoreCSIDriverLivenessProbeSecretStoreCSIDriverCRDsVMwareCloudDirectorCSIVsphereCSIDriverVsphereCSISyncerVsphereCSIAttacherVsphereCSILivenessProbeVsphereCSINodeDriverRegistarVsphereCSIProvisionerVsphereCSIResizerVsphereCSISnapshotterVsphereCSISnapshotControllerVsphereCSISnapshotValidationWebhookGCPComputeCSIDriverGCPComputeCSIProvisionerGCPComputeCSIAttacherGCPComputeCSIResizerGCPComputeCSISnapshotterGCPComputeCSISnapshotControllerGCPComputeCSISnapshotValidationWebhookGCPComputeCSINodeDriverRegistrarCalicoVXLANCNICalicoVXLANControllerCalicoVXLANNode"
+const _Resource_name = "CalicoCNICalicoControllerCalicoNodeFlannelCiliumCiliumOperatorHubbleRelayHubbleUIHubbleUIBackendCiliumCertGenWeaveNetCNIKubeWeaveNetCNINPCDNSNodeCacheMachineControllerMetricsServerOperatingSystemManagerClusterAutoscalerCSIAttacherCSINodeDriverRegistarCSIProvisionerCSISnapshotterCSIResizerCSILivenessProbeAwsCCMAzureCCMAzureCNMAwsEbsCSIAwsEbsCSIAttacherAwsEbsCSILivenessProbeAwsEbsCSINodeDriverRegistrarAwsEbsCSIProvisionerAwsEbsCSIResizerAwsEbsCSISnapshotterAwsEbsCSISnapshotControllerAzureFileCSIAzureFileCSIAttacherAzureFileCSILivenessProbeAzureFileCSINodeDriverRegistarAzureFileCSIProvisionerAzureFileCSIResizerAzureFileCSISnapshotterAzureFileCSISnapshotterControllerAzureDiskCSIAzureDiskCSIAttacherAzureDiskCSILivenessProbeAzureDiskCSINodeDriverRegistarAzureDiskCSIProvisionerAzureDiskCSIResizerAzureDiskCSISnapshotterAzureDiskCSISnapshotterControllerNutanixCSILivenessProbeNutanixCSINutanixCSIProvisionerNutanixCSIRegistrarNutanixCSIResizerNutanixCSISnapshotterNutanixCSISnapshotControllerNutanixCSISnapshotValidationWebhookDigitalOceanCSIDigitalOceanCSIAlpineDigitalOceanCSIAttacherDigitalOceanCSINodeDriverRegistarDigitalOceanCSIProvisionerDigitalOceanCSIResizerDigitalOceanCSISnapshotControllerDigitalOceanCSISnapshotValidationWebhookDigitalOceanCSISnapshotterOpenstackCSIOpenstackCSINodeDriverRegistarOpenstackCSILivenessProbeOpenstackCSIAttacherOpenstackCSIProvisionerOpenstackCSIResizerOpenstackCSISnapshotterOpenstackCSISnapshotControllerOpenstackCSISnapshotWebhookDigitaloceanCCMHetznerCCMHetznerCSIOpenstackCCMEquinixMetalCCMVsphereCCMCSIVaultSecretProviderSecretStoreCSIDriverNodeRegistrarSecretStoreCSIDriverSecretStoreCSIDriverLivenessProbeSecretStoreCSIDriverCRDsVMwareCloudDirectorCSIVMwareCloudDirectorCSIAttacherVMwareCloudDirectorCSIProvisionerVMwareCloudDirectorCSINodeDriverRegistrarVsphereCSIDriverVsphereCSISyncerVsphereCSIAttacherVsphereCSILivenessProbeVsphereCSINodeDriverRegistarVsphereCSIProvisionerVsphereCSIResizerVsphereCSISnapshotterVsphereCSISnapshotControllerVsphereCSISnapshotValidationWebhookGCPComputeCSIDriverGCPComputeCSIProvisionerGCPComputeCSIAttacherGCPComputeCSIResizerGCPComputeCSISnapshotterGCPComputeCSISnapshotControllerGCPComputeCSISnapshotValidationWebhookGCPComputeCSINodeDriverRegistrarCalicoVXLANCNICalicoVXLANControllerCalicoVXLANNode"
 
-var _Resource_index = [...]uint16{0, 9, 25, 35, 42, 48, 62, 73, 81, 96, 109, 124, 138, 150, 167, 180, 202, 219, 230, 251, 265, 279, 289, 305, 311, 319, 327, 336, 353, 375, 403, 423, 439, 459, 486, 498, 518, 543, 573, 596, 615, 638, 671, 683, 703, 728, 758, 781, 800, 823, 856, 879, 889, 910, 929, 946, 967, 995, 1030, 1045, 1066, 1089, 1122, 1148, 1170, 1203, 1243, 1269, 1281, 1311, 1336, 1356, 1379, 1398, 1421, 1451, 1478, 1493, 1503, 1513, 1525, 1540, 1550, 1572, 1605, 1625, 1658, 1682, 1704, 1720, 1736, 1754, 1777, 1805, 1826, 1843, 1864, 1892, 1927, 1946, 1970, 1991, 2011, 2035, 2066, 2104, 2136, 2150, 2171, 2186}
+var _Resource_index = [...]uint16{0, 9, 25, 35, 42, 48, 62, 73, 81, 96, 109, 124, 138, 150, 167, 180, 202, 219, 230, 251, 265, 279, 289, 305, 311, 319, 327, 336, 353, 375, 403, 423, 439, 459, 486, 498, 518, 543, 573, 596, 615, 638, 671, 683, 703, 728, 758, 781, 800, 823, 856, 879, 889, 910, 929, 946, 967, 995, 1030, 1045, 1066, 1089, 1122, 1148, 1170, 1203, 1243, 1269, 1281, 1311, 1336, 1356, 1379, 1398, 1421, 1451, 1478, 1493, 1503, 1513, 1525, 1540, 1550, 1572, 1605, 1625, 1658, 1682, 1704, 1734, 1767, 1808, 1824, 1840, 1858, 1881, 1909, 1930, 1947, 1968, 1996, 2031, 2050, 2074, 2095, 2115, 2139, 2170, 2208, 2240, 2254, 2275, 2290}
 
 func (i Resource) String() string {
 	i -= 1

--- a/test/e2e/cloudprovider.go
+++ b/test/e2e/cloudprovider.go
@@ -131,7 +131,7 @@ func (c *cloudProviderTests) createStatefulSetWithStorage(t *testing.T) {
 					Containers: []corev1.Container{
 						{
 							Name:  "echoserver",
-							Image: "k8s.gcr.io/echoserver:1.10",
+							Image: "registry.k8s.io/echoserver:1.10",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "web",
@@ -141,7 +141,7 @@ func (c *cloudProviderTests) createStatefulSetWithStorage(t *testing.T) {
 						},
 						{
 							Name:  "busybox",
-							Image: "k8s.gcr.io/busybox",
+							Image: "registry.k8s.io/busybox",
 							Args: []string{
 								"/bin/sh",
 								"-c",


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual cherry-pick of #2501 to the `release/v1.5` branch.

**Which issue(s) this PR fixes**:
xref #2458

**What type of PR is this?**

/kind feature
/kind api-change

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Image references are changed from `k8s.gcr.io` to `registry.k8s.io`. This is done to keep up with [the latest upstream changes](https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/3000-artifact-distribution). Please ensure that any mirrors you use are able to host `registry.k8s.io` and/or that firewall rules are going to allow access to `registry.k8s.io` to pull images before applying the next KubeOne patch releases.
```

**Documentation**:
```documentation
TBD
```