### PR TITLE
Update Go to 1.19.4

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-docker-push-kubermatic: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
           command:
             - /bin/bash
             - -c
@@ -44,7 +44,7 @@ postsubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
           command:
             - /bin/bash
             - -c
@@ -68,7 +68,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28
           command:
             - ./hack/ci/upload-gocache.sh
           resources:
@@ -87,7 +87,7 @@ postsubmits:
       containers:
         # This must match the go version used for building, else go will rightfully
         # not use the cache
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28
           command:
             - ./hack/ci/upload-gocache.sh
           env:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.3
+        - image: golang:1.19.4
           command:
             - make
           args:
@@ -45,7 +45,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.3
+        - image: golang:1.19.4
           command:
             - make
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
           command:
             - make
           args:
@@ -85,7 +85,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.3
+        - image: golang:1.19.4
           command:
             - make
           args:
@@ -105,7 +105,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.3
+        - image: golang:1.19.4
           command:
             - make
           args:
@@ -145,7 +145,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
           command:
             - /bin/bash
             - -c

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.19.3 as builder
+FROM docker.io/golang:1.19.4 as builder
 
 ARG GOPROXY=
 ENV GOPROXY=$GOPROXY

--- a/hack/images/kubeone-e2e/Dockerfile
+++ b/hack/images/kubeone-e2e/Dockerfile
@@ -14,28 +14,31 @@
 
 # building image
 
-FROM golang:1.19.3 as builder
+FROM golang:1.19.4 as builder
 
 RUN apt-get update && apt-get install -y \
     unzip
 
 WORKDIR /download
 
-ENV TERRAFORM_VERSION "1.3.2"
+# Source: https://github.com/hashicorp/terraform
+ENV TERRAFORM_VERSION "1.3.6"
 RUN curl -fL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip >/usr/local/bin/terraform
 RUN chmod +x /usr/local/bin/terraform
 
-ENV SONOBUOY_VERSION "0.56.10"
+# Source: https://github.com/vmware-tanzu/sonobuoy
+ENV SONOBUOY_VERSION "0.56.12"
 RUN curl -fL https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz | tar vxz
 RUN chmod +x sonobuoy
 
-ENV KUBECTL_VERSION="v1.24.7"
+# Source: https://dl.k8s.io/release/stable-1.24.txt
+ENV KUBECTL_VERSION="v1.24.8"
 RUN curl --fail -Lo kubectl https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
 RUN chmod +x kubectl
 
 # resulting image
 
-FROM golang:1.19.3
+FROM golang:1.19.4
 
 ARG version
 

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.27
+TAG=v0.1.28
 
 docker build --build-arg version=${TAG} --pull -t quay.io/kubermatic/kubeone-e2e:${TAG} .
 docker push quay.io/kubermatic/kubeone-e2e:${TAG}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "quay.io/kubermatic/kubeone-e2e:v0.1.27"
