### PR TITLE
Add tests for the December Kubernetes patch releases

### DIFF
--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -6,14 +6,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_23_14
+      - TestAwsAmznInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -29,485 +29,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: true
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-gce: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_23_14
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_24_8
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_24_8
+      - TestAwsCentosInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -523,14 +52,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_24_8
+      - TestAwsDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -546,14 +75,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_24_8
+      - TestAwsFlatcarInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -569,14 +98,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_24_8
+      - TestAwsRhelInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -592,14 +121,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_24_8
+      - TestAwsRockylinuxInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -615,14 +144,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_24_8
+      - TestAzureDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -640,14 +169,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_24_8
+      - TestAzureCentosInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -665,14 +194,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_24_8
+      - TestAzureFlatcarInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -691,14 +220,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_24_8
+      - TestAzureRhelInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -716,14 +245,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_24_8
+      - TestAzureRockylinuxInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -741,14 +270,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_24_8
+      - TestGceDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -764,14 +293,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_24_8
+      - TestOpenstackDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -787,14 +316,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_24_8
+      - TestOpenstackCentosInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -810,14 +339,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_24_8
+      - TestOpenstackRockylinuxInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -833,14 +362,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_24_8
+      - TestOpenstackRhelInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -856,14 +385,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_24_8
+      - TestOpenstackFlatcarInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -879,14 +408,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_24_8
+      - TestVsphereDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -902,14 +431,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_24_8
+      - TestVsphereCentosInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -925,14 +454,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.8
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_24_8
+      - TestVsphereFlatcarInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -948,14 +477,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_25_4
+      - TestAwsAmznInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -971,14 +500,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_25_4
+      - TestAwsCentosInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -994,14 +523,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_25_4
+      - TestAwsDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -1017,14 +546,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_25_4
+      - TestAwsFlatcarInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -1040,14 +569,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_25_4
+      - TestAwsRhelInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -1063,14 +592,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_25_4
+      - TestAwsRockylinuxInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -1086,14 +615,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_25_4
+      - TestAzureDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1111,14 +640,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_25_4
+      - TestAzureCentosInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1136,14 +665,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_25_4
+      - TestAzureFlatcarInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1162,14 +691,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_25_4
+      - TestAzureRhelInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1187,14 +716,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_25_4
+      - TestAzureRockylinuxInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1212,14 +741,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_25_4
+      - TestGceDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: gce
@@ -1235,14 +764,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_25_4
+      - TestOpenstackDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1258,14 +787,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_25_4
+      - TestOpenstackCentosInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1281,14 +810,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_25_4
+      - TestOpenstackRockylinuxInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1304,14 +833,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_25_4
+      - TestOpenstackRhelInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1327,14 +856,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_25_4
+      - TestOpenstackFlatcarInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1350,14 +879,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_25_4
+      - TestVsphereDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -1373,14 +902,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_25_4
+      - TestVsphereCentosInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -1396,14 +925,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_25_4
+      - TestVsphereFlatcarInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -1419,14 +948,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerV1_23_14
+      - TestAwsAmznInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -1442,14 +971,37 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerV1_23_14
+      - TestAwsCentosInstallContainerdV1_25_5
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: true
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -1465,14 +1017,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerV1_23_14
+      - TestAwsFlatcarInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -1488,14 +1040,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerV1_23_14
+      - TestAwsRhelInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -1511,37 +1063,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerV1_23_14
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.14
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerV1_23_14
+      - TestAwsRockylinuxInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -1557,14 +1086,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerV1_23_14
+      - TestAzureDefaultInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -1582,14 +1111,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerV1_23_14
+      - TestAzureCentosInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -1607,14 +1136,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerV1_23_14
+      - TestAzureFlatcarInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -1633,14 +1162,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerV1_23_14
+      - TestAzureRhelInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -1658,14 +1187,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerV1_23_14
+      - TestAzureRockylinuxInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -1683,14 +1212,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.14
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallDockerV1_23_14
+      - TestGceDefaultInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: gce
@@ -1706,14 +1235,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerV1_23_14
+      - TestOpenstackDefaultInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -1729,14 +1258,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerV1_23_14
+      - TestOpenstackCentosInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -1752,14 +1281,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerV1_23_14
+      - TestOpenstackRockylinuxInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -1775,14 +1304,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerV1_23_14
+      - TestOpenstackRhelInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -1798,14 +1327,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerV1_23_14
+      - TestOpenstackFlatcarInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -1821,14 +1350,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerV1_23_14
+      - TestVsphereDefaultInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -1844,14 +1373,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerV1_23_14
+      - TestVsphereCentosInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -1867,14 +1396,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerV1_23_14
+      - TestVsphereFlatcarInstallContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -1887,22 +1416,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAwsAmznInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -1915,22 +1439,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAwsCentosInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -1943,22 +1462,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAwsDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -1971,22 +1485,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAwsFlatcarInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -1999,22 +1508,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAwsRhelInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -2027,22 +1531,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAwsRockylinuxInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -2055,22 +1554,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAzureDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2085,22 +1579,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAzureCentosInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2115,22 +1604,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAzureFlatcarInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2145,23 +1629,18 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAzureRhelInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2176,22 +1655,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestAzureRockylinuxInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2206,22 +1680,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestGceDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -2234,22 +1703,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestOpenstackDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2262,22 +1726,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestOpenstackCentosInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2290,22 +1749,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestOpenstackRockylinuxInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2318,22 +1772,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestOpenstackRhelInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2346,22 +1795,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestOpenstackFlatcarInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2374,22 +1818,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestVsphereDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -2402,22 +1841,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestVsphereCentosInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -2430,22 +1864,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4
+      - TestVsphereFlatcarInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -2466,14 +1895,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAwsAmznStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -2494,14 +1923,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAwsCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -2522,14 +1951,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAwsDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -2550,14 +1979,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -2578,14 +2007,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAwsRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -2606,14 +2035,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -2634,14 +2063,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAzureDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -2664,14 +2093,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAzureCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -2694,14 +2123,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -2725,14 +2154,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAzureRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -2755,14 +2184,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -2785,14 +2214,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestGceDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: gce
@@ -2813,14 +2242,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -2841,14 +2270,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -2869,14 +2298,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -2897,14 +2326,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -2925,14 +2354,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -2953,14 +2382,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -2981,14 +2410,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestVsphereCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -3009,14 +2438,585 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: gce
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -3032,14 +3032,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoContainerdV1_25_4
+      - TestAwsAmznCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -3055,14 +3055,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdV1_25_4
+      - TestAwsCentosCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -3078,14 +3078,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoContainerdV1_25_4
+      - TestAwsDefaultCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -3101,14 +3101,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoContainerdV1_25_4
+      - TestAwsFlatcarCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -3124,14 +3124,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoContainerdV1_25_4
+      - TestAwsRhelCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -3147,14 +3147,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoContainerdV1_25_4
+      - TestAwsRockylinuxCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -3170,14 +3170,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoContainerdV1_25_4
+      - TestAzureDefaultCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -3195,14 +3195,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdV1_25_4
+      - TestAzureCentosCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -3220,14 +3220,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoContainerdV1_25_4
+      - TestAzureFlatcarCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -3246,14 +3246,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoContainerdV1_25_4
+      - TestAzureRhelCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -3271,14 +3271,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoContainerdV1_25_4
+      - TestAzureRockylinuxCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -3296,14 +3296,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoContainerdV1_25_4
+      - TestGceDefaultCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: gce
@@ -3319,14 +3319,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoContainerdV1_25_4
+      - TestOpenstackDefaultCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -3342,14 +3342,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdV1_25_4
+      - TestOpenstackCentosCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -3365,14 +3365,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoContainerdV1_25_4
+      - TestOpenstackRockylinuxCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -3388,14 +3388,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoContainerdV1_25_4
+      - TestOpenstackRhelCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -3411,14 +3411,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoContainerdV1_25_4
+      - TestOpenstackFlatcarCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -3434,14 +3434,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoContainerdV1_25_4
+      - TestVsphereDefaultCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -3457,14 +3457,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoContainerdV1_25_4
+      - TestVsphereCentosCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -3480,14 +3480,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoContainerdV1_25_4
+      - TestVsphereFlatcarCalicoContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -3503,14 +3503,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoDockerV1_23_14
+      - TestAwsAmznCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3526,14 +3526,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoDockerV1_23_14
+      - TestAwsCentosCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3549,14 +3549,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-default-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoDockerV1_23_14
+      - TestAwsDefaultCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3572,14 +3572,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-flatcar-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoDockerV1_23_14
+      - TestAwsFlatcarCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3595,14 +3595,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rhel-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoDockerV1_23_14
+      - TestAwsRhelCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3618,14 +3618,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rockylinux-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoDockerV1_23_14
+      - TestAwsRockylinuxCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3641,14 +3641,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-default-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoDockerV1_23_14
+      - TestAzureDefaultCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3666,14 +3666,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoDockerV1_23_14
+      - TestAzureCentosCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3691,14 +3691,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoDockerV1_23_14
+      - TestAzureFlatcarCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3717,14 +3717,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoDockerV1_23_14
+      - TestAzureRhelCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3742,14 +3742,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoDockerV1_23_14
+      - TestAzureRockylinuxCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3767,14 +3767,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-gce-default-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoDockerV1_23_14
+      - TestGceDefaultCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -3790,14 +3790,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoDockerV1_23_14
+      - TestOpenstackDefaultCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3813,14 +3813,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoDockerV1_23_14
+      - TestOpenstackCentosCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3836,14 +3836,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoDockerV1_23_14
+      - TestOpenstackRockylinuxCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3859,14 +3859,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoDockerV1_23_14
+      - TestOpenstackRhelCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3882,14 +3882,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoDockerV1_23_14
+      - TestOpenstackFlatcarCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3905,14 +3905,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoDockerV1_23_14
+      - TestVsphereDefaultCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -3928,14 +3928,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoDockerV1_23_14
+      - TestVsphereCentosCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -3951,14 +3951,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoDockerV1_23_14
+      - TestVsphereFlatcarCalicoDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -3974,14 +3974,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveContainerdV1_25_4
+      - TestAwsAmznWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -3997,14 +3997,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveContainerdV1_25_4
+      - TestAwsCentosWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -4020,14 +4020,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveContainerdV1_25_4
+      - TestAwsDefaultWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -4043,14 +4043,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveContainerdV1_25_4
+      - TestAwsFlatcarWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -4066,14 +4066,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveContainerdV1_25_4
+      - TestAwsRhelWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -4089,14 +4089,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveContainerdV1_25_4
+      - TestAwsRockylinuxWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -4112,14 +4112,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveContainerdV1_25_4
+      - TestAzureDefaultWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -4137,14 +4137,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveContainerdV1_25_4
+      - TestAzureCentosWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -4162,14 +4162,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveContainerdV1_25_4
+      - TestAzureFlatcarWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -4188,14 +4188,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveContainerdV1_25_4
+      - TestAzureRhelWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -4213,14 +4213,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveContainerdV1_25_4
+      - TestAzureRockylinuxWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -4238,14 +4238,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveContainerdV1_25_4
+      - TestGceDefaultWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: gce
@@ -4261,14 +4261,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveContainerdV1_25_4
+      - TestOpenstackDefaultWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -4284,14 +4284,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveContainerdV1_25_4
+      - TestOpenstackCentosWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -4307,14 +4307,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveContainerdV1_25_4
+      - TestOpenstackRockylinuxWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -4330,14 +4330,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveContainerdV1_25_4
+      - TestOpenstackRhelWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -4353,14 +4353,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveContainerdV1_25_4
+      - TestOpenstackFlatcarWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -4376,14 +4376,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveContainerdV1_25_4
+      - TestVsphereDefaultWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -4399,14 +4399,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosWeaveContainerdV1_25_4
+      - TestVsphereCentosWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -4422,14 +4422,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveContainerdV1_25_4
+      - TestVsphereFlatcarWeaveContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -4445,14 +4445,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveDockerV1_23_14
+      - TestAwsAmznWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4468,14 +4468,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveDockerV1_23_14
+      - TestAwsCentosWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4491,14 +4491,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-default-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveDockerV1_23_14
+      - TestAwsDefaultWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4514,14 +4514,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-flatcar-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveDockerV1_23_14
+      - TestAwsFlatcarWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4537,14 +4537,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rhel-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveDockerV1_23_14
+      - TestAwsRhelWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4560,14 +4560,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rockylinux-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveDockerV1_23_14
+      - TestAwsRockylinuxWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4583,14 +4583,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-default-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveDockerV1_23_14
+      - TestAzureDefaultWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4608,14 +4608,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveDockerV1_23_14
+      - TestAzureCentosWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4633,14 +4633,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveDockerV1_23_14
+      - TestAzureFlatcarWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4659,14 +4659,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveDockerV1_23_14
+      - TestAzureRhelWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4684,14 +4684,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveDockerV1_23_14
+      - TestAzureRockylinuxWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4709,14 +4709,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-gce-default-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveDockerV1_23_14
+      - TestGceDefaultWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -4732,14 +4732,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveDockerV1_23_14
+      - TestOpenstackDefaultWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -4755,14 +4755,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveDockerV1_23_14
+      - TestOpenstackCentosWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -4778,14 +4778,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveDockerV1_23_14
+      - TestOpenstackRockylinuxWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -4801,14 +4801,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveDockerV1_23_14
+      - TestOpenstackRhelWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -4824,14 +4824,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveDockerV1_23_14
+      - TestOpenstackFlatcarWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -4847,14 +4847,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveDockerV1_23_14
+      - TestVsphereDefaultWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -4870,14 +4870,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosWeaveDockerV1_23_14
+      - TestVsphereCentosWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -4893,14 +4893,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveDockerV1_23_14
+      - TestVsphereFlatcarWeaveDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -4916,14 +4916,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumContainerdV1_25_4
+      - TestAwsAmznCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -4939,14 +4939,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdV1_25_4
+      - TestAwsCentosCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -4962,14 +4962,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumContainerdV1_25_4
+      - TestAwsDefaultCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -4985,14 +4985,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumContainerdV1_25_4
+      - TestAwsFlatcarCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -5008,14 +5008,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumContainerdV1_25_4
+      - TestAwsRhelCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -5031,14 +5031,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumContainerdV1_25_4
+      - TestAwsRockylinuxCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -5054,14 +5054,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumContainerdV1_25_4
+      - TestAzureDefaultCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -5079,14 +5079,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdV1_25_4
+      - TestAzureCentosCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -5104,14 +5104,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumContainerdV1_25_4
+      - TestAzureFlatcarCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -5130,14 +5130,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumContainerdV1_25_4
+      - TestAzureRhelCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -5155,14 +5155,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumContainerdV1_25_4
+      - TestAzureRockylinuxCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -5180,14 +5180,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumContainerdV1_25_4
+      - TestGceDefaultCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: gce
@@ -5203,14 +5203,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumContainerdV1_25_4
+      - TestOpenstackDefaultCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -5226,14 +5226,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdV1_25_4
+      - TestOpenstackCentosCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -5249,14 +5249,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumContainerdV1_25_4
+      - TestOpenstackRockylinuxCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -5272,14 +5272,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumContainerdV1_25_4
+      - TestOpenstackRhelCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -5295,14 +5295,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumContainerdV1_25_4
+      - TestOpenstackFlatcarCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -5318,14 +5318,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumContainerdV1_25_4
+      - TestVsphereDefaultCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -5341,14 +5341,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumContainerdV1_25_4
+      - TestVsphereCentosCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -5364,14 +5364,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumContainerdV1_25_4
+      - TestVsphereFlatcarCiliumContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -5387,14 +5387,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumDockerV1_23_14
+      - TestAwsAmznCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -5410,14 +5410,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumDockerV1_23_14
+      - TestAwsCentosCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -5433,14 +5433,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-default-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumDockerV1_23_14
+      - TestAwsDefaultCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -5456,14 +5456,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-flatcar-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumDockerV1_23_14
+      - TestAwsFlatcarCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -5479,14 +5479,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rhel-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumDockerV1_23_14
+      - TestAwsRhelCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -5502,14 +5502,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumDockerV1_23_14
+      - TestAwsRockylinuxCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -5525,14 +5525,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-default-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumDockerV1_23_14
+      - TestAzureDefaultCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -5550,14 +5550,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumDockerV1_23_14
+      - TestAzureCentosCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -5575,14 +5575,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumDockerV1_23_14
+      - TestAzureFlatcarCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -5601,14 +5601,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumDockerV1_23_14
+      - TestAzureRhelCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -5626,14 +5626,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumDockerV1_23_14
+      - TestAzureRockylinuxCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -5651,14 +5651,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-gce-default-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumDockerV1_23_14
+      - TestGceDefaultCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -5674,14 +5674,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumDockerV1_23_14
+      - TestOpenstackDefaultCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -5697,14 +5697,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumDockerV1_23_14
+      - TestOpenstackCentosCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -5720,14 +5720,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumDockerV1_23_14
+      - TestOpenstackRockylinuxCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -5743,14 +5743,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumDockerV1_23_14
+      - TestOpenstackRhelCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -5766,14 +5766,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumDockerV1_23_14
+      - TestOpenstackFlatcarCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -5789,14 +5789,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumDockerV1_23_14
+      - TestVsphereDefaultCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -5812,14 +5812,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumDockerV1_23_14
+      - TestVsphereCentosCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -5835,14 +5835,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumDockerV1_23_14
+      - TestVsphereFlatcarCiliumDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -5858,14 +5858,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.14
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_14
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -5883,14 +5883,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_8
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -5908,14 +5908,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_25_4
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -5933,14 +5933,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_14
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -5958,14 +5958,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_8
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -5983,14 +5983,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_4
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -6008,14 +6008,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.25.4
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_25_4
+      - TestAwsDefaultKubeProxyIpvsV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -6031,14 +6031,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_23_14
+      - TestAwsAmznLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -6054,14 +6054,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_23_14
+      - TestAwsCentosLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -6077,14 +6077,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_14
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -6100,14 +6100,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_14
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -6123,14 +6123,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_23_14
+      - TestAwsRhelLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -6146,14 +6146,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_14
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -6169,14 +6169,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_14
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -6194,14 +6194,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_23_14
+      - TestAzureCentosLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -6219,14 +6219,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_14
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -6245,14 +6245,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_23_14
+      - TestAzureRhelLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -6270,14 +6270,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_14
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -6295,14 +6295,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_23_14
+      - TestGceDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -6318,14 +6318,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_14
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -6341,14 +6341,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_14
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -6364,14 +6364,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_14
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -6387,14 +6387,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_14
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -6410,14 +6410,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_14
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -6433,14 +6433,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_14
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -6456,14 +6456,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_23_14
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -6479,14 +6479,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_14
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -6502,14 +6502,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_24_8
+      - TestAwsAmznLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -6525,14 +6525,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_24_8
+      - TestAwsCentosLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -6548,14 +6548,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_8
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -6571,14 +6571,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_8
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -6594,14 +6594,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_24_8
+      - TestAwsRhelLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -6617,14 +6617,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_8
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -6640,14 +6640,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_8
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -6665,14 +6665,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_24_8
+      - TestAzureCentosLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -6690,14 +6690,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_8
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -6716,14 +6716,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_24_8
+      - TestAzureRhelLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -6741,14 +6741,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_8
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -6766,14 +6766,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_24_8
+      - TestGceDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: gce
@@ -6789,14 +6789,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_8
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -6812,14 +6812,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_8
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -6835,14 +6835,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_8
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -6858,14 +6858,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_8
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -6881,14 +6881,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_8
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -6904,14 +6904,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_8
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -6927,14 +6927,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_8
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -6950,14 +6950,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.8
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_8
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -6973,14 +6973,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_25_4
+      - TestAwsAmznLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -6996,14 +6996,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_25_4
+      - TestAwsCentosLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -7019,14 +7019,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_25_4
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -7042,14 +7042,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_25_4
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -7065,14 +7065,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_25_4
+      - TestAwsRhelLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -7088,14 +7088,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_4
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -7111,14 +7111,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_25_4
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -7136,14 +7136,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_25_4
+      - TestAzureCentosLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -7161,14 +7161,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_25_4
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -7187,14 +7187,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_25_4
+      - TestAzureRhelLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -7212,14 +7212,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_4
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -7237,14 +7237,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_25_4
+      - TestGceDefaultLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: gce
@@ -7260,14 +7260,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_4
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -7283,14 +7283,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_25_4
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -7306,14 +7306,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_4
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -7329,14 +7329,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_25_4
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -7352,14 +7352,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_4
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -7375,14 +7375,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_25_4
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -7398,14 +7398,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_25_4
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -7421,14 +7421,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_4
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -7444,14 +7444,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerDockerV1_23_14
+      - TestAwsAmznLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -7467,14 +7467,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerDockerV1_23_14
+      - TestAwsCentosLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -7490,14 +7490,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerDockerV1_23_14
+      - TestAwsDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -7513,14 +7513,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_14
+      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -7536,14 +7536,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerDockerV1_23_14
+      - TestAwsRhelLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -7559,14 +7559,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_14
+      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -7582,14 +7582,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerDockerV1_23_14
+      - TestAzureDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -7607,14 +7607,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerDockerV1_23_14
+      - TestAzureCentosLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -7632,14 +7632,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_14
+      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -7658,14 +7658,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerDockerV1_23_14
+      - TestAzureRhelLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -7683,14 +7683,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_14
+      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -7708,14 +7708,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerDockerV1_23_14
+      - TestGceDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -7731,14 +7731,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_14
+      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -7754,14 +7754,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_14
+      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -7777,14 +7777,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_14
+      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -7800,14 +7800,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_14
+      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -7823,14 +7823,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_14
+      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -7846,14 +7846,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_14
+      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -7869,14 +7869,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerDockerV1_23_14
+      - TestVsphereCentosLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -7892,14 +7892,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_14
+      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -7915,14 +7915,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_23_14
+      - TestAwsDefaultCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -7938,14 +7938,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_23_14
+      - TestOpenstackDefaultCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -7961,14 +7961,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_23_14
+      - TestOpenstackCentosCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -7984,14 +7984,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_14
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -8007,14 +8007,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_23_14
+      - TestOpenstackRhelCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -8030,14 +8030,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_23_14
+      - TestOpenstackFlatcarCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -8053,14 +8053,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_23_14
+      - TestAzureDefaultCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8078,14 +8078,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_23_14
+      - TestAzureCentosCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8103,14 +8103,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_23_14
+      - TestAzureFlatcarCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8129,14 +8129,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_23_14
+      - TestAzureRhelCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8154,14 +8154,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_23_14
+      - TestAzureRockylinuxCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8179,14 +8179,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_23_14
+      - TestVsphereDefaultCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -8202,14 +8202,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_23_14
+      - TestVsphereCentosCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -8225,14 +8225,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_23_14
+      - TestVsphereFlatcarCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -8248,14 +8248,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_24_8
+      - TestAwsDefaultCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -8271,14 +8271,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_24_8
+      - TestOpenstackDefaultCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -8294,14 +8294,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_24_8
+      - TestOpenstackCentosCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -8317,14 +8317,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_8
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -8340,14 +8340,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_24_8
+      - TestOpenstackRhelCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -8363,14 +8363,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_24_8
+      - TestOpenstackFlatcarCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -8386,14 +8386,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_24_8
+      - TestAzureDefaultCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -8411,14 +8411,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_24_8
+      - TestAzureCentosCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -8436,14 +8436,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_24_8
+      - TestAzureFlatcarCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -8462,14 +8462,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_24_8
+      - TestAzureRhelCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -8487,14 +8487,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_24_8
+      - TestAzureRockylinuxCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -8512,14 +8512,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_24_8
+      - TestVsphereDefaultCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -8535,14 +8535,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_24_8
+      - TestVsphereCentosCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -8558,14 +8558,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.8
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_24_8
+      - TestVsphereFlatcarCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -8581,14 +8581,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_25_4
+      - TestAwsDefaultCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -8604,14 +8604,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_25_4
+      - TestOpenstackDefaultCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -8627,14 +8627,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_25_4
+      - TestOpenstackCentosCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -8650,14 +8650,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_25_4
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -8673,14 +8673,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_25_4
+      - TestOpenstackRhelCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -8696,14 +8696,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_25_4
+      - TestOpenstackFlatcarCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -8719,14 +8719,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_25_4
+      - TestAzureDefaultCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -8744,14 +8744,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_25_4
+      - TestAzureCentosCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -8769,14 +8769,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_25_4
+      - TestAzureFlatcarCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -8795,14 +8795,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_25_4
+      - TestAzureRhelCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -8820,14 +8820,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_25_4
+      - TestAzureRockylinuxCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -8845,14 +8845,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_25_4
+      - TestVsphereDefaultCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -8868,14 +8868,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_25_4
+      - TestVsphereCentosCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -8891,14 +8891,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_25_4
+      - TestVsphereFlatcarCsiCcmMigrationV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -8914,14 +8914,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_23_14
+      - TestAwsAmznInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8937,14 +8937,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_23_14
+      - TestAwsCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8960,14 +8960,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_23_14
+      - TestAwsDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8983,14 +8983,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_23_14
+      - TestAwsFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -9006,14 +9006,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_23_14
+      - TestAwsRhelInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -9029,14 +9029,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_23_14
+      - TestAwsRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -9052,14 +9052,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_23_14
+      - TestAzureDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -9077,14 +9077,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_23_14
+      - TestAzureCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -9102,14 +9102,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_23_14
+      - TestAzureFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -9128,14 +9128,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_23_14
+      - TestAzureRhelInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -9153,14 +9153,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_23_14
+      - TestAzureRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -9178,14 +9178,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_14
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9201,14 +9201,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_23_14
+      - TestDigitaloceanCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9224,14 +9224,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_14
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9247,14 +9247,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_14
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9270,14 +9270,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_23_14
+      - TestEquinixmetalCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9293,14 +9293,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_14
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9316,14 +9316,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_14
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9339,14 +9339,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_23_14
+      - TestHetznerDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -9362,14 +9362,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_23_14
+      - TestHetznerCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -9385,14 +9385,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_23_14
+      - TestHetznerRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -9408,14 +9408,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_23_14
+      - TestOpenstackDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -9431,14 +9431,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_23_14
+      - TestOpenstackCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -9454,14 +9454,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_14
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -9477,14 +9477,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_23_14
+      - TestOpenstackRhelInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -9500,14 +9500,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_23_14
+      - TestOpenstackFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -9523,14 +9523,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_23_14
+      - TestVsphereDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -9546,14 +9546,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_23_14
+      - TestVsphereCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -9569,14 +9569,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_23_14
+      - TestVsphereFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -9592,14 +9592,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_24_8
+      - TestAwsAmznInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9615,14 +9615,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_24_8
+      - TestAwsCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9638,14 +9638,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_24_8
+      - TestAwsDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9661,14 +9661,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_24_8
+      - TestAwsFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9684,14 +9684,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_24_8
+      - TestAwsRhelInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9707,14 +9707,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_24_8
+      - TestAwsRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9730,14 +9730,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_24_8
+      - TestAzureDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9755,14 +9755,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_24_8
+      - TestAzureCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9780,14 +9780,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_24_8
+      - TestAzureFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9806,14 +9806,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_24_8
+      - TestAzureRhelInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9831,14 +9831,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_24_8
+      - TestAzureRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9856,14 +9856,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_8
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9879,14 +9879,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_24_8
+      - TestDigitaloceanCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9902,14 +9902,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_8
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9925,14 +9925,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_8
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9948,14 +9948,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_24_8
+      - TestEquinixmetalCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9971,14 +9971,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_8
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9994,14 +9994,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_8
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -10017,14 +10017,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_24_8
+      - TestHetznerDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -10040,14 +10040,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_24_8
+      - TestHetznerCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -10063,14 +10063,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_24_8
+      - TestHetznerRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -10086,14 +10086,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_24_8
+      - TestOpenstackDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -10109,14 +10109,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_24_8
+      - TestOpenstackCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -10132,14 +10132,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_8
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -10155,14 +10155,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_24_8
+      - TestOpenstackRhelInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -10178,14 +10178,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_24_8
+      - TestOpenstackFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -10201,14 +10201,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_24_8
+      - TestVsphereDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -10224,14 +10224,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_24_8
+      - TestVsphereCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -10247,14 +10247,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_24_8
+      - TestVsphereFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -10270,14 +10270,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_25_4
+      - TestAwsAmznInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -10293,14 +10293,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_25_4
+      - TestAwsCentosInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -10316,14 +10316,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_25_4
+      - TestAwsDefaultInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -10339,14 +10339,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_25_4
+      - TestAwsFlatcarInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -10362,14 +10362,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_25_4
+      - TestAwsRhelInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -10385,14 +10385,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_25_4
+      - TestAwsRockylinuxInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -10408,14 +10408,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_25_4
+      - TestAzureDefaultInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -10433,14 +10433,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_25_4
+      - TestAzureCentosInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -10458,14 +10458,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_25_4
+      - TestAzureFlatcarInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -10484,14 +10484,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_25_4
+      - TestAzureRhelInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -10509,14 +10509,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_25_4
+      - TestAzureRockylinuxInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -10534,14 +10534,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_25_4
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: digitalocean
@@ -10557,14 +10557,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_25_4
+      - TestDigitaloceanCentosInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: digitalocean
@@ -10580,14 +10580,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_4
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: digitalocean
@@ -10603,14 +10603,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_25_4
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -10626,14 +10626,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_25_4
+      - TestEquinixmetalCentosInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -10649,14 +10649,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_4
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -10672,14 +10672,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_25_4
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -10695,14 +10695,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_25_4
+      - TestHetznerDefaultInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: hetzner
@@ -10718,14 +10718,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_25_4
+      - TestHetznerCentosInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: hetzner
@@ -10741,14 +10741,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_25_4
+      - TestHetznerRockylinuxInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: hetzner
@@ -10764,14 +10764,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_25_4
+      - TestOpenstackDefaultInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -10787,14 +10787,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_25_4
+      - TestOpenstackCentosInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -10810,14 +10810,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_25_4
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -10833,14 +10833,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_25_4
+      - TestOpenstackRhelInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -10856,14 +10856,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_25_4
+      - TestOpenstackFlatcarInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -10879,14 +10879,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_25_4
+      - TestVsphereDefaultInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -10902,14 +10902,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_25_4
+      - TestVsphereCentosInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -10925,14 +10925,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_25_4
+      - TestVsphereFlatcarInstallContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -10948,14 +10948,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerExternalV1_23_14
+      - TestAwsAmznInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -10971,14 +10971,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerExternalV1_23_14
+      - TestAwsCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -10994,14 +10994,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerExternalV1_23_14
+      - TestAwsDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -11017,14 +11017,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerExternalV1_23_14
+      - TestAwsFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -11040,14 +11040,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerExternalV1_23_14
+      - TestAwsRhelInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -11063,14 +11063,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerExternalV1_23_14
+      - TestAwsRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -11086,14 +11086,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerExternalV1_23_14
+      - TestAzureDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -11111,14 +11111,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerExternalV1_23_14
+      - TestAzureCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -11136,14 +11136,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerExternalV1_23_14
+      - TestAzureFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -11162,14 +11162,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerExternalV1_23_14
+      - TestAzureRhelInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -11187,14 +11187,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerExternalV1_23_14
+      - TestAzureRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -11212,14 +11212,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallDockerExternalV1_23_14
+      - TestDigitaloceanDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11235,14 +11235,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallDockerExternalV1_23_14
+      - TestDigitaloceanCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11258,14 +11258,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_14
+      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11281,14 +11281,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallDockerExternalV1_23_14
+      - TestEquinixmetalDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11304,14 +11304,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallDockerExternalV1_23_14
+      - TestEquinixmetalCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11327,14 +11327,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_14
+      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11350,14 +11350,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_14
+      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11373,14 +11373,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallDockerExternalV1_23_14
+      - TestHetznerDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -11396,14 +11396,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallDockerExternalV1_23_14
+      - TestHetznerCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -11419,14 +11419,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallDockerExternalV1_23_14
+      - TestHetznerRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -11442,14 +11442,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerExternalV1_23_14
+      - TestOpenstackDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -11465,14 +11465,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerExternalV1_23_14
+      - TestOpenstackCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -11488,14 +11488,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerExternalV1_23_14
+      - TestOpenstackRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -11511,14 +11511,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerExternalV1_23_14
+      - TestOpenstackRhelInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -11534,14 +11534,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerExternalV1_23_14
+      - TestOpenstackFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -11557,14 +11557,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerExternalV1_23_14
+      - TestVsphereDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -11580,14 +11580,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerExternalV1_23_14
+      - TestVsphereCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -11603,14 +11603,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerExternalV1_23_14
+      - TestVsphereFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -11631,14 +11631,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -11659,14 +11659,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -11687,14 +11687,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -11715,14 +11715,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -11743,14 +11743,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -11771,14 +11771,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -11799,14 +11799,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -11829,14 +11829,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -11859,837 +11859,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.23.14-to-v1.24.8
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.5
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -12713,14 +11890,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -12743,14 +11920,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -12773,14 +11950,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -12801,14 +11978,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -12829,14 +12006,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -12857,14 +12034,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12885,14 +12062,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12913,14 +12090,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12941,14 +12118,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12969,14 +12146,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -12997,14 +12174,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -13025,14 +12202,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -13053,14 +12230,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13081,14 +12258,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13109,14 +12286,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13137,14 +12314,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13165,14 +12342,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13193,14 +12370,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -13221,14 +12398,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -13249,14 +12426,837 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.24.8-to-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -13272,14 +13272,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -13295,14 +13295,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -13318,14 +13318,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -13341,14 +13341,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -13364,14 +13364,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -13387,14 +13387,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -13410,14 +13410,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -13435,14 +13435,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -13460,14 +13460,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -13486,14 +13486,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -13511,14 +13511,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -13536,14 +13536,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_14
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13559,14 +13559,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_14
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13582,14 +13582,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13605,14 +13605,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_14
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13628,14 +13628,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_14
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13651,14 +13651,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13674,14 +13674,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_14
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13697,14 +13697,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_14
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -13720,14 +13720,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_14
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -13743,14 +13743,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -13766,14 +13766,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_14
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -13789,14 +13789,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_14
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -13812,14 +13812,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_14
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -13835,14 +13835,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_14
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -13858,14 +13858,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_14
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -13881,14 +13881,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_14
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -13904,14 +13904,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_14
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -13927,14 +13927,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.14
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_14
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -13950,14 +13950,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -13973,14 +13973,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -13996,14 +13996,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -14019,14 +14019,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -14042,14 +14042,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -14065,14 +14065,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -14088,14 +14088,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -14113,14 +14113,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -14138,14 +14138,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -14164,14 +14164,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -14189,14 +14189,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -14214,14 +14214,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_8
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14237,14 +14237,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_8
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14260,14 +14260,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14283,14 +14283,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_8
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14306,14 +14306,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_8
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14329,14 +14329,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14352,14 +14352,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_8
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14375,14 +14375,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_8
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -14398,14 +14398,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_8
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -14421,14 +14421,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -14444,14 +14444,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_8
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -14467,14 +14467,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_8
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -14490,14 +14490,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_8
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -14513,14 +14513,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_8
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -14536,14 +14536,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_8
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -14559,14 +14559,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_8
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -14582,14 +14582,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_8
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -14605,14 +14605,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.8
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_8
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -14628,14 +14628,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -14651,14 +14651,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -14674,14 +14674,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -14697,14 +14697,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -14720,14 +14720,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -14743,14 +14743,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: aws
@@ -14766,14 +14766,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -14791,14 +14791,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -14816,14 +14816,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -14842,14 +14842,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -14867,14 +14867,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: azure
@@ -14892,14 +14892,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_4
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14915,14 +14915,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_4
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14938,14 +14938,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14961,14 +14961,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_4
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14984,14 +14984,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_4
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15007,14 +15007,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15030,14 +15030,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_4
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15053,14 +15053,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_4
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: hetzner
@@ -15076,14 +15076,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_4
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: hetzner
@@ -15099,14 +15099,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: hetzner
@@ -15122,14 +15122,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_4
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -15145,14 +15145,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_4
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -15168,14 +15168,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_4
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -15191,14 +15191,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_4
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -15214,14 +15214,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_4
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: openstack
@@ -15237,14 +15237,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_4
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -15260,14 +15260,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_4
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -15283,14 +15283,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.25.4
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_4
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_5
       env:
       - name: PROVIDER
         value: vsphere
