### PR TITLE
[release/v1.5] Add tests for the December Kubernetes patch releases

### DIFF
--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -6,14 +6,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_22_12
+      - TestAwsAmznInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -29,485 +29,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: true
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-gce: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_22_12
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_23_9
+      - TestAwsCentosInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -523,14 +52,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_23_9
+      - TestAwsDefaultInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -546,14 +75,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_23_9
+      - TestAwsFlatcarInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -569,14 +98,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_23_9
+      - TestAwsRhelInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -592,14 +121,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_23_9
+      - TestAwsRockylinuxInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -615,14 +144,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_23_9
+      - TestAzureDefaultInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -640,14 +169,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_23_9
+      - TestAzureCentosInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -665,14 +194,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_23_9
+      - TestAzureFlatcarInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -691,14 +220,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_23_9
+      - TestAzureRhelInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -716,14 +245,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_23_9
+      - TestAzureRockylinuxInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -741,14 +270,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_23_9
+      - TestGceDefaultInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -764,14 +293,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_23_9
+      - TestOpenstackDefaultInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -787,14 +316,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_23_9
+      - TestOpenstackCentosInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -810,14 +339,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_23_9
+      - TestOpenstackRockylinuxInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -833,14 +362,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_23_9
+      - TestOpenstackRhelInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -856,14 +385,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_23_9
+      - TestOpenstackFlatcarInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -879,14 +408,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_23_9
+      - TestVsphereDefaultInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -902,14 +431,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_23_9
+      - TestVsphereCentosInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -925,14 +454,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_23_9
+      - TestVsphereFlatcarInstallContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -948,14 +477,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_24_3
+      - TestAwsAmznInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -971,14 +500,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_24_3
+      - TestAwsCentosInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -994,14 +523,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_24_3
+      - TestAwsDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -1017,14 +546,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_24_3
+      - TestAwsFlatcarInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -1040,14 +569,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_24_3
+      - TestAwsRhelInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -1063,14 +592,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_24_3
+      - TestAwsRockylinuxInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -1086,14 +615,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_24_3
+      - TestAzureDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -1111,14 +640,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_24_3
+      - TestAzureCentosInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -1136,14 +665,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_24_3
+      - TestAzureFlatcarInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -1162,14 +691,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_24_3
+      - TestAzureRhelInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -1187,14 +716,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_24_3
+      - TestAzureRockylinuxInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -1212,14 +741,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_24_3
+      - TestGceDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -1235,14 +764,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_24_3
+      - TestOpenstackDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -1258,14 +787,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_24_3
+      - TestOpenstackCentosInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -1281,14 +810,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_24_3
+      - TestOpenstackRockylinuxInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -1304,14 +833,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_24_3
+      - TestOpenstackRhelInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -1327,14 +856,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_24_3
+      - TestOpenstackFlatcarInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -1350,14 +879,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_24_3
+      - TestVsphereDefaultInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -1373,14 +902,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_24_3
+      - TestVsphereCentosInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -1396,14 +925,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_24_3
+      - TestVsphereFlatcarInstallContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -1419,14 +948,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerV1_22_12
+      - TestAwsAmznInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -1442,14 +971,37 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerV1_22_12
+      - TestAwsCentosInstallContainerdV1_24_9
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: true
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.9
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -1465,14 +1017,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerV1_22_12
+      - TestAwsFlatcarInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -1488,14 +1040,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerV1_22_12
+      - TestAwsRhelInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -1511,37 +1063,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerV1_22_12
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerV1_22_12
+      - TestAwsRockylinuxInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -1557,14 +1086,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerV1_22_12
+      - TestAzureDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1582,14 +1111,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerV1_22_12
+      - TestAzureCentosInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1607,14 +1136,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerV1_22_12
+      - TestAzureFlatcarInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1633,14 +1162,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerV1_22_12
+      - TestAzureRhelInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1658,14 +1187,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerV1_22_12
+      - TestAzureRockylinuxInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -1683,14 +1212,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallDockerV1_22_12
+      - TestGceDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: gce
@@ -1706,14 +1235,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerV1_22_12
+      - TestOpenstackDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1729,14 +1258,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerV1_22_12
+      - TestOpenstackCentosInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1752,14 +1281,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerV1_22_12
+      - TestOpenstackRockylinuxInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1775,14 +1304,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerV1_22_12
+      - TestOpenstackRhelInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1798,14 +1327,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerV1_22_12
+      - TestOpenstackFlatcarInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -1821,14 +1350,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerV1_22_12
+      - TestVsphereDefaultInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -1844,14 +1373,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerV1_22_12
+      - TestVsphereCentosInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -1867,14 +1396,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerV1_22_12
+      - TestVsphereFlatcarInstallContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -1890,14 +1419,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerV1_23_9
+      - TestAwsAmznInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -1913,14 +1442,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerV1_23_9
+      - TestAwsCentosInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -1936,14 +1465,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-default-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerV1_23_9
+      - TestAwsDefaultInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -1959,14 +1488,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerV1_23_9
+      - TestAwsFlatcarInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -1982,14 +1511,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerV1_23_9
+      - TestAwsRhelInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -2005,14 +1534,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerV1_23_9
+      - TestAwsRockylinuxInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -2028,14 +1557,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-default-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerV1_23_9
+      - TestAzureDefaultInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -2053,14 +1582,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerV1_23_9
+      - TestAzureCentosInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -2078,14 +1607,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerV1_23_9
+      - TestAzureFlatcarInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -2104,14 +1633,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerV1_23_9
+      - TestAzureRhelInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -2129,14 +1658,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerV1_23_9
+      - TestAzureRockylinuxInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -2154,14 +1683,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-gce-default-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallDockerV1_23_9
+      - TestGceDefaultInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -2177,14 +1706,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerV1_23_9
+      - TestOpenstackDefaultInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -2200,14 +1729,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerV1_23_9
+      - TestOpenstackCentosInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -2223,14 +1752,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerV1_23_9
+      - TestOpenstackRockylinuxInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -2246,14 +1775,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerV1_23_9
+      - TestOpenstackRhelInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -2269,14 +1798,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerV1_23_9
+      - TestOpenstackFlatcarInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -2292,14 +1821,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerV1_23_9
+      - TestVsphereDefaultInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -2315,14 +1844,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerV1_23_9
+      - TestVsphereCentosInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -2338,14 +1867,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerV1_23_9
+      - TestVsphereFlatcarInstallDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -2358,22 +1887,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsAmznInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -2386,22 +1910,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsCentosInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -2414,22 +1933,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -2442,22 +1956,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsFlatcarInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -2470,22 +1979,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsRhelInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -2498,22 +2002,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAwsRockylinuxInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -2526,22 +2025,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2556,22 +2050,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureCentosInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2586,22 +2075,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureFlatcarInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2616,23 +2100,18 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureRhelInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2647,22 +2126,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestAzureRockylinuxInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -2677,22 +2151,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestGceDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -2705,22 +2174,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2733,22 +2197,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackCentosInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2761,22 +2220,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackRockylinuxInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2789,22 +2243,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackRhelInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2817,22 +2266,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestOpenstackFlatcarInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -2845,22 +2289,17 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestVsphereDefaultInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -2873,22 +2312,40 @@ presubmits:
 - always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallDockerV1_23_15
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_23_9_ToV1_24_3
+      - TestVsphereFlatcarInstallDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -2909,14 +2366,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsAmznStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -2937,14 +2394,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -2965,14 +2422,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -2993,14 +2450,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -3021,14 +2478,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -3049,14 +2506,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -3077,14 +2534,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -3107,14 +2564,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -3137,14 +2594,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -3168,14 +2625,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -3198,14 +2655,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -3228,14 +2685,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestGceDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: gce
@@ -3256,14 +2713,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -3284,14 +2741,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -3312,14 +2769,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -3340,14 +2797,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -3368,14 +2825,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -3396,14 +2853,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -3424,14 +2881,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_22_12_ToV1_23_9
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -3452,14 +2909,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsAmznStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3480,14 +2937,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3508,14 +2965,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3536,14 +2993,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3564,14 +3021,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3592,14 +3049,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -3620,14 +3077,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3650,14 +3107,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3680,14 +3137,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3711,14 +3168,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3741,14 +3198,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -3771,14 +3228,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestGceDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -3799,14 +3256,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3827,14 +3284,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3855,14 +3312,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3883,14 +3340,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3911,14 +3368,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -3939,14 +3396,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -3967,14 +3424,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_12
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -3995,14 +3452,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsAmznStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -4023,14 +3480,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -4051,14 +3508,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -4079,14 +3536,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -4107,14 +3564,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -4135,14 +3592,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -4163,14 +3620,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -4193,14 +3650,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -4223,14 +3680,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -4254,14 +3711,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -4284,14 +3741,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -4314,14 +3771,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestGceDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -4342,14 +3799,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -4370,14 +3827,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -4398,14 +3855,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -4426,14 +3883,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -4454,14 +3911,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -4482,14 +3939,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -4510,14 +3967,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeDockerFromV1_22_12_ToV1_23_9
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -4538,14 +3995,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsAmznStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4566,14 +4023,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4594,14 +4051,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4622,14 +4079,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4650,14 +4107,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4678,14 +4135,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAwsRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -4706,14 +4163,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4736,14 +4193,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4766,14 +4223,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4797,14 +4254,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4827,14 +4284,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestAzureRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -4857,14 +4314,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestGceDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -4885,14 +4342,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -4913,14 +4370,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -4941,14 +4398,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackRockylinuxUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -4969,14 +4426,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -4997,14 +4454,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestOpenstackFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -5025,14 +4482,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestVsphereDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -5053,14 +4510,557 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_12
+      - TestVsphereFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: gce
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-from-v1.21.14-to-v1.22.17
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -5076,14 +5076,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoContainerdV1_22_12
+      - TestAwsAmznCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5099,14 +5099,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdV1_22_12
+      - TestAwsCentosCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5122,14 +5122,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoContainerdV1_22_12
+      - TestAwsDefaultCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5145,14 +5145,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoContainerdV1_22_12
+      - TestAwsFlatcarCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5168,14 +5168,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoContainerdV1_22_12
+      - TestAwsRhelCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5191,14 +5191,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoContainerdV1_22_12
+      - TestAwsRockylinuxCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5214,14 +5214,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoContainerdV1_22_12
+      - TestAzureDefaultCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5239,14 +5239,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdV1_22_12
+      - TestAzureCentosCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5264,14 +5264,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoContainerdV1_22_12
+      - TestAzureFlatcarCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5290,14 +5290,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoContainerdV1_22_12
+      - TestAzureRhelCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5315,14 +5315,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoContainerdV1_22_12
+      - TestAzureRockylinuxCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5340,14 +5340,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoContainerdV1_22_12
+      - TestGceDefaultCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -5363,14 +5363,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoContainerdV1_22_12
+      - TestOpenstackDefaultCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5386,14 +5386,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdV1_22_12
+      - TestOpenstackCentosCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5409,14 +5409,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoContainerdV1_22_12
+      - TestOpenstackRockylinuxCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5432,14 +5432,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoContainerdV1_22_12
+      - TestOpenstackRhelCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5455,14 +5455,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoContainerdV1_22_12
+      - TestOpenstackFlatcarCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5478,14 +5478,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoContainerdV1_22_12
+      - TestVsphereDefaultCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -5501,14 +5501,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoContainerdV1_22_12
+      - TestVsphereCentosCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -5524,14 +5524,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoContainerdV1_22_12
+      - TestVsphereFlatcarCalicoContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -5547,14 +5547,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoDockerV1_22_12
+      - TestAwsAmznCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5570,14 +5570,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoDockerV1_22_12
+      - TestAwsCentosCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5593,14 +5593,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-default-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoDockerV1_22_12
+      - TestAwsDefaultCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5616,14 +5616,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoDockerV1_22_12
+      - TestAwsFlatcarCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5639,14 +5639,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoDockerV1_22_12
+      - TestAwsRhelCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5662,14 +5662,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoDockerV1_22_12
+      - TestAwsRockylinuxCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -5685,14 +5685,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoDockerV1_22_12
+      - TestAzureDefaultCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5710,14 +5710,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoDockerV1_22_12
+      - TestAzureCentosCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5735,14 +5735,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoDockerV1_22_12
+      - TestAzureFlatcarCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5761,14 +5761,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoDockerV1_22_12
+      - TestAzureRhelCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5786,14 +5786,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoDockerV1_22_12
+      - TestAzureRockylinuxCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -5811,14 +5811,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoDockerV1_22_12
+      - TestGceDefaultCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -5834,14 +5834,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoDockerV1_22_12
+      - TestOpenstackDefaultCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5857,14 +5857,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoDockerV1_22_12
+      - TestOpenstackCentosCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5880,14 +5880,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoDockerV1_22_12
+      - TestOpenstackRockylinuxCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5903,14 +5903,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoDockerV1_22_12
+      - TestOpenstackRhelCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5926,14 +5926,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoDockerV1_22_12
+      - TestOpenstackFlatcarCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -5949,14 +5949,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoDockerV1_22_12
+      - TestVsphereDefaultCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -5972,14 +5972,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoDockerV1_22_12
+      - TestVsphereCentosCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -5995,14 +5995,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoDockerV1_22_12
+      - TestVsphereFlatcarCalicoDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -6018,14 +6018,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveContainerdV1_22_12
+      - TestAwsAmznWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6041,14 +6041,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveContainerdV1_22_12
+      - TestAwsCentosWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6064,14 +6064,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveContainerdV1_22_12
+      - TestAwsDefaultWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6087,14 +6087,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveContainerdV1_22_12
+      - TestAwsFlatcarWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6110,14 +6110,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveContainerdV1_22_12
+      - TestAwsRhelWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6133,14 +6133,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveContainerdV1_22_12
+      - TestAwsRockylinuxWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6156,14 +6156,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveContainerdV1_22_12
+      - TestAzureDefaultWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6181,14 +6181,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveContainerdV1_22_12
+      - TestAzureCentosWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6206,14 +6206,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveContainerdV1_22_12
+      - TestAzureFlatcarWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6232,14 +6232,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveContainerdV1_22_12
+      - TestAzureRhelWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6257,14 +6257,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveContainerdV1_22_12
+      - TestAzureRockylinuxWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6282,14 +6282,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveContainerdV1_22_12
+      - TestGceDefaultWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -6305,14 +6305,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveContainerdV1_22_12
+      - TestOpenstackDefaultWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6328,14 +6328,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveContainerdV1_22_12
+      - TestOpenstackCentosWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6351,14 +6351,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveContainerdV1_22_12
+      - TestOpenstackRockylinuxWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6374,14 +6374,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveContainerdV1_22_12
+      - TestOpenstackRhelWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6397,14 +6397,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveContainerdV1_22_12
+      - TestOpenstackFlatcarWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6420,14 +6420,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveContainerdV1_22_12
+      - TestVsphereDefaultWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -6443,14 +6443,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosWeaveContainerdV1_22_12
+      - TestVsphereCentosWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -6466,14 +6466,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveContainerdV1_22_12
+      - TestVsphereFlatcarWeaveContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -6489,14 +6489,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveDockerV1_22_12
+      - TestAwsAmznWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6512,14 +6512,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveDockerV1_22_12
+      - TestAwsCentosWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6535,14 +6535,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-default-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveDockerV1_22_12
+      - TestAwsDefaultWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6558,14 +6558,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveDockerV1_22_12
+      - TestAwsFlatcarWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6581,14 +6581,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveDockerV1_22_12
+      - TestAwsRhelWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6604,14 +6604,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveDockerV1_22_12
+      - TestAwsRockylinuxWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6627,14 +6627,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveDockerV1_22_12
+      - TestAzureDefaultWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6652,14 +6652,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveDockerV1_22_12
+      - TestAzureCentosWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6677,14 +6677,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveDockerV1_22_12
+      - TestAzureFlatcarWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6703,14 +6703,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveDockerV1_22_12
+      - TestAzureRhelWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6728,14 +6728,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveDockerV1_22_12
+      - TestAzureRockylinuxWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -6753,14 +6753,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveDockerV1_22_12
+      - TestGceDefaultWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -6776,14 +6776,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveDockerV1_22_12
+      - TestOpenstackDefaultWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6799,14 +6799,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveDockerV1_22_12
+      - TestOpenstackCentosWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6822,14 +6822,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveDockerV1_22_12
+      - TestOpenstackRockylinuxWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6845,14 +6845,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveDockerV1_22_12
+      - TestOpenstackRhelWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6868,14 +6868,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveDockerV1_22_12
+      - TestOpenstackFlatcarWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -6891,14 +6891,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveDockerV1_22_12
+      - TestVsphereDefaultWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -6914,14 +6914,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosWeaveDockerV1_22_12
+      - TestVsphereCentosWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -6937,14 +6937,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveDockerV1_22_12
+      - TestVsphereFlatcarWeaveDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -6960,14 +6960,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumContainerdV1_22_12
+      - TestAwsAmznCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -6983,14 +6983,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdV1_22_12
+      - TestAwsCentosCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7006,14 +7006,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumContainerdV1_22_12
+      - TestAwsDefaultCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7029,14 +7029,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumContainerdV1_22_12
+      - TestAwsFlatcarCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7052,14 +7052,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumContainerdV1_22_12
+      - TestAwsRhelCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7075,14 +7075,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumContainerdV1_22_12
+      - TestAwsRockylinuxCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7098,14 +7098,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumContainerdV1_22_12
+      - TestAzureDefaultCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7123,14 +7123,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdV1_22_12
+      - TestAzureCentosCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7148,14 +7148,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumContainerdV1_22_12
+      - TestAzureFlatcarCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7174,14 +7174,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumContainerdV1_22_12
+      - TestAzureRhelCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7199,14 +7199,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumContainerdV1_22_12
+      - TestAzureRockylinuxCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7224,14 +7224,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumContainerdV1_22_12
+      - TestGceDefaultCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -7247,14 +7247,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumContainerdV1_22_12
+      - TestOpenstackDefaultCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7270,14 +7270,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdV1_22_12
+      - TestOpenstackCentosCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7293,14 +7293,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumContainerdV1_22_12
+      - TestOpenstackRockylinuxCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7316,14 +7316,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumContainerdV1_22_12
+      - TestOpenstackRhelCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7339,14 +7339,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumContainerdV1_22_12
+      - TestOpenstackFlatcarCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7362,14 +7362,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumContainerdV1_22_12
+      - TestVsphereDefaultCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -7385,14 +7385,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumContainerdV1_22_12
+      - TestVsphereCentosCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -7408,14 +7408,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumContainerdV1_22_12
+      - TestVsphereFlatcarCiliumContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -7431,14 +7431,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumDockerV1_22_12
+      - TestAwsAmznCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7454,14 +7454,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumDockerV1_22_12
+      - TestAwsCentosCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7477,14 +7477,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-default-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumDockerV1_22_12
+      - TestAwsDefaultCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7500,14 +7500,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumDockerV1_22_12
+      - TestAwsFlatcarCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7523,14 +7523,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumDockerV1_22_12
+      - TestAwsRhelCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7546,14 +7546,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumDockerV1_22_12
+      - TestAwsRockylinuxCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7569,14 +7569,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumDockerV1_22_12
+      - TestAzureDefaultCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7594,14 +7594,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumDockerV1_22_12
+      - TestAzureCentosCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7619,14 +7619,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumDockerV1_22_12
+      - TestAzureFlatcarCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7645,14 +7645,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumDockerV1_22_12
+      - TestAzureRhelCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7670,14 +7670,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumDockerV1_22_12
+      - TestAzureRockylinuxCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -7695,14 +7695,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumDockerV1_22_12
+      - TestGceDefaultCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -7718,14 +7718,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumDockerV1_22_12
+      - TestOpenstackDefaultCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7741,14 +7741,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumDockerV1_22_12
+      - TestOpenstackCentosCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7764,14 +7764,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumDockerV1_22_12
+      - TestOpenstackRockylinuxCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7787,14 +7787,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumDockerV1_22_12
+      - TestOpenstackRhelCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7810,14 +7810,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumDockerV1_22_12
+      - TestOpenstackFlatcarCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -7833,14 +7833,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumDockerV1_22_12
+      - TestVsphereDefaultCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -7856,14 +7856,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumDockerV1_22_12
+      - TestVsphereCentosCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -7879,14 +7879,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumDockerV1_22_12
+      - TestVsphereFlatcarCiliumDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -7902,14 +7902,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_22_12
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -7927,14 +7927,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_9
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -7952,14 +7952,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_3
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -7977,14 +7977,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_12
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -8002,14 +8002,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_9
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8027,14 +8027,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_3
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -8052,14 +8052,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.22.12
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_22_12
+      - TestAwsDefaultKubeProxyIpvsV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -8075,14 +8075,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.23.9
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_23_9
+      - TestAwsDefaultKubeProxyIpvsV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8098,14 +8098,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_22_12
+      - TestAwsAmznLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -8121,14 +8121,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_22_12
+      - TestAwsCentosLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -8144,14 +8144,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -8167,14 +8167,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_12
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -8190,14 +8190,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_22_12
+      - TestAwsRhelLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -8213,14 +8213,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_12
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -8236,14 +8236,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -8261,14 +8261,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_22_12
+      - TestAzureCentosLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -8286,14 +8286,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_22_12
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -8312,14 +8312,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_22_12
+      - TestAzureRhelLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -8337,14 +8337,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_12
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -8362,14 +8362,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestGceDefaultLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -8385,14 +8385,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -8408,14 +8408,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -8431,14 +8431,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -8454,14 +8454,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -8477,14 +8477,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_12
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -8500,14 +8500,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_22_12
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -8523,14 +8523,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_22_12
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -8546,14 +8546,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_12
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -8569,14 +8569,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_23_9
+      - TestAwsAmznLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8592,14 +8592,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_23_9
+      - TestAwsCentosLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8615,14 +8615,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8638,14 +8638,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_9
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8661,14 +8661,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_23_9
+      - TestAwsRhelLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8684,14 +8684,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_9
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -8707,14 +8707,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8732,14 +8732,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_23_9
+      - TestAzureCentosLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8757,14 +8757,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_9
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8783,14 +8783,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_23_9
+      - TestAzureRhelLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8808,14 +8808,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_9
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -8833,14 +8833,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestGceDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -8856,14 +8856,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -8879,14 +8879,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -8902,14 +8902,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -8925,14 +8925,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -8948,14 +8948,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_9
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -8971,14 +8971,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_9
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -8994,14 +8994,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_23_9
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -9017,14 +9017,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_9
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -9040,14 +9040,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_24_3
+      - TestAwsAmznLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9063,14 +9063,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_24_3
+      - TestAwsCentosLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9086,14 +9086,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9109,14 +9109,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_3
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9132,14 +9132,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_24_3
+      - TestAwsRhelLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9155,14 +9155,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_3
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -9178,14 +9178,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9203,14 +9203,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_24_3
+      - TestAzureCentosLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9228,14 +9228,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_3
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9254,14 +9254,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_24_3
+      - TestAzureRhelLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9279,14 +9279,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_3
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -9304,14 +9304,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestGceDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: gce
@@ -9327,14 +9327,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -9350,14 +9350,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -9373,14 +9373,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -9396,14 +9396,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -9419,14 +9419,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_3
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -9442,14 +9442,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_3
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -9465,14 +9465,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_3
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -9488,14 +9488,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_3
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -9511,14 +9511,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerDockerV1_22_12
+      - TestAwsAmznLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -9534,14 +9534,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerDockerV1_22_12
+      - TestAwsCentosLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -9557,14 +9557,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerDockerV1_22_12
+      - TestAwsDefaultLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -9580,14 +9580,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerDockerV1_22_12
+      - TestAwsFlatcarLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -9603,14 +9603,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerDockerV1_22_12
+      - TestAwsRhelLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -9626,14 +9626,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerDockerV1_22_12
+      - TestAwsRockylinuxLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -9649,14 +9649,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerDockerV1_22_12
+      - TestAzureDefaultLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -9674,14 +9674,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerDockerV1_22_12
+      - TestAzureCentosLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -9699,14 +9699,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerDockerV1_22_12
+      - TestAzureFlatcarLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -9725,14 +9725,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerDockerV1_22_12
+      - TestAzureRhelLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -9750,14 +9750,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerDockerV1_22_12
+      - TestAzureRockylinuxLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -9775,14 +9775,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerDockerV1_22_12
+      - TestGceDefaultLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: gce
@@ -9798,14 +9798,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackDefaultLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -9821,14 +9821,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackCentosLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -9844,14 +9844,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -9867,14 +9867,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackRhelLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -9890,14 +9890,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_12
+      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -9913,14 +9913,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerDockerV1_22_12
+      - TestVsphereDefaultLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -9936,14 +9936,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerDockerV1_22_12
+      - TestVsphereCentosLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -9959,14 +9959,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerDockerV1_22_12
+      - TestVsphereFlatcarLegacyMachineControllerDockerV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -9982,14 +9982,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerDockerV1_23_9
+      - TestAwsAmznLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -10005,14 +10005,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerDockerV1_23_9
+      - TestAwsCentosLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -10028,14 +10028,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerDockerV1_23_9
+      - TestAwsDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -10051,14 +10051,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_9
+      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -10074,14 +10074,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerDockerV1_23_9
+      - TestAwsRhelLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -10097,14 +10097,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_9
+      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -10120,14 +10120,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerDockerV1_23_9
+      - TestAzureDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -10145,14 +10145,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerDockerV1_23_9
+      - TestAzureCentosLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -10170,14 +10170,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_9
+      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -10196,14 +10196,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerDockerV1_23_9
+      - TestAzureRhelLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -10221,14 +10221,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_9
+      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -10246,14 +10246,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerDockerV1_23_9
+      - TestGceDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: gce
@@ -10269,14 +10269,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10292,14 +10292,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10315,14 +10315,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10338,14 +10338,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10361,14 +10361,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_9
+      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10384,14 +10384,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_9
+      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -10407,14 +10407,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerDockerV1_23_9
+      - TestVsphereCentosLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -10430,14 +10430,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_9
+      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -10453,14 +10453,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.24.3
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_24_3
+      - TestAwsDefaultKubeProxyIpvsV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -10476,14 +10476,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_22_12
+      - TestAwsDefaultCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -10499,14 +10499,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_22_12
+      - TestOpenstackDefaultCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -10522,14 +10522,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_22_12
+      - TestOpenstackCentosCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -10545,14 +10545,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_22_12
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -10568,14 +10568,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_22_12
+      - TestOpenstackRhelCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -10591,14 +10591,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_22_12
+      - TestOpenstackFlatcarCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -10614,14 +10614,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_22_12
+      - TestAzureDefaultCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -10639,14 +10639,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_22_12
+      - TestAzureCentosCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -10664,14 +10664,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_22_12
+      - TestAzureFlatcarCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -10690,14 +10690,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_22_12
+      - TestAzureRhelCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -10715,14 +10715,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_22_12
+      - TestAzureRockylinuxCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -10740,14 +10740,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_22_12
+      - TestVsphereDefaultCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -10763,14 +10763,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_22_12
+      - TestVsphereCentosCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -10786,14 +10786,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_22_12
+      - TestVsphereFlatcarCsiCcmMigrationV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -10809,14 +10809,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_23_9
+      - TestAwsDefaultCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -10832,14 +10832,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_23_9
+      - TestOpenstackDefaultCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10855,14 +10855,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_23_9
+      - TestOpenstackCentosCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10878,14 +10878,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_9
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10901,14 +10901,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_23_9
+      - TestOpenstackRhelCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10924,14 +10924,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_23_9
+      - TestOpenstackFlatcarCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -10947,14 +10947,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_23_9
+      - TestAzureDefaultCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -10972,14 +10972,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_23_9
+      - TestAzureCentosCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -10997,14 +10997,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_23_9
+      - TestAzureFlatcarCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -11023,14 +11023,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_23_9
+      - TestAzureRhelCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -11048,14 +11048,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_23_9
+      - TestAzureRockylinuxCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -11073,14 +11073,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_23_9
+      - TestVsphereDefaultCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -11096,14 +11096,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_23_9
+      - TestVsphereCentosCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -11119,14 +11119,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_23_9
+      - TestVsphereFlatcarCsiCcmMigrationV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -11142,14 +11142,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_24_3
+      - TestAwsDefaultCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -11165,14 +11165,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_24_3
+      - TestOpenstackDefaultCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -11188,14 +11188,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_24_3
+      - TestOpenstackCentosCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -11211,14 +11211,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_3
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -11234,14 +11234,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_24_3
+      - TestOpenstackRhelCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -11257,14 +11257,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_24_3
+      - TestOpenstackFlatcarCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -11280,14 +11280,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_24_3
+      - TestAzureDefaultCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -11305,14 +11305,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_24_3
+      - TestAzureCentosCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -11330,14 +11330,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_24_3
+      - TestAzureFlatcarCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -11356,14 +11356,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_24_3
+      - TestAzureRhelCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -11381,14 +11381,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_24_3
+      - TestAzureRockylinuxCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -11406,14 +11406,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_24_3
+      - TestVsphereDefaultCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -11429,14 +11429,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_24_3
+      - TestVsphereCentosCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -11452,14 +11452,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_24_3
+      - TestVsphereFlatcarCsiCcmMigrationV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -11475,14 +11475,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_22_12
+      - TestAwsAmznInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -11498,14 +11498,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_22_12
+      - TestAwsCentosInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -11521,14 +11521,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_22_12
+      - TestAwsDefaultInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -11544,14 +11544,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_22_12
+      - TestAwsFlatcarInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -11567,14 +11567,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_22_12
+      - TestAwsRhelInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -11590,14 +11590,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_22_12
+      - TestAwsRockylinuxInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -11613,14 +11613,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_22_12
+      - TestAzureDefaultInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -11638,14 +11638,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_22_12
+      - TestAzureCentosInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -11663,14 +11663,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_22_12
+      - TestAzureFlatcarInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -11689,14 +11689,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_22_12
+      - TestAzureRhelInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -11714,14 +11714,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_22_12
+      - TestAzureRockylinuxInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -11739,14 +11739,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_22_12
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11762,14 +11762,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_22_12
+      - TestDigitaloceanCentosInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11785,14 +11785,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_12
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11808,14 +11808,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_22_12
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11831,14 +11831,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_22_12
+      - TestEquinixmetalCentosInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11854,14 +11854,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_12
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11877,14 +11877,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_22_12
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11900,14 +11900,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_22_12
+      - TestHetznerDefaultInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -11923,14 +11923,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_22_12
+      - TestHetznerCentosInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -11946,14 +11946,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_22_12
+      - TestHetznerRockylinuxInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -11969,14 +11969,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_22_12
+      - TestOpenstackDefaultInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -11992,14 +11992,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_22_12
+      - TestOpenstackCentosInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -12015,14 +12015,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_22_12
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -12038,14 +12038,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_22_12
+      - TestOpenstackRhelInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -12061,14 +12061,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_22_12
+      - TestOpenstackFlatcarInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -12084,14 +12084,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_22_12
+      - TestVsphereDefaultInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -12107,14 +12107,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_22_12
+      - TestVsphereCentosInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -12130,14 +12130,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_22_12
+      - TestVsphereFlatcarInstallContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -12153,14 +12153,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_23_9
+      - TestAwsAmznInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -12176,14 +12176,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_23_9
+      - TestAwsCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -12199,14 +12199,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_23_9
+      - TestAwsDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -12222,14 +12222,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_23_9
+      - TestAwsFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -12245,14 +12245,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_23_9
+      - TestAwsRhelInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -12268,14 +12268,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_23_9
+      - TestAwsRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -12291,14 +12291,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_23_9
+      - TestAzureDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -12316,14 +12316,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_23_9
+      - TestAzureCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -12341,14 +12341,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_23_9
+      - TestAzureFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -12367,14 +12367,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_23_9
+      - TestAzureRhelInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -12392,14 +12392,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_23_9
+      - TestAzureRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -12417,14 +12417,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_9
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -12440,14 +12440,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_23_9
+      - TestDigitaloceanCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -12463,14 +12463,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_9
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -12486,14 +12486,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_9
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12509,14 +12509,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_23_9
+      - TestEquinixmetalCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12532,14 +12532,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_9
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12555,14 +12555,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_9
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12578,14 +12578,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_23_9
+      - TestHetznerDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -12601,14 +12601,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_23_9
+      - TestHetznerCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -12624,14 +12624,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_23_9
+      - TestHetznerRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -12647,14 +12647,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_23_9
+      - TestOpenstackDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -12670,14 +12670,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_23_9
+      - TestOpenstackCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -12693,14 +12693,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_9
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -12716,14 +12716,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_23_9
+      - TestOpenstackRhelInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -12739,14 +12739,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_23_9
+      - TestOpenstackFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -12762,14 +12762,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_23_9
+      - TestVsphereDefaultInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -12785,14 +12785,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_23_9
+      - TestVsphereCentosInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -12808,14 +12808,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_23_9
+      - TestVsphereFlatcarInstallContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -12831,14 +12831,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_24_3
+      - TestAwsAmznInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -12854,14 +12854,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_24_3
+      - TestAwsCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -12877,14 +12877,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_24_3
+      - TestAwsDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -12900,14 +12900,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_24_3
+      - TestAwsFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -12923,14 +12923,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_24_3
+      - TestAwsRhelInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -12946,14 +12946,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_24_3
+      - TestAwsRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -12969,14 +12969,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_24_3
+      - TestAzureDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -12994,14 +12994,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_24_3
+      - TestAzureCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -13019,14 +13019,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_24_3
+      - TestAzureFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -13045,14 +13045,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_24_3
+      - TestAzureRhelInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -13070,14 +13070,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_24_3
+      - TestAzureRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -13095,14 +13095,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_3
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13118,14 +13118,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_24_3
+      - TestDigitaloceanCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13141,14 +13141,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_3
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13164,14 +13164,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_3
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13187,14 +13187,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_24_3
+      - TestEquinixmetalCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13210,14 +13210,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_3
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13233,14 +13233,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_3
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13256,14 +13256,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_24_3
+      - TestHetznerDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -13279,14 +13279,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_24_3
+      - TestHetznerCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -13302,14 +13302,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_24_3
+      - TestHetznerRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -13325,14 +13325,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_24_3
+      - TestOpenstackDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13348,14 +13348,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_24_3
+      - TestOpenstackCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13371,14 +13371,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_3
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13394,14 +13394,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_24_3
+      - TestOpenstackRhelInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13417,14 +13417,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_24_3
+      - TestOpenstackFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -13440,14 +13440,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_24_3
+      - TestVsphereDefaultInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -13463,14 +13463,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_24_3
+      - TestVsphereCentosInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -13486,14 +13486,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_24_3
+      - TestVsphereFlatcarInstallContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -13509,14 +13509,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerExternalV1_22_12
+      - TestAwsAmznInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -13532,14 +13532,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerExternalV1_22_12
+      - TestAwsCentosInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -13555,14 +13555,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerExternalV1_22_12
+      - TestAwsDefaultInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -13578,14 +13578,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerExternalV1_22_12
+      - TestAwsFlatcarInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -13601,14 +13601,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerExternalV1_22_12
+      - TestAwsRhelInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -13624,14 +13624,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerExternalV1_22_12
+      - TestAwsRockylinuxInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -13647,14 +13647,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerExternalV1_22_12
+      - TestAzureDefaultInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -13672,14 +13672,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerExternalV1_22_12
+      - TestAzureCentosInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -13697,14 +13697,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerExternalV1_22_12
+      - TestAzureFlatcarInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -13723,14 +13723,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerExternalV1_22_12
+      - TestAzureRhelInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -13748,14 +13748,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerExternalV1_22_12
+      - TestAzureRockylinuxInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -13773,14 +13773,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallDockerExternalV1_22_12
+      - TestDigitaloceanDefaultInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13796,14 +13796,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallDockerExternalV1_22_12
+      - TestDigitaloceanCentosInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13819,14 +13819,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallDockerExternalV1_22_12
+      - TestDigitaloceanRockylinuxInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13842,14 +13842,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallDockerExternalV1_22_12
+      - TestEquinixmetalDefaultInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13865,14 +13865,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallDockerExternalV1_22_12
+      - TestEquinixmetalCentosInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13888,14 +13888,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallDockerExternalV1_22_12
+      - TestEquinixmetalRockylinuxInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13911,14 +13911,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallDockerExternalV1_22_12
+      - TestEquinixmetalFlatcarInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13934,14 +13934,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallDockerExternalV1_22_12
+      - TestHetznerDefaultInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -13957,14 +13957,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallDockerExternalV1_22_12
+      - TestHetznerCentosInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -13980,14 +13980,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallDockerExternalV1_22_12
+      - TestHetznerRockylinuxInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -14003,14 +14003,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerExternalV1_22_12
+      - TestOpenstackDefaultInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -14026,14 +14026,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerExternalV1_22_12
+      - TestOpenstackCentosInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -14049,14 +14049,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerExternalV1_22_12
+      - TestOpenstackRockylinuxInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -14072,14 +14072,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerExternalV1_22_12
+      - TestOpenstackRhelInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -14095,14 +14095,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerExternalV1_22_12
+      - TestOpenstackFlatcarInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -14118,14 +14118,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerExternalV1_22_12
+      - TestVsphereDefaultInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -14141,14 +14141,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerExternalV1_22_12
+      - TestVsphereCentosInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -14164,14 +14164,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerExternalV1_22_12
+      - TestVsphereFlatcarInstallDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -14187,14 +14187,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerExternalV1_23_9
+      - TestAwsAmznInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -14210,14 +14210,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerExternalV1_23_9
+      - TestAwsCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -14233,14 +14233,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerExternalV1_23_9
+      - TestAwsDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -14256,14 +14256,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerExternalV1_23_9
+      - TestAwsFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -14279,14 +14279,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerExternalV1_23_9
+      - TestAwsRhelInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -14302,14 +14302,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerExternalV1_23_9
+      - TestAwsRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -14325,14 +14325,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerExternalV1_23_9
+      - TestAzureDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -14350,14 +14350,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerExternalV1_23_9
+      - TestAzureCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -14375,14 +14375,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerExternalV1_23_9
+      - TestAzureFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -14401,14 +14401,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerExternalV1_23_9
+      - TestAzureRhelInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -14426,14 +14426,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerExternalV1_23_9
+      - TestAzureRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -14451,14 +14451,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallDockerExternalV1_23_9
+      - TestDigitaloceanDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14474,14 +14474,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallDockerExternalV1_23_9
+      - TestDigitaloceanCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14497,14 +14497,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_9
+      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14520,14 +14520,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallDockerExternalV1_23_9
+      - TestEquinixmetalDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14543,14 +14543,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallDockerExternalV1_23_9
+      - TestEquinixmetalCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14566,14 +14566,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_9
+      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14589,14 +14589,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_9
+      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14612,14 +14612,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallDockerExternalV1_23_9
+      - TestHetznerDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -14635,14 +14635,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallDockerExternalV1_23_9
+      - TestHetznerCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -14658,14 +14658,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallDockerExternalV1_23_9
+      - TestHetznerRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -14681,14 +14681,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerExternalV1_23_9
+      - TestOpenstackDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -14704,14 +14704,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerExternalV1_23_9
+      - TestOpenstackCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -14727,14 +14727,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerExternalV1_23_9
+      - TestOpenstackRockylinuxInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -14750,14 +14750,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerExternalV1_23_9
+      - TestOpenstackRhelInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -14773,14 +14773,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerExternalV1_23_9
+      - TestOpenstackFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -14796,14 +14796,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerExternalV1_23_9
+      - TestVsphereDefaultInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -14819,14 +14819,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerExternalV1_23_9
+      - TestVsphereCentosInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -14842,14 +14842,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerExternalV1_23_9
+      - TestVsphereFlatcarInstallDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -14870,14 +14870,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -14898,14 +14898,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -14926,14 +14926,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -14954,14 +14954,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -14982,14 +14982,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -15010,14 +15010,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -15038,14 +15038,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -15068,14 +15068,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -15098,809 +15098,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.12
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -15924,14 +15129,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -15954,14 +15159,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -15984,14 +15189,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16012,14 +15217,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16040,14 +15245,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16068,14 +15273,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16096,14 +15301,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16124,14 +15329,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16152,14 +15357,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16180,14 +15385,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -16208,14 +15413,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -16236,14 +15441,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -16264,14 +15469,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -16292,14 +15497,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -16320,14 +15525,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -16348,14 +15553,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -16376,14 +15581,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -16404,14 +15609,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -16432,14 +15637,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -16460,14 +15665,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -16488,14 +15693,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -16516,14 +15721,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -16544,14 +15749,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -16572,14 +15777,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -16600,14 +15805,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -16628,14 +15833,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -16658,14 +15863,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -16688,14 +15893,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -16719,14 +15924,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -16749,14 +15954,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -16779,14 +15984,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16807,14 +16012,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16835,14 +16040,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16863,14 +16068,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16891,14 +16096,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16919,14 +16124,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16947,14 +16152,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16975,14 +16180,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -17003,14 +16208,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -17031,14 +16236,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -17059,14 +16264,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -17087,14 +16292,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -17115,14 +16320,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -17143,14 +16348,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -17171,14 +16376,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -17199,14 +16404,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -17227,14 +16432,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.23.9-to-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -17255,14 +16460,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -17283,14 +16488,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -17311,14 +16516,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -17339,14 +16544,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -17367,14 +16572,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -17395,14 +16600,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -17423,14 +16628,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -17453,14 +16658,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -17483,14 +16688,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -17514,14 +16719,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -17544,14 +16749,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -17574,14 +16779,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -17602,14 +16807,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -17630,14 +16835,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -17658,14 +16863,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17686,14 +16891,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17714,14 +16919,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17742,14 +16947,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -17770,14 +16975,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -17798,14 +17003,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -17826,14 +17031,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -17854,14 +17059,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -17882,14 +17087,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -17910,14 +17115,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -17938,14 +17143,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -17966,14 +17171,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -17994,14 +17199,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -18022,14 +17227,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -18050,14 +17255,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsAmznStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18078,14 +17283,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18106,14 +17311,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18134,14 +17339,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18162,14 +17367,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18190,14 +17395,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAwsRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18218,14 +17423,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -18248,14 +17453,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -18278,14 +17483,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -18309,14 +17514,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -18339,14 +17544,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestAzureRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -18369,14 +17574,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18397,14 +17602,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18425,14 +17630,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18453,14 +17658,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18481,14 +17686,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18509,14 +17714,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18537,14 +17742,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18565,14 +17770,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -18593,14 +17798,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -18621,14 +17826,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -18649,14 +17854,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -18677,14 +17882,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -18705,14 +17910,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -18733,14 +17938,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -18761,14 +17966,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -18789,14 +17994,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestVsphereDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -18817,14 +18022,809 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-external-from-v1.22.12-to-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-external-from-v1.21.14-to-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9
+      - TestVsphereFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -18840,14 +18840,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18863,14 +18863,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18886,14 +18886,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18909,14 +18909,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18932,14 +18932,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18955,14 +18955,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: aws
@@ -18978,14 +18978,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -19003,14 +19003,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -19028,14 +19028,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -19054,14 +19054,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -19079,14 +19079,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: azure
@@ -19104,14 +19104,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19127,14 +19127,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19150,14 +19150,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19173,14 +19173,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19196,14 +19196,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19219,14 +19219,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19242,14 +19242,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_12
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19265,14 +19265,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -19288,14 +19288,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -19311,14 +19311,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -19334,14 +19334,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -19357,14 +19357,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -19380,14 +19380,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -19403,14 +19403,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -19426,14 +19426,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_12
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: openstack
@@ -19449,14 +19449,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_12
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -19472,14 +19472,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_12
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -19495,14 +19495,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.22.12
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_12
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_17
       env:
       - name: PROVIDER
         value: vsphere
