### PR TITLE
Add an option for tasks to mutate the State object

### DIFF
--- a/pkg/tasks/kubeadm_config.go
+++ b/pkg/tasks/kubeadm_config.go
@@ -28,13 +28,11 @@ import (
 )
 
 func determinePauseImage(s *state.State) error {
-	if rc := s.Cluster.RegistryConfiguration; rc == nil || rc.OverwriteRegistry == "" {
-		return nil
-	}
-
 	s.Logger.Infoln("Determining Kubernetes pause image...")
 
-	return s.RunTaskOnLeader(determinePauseImageExecutor)
+	return s.RunTaskOnLeaderWithMutator(determinePauseImageExecutor, func(original *state.State, tmp *state.State) {
+		original.PauseImage = tmp.PauseImage
+	})
 }
 
 func determinePauseImageExecutor(s *state.State, node *kubeoneapi.HostConfig, conn executor.Interface) error {

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -214,6 +214,10 @@ func WithResources(t Tasks) Tasks {
 				},
 			},
 			{
+				Fn:        determinePauseImage,
+				Operation: "determining the pause image",
+			},
+			{
 				Fn:        patchStaticPods,
 				Operation: "patching static pods",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

We have a task to determine the pause image by asking kubeadm what pause image we should use: https://github.com/kubermatic/kubeone/blob/5a489d65729cbb4cac0166af31f6e556a541e736/pkg/tasks/kubeadm_config.go#L30-L54

The output from kubeadm is taken and the State object is updated by using `state.PauseImage = ...`. However, that doesn't work because when running a task, we're creating a shallow copy of the State object and we use that one for running the task: https://github.com/kubermatic/kubeone/blob/5a489d65729cbb4cac0166af31f6e556a541e736/pkg/state/task.go#L67

Copying the State object is required because we might be running a task concurrently and multiple goroutines editing the same struct concurrently is never a good idea. But we still need a way to mutate the State from a task, for example, in this case, the only way to get the pause image is to ask kubeadm.

This issue is addressed by adding a state mutator function to the task executor (`RunTaskOnNodes`). This mutator function is guarded with a mutex so that it's safe to run it concurrently. This PR also integrates this mutator into a task responsible for getting the pause image, so this is now supposed to work properly.

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Use the pause image from `registry.k8s.io` for all Kubernetes releases
```

**Documentation**:
```documentation
NONE
```