@@ -15306,14 +15306,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_14
+      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -15329,14 +15329,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_14
+      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -15352,14 +15352,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_14
+      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -15375,14 +15375,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_14
+      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15398,14 +15398,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_14
+      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15421,14 +15421,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_14
+      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15444,14 +15444,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_14
+      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -15467,14 +15467,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_14
+      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -15490,14 +15490,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_14
+      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -15513,14 +15513,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.14
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_14
+      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -10,5762 +10,5762 @@ import (
 func TestStub(t *testing.T) {
 	t.Skip("stub is skipped")
 }
-func TestAwsAmznInstallContainerdV1_23_14(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_23_14(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_23_14(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_23_14(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_23_14(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_23_14(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_23_14(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_23_14(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_23_14(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_23_14(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_23_14(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_23_14(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_23_14(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_23_14(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_23_14(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_23_14(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_23_14(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_23_14(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_24_8(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_24_8(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_24_8(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_24_8(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_24_8(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_24_8(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_24_8(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_24_8(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_24_8(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_24_8(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_24_8(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_24_8(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_24_8(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_24_8(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_24_8(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_24_8(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_24_8(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_24_8(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_24_8(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_24_8(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_25_4(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_25_4(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_25_4(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_25_4(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_25_4(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_25_4(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_25_4(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_25_4(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_25_4(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_25_4(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_25_4(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_25_4(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_25_4(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_25_4(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_25_4(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_25_4(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_25_4(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerV1_23_14(t *testing.T) {
+func TestAwsAmznInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerV1_23_14(t *testing.T) {
+func TestAwsCentosInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerV1_23_14(t *testing.T) {
+func TestAwsDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerV1_23_14(t *testing.T) {
+func TestAwsFlatcarInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerV1_23_14(t *testing.T) {
+func TestAwsRhelInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerV1_23_14(t *testing.T) {
+func TestAwsRockylinuxInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerV1_23_14(t *testing.T) {
+func TestAzureDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerV1_23_14(t *testing.T) {
+func TestAzureCentosInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerV1_23_14(t *testing.T) {
+func TestAzureFlatcarInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerV1_23_14(t *testing.T) {
+func TestAzureRhelInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerV1_23_14(t *testing.T) {
+func TestAzureRockylinuxInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallDockerV1_23_14(t *testing.T) {
+func TestGceDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerV1_23_14(t *testing.T) {
+func TestOpenstackDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerV1_23_14(t *testing.T) {
+func TestOpenstackCentosInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerV1_23_14(t *testing.T) {
+func TestOpenstackRhelInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerV1_23_14(t *testing.T) {
+func TestVsphereDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerV1_23_14(t *testing.T) {
+func TestVsphereCentosInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerV1_23_14(t *testing.T) {
+func TestVsphereFlatcarInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCalicoContainerdV1_25_4(t *testing.T) {
+func TestAwsAmznCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoContainerdV1_25_4(t *testing.T) {
+func TestAwsCentosCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoContainerdV1_25_4(t *testing.T) {
+func TestAwsDefaultCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoContainerdV1_25_4(t *testing.T) {
+func TestAwsFlatcarCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoContainerdV1_25_4(t *testing.T) {
+func TestAwsRhelCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoContainerdV1_25_4(t *testing.T) {
+func TestAwsRockylinuxCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoContainerdV1_25_4(t *testing.T) {
+func TestAzureDefaultCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdV1_25_4(t *testing.T) {
+func TestAzureCentosCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoContainerdV1_25_4(t *testing.T) {
+func TestAzureFlatcarCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoContainerdV1_25_4(t *testing.T) {
+func TestAzureRhelCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoContainerdV1_25_4(t *testing.T) {
+func TestAzureRockylinuxCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoContainerdV1_25_4(t *testing.T) {
+func TestGceDefaultCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoContainerdV1_25_4(t *testing.T) {
+func TestOpenstackDefaultCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoContainerdV1_25_4(t *testing.T) {
+func TestOpenstackCentosCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRhelCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoContainerdV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoContainerdV1_25_4(t *testing.T) {
+func TestVsphereDefaultCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoContainerdV1_25_4(t *testing.T) {
+func TestVsphereCentosCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoContainerdV1_25_4(t *testing.T) {
+func TestVsphereFlatcarCalicoContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCalicoDockerV1_23_14(t *testing.T) {
+func TestAwsAmznCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoDockerV1_23_14(t *testing.T) {
+func TestAwsCentosCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoDockerV1_23_14(t *testing.T) {
+func TestAwsDefaultCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoDockerV1_23_14(t *testing.T) {
+func TestAwsFlatcarCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoDockerV1_23_14(t *testing.T) {
+func TestAwsRhelCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoDockerV1_23_14(t *testing.T) {
+func TestAwsRockylinuxCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoDockerV1_23_14(t *testing.T) {
+func TestAzureDefaultCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoDockerV1_23_14(t *testing.T) {
+func TestAzureCentosCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoDockerV1_23_14(t *testing.T) {
+func TestAzureFlatcarCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoDockerV1_23_14(t *testing.T) {
+func TestAzureRhelCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoDockerV1_23_14(t *testing.T) {
+func TestAzureRockylinuxCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoDockerV1_23_14(t *testing.T) {
+func TestGceDefaultCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoDockerV1_23_14(t *testing.T) {
+func TestOpenstackDefaultCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoDockerV1_23_14(t *testing.T) {
+func TestOpenstackCentosCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoDockerV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoDockerV1_23_14(t *testing.T) {
+func TestOpenstackRhelCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoDockerV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoDockerV1_23_14(t *testing.T) {
+func TestVsphereDefaultCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoDockerV1_23_14(t *testing.T) {
+func TestVsphereCentosCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoDockerV1_23_14(t *testing.T) {
+func TestVsphereFlatcarCalicoDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveContainerdV1_25_4(t *testing.T) {
+func TestAwsAmznWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveContainerdV1_25_4(t *testing.T) {
+func TestAwsCentosWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveContainerdV1_25_4(t *testing.T) {
+func TestAwsDefaultWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveContainerdV1_25_4(t *testing.T) {
+func TestAwsFlatcarWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveContainerdV1_25_4(t *testing.T) {
+func TestAwsRhelWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveContainerdV1_25_4(t *testing.T) {
+func TestAwsRockylinuxWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveContainerdV1_25_4(t *testing.T) {
+func TestAzureDefaultWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveContainerdV1_25_4(t *testing.T) {
+func TestAzureCentosWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveContainerdV1_25_4(t *testing.T) {
+func TestAzureFlatcarWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveContainerdV1_25_4(t *testing.T) {
+func TestAzureRhelWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveContainerdV1_25_4(t *testing.T) {
+func TestAzureRockylinuxWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveContainerdV1_25_4(t *testing.T) {
+func TestGceDefaultWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveContainerdV1_25_4(t *testing.T) {
+func TestOpenstackDefaultWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveContainerdV1_25_4(t *testing.T) {
+func TestOpenstackCentosWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRhelWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveContainerdV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveContainerdV1_25_4(t *testing.T) {
+func TestVsphereDefaultWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosWeaveContainerdV1_25_4(t *testing.T) {
+func TestVsphereCentosWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveContainerdV1_25_4(t *testing.T) {
+func TestVsphereFlatcarWeaveContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveDockerV1_23_14(t *testing.T) {
+func TestAwsAmznWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveDockerV1_23_14(t *testing.T) {
+func TestAwsCentosWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveDockerV1_23_14(t *testing.T) {
+func TestAwsDefaultWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveDockerV1_23_14(t *testing.T) {
+func TestAwsFlatcarWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveDockerV1_23_14(t *testing.T) {
+func TestAwsRhelWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveDockerV1_23_14(t *testing.T) {
+func TestAwsRockylinuxWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveDockerV1_23_14(t *testing.T) {
+func TestAzureDefaultWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveDockerV1_23_14(t *testing.T) {
+func TestAzureCentosWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveDockerV1_23_14(t *testing.T) {
+func TestAzureFlatcarWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveDockerV1_23_14(t *testing.T) {
+func TestAzureRhelWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveDockerV1_23_14(t *testing.T) {
+func TestAzureRockylinuxWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveDockerV1_23_14(t *testing.T) {
+func TestGceDefaultWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveDockerV1_23_14(t *testing.T) {
+func TestOpenstackDefaultWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveDockerV1_23_14(t *testing.T) {
+func TestOpenstackCentosWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveDockerV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveDockerV1_23_14(t *testing.T) {
+func TestOpenstackRhelWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveDockerV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveDockerV1_23_14(t *testing.T) {
+func TestVsphereDefaultWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosWeaveDockerV1_23_14(t *testing.T) {
+func TestVsphereCentosWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveDockerV1_23_14(t *testing.T) {
+func TestVsphereFlatcarWeaveDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumContainerdV1_25_4(t *testing.T) {
+func TestAwsAmznCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumContainerdV1_25_4(t *testing.T) {
+func TestAwsCentosCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumContainerdV1_25_4(t *testing.T) {
+func TestAwsDefaultCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumContainerdV1_25_4(t *testing.T) {
+func TestAwsFlatcarCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumContainerdV1_25_4(t *testing.T) {
+func TestAwsRhelCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumContainerdV1_25_4(t *testing.T) {
+func TestAwsRockylinuxCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumContainerdV1_25_4(t *testing.T) {
+func TestAzureDefaultCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdV1_25_4(t *testing.T) {
+func TestAzureCentosCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumContainerdV1_25_4(t *testing.T) {
+func TestAzureFlatcarCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumContainerdV1_25_4(t *testing.T) {
+func TestAzureRhelCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumContainerdV1_25_4(t *testing.T) {
+func TestAzureRockylinuxCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumContainerdV1_25_4(t *testing.T) {
+func TestGceDefaultCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumContainerdV1_25_4(t *testing.T) {
+func TestOpenstackDefaultCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumContainerdV1_25_4(t *testing.T) {
+func TestOpenstackCentosCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRhelCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumContainerdV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumContainerdV1_25_4(t *testing.T) {
+func TestVsphereDefaultCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumContainerdV1_25_4(t *testing.T) {
+func TestVsphereCentosCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumContainerdV1_25_4(t *testing.T) {
+func TestVsphereFlatcarCiliumContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumDockerV1_23_14(t *testing.T) {
+func TestAwsAmznCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumDockerV1_23_14(t *testing.T) {
+func TestAwsCentosCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumDockerV1_23_14(t *testing.T) {
+func TestAwsDefaultCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumDockerV1_23_14(t *testing.T) {
+func TestAwsFlatcarCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumDockerV1_23_14(t *testing.T) {
+func TestAwsRhelCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumDockerV1_23_14(t *testing.T) {
+func TestAwsRockylinuxCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumDockerV1_23_14(t *testing.T) {
+func TestAzureDefaultCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumDockerV1_23_14(t *testing.T) {
+func TestAzureCentosCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumDockerV1_23_14(t *testing.T) {
+func TestAzureFlatcarCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumDockerV1_23_14(t *testing.T) {
+func TestAzureRhelCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumDockerV1_23_14(t *testing.T) {
+func TestAzureRockylinuxCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumDockerV1_23_14(t *testing.T) {
+func TestGceDefaultCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumDockerV1_23_14(t *testing.T) {
+func TestOpenstackDefaultCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumDockerV1_23_14(t *testing.T) {
+func TestOpenstackCentosCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumDockerV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumDockerV1_23_14(t *testing.T) {
+func TestOpenstackRhelCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumDockerV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumDockerV1_23_14(t *testing.T) {
+func TestVsphereDefaultCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumDockerV1_23_14(t *testing.T) {
+func TestVsphereCentosCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumDockerV1_23_14(t *testing.T) {
+func TestVsphereFlatcarCiliumDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_14(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_8(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_25_4(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_25_4(t *testing.T) {
+func TestAwsDefaultKubeProxyIpvsV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_14(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_8(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_4(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_14(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_23_14(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_24_8(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_25_4(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_23_14(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_24_8(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_25_4(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAwsAmznInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAwsCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAwsDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAwsFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAwsRhelInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAwsRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAzureDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAzureCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAzureFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAzureRhelInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
+func TestAzureRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallDockerExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallDockerExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallDockerExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallDockerExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallDockerExternalV1_23_14(t *testing.T) {
+func TestHetznerDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallDockerExternalV1_23_14(t *testing.T) {
+func TestHetznerCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
+func TestHetznerRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerExternalV1_23_14(t *testing.T) {
+func TestOpenstackDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerExternalV1_23_14(t *testing.T) {
+func TestOpenstackCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerExternalV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerExternalV1_23_14(t *testing.T) {
+func TestOpenstackRhelInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerExternalV1_23_14(t *testing.T) {
+func TestVsphereDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerExternalV1_23_14(t *testing.T) {
+func TestVsphereCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerExternalV1_23_14(t *testing.T) {
+func TestVsphereFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_14_ToV1_24_8(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14", "v1.24.8")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_8_ToV1_25_4(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8", "v1.25.4")
+	scenario.SetVersions("v1.24.9", "v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_14(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_8(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.8")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_4(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.4")
+	scenario.SetVersions("v1.25.5")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_14(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.14")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -1,5 +1,5 @@
 - scenario: install_containerd
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -24,7 +24,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.24.8
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -49,7 +49,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.25.4
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -74,7 +74,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -98,8 +98,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd
-  initVersion: v1.24.8
-  upgradedVersion: v1.25.4
+  initVersion: v1.24.9
+  upgradedVersion: v1.25.5
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -123,8 +123,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd
-  initVersion: v1.23.14
-  upgradedVersion: v1.24.8
+  initVersion: v1.23.15
+  upgradedVersion: v1.24.9
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -148,7 +148,7 @@
     - name: vsphere_flatcar_stable
 
 - scenario: calico_containerd
-  initVersion: v1.25.4
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -172,7 +172,7 @@
     - name: vsphere_flatcar
 
 - scenario: calico_docker
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -196,7 +196,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_containerd
-  initVersion: v1.25.4
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -220,7 +220,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_docker
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -244,7 +244,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_containerd
-  initVersion: v1.25.4
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -268,7 +268,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_docker
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -292,66 +292,42 @@
     - name: vsphere_flatcar
 
 - scenario: conformance_containerd
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.24.8
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.25.4
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.24.8
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.25.4
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.25.4
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_default
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.23.14
-  infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: gce_default
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_centos
-    - name: vsphere_flatcar
-
-- scenario: legacy_machine_controller_containerd
-  initVersion: v1.24.8
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -375,7 +351,31 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.25.4
+  initVersion: v1.24.9
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: gce_default
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_centos
+    - name: vsphere_flatcar
+
+- scenario: legacy_machine_controller_containerd
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -399,7 +399,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -423,7 +423,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_default  
     - name: openstack_default
@@ -441,7 +441,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.24.8
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -459,7 +459,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.25.4
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -477,40 +477,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.23.14
-  infrastructures:
-    - name: aws_amzn
-    - name: aws_centos
-    - name: aws_default
-    - name: aws_flatcar
-    - name: aws_rhel
-    - name: aws_rockylinux
-    - name: azure_default
-    - name: azure_centos
-    - name: azure_flatcar
-    - name: azure_rhel
-    - name: azure_rockylinux
-    - name: digitalocean_default
-    - name: digitalocean_centos
-    - name: digitalocean_rockylinux
-    - name: equinixmetal_default
-    - name: equinixmetal_centos
-    - name: equinixmetal_rockylinux
-    - name: equinixmetal_flatcar
-    - name: hetzner_default
-    - name: hetzner_centos
-    - name: hetzner_rockylinux
-    - name: openstack_default
-    - name: openstack_centos
-    - name: openstack_rockylinux
-    - name: openstack_rhel
-    - name: openstack_flatcar
-    - name: vsphere_default
-    - name: vsphere_centos
-    - name: vsphere_flatcar
-
-- scenario: install_containerd_external
-  initVersion: v1.24.8
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -543,7 +510,40 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.25.4
+  initVersion: v1.24.9
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: digitalocean_default
+    - name: digitalocean_centos
+    - name: digitalocean_rockylinux
+    - name: equinixmetal_default
+    - name: equinixmetal_centos
+    - name: equinixmetal_rockylinux
+    - name: equinixmetal_flatcar
+    - name: hetzner_default
+    - name: hetzner_centos
+    - name: hetzner_rockylinux
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_centos
+    - name: vsphere_flatcar
+
+- scenario: install_containerd_external
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -576,7 +576,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -609,8 +609,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.23.14
-  upgradedVersion: v1.24.8
+  initVersion: v1.23.15
+  upgradedVersion: v1.24.9
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -643,8 +643,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.24.8
-  upgradedVersion: v1.25.4
+  initVersion: v1.24.9
+  upgradedVersion: v1.25.5
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -677,7 +677,7 @@
     - name: vsphere_flatcar_stable
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -710,7 +710,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.24.8
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -743,7 +743,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.25.4
+  initVersion: v1.25.5
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -776,7 +776,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker_external
-  initVersion: v1.23.14
+  initVersion: v1.23.15
   infrastructures:
     - name: digitalocean_default
     - name: digitalocean_centos


### PR DESCRIPTION
**What this PR does / why we need it**:

Add tests for the December Kubernetes patch releases (1.25.5, 1.24.9, 1.23.15).

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Validate support for Kubernetes patch releases 1.25.5, 1.24.9, and 1.23.15. Upgrading to Kubernetes 1.25.5 or 1.24.9 is strongly advised because those releases are built with Go 1.19.4 which includes fixes for [CVE-2022-41720 and CVE-2022-41717](https://groups.google.com/g/golang-announce/c/L_3rmdT0BMU/m/yZDrXjIiBQAJ)
```

**Documentation**:
```documentation
NONE
```