### PR TITLE
image-loader: fix an issue with mirroring the CoreDNS image

### DIFF
--- a/hack/image-loader.sh
+++ b/hack/image-loader.sh
@@ -104,7 +104,7 @@ if ! [ -x "$(command -v $kubeadm)" ]; then
   echodate "Done!"
 fi
 
-k8simages=$("$kubeadm" config images list --kubernetes-version="$KUBERNETES_VERSION")
+k8simages=$("$kubeadm" config images list --image-repository=registry.k8s.io --kubernetes-version="$KUBERNETES_VERSION")
 k1images=$(kubeone config images list --filter=base --kubernetes-version="$KUBERNETES_VERSION")
 optionalimages=$(kubeone config images list --filter=optional --kubernetes-version="$KUBERNETES_VERSION")
 
@@ -112,7 +112,7 @@ for IMAGE in $k8simages; do
   # The CoreDNS image has a different override semantics than other images.
   # The image will be overridden in the following way:
   #   registry.k8s.io/coredns/coredns -> custom-registry/coredns
-  if [[ "$IMAGE" == "registry.k8s.io/coredns/coredns:"* ]]; then
+  if [[ "$IMAGE" == "registry.k8s.io/coredns:"* ]]; then
     corednsVersion=$(cut -d ':' -f 2 <<< "${IMAGE}")
     retag "registry.k8s.io/coredns/coredns:${corednsVersion}" "coredns"
   else


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to different semantics for overriding the CoreDNS image, the image-loader script is failing with the following error since switching to the `registry.k8s.io` image registry:

```
[2022-11-26T17:22:08+00:00] Retagging "registry.k8s.io/coredns:v1.8.6" => "127.0.0.1:5000/coredns:v1.8.6"...
Error response from daemon: manifest for registry.k8s.io/coredns:v1.8.6 not found: manifest unknown: Failed to fetch "v1.8.6"
```

This PR:

- uses `--image-repository=registry.k8s.io` flag with `kubeadm config images` to properly accommodate all Kubernetes versions
- ensures we properly handle the CoreDNS image

**Which issue(s) this PR fixes**:
xref #2458 

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```