@@ -19518,14 +19518,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -19541,14 +19541,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -19564,14 +19564,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -19587,14 +19587,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -19610,14 +19610,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -19633,14 +19633,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: aws
@@ -19656,14 +19656,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -19681,14 +19681,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -19706,14 +19706,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -19732,14 +19732,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -19757,14 +19757,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: azure
@@ -19782,14 +19782,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19805,14 +19805,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19828,14 +19828,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -19851,14 +19851,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19874,14 +19874,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19897,14 +19897,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19920,14 +19920,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_9
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -19943,14 +19943,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -19966,14 +19966,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -19989,14 +19989,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -20012,14 +20012,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -20035,14 +20035,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -20058,14 +20058,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -20081,14 +20081,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -20104,14 +20104,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_9
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: openstack
@@ -20127,14 +20127,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_9
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -20150,14 +20150,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_9
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -20173,14 +20173,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_9
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_15
       env:
       - name: PROVIDER
         value: vsphere
@@ -20196,14 +20196,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -20219,14 +20219,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -20242,14 +20242,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -20265,14 +20265,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -20288,14 +20288,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -20311,14 +20311,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: aws
@@ -20334,14 +20334,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -20359,14 +20359,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -20384,14 +20384,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -20410,14 +20410,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -20435,14 +20435,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: azure
@@ -20460,14 +20460,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20483,14 +20483,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20506,14 +20506,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20529,14 +20529,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20552,14 +20552,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20575,14 +20575,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20598,14 +20598,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20621,14 +20621,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -20644,14 +20644,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -20667,14 +20667,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: hetzner
@@ -20690,14 +20690,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -20713,14 +20713,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -20736,14 +20736,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -20759,14 +20759,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -20782,14 +20782,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: openstack
@@ -20805,14 +20805,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_3
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -20828,14 +20828,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_3
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -20851,14 +20851,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.3
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_3
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_9
       env:
       - name: PROVIDER
         value: vsphere
