### PR TITLE
[release/v1.4] Use `registry.k8s.io` instead of `k8s.gcr.io` for Kubernetes upstream images

### DIFF
--- a/hack/image-loader.sh
+++ b/hack/image-loader.sh
@@ -104,25 +104,29 @@ if ! [ -x "$(command -v $kubeadm)" ]; then
   echodate "Done!"
 fi
 
-k8simages=$("$kubeadm" config images list --kubernetes-version="$KUBERNETES_VERSION")
+k8simages=$("$kubeadm" config images list --image-repository=registry.k8s.io --kubernetes-version="$KUBERNETES_VERSION")
 k1images=$(kubeone config images list --filter=base --kubernetes-version="$KUBERNETES_VERSION")
 optionalimages=$(kubeone config images list --filter=optional --kubernetes-version="$KUBERNETES_VERSION")
 
 for IMAGE in $k8simages; do
-  # The CoreDNS image has a different override semantics in Kubernetes 1.21 and
-  # in other Kubernetes minor releases (due to a bug).
-  # The image will be overriden in the following way depending on the
-  # Kubernetes version:
-  #   * 1.21: k8s.gcr.io/coredns/coredns -> custom-registry/coredns/coredns
-  #   * all other releases: k8s.gcr.io/coredns/coredns -> custom-registry/coredns
-  if [[ "$IMAGE" == "k8s.gcr.io/coredns/coredns:"* ]]; then
+  # The CoreDNS image has a different override semantics than other images.
+  # If you provide a custom registry, kubeadm will override the CoreDNS image 
+  # in the following way:
+  #   <default-registry>/coredns/coredns -> <custom-registry>/coredns
+  # We have an issue because we enforce `registry.k8s.io` for all Kubernetes versions:
+  #   - for Kubernetes versions that use `k8s.gcr.io` by default,
+  #     the CoreDNS image will be overridden as:
+  #       k8s.gcr.io/coredns/coredns -> registry.k8s.io/coredns
+  #   - for Kubernetes versions that use `registry.k8s.io` by default,
+  #     the CoreDNS image will be overridden as:
+  #       registry.k8s.io/coredns/coredns -> registry.k8s.io/coredns/coredns
+  # This is causing an issue when retagging so in the first case you'll end
+  # up with: `<custom-registry>/coredns:<version>`, but in the second case,
+  # you'll end up with: `<custom-registry>/coredns/coredns:<version>`.
+  # The following if branch is supposed to mitigate this issue.
+  if [[ "$IMAGE" == "registry.k8s.io/coredns"* ]]; then
     corednsVersion=$(cut -d ':' -f 2 <<< "${IMAGE}")
-    kubernetesMinor=$(cut -d '.' -f 2 <<< "${KUBERNETES_VERSION}")
-    if [ "${kubernetesMinor}" -eq "21" ]; then
-      retag "k8s.gcr.io/coredns/coredns:${corednsVersion}" "coredns/coredns"
-    else
-      retag "k8s.gcr.io/coredns/coredns:${corednsVersion}" "coredns"
-    fi
+    retag "registry.k8s.io/coredns/coredns:${corednsVersion}" "coredns"
   else
     retag "${IMAGE}"
   fi

--- a/pkg/addons/manifest_test.go
+++ b/pkg/addons/manifest_test.go
@@ -113,7 +113,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: {{ Registry "k8s.gcr.io" }}/kube-apiserver:v1.19.3
+  - image: {{ Registry "registry.k8s.io" }}/kube-apiserver:v1.19.3
 `
 
 	testManifest1WithImageParsed = `apiVersion: v1