+	prowImage             = "quay.io/kubermatic/kubeone-e2e:v0.1.28"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -63,7 +63,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -86,7 +86,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -109,7 +109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -132,7 +132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -157,7 +157,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -182,7 +182,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -207,7 +207,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -233,7 +233,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -258,7 +258,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -281,7 +281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -304,7 +304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -327,7 +327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -350,7 +350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -373,7 +373,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -396,7 +396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -419,7 +419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -442,7 +442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -465,7 +465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -488,7 +488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -511,7 +511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -534,7 +534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -557,7 +557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -580,7 +580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -603,7 +603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -628,7 +628,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -653,7 +653,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -678,7 +678,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -704,7 +704,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -729,7 +729,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -752,7 +752,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -775,7 +775,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -798,7 +798,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -821,7 +821,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -844,7 +844,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -867,7 +867,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -890,7 +890,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -913,7 +913,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -936,7 +936,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -959,7 +959,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -982,7 +982,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1005,7 +1005,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1028,7 +1028,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1051,7 +1051,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1074,7 +1074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1099,7 +1099,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1124,7 +1124,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1149,7 +1149,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1175,7 +1175,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1200,7 +1200,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1223,7 +1223,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1246,7 +1246,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1269,7 +1269,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1292,7 +1292,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1315,7 +1315,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1338,7 +1338,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1361,7 +1361,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1384,7 +1384,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1407,7 +1407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1430,7 +1430,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1453,7 +1453,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1476,7 +1476,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1499,7 +1499,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1522,7 +1522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1545,7 +1545,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1570,7 +1570,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1595,7 +1595,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1620,7 +1620,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1646,7 +1646,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1671,7 +1671,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1694,7 +1694,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1717,7 +1717,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1740,7 +1740,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1763,7 +1763,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1786,7 +1786,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1809,7 +1809,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1832,7 +1832,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1855,7 +1855,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1878,7 +1878,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1906,7 +1906,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1934,7 +1934,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1962,7 +1962,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1990,7 +1990,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2018,7 +2018,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2046,7 +2046,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2076,7 +2076,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2106,7 +2106,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2136,7 +2136,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2167,7 +2167,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2197,7 +2197,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2225,7 +2225,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2253,7 +2253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2281,7 +2281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2309,7 +2309,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2337,7 +2337,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2365,7 +2365,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2393,7 +2393,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2421,7 +2421,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2449,7 +2449,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2477,7 +2477,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2505,7 +2505,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2533,7 +2533,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2561,7 +2561,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2589,7 +2589,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2617,7 +2617,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2647,7 +2647,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2677,7 +2677,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2707,7 +2707,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2738,7 +2738,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2768,7 +2768,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2796,7 +2796,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2824,7 +2824,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2852,7 +2852,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2880,7 +2880,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2908,7 +2908,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2936,7 +2936,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2964,7 +2964,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2992,7 +2992,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3020,7 +3020,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3043,7 +3043,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3066,7 +3066,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3089,7 +3089,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3112,7 +3112,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3135,7 +3135,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3158,7 +3158,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3183,7 +3183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3208,7 +3208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3233,7 +3233,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3259,7 +3259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3284,7 +3284,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3307,7 +3307,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3330,7 +3330,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3353,7 +3353,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3376,7 +3376,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3399,7 +3399,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3422,7 +3422,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3445,7 +3445,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3468,7 +3468,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3491,7 +3491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3514,7 +3514,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3537,7 +3537,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3560,7 +3560,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3583,7 +3583,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3606,7 +3606,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3629,7 +3629,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3654,7 +3654,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3679,7 +3679,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3704,7 +3704,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3730,7 +3730,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3755,7 +3755,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3778,7 +3778,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3801,7 +3801,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3824,7 +3824,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3847,7 +3847,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3870,7 +3870,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3893,7 +3893,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3916,7 +3916,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3939,7 +3939,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3962,7 +3962,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3985,7 +3985,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4008,7 +4008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4031,7 +4031,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4054,7 +4054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4077,7 +4077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4100,7 +4100,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4125,7 +4125,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4150,7 +4150,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4175,7 +4175,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4201,7 +4201,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4226,7 +4226,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4249,7 +4249,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4272,7 +4272,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4295,7 +4295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4318,7 +4318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4341,7 +4341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4364,7 +4364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4387,7 +4387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4410,7 +4410,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4433,7 +4433,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4456,7 +4456,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4479,7 +4479,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4502,7 +4502,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4525,7 +4525,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4548,7 +4548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4571,7 +4571,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4596,7 +4596,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4621,7 +4621,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4646,7 +4646,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4672,7 +4672,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4697,7 +4697,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4720,7 +4720,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4743,7 +4743,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4766,7 +4766,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4789,7 +4789,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4812,7 +4812,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4835,7 +4835,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4858,7 +4858,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4881,7 +4881,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4904,7 +4904,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4927,7 +4927,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4950,7 +4950,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4973,7 +4973,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4996,7 +4996,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5019,7 +5019,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5042,7 +5042,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5067,7 +5067,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5092,7 +5092,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5117,7 +5117,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5143,7 +5143,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5168,7 +5168,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5191,7 +5191,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5214,7 +5214,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5237,7 +5237,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5260,7 +5260,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5283,7 +5283,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5306,7 +5306,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5329,7 +5329,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5352,7 +5352,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5375,7 +5375,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5398,7 +5398,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5421,7 +5421,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5444,7 +5444,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5467,7 +5467,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5490,7 +5490,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5513,7 +5513,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5538,7 +5538,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5563,7 +5563,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5588,7 +5588,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5614,7 +5614,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5639,7 +5639,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5662,7 +5662,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5685,7 +5685,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5708,7 +5708,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5731,7 +5731,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5754,7 +5754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5777,7 +5777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5800,7 +5800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5823,7 +5823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5846,7 +5846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5871,7 +5871,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5896,7 +5896,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5921,7 +5921,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5946,7 +5946,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5971,7 +5971,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5996,7 +5996,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6019,7 +6019,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6042,7 +6042,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6065,7 +6065,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6088,7 +6088,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6111,7 +6111,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6134,7 +6134,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6157,7 +6157,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6182,7 +6182,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6207,7 +6207,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6232,7 +6232,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6258,7 +6258,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6283,7 +6283,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6306,7 +6306,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6329,7 +6329,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6352,7 +6352,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6375,7 +6375,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6398,7 +6398,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6421,7 +6421,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6444,7 +6444,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6467,7 +6467,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6490,7 +6490,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6513,7 +6513,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6536,7 +6536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6559,7 +6559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6582,7 +6582,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6605,7 +6605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6628,7 +6628,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6653,7 +6653,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6678,7 +6678,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6703,7 +6703,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6729,7 +6729,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6754,7 +6754,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6777,7 +6777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6800,7 +6800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6823,7 +6823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6846,7 +6846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6869,7 +6869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6892,7 +6892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6915,7 +6915,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6938,7 +6938,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6961,7 +6961,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6984,7 +6984,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7007,7 +7007,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7030,7 +7030,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7053,7 +7053,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7076,7 +7076,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7099,7 +7099,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7124,7 +7124,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7149,7 +7149,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7174,7 +7174,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7200,7 +7200,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7225,7 +7225,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7248,7 +7248,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7271,7 +7271,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7294,7 +7294,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7317,7 +7317,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7340,7 +7340,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7363,7 +7363,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7386,7 +7386,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7409,7 +7409,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7432,7 +7432,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7455,7 +7455,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7478,7 +7478,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7501,7 +7501,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7524,7 +7524,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7547,7 +7547,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7570,7 +7570,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7595,7 +7595,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7620,7 +7620,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7645,7 +7645,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7671,7 +7671,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7696,7 +7696,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7719,7 +7719,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7742,7 +7742,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7765,7 +7765,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7788,7 +7788,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7811,7 +7811,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7834,7 +7834,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7857,7 +7857,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7880,7 +7880,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7903,7 +7903,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7926,7 +7926,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7949,7 +7949,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7972,7 +7972,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7995,7 +7995,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8018,7 +8018,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8041,7 +8041,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8066,7 +8066,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8091,7 +8091,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8116,7 +8116,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8142,7 +8142,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8167,7 +8167,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8190,7 +8190,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8213,7 +8213,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8236,7 +8236,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8259,7 +8259,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8282,7 +8282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8305,7 +8305,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8328,7 +8328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8351,7 +8351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8374,7 +8374,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8399,7 +8399,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8424,7 +8424,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8449,7 +8449,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8475,7 +8475,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8500,7 +8500,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8523,7 +8523,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8546,7 +8546,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8569,7 +8569,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8592,7 +8592,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8615,7 +8615,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8638,7 +8638,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8661,7 +8661,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8684,7 +8684,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8707,7 +8707,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8732,7 +8732,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8757,7 +8757,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8782,7 +8782,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8808,7 +8808,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8833,7 +8833,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8856,7 +8856,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8879,7 +8879,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8902,7 +8902,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8925,7 +8925,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8948,7 +8948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8971,7 +8971,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8994,7 +8994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9017,7 +9017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9040,7 +9040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9065,7 +9065,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9090,7 +9090,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9115,7 +9115,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9141,7 +9141,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9166,7 +9166,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9189,7 +9189,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9212,7 +9212,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9235,7 +9235,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9258,7 +9258,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9281,7 +9281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9304,7 +9304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9327,7 +9327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9350,7 +9350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9373,7 +9373,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9396,7 +9396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9419,7 +9419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9442,7 +9442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9465,7 +9465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9488,7 +9488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9511,7 +9511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9534,7 +9534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9557,7 +9557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9580,7 +9580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9603,7 +9603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9626,7 +9626,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9649,7 +9649,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9672,7 +9672,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9695,7 +9695,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9718,7 +9718,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9743,7 +9743,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9768,7 +9768,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9793,7 +9793,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9819,7 +9819,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9844,7 +9844,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9867,7 +9867,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9890,7 +9890,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9913,7 +9913,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9936,7 +9936,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9959,7 +9959,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9982,7 +9982,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10005,7 +10005,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10028,7 +10028,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10051,7 +10051,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10074,7 +10074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10097,7 +10097,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10120,7 +10120,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10143,7 +10143,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10166,7 +10166,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10189,7 +10189,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10212,7 +10212,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10235,7 +10235,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10258,7 +10258,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10281,7 +10281,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10304,7 +10304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10327,7 +10327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10350,7 +10350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10373,7 +10373,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10396,7 +10396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10421,7 +10421,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10446,7 +10446,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10471,7 +10471,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10497,7 +10497,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10522,7 +10522,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10545,7 +10545,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10568,7 +10568,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10591,7 +10591,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10614,7 +10614,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10637,7 +10637,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10660,7 +10660,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10683,7 +10683,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10706,7 +10706,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10729,7 +10729,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10752,7 +10752,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10775,7 +10775,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10798,7 +10798,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10821,7 +10821,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10844,7 +10844,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10867,7 +10867,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10890,7 +10890,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10913,7 +10913,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10936,7 +10936,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10959,7 +10959,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10982,7 +10982,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11005,7 +11005,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11028,7 +11028,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11051,7 +11051,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11074,7 +11074,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11099,7 +11099,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11124,7 +11124,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11149,7 +11149,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11175,7 +11175,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11200,7 +11200,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11223,7 +11223,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11246,7 +11246,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11269,7 +11269,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11292,7 +11292,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11315,7 +11315,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11338,7 +11338,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11361,7 +11361,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11384,7 +11384,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11407,7 +11407,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11430,7 +11430,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11453,7 +11453,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11476,7 +11476,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11499,7 +11499,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11522,7 +11522,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11545,7 +11545,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11568,7 +11568,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11591,7 +11591,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11614,7 +11614,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11642,7 +11642,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11670,7 +11670,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11698,7 +11698,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11726,7 +11726,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11754,7 +11754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11782,7 +11782,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11812,7 +11812,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11842,7 +11842,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11872,7 +11872,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11903,7 +11903,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11933,7 +11933,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11961,7 +11961,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11989,7 +11989,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12017,7 +12017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12045,7 +12045,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12073,7 +12073,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12101,7 +12101,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12129,7 +12129,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12157,7 +12157,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12185,7 +12185,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12213,7 +12213,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12241,7 +12241,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12269,7 +12269,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12297,7 +12297,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12325,7 +12325,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12353,7 +12353,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12381,7 +12381,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12409,7 +12409,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12437,7 +12437,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12465,7 +12465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12493,7 +12493,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12521,7 +12521,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12549,7 +12549,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12577,7 +12577,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12605,7 +12605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12635,7 +12635,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12665,7 +12665,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12695,7 +12695,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12726,7 +12726,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12756,7 +12756,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12784,7 +12784,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12812,7 +12812,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12840,7 +12840,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12868,7 +12868,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12896,7 +12896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12924,7 +12924,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12952,7 +12952,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12980,7 +12980,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13008,7 +13008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13036,7 +13036,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13064,7 +13064,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13092,7 +13092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13120,7 +13120,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13148,7 +13148,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13176,7 +13176,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13204,7 +13204,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13232,7 +13232,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13260,7 +13260,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13283,7 +13283,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13306,7 +13306,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13329,7 +13329,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13352,7 +13352,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13375,7 +13375,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13398,7 +13398,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13423,7 +13423,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13448,7 +13448,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13473,7 +13473,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13499,7 +13499,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13524,7 +13524,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13547,7 +13547,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13570,7 +13570,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13593,7 +13593,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13616,7 +13616,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13639,7 +13639,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13662,7 +13662,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13685,7 +13685,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13708,7 +13708,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13731,7 +13731,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13754,7 +13754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13777,7 +13777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13800,7 +13800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13823,7 +13823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13846,7 +13846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13869,7 +13869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13892,7 +13892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13915,7 +13915,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13938,7 +13938,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13961,7 +13961,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13984,7 +13984,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14007,7 +14007,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14030,7 +14030,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14053,7 +14053,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14076,7 +14076,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14101,7 +14101,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14126,7 +14126,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14151,7 +14151,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14177,7 +14177,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14202,7 +14202,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14225,7 +14225,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14248,7 +14248,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14271,7 +14271,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14294,7 +14294,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14317,7 +14317,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14340,7 +14340,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14363,7 +14363,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14386,7 +14386,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14409,7 +14409,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14432,7 +14432,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14455,7 +14455,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14478,7 +14478,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14501,7 +14501,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14524,7 +14524,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14547,7 +14547,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14570,7 +14570,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14593,7 +14593,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14616,7 +14616,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14639,7 +14639,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14662,7 +14662,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14685,7 +14685,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14708,7 +14708,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14731,7 +14731,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14754,7 +14754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14779,7 +14779,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14804,7 +14804,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14829,7 +14829,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14855,7 +14855,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14880,7 +14880,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14903,7 +14903,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14926,7 +14926,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14949,7 +14949,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14972,7 +14972,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14995,7 +14995,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15018,7 +15018,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15041,7 +15041,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15064,7 +15064,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15087,7 +15087,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15110,7 +15110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15133,7 +15133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15156,7 +15156,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15179,7 +15179,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15202,7 +15202,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15225,7 +15225,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15248,7 +15248,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15271,7 +15271,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15294,7 +15294,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15317,7 +15317,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15340,7 +15340,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15363,7 +15363,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15386,7 +15386,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15409,7 +15409,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15432,7 +15432,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15455,7 +15455,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15478,7 +15478,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15501,7 +15501,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15524,7 +15524,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.27
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
       imagePullPolicy: Always
       name: ""
       resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update kubeone-e2e image to Go 1.19.4
  - I already pushed the image manually so that we can update everything in one PR
- Update CI jobs to Go 1.19.4
- Update the kubeone image to Go 1.19.4

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
KubeOne is now built using Go 1.19.4
```

**Documentation**:
```documentation
NONE
```

/assign @kron4eg @ahmedwaleedmalik 