@@ -20874,14 +20874,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_12
+      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20897,14 +20897,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_12
+      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20920,14 +20920,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_12
+      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20943,14 +20943,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_12
+      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20966,14 +20966,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_12
+      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20989,14 +20989,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_12
+      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21012,14 +21012,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_12
+      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21035,14 +21035,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_12
+      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -21058,14 +21058,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_12
+      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -21081,14 +21081,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.22.12
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.22.17
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_12
+      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_17
       env:
       - name: PROVIDER
         value: hetzner
@@ -21104,14 +21104,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_9
+      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -21127,14 +21127,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_9
+      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -21150,14 +21150,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_9
+      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: digitalocean
@@ -21173,14 +21173,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_9
+      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21196,14 +21196,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_9
+      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21219,14 +21219,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_9
+      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21242,14 +21242,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_9
+      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21265,14 +21265,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_9
+      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -21288,14 +21288,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_9
+      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner
@@ -21311,14 +21311,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_9
+      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_15
       env:
       - name: PROVIDER
         value: hetzner

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -10,7724 +10,7724 @@ import (
 func TestStub(t *testing.T) {
 	t.Skip("stub is skipped")
 }
-func TestAwsAmznInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_22_12(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_23_9(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_23_9(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_23_9(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_23_9(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_23_9(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_24_3(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_24_3(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_24_3(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_24_3(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_24_3(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerV1_22_12(t *testing.T) {
+func TestAwsAmznInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerV1_22_12(t *testing.T) {
+func TestAwsCentosInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerV1_22_12(t *testing.T) {
+func TestAwsRhelInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerV1_22_12(t *testing.T) {
+func TestAzureCentosInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerV1_22_12(t *testing.T) {
+func TestAzureRhelInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestGceDefaultInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerV1_22_12(t *testing.T) {
+func TestVsphereCentosInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarInstallDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerV1_23_9(t *testing.T) {
+func TestAwsAmznInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerV1_23_9(t *testing.T) {
+func TestAwsCentosInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestAwsDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerV1_23_9(t *testing.T) {
+func TestAwsFlatcarInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerV1_23_9(t *testing.T) {
+func TestAwsRhelInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerV1_23_9(t *testing.T) {
+func TestAwsRockylinuxInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestAzureDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerV1_23_9(t *testing.T) {
+func TestAzureCentosInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerV1_23_9(t *testing.T) {
+func TestAzureFlatcarInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerV1_23_9(t *testing.T) {
+func TestAzureRhelInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerV1_23_9(t *testing.T) {
+func TestAzureRockylinuxInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestGceDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackCentosInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackRhelInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerV1_23_9(t *testing.T) {
+func TestVsphereDefaultInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerV1_23_9(t *testing.T) {
+func TestVsphereCentosInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerV1_23_9(t *testing.T) {
+func TestVsphereFlatcarInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestGceDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeDockerFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestGceDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoContainerdV1_22_12(t *testing.T) {
+func TestVsphereCentosCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCalicoContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsAmznCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsCentosCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsRhelCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureCentosCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureRhelCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestGceDefaultCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoDockerV1_22_12(t *testing.T) {
+func TestVsphereCentosCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCalicoDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosWeaveContainerdV1_22_12(t *testing.T) {
+func TestVsphereCentosWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarWeaveContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsAmznWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsCentosWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsRhelWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureCentosWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureRhelWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestGceDefaultWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosWeaveDockerV1_22_12(t *testing.T) {
+func TestVsphereCentosWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarWeaveDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumContainerdV1_22_12(t *testing.T) {
+func TestVsphereCentosCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCiliumContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsAmznCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsCentosCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsRhelCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureCentosCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureRhelCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestGceDefaultCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumDockerV1_22_12(t *testing.T) {
+func TestVsphereCentosCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCiliumDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_22_12(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_9(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_3(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_22_12(t *testing.T) {
+func TestAwsDefaultKubeProxyIpvsV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_23_9(t *testing.T) {
+func TestAwsDefaultKubeProxyIpvsV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_12(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_3(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerDockerV1_22_12(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_24_3(t *testing.T) {
+func TestAwsDefaultKubeProxyIpvsV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_22_12(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_23_9(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_24_3(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsAmznInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsCentosInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsDefaultInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsFlatcarInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsRhelInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAwsRockylinuxInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureDefaultInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureCentosInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureFlatcarInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureRhelInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestAzureRockylinuxInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerDefaultInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerCentosInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackDefaultInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackCentosInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackRhelInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerExternalV1_22_12(t *testing.T) {
+func TestVsphereDefaultInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerExternalV1_22_12(t *testing.T) {
+func TestVsphereCentosInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerExternalV1_22_12(t *testing.T) {
+func TestVsphereFlatcarInstallDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsAmznInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsRhelInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAwsRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureRhelInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestAzureRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackRhelInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerExternalV1_23_9(t *testing.T) {
+func TestVsphereDefaultInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerExternalV1_23_9(t *testing.T) {
+func TestVsphereCentosInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerExternalV1_23_9(t *testing.T) {
+func TestVsphereFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_9_ToV1_24_3(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9", "v1.24.3")
+	scenario.SetVersions("v1.23.15", "v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_12(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.21.14", "v1.22.12")
+	scenario.SetVersions("v1.21.14", "v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestHetznerCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_12_ToV1_23_9(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12", "v1.23.9")
+	scenario.SetVersions("v1.22.17", "v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_12(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_3(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.3")
+	scenario.SetVersions("v1.24.9")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_12(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_17(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.12")
+	scenario.SetVersions("v1.22.17")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_9(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.9")
+	scenario.SetVersions("v1.23.15")
 	scenario.Run(ctx, t)
 }

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -1,5 +1,5 @@
 - scenario: install_containerd
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -24,7 +24,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -49,7 +49,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.24.3
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -74,7 +74,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -98,7 +98,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -122,8 +122,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd
-  initVersion: v1.23.9
-  upgradedVersion: v1.24.3
+  initVersion: v1.23.15
+  upgradedVersion: v1.24.9
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -146,8 +146,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd
-  initVersion: v1.22.12
-  upgradedVersion: v1.23.9
+  initVersion: v1.22.17
+  upgradedVersion: v1.23.15
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -171,7 +171,7 @@
 
 - scenario: upgrade_containerd
   initVersion: v1.21.14
-  upgradedVersion: v1.22.12
+  upgradedVersion: v1.22.17
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -194,8 +194,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_docker
-  initVersion: v1.22.12
-  upgradedVersion: v1.23.9
+  initVersion: v1.22.17
+  upgradedVersion: v1.23.15
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -219,7 +219,7 @@
 
 - scenario: upgrade_docker
   initVersion: v1.21.14
-  upgradedVersion: v1.22.12
+  upgradedVersion: v1.22.17
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -242,7 +242,7 @@
     - name: vsphere_flatcar_stable
 
 - scenario: calico_containerd
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -266,7 +266,7 @@
     - name: vsphere_flatcar
 
 - scenario: calico_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -290,7 +290,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_containerd
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -314,7 +314,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -338,7 +338,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_containerd
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -362,7 +362,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -386,47 +386,47 @@
     - name: vsphere_flatcar
 
 - scenario: conformance_containerd
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.24.3
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.24.3
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_default
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_default
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -450,7 +450,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -474,7 +474,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.24.3
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -498,7 +498,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -522,7 +522,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -546,12 +546,12 @@
     - name: vsphere_flatcar
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.24.3
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_default
 
 - scenario: csi_ccm_migration
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_default  
     - name: openstack_default
@@ -569,7 +569,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_default  
     - name: openstack_default
@@ -587,7 +587,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.24.3
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -605,7 +605,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -638,7 +638,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -671,7 +671,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.24.3
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -704,7 +704,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -737,7 +737,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -771,7 +771,7 @@
 
 - scenario: upgrade_containerd_external
   initVersion: v1.21.14
-  upgradedVersion: v1.22.12
+  upgradedVersion: v1.22.17
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -803,8 +803,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.22.12
-  upgradedVersion: v1.23.9
+  initVersion: v1.22.17
+  upgradedVersion: v1.23.15
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -836,8 +836,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.23.9
-  upgradedVersion: v1.24.3
+  initVersion: v1.23.15
+  upgradedVersion: v1.24.9
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -870,7 +870,7 @@
 
 - scenario: upgrade_docker_external
   initVersion: v1.21.14
-  upgradedVersion: v1.22.12
+  upgradedVersion: v1.22.17
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -902,8 +902,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_docker_external
-  initVersion: v1.22.12
-  upgradedVersion: v1.23.9
+  initVersion: v1.22.17
+  upgradedVersion: v1.23.15
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -935,7 +935,7 @@
     - name: vsphere_flatcar_stable
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -968,7 +968,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -1001,7 +1001,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.24.3
+  initVersion: v1.24.9
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -1034,7 +1034,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker_external
-  initVersion: v1.22.12
+  initVersion: v1.22.17
   infrastructures:
     - name: digitalocean_default
     - name: digitalocean_centos
@@ -1048,7 +1048,7 @@
     - name: hetzner_rockylinux
 
 - scenario: legacy_machine_controller_docker_external
-  initVersion: v1.23.9
+  initVersion: v1.23.15
   infrastructures:
     - name: digitalocean_default
     - name: digitalocean_centos


### PR DESCRIPTION
**What this PR does / why we need it**:

Add tests for the December Kubernetes patch releases (1.24.9, 1.23.15, 1.22.17).

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Validate support for Kubernetes patch releases 1.24.9, 1.23.15, and 1.22.17. Upgrading to Kubernetes 1.24.9 is strongly advised because it's built with Go 1.19.4 which includes fixes for [CVE-2022-41720 and CVE-2022-41717](https://groups.google.com/g/golang-announce/c/L_3rmdT0BMU/m/yZDrXjIiBQAJ)
```

**Documentation**:
```documentation
NONE
```