@@ -127,7 +127,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: k8s.gcr.io/kube-apiserver:v1.19.3
+  - image: registry.k8s.io/kube-apiserver:v1.19.3
 `
 
 	testManifest1WithCustomImageParsed = `apiVersion: v1

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -153,8 +153,8 @@ func (crc ContainerRuntimeConfig) MachineControllerFlags() []string {
 		// example output:
 		// -node-containerd-registry-mirrors=docker.io=custom.tld
 		// -node-containerd-registry-mirrors=docker.io=https://secure-custom.tld
-		// -node-containerd-registry-mirrors=k8s.gcr.io=http://somewhere
-		// -node-insecure-registries=docker.io,k8s.gcr.io
+		// -node-containerd-registry-mirrors=registry.k8s.io=http://somewhere
+		// -node-insecure-registries=docker.io,registry.k8s.io
 		var (
 			registryNames                 []string
 			insecureSet                   = map[string]struct{}{}

--- a/pkg/apis/kubeone/helpers_test.go
+++ b/pkg/apis/kubeone/helpers_test.go
@@ -118,7 +118,7 @@ func TestContainerRuntimeConfig_MachineControllerFlags(t *testing.T) {
 								"registry3",
 							},
 						},
-						"k8s.gcr.io": {
+						"registry.k8s.io": {
 							Mirrors: []string{
 								"https://insecure.registry",
 							},
@@ -133,8 +133,8 @@ func TestContainerRuntimeConfig_MachineControllerFlags(t *testing.T) {
 				"-node-containerd-registry-mirrors=docker.io=http://registry1",
 				"-node-containerd-registry-mirrors=docker.io=https://registry2",
 				"-node-containerd-registry-mirrors=docker.io=registry3",
-				"-node-containerd-registry-mirrors=k8s.gcr.io=https://insecure.registry",
-				"-node-insecure-registries=k8s.gcr.io",
+				"-node-containerd-registry-mirrors=registry.k8s.io=https://insecure.registry",
+				"-node-insecure-registries=registry.k8s.io",
 			},
 		},
 	}

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -624,7 +624,7 @@ containerRuntime:
   # Default for 1.21+ Kubernetes clusters.
   # containerd:
   #   registries:
-  #     k8s.gcr.io:
+  #     registry.k8s.io:
   #       mirrors:
   #       - https://self-signed.pull-through.cache.tld
   #       tlsConfig:

--- a/pkg/containerruntime/containerd_config_test.go
+++ b/pkg/containerruntime/containerd_config_test.go
@@ -55,7 +55,7 @@ func Test_marshalContainerdConfig(t *testing.T) {
 		{
 			name: "multi registry mirrors",
 			cluster: genCluster(withContainerdRegistry(map[string]kubeoneapi.ContainerdRegistry{
-				"k8s.gcr.io": {
+				"registry.k8s.io": {
 					Mirrors: []string{"https://some"},
 				},
 				"*": {

--- a/pkg/containerruntime/testdata/Test_marshalContainerdConfig-multi_registry_mirrors.golden
+++ b/pkg/containerruntime/testdata/Test_marshalContainerdConfig-multi_registry_mirrors.golden
@@ -15,7 +15,7 @@ SystemdCgroup = true
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."*"]
 endpoint = ["https://custom.insecure.registry"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
 endpoint = ["https://some"]
 [plugins."io.containerd.grpc.v1.cri".registry.configs]
 [plugins."io.containerd.grpc.v1.cri".registry.configs."*"]

--- a/pkg/scripts/kubeadm.go
+++ b/pkg/scripts/kubeadm.go
@@ -62,8 +62,8 @@ var (
 	`)
 
 	kubeadmPauseImageVersionScriptTemplate = heredoc.Doc(`
-		sudo kubeadm config images list --kubernetes-version={{ .KUBERNETES_VERSION }} |
-			grep "k8s.gcr.io/pause" |
+		sudo kubeadm config images list --image-repository=registry.k8s.io --kubernetes-version={{ .KUBERNETES_VERSION }} |
+			grep "registry.k8s.io/pause" |
 			cut -d ":" -f2
 	`)
 )

--- a/pkg/scripts/os_test.go
+++ b/pkg/scripts/os_test.go
@@ -81,7 +81,7 @@ func withInsecureRegistry(registry string) genClusterOpts {
 func withDefaultAssetConfiguration(cls *kubeoneapi.KubeOneCluster) {
 	cls.AssetConfiguration = kubeoneapi.AssetConfiguration{
 		Kubernetes: kubeoneapi.ImageAsset{
-			ImageRepository: "k8s.gcr.io",
+			ImageRepository: "registry.k8s.io",
 		},
 		CNI: kubeoneapi.BinaryAsset{
 			URL: "http://127.0.0.1/cni.tar.gz",

--- a/pkg/tasks/kubeadm_config.go
+++ b/pkg/tasks/kubeadm_config.go
@@ -49,7 +49,7 @@ func determinePauseImageExecutor(s *state.State, node *kubeoneapi.HostConfig, co
 		return err
 	}
 
-	s.PauseImage = s.Cluster.RegistryConfiguration.ImageRegistry("k8s.gcr.io") + "/pause:" + out
+	s.PauseImage = s.Cluster.RegistryConfiguration.ImageRegistry("registry.k8s.io") + "/pause:" + out
 
 	return err
 }

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -186,32 +186,32 @@ func baseResources() map[Resource]map[string]string {
 		CalicoCNI:         {"*": "quay.io/calico/cni:v3.22.4"},
 		CalicoController:  {"*": "quay.io/calico/kube-controllers:v3.22.4"},
 		CalicoNode:        {"*": "quay.io/calico/node:v3.22.4"},
-		DNSNodeCache:      {"*": "k8s.gcr.io/k8s-dns-node-cache:1.15.13"},
+		DNSNodeCache:      {"*": "registry.k8s.io/k8s-dns-node-cache:1.15.13"},
 		Flannel:           {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController: {"*": "docker.io/kubermatic/machine-controller:v1.43.7"},
-		MetricsServer:     {"*": "k8s.gcr.io/metrics-server/metrics-server:v0.5.0"},
+		MetricsServer:     {"*": "registry.k8s.io/metrics-server/metrics-server:v0.5.0"},
 	}
 }
 
 func optionalResources() map[Resource]map[string]string {
 	return map[Resource]map[string]string{
 		// General CSI images (could be used for all providers)
-		CSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0"},
-		CSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.4.0"},
-		CSIAttacher:           {">= 1.19.0": "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"},
-		CSIProvisioner:        {">= 1.19.0": "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"},
-		CSIResizer:            {">= 1.19.0": "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"},
+		CSINodeDriverRegistar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0"},
+		CSILivenessProbe:      {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.4.0"},
+		CSIAttacher:           {">= 1.19.0": "registry.k8s.io/sig-storage/csi-attacher:v3.3.0"},
+		CSIProvisioner:        {">= 1.19.0": "registry.k8s.io/sig-storage/csi-provisioner:v2.2.2"},
+		CSIResizer:            {">= 1.19.0": "registry.k8s.io/sig-storage/csi-resizer:v1.3.0"},
 		CSISnapshotter: {
-			">= 1.19.0, < 1.20.0": "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3",
-			">= 1.20.0":           "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0",
+			">= 1.19.0, < 1.20.0": "registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3",
+			">= 1.20.0":           "registry.k8s.io/sig-storage/csi-snapshotter:v4.2.0",
 		},
 
 		AwsCCM: {
-			"1.19.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.19.0-alpha.1",
-			"1.20.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.20.0-alpha.0",
-			"1.21.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0",
-			"1.22.x":    "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.22.0-alpha.0",
-			">= 1.23.0": "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0",
+			"1.19.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.19.0-alpha.1",
+			"1.20.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.20.0-alpha.0",
+			"1.21.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0",
+			"1.22.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.22.0-alpha.0",
+			">= 1.23.0": "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0",
 		},
 
 		// Azure CCM
@@ -231,29 +231,29 @@ func optionalResources() map[Resource]map[string]string {
 		},
 
 		// AWS EBS CSI driver
-		AwsEbsCSI:                    {"*": "k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.5.0"},
-		AwsEbsCSIAttacher:            {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.1.0"},
-		AwsEbsCSILivenessProbe:       {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.4.0"},
-		AwsEbsCSINodeDriverRegistrar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0"},
-		AwsEbsCSIProvisioner:         {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1"},
-		AwsEbsCSIResizer:             {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.1.0"},
+		AwsEbsCSI:                    {"*": "registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.5.0"},
+		AwsEbsCSIAttacher:            {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.1.0"},
+		AwsEbsCSILivenessProbe:       {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.4.0"},
+		AwsEbsCSINodeDriverRegistrar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0"},
+		AwsEbsCSIProvisioner:         {"*": "registry.k8s.io/sig-storage/csi-provisioner:v2.1.1"},
+		AwsEbsCSIResizer:             {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.1.0"},
 		AwsEbsCSISnapshotter: {
-			">= 1.19.0, < 1.20.0": "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3",
-			">= 1.20.0":           "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1",
+			">= 1.19.0, < 1.20.0": "registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3",
+			">= 1.20.0":           "registry.k8s.io/sig-storage/csi-snapshotter:v4.2.1",
 		},
 		AwsEbsCSISnapshotController: {
-			">= 1.19.0, < 1.20.0": "k8s.gcr.io/sig-storage/snapshot-controller:v3.0.3",
-			">= 1.20.0":           "k8s.gcr.io/sig-storage/snapshot-controller:v4.2.1",
+			">= 1.19.0, < 1.20.0": "registry.k8s.io/sig-storage/snapshot-controller:v3.0.3",
+			">= 1.20.0":           "registry.k8s.io/sig-storage/snapshot-controller:v4.2.1",
 		},
 
 		// AzureFile CSI driver
 		AzureFileCSI:                      {"*": "mcr.microsoft.com/k8s/csi/azurefile-csi:v1.9.0"},
-		AzureFileCSIAttacher:              {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"},
-		AzureFileCSILivenessProbe:         {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.5.0"},
-		AzureFileCSINodeDriverRegistar:    {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0"},
+		AzureFileCSIAttacher:              {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.3.0"},
+		AzureFileCSILivenessProbe:         {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.5.0"},
+		AzureFileCSINodeDriverRegistar:    {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0"},
 		AzureFileCSIProvisioner:           {"*": "mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v2.2.2"},
-		AzureFileCSIResizer:               {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"},
-		AzureFileCSISnapshotter:           {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3"},
+		AzureFileCSIResizer:               {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.3.0"},
+		AzureFileCSISnapshotter:           {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3"},
 		AzureFileCSISnapshotterController: {"*": "mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v3.0.3"},
 
 		// AzureDisk CSI driver
@@ -271,13 +271,13 @@ func optionalResources() map[Resource]map[string]string {
 
 		DigitalOceanCSI:                          {"*": "docker.io/digitalocean/do-csi-plugin:v4.0.0"},
 		DigitalOceanCSIAlpine:                    {"*": "docker.io/alpine:3"},
-		DigitalOceanCSIAttacher:                  {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.3.0"},
-		DigitalOceanCSINodeDriverRegistar:        {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0"},
-		DigitalOceanCSIProvisioner:               {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0"},
-		DigitalOceanCSIResizer:                   {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"},
-		DigitalOceanCSISnapshotController:        {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v5.0.0"},
-		DigitalOceanCSISnapshotValidationWebhook: {"*": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v5.0.0"},
-		DigitalOceanCSISnapshotter:               {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.0"},
+		DigitalOceanCSIAttacher:                  {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.3.0"},
+		DigitalOceanCSINodeDriverRegistar:        {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0"},
+		DigitalOceanCSIProvisioner:               {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.0.0"},
+		DigitalOceanCSIResizer:                   {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.3.0"},
+		DigitalOceanCSISnapshotController:        {"*": "registry.k8s.io/sig-storage/snapshot-controller:v5.0.0"},
+		DigitalOceanCSISnapshotValidationWebhook: {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.0"},
+		DigitalOceanCSISnapshotter:               {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v5.0.0"},
 
 		// Hetzner CCM
 		HetznerCCM: {"*": "docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.12.1"},
@@ -302,14 +302,14 @@ func optionalResources() map[Resource]map[string]string {
 			"1.22.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.22.0",
 			">= 1.23.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.4",
 		},
-		OpenstackCSINodeDriverRegistar: {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
-		OpenstackCSILivenessProbe:      {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.6.0"},
-		OpenstackCSIAttacher:           {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
-		OpenstackCSIProvisioner:        {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"},
-		OpenstackCSIResizer:            {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},
-		OpenstackCSISnapshotter:        {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1"},
-		OpenstackCSISnapshotController: {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v5.0.1"},
-		OpenstackCSISnapshotWebhook:    {"*": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v5.0.1"},
+		OpenstackCSINodeDriverRegistar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
+		OpenstackCSILivenessProbe:      {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.6.0"},
+		OpenstackCSIAttacher:           {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"},
+		OpenstackCSIProvisioner:        {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"},
+		OpenstackCSIResizer:            {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"},
+		OpenstackCSISnapshotter:        {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1"},
+		OpenstackCSISnapshotController: {"*": "registry.k8s.io/sig-storage/snapshot-controller:v5.0.1"},
+		OpenstackCSISnapshotWebhook:    {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.1"},
 
 		// Equinix Metal CCM
 		EquinixMetalCCM: {"*": "docker.io/equinix/cloud-provider-equinix-metal:v3.3.0"},
@@ -326,30 +326,30 @@ func optionalResources() map[Resource]map[string]string {
 		// vSphere CSI
 		VsphereCSIDriver:      {"*": "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.0"},
 		VsphereCSISyncer:      {"*": "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.0"},
-		VsphereCSIProvisioner: {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0"},
+		VsphereCSIProvisioner: {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.0.0"},
 
 		// Nutanix CSI
 		NutanixCSI:                          {"*": "quay.io/karbon/ntnx-csi:v2.5.0"},
-		NutanixCSILivenessProbe:             {"*": "k8s.gcr.io/sig-storage/livenessprobe:v2.3.0"},
-		NutanixCSIProvisioner:               {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"},
-		NutanixCSIRegistrar:                 {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"},
-		NutanixCSIResizer:                   {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.2.0"},
-		NutanixCSISnapshotter:               {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1"},
-		NutanixCSISnapshotController:        {">= 1.20.0": "k8s.gcr.io/sig-storage/snapshot-controller:v4.2.1"},
-		NutanixCSISnapshotValidationWebhook: {">= 1.20.0": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.2.1"},
+		NutanixCSILivenessProbe:             {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.3.0"},
+		NutanixCSIProvisioner:               {"*": "registry.k8s.io/sig-storage/csi-provisioner:v2.2.2"},
+		NutanixCSIRegistrar:                 {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0"},
+		NutanixCSIResizer:                   {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.2.0"},
+		NutanixCSISnapshotter:               {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v4.2.1"},
+		NutanixCSISnapshotController:        {">= 1.20.0": "registry.k8s.io/sig-storage/snapshot-controller:v4.2.1"},
+		NutanixCSISnapshotValidationWebhook: {">= 1.20.0": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v4.2.1"},
 
 		// GCP Compute Persistent Disk CSI
 		GCPComputeCSIDriver: {
 			"1.21.x":    "gke.gcr.io/gcp-compute-persistent-disk-csi-driver:v1.4.0",
-			">= 1.22.0": "k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.7.1",
+			">= 1.22.0": "registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.7.1",
 		},
-		GCPComputeCSIProvisioner:               {"*": "k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0"},
-		GCPComputeCSIAttacher:                  {"*": "k8s.gcr.io/sig-storage/csi-attacher:v3.4.0"},
-		GCPComputeCSIResizer:                   {"*": "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"},
-		GCPComputeCSISnapshotter:               {"*": "k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.1"},
-		GCPComputeCSISnapshotController:        {"*": "k8s.gcr.io/sig-storage/snapshot-controller:v4.0.1"},
-		GCPComputeCSISnapshotValidationWebhook: {"*": "k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.0.1"},
-		GCPComputeCSINodeDriverRegistrar:       {"*": "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
+		GCPComputeCSIProvisioner:               {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"},
+		GCPComputeCSIAttacher:                  {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"},
+		GCPComputeCSIResizer:                   {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"},
+		GCPComputeCSISnapshotter:               {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v4.0.1"},
+		GCPComputeCSISnapshotController:        {"*": "registry.k8s.io/sig-storage/snapshot-controller:v4.0.1"},
+		GCPComputeCSISnapshotValidationWebhook: {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v4.0.1"},
+		GCPComputeCSINodeDriverRegistrar:       {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0"},
 
 		// WeaveNet CNI plugin
 		WeaveNetCNIKube: {"*": "docker.io/weaveworks/weave-kube:2.8.1"},
@@ -368,11 +368,11 @@ func optionalResources() map[Resource]map[string]string {
 
 		// Cluster-autoscaler addon
 		ClusterAutoscaler: {
-			"1.19.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.0",
-			"1.20.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0",
-			"1.21.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0",
-			"1.22.x":    "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.0",
-			">= 1.23.0": "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.0",
+			"1.19.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.19.0",
+			"1.20.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.20.0",
+			"1.21.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.21.0",
+			"1.22.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.0",
+			">= 1.23.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.0",
 		},
 		// operating-system-manager addon
 		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v0.4.1"},

--- a/pkg/templates/kubeadm/v1beta3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm.go
@@ -70,6 +70,10 @@ const (
 	lowerThan122 = "< 1.22.0"
 )
 
+const (
+	registryK8sio = "registry.k8s.io"
+)
+
 var (
 	fixedEtcd123Constraint       = semverutil.MustParseConstraint(fixedEtcd123)
 	fixedEtcd124Constraint       = semverutil.MustParseConstraint(fixedEtcd124)
@@ -178,11 +182,11 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 			ExtraVolumes: []kubeadmv1beta3.HostPathMount{},
 		},
 		ClusterName:     cluster.Name,
-		ImageRepository: cluster.AssetConfiguration.Kubernetes.ImageRepository,
+		ImageRepository: defaults(cluster.AssetConfiguration.Kubernetes.ImageRepository, registryK8sio),
 		Etcd: kubeadmv1beta3.Etcd{
 			Local: &kubeadmv1beta3.LocalEtcd{
 				ImageMeta: kubeadmv1beta3.ImageMeta{
-					ImageRepository: cluster.AssetConfiguration.Etcd.ImageRepository,
+					ImageRepository: defaults(cluster.AssetConfiguration.Etcd.ImageRepository, registryK8sio),
 					ImageTag:        etcdImageTag,
 				},
 				ExtraArgs: etcdExtraArgs,
@@ -190,7 +194,7 @@ func NewConfig(s *state.State, host kubeoneapi.HostConfig) ([]runtime.Object, er
 		},
 		DNS: kubeadmv1beta3.DNS{
 			ImageMeta: kubeadmv1beta3.ImageMeta{
-				ImageRepository: cluster.AssetConfiguration.CoreDNS.ImageRepository,
+				ImageRepository: defaults(cluster.AssetConfiguration.CoreDNS.ImageRepository, fmt.Sprintf("%s/coredns", registryK8sio)),
 				ImageTag:        cluster.AssetConfiguration.CoreDNS.ImageTag,
 			},
 		},
@@ -546,4 +550,12 @@ func etcdVersionCorruptCheckExtraArgs(kubeVersion *semver.Version, etcdImageTag 
 	default:
 		return fixedEtcdVersion, etcdExtraArgs
 	}
+}
+
+func defaults(input, defaultValue string) string {
+	if input != "" {
+		return input
+	}
+
+	return defaultValue
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual cherry-pick of #2501, #2507, and #2509 to the `release/v1.4` branch.

**Which issue(s) this PR fixes**:
xref #2458

**What type of PR is this?**

/kind feature
/kind api-change

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Image references are changed from `k8s.gcr.io` to `registry.k8s.io`. This is done to keep up with [the latest upstream changes](https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/3000-artifact-distribution). Please ensure that any mirrors you use are able to host `registry.k8s.io` and/or that firewall rules are going to allow access to `registry.k8s.io` to pull images before applying the next KubeOne patch releases.
```

**Documentation**:
```documentation
TBD
```