### PR TITLE
[release/v1.4] Add tests for the December Kubernetes patch releases

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -148,7 +148,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -177,7 +177,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -214,7 +214,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -241,7 +241,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -266,7 +266,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -293,7 +293,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -320,7 +320,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -352,7 +352,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -377,7 +377,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -402,7 +402,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -429,7 +429,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -459,7 +459,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -484,7 +484,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -509,7 +509,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -536,7 +536,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -566,7 +566,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -593,7 +593,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -620,7 +620,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -649,7 +649,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -681,7 +681,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -706,7 +706,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -731,7 +731,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -758,7 +758,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -788,7 +788,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -813,7 +813,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -838,7 +838,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -865,7 +865,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -895,7 +895,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -925,7 +925,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -953,7 +953,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -983,7 +983,7 @@ presubmits:
       preset-aws-e2e-kubeone: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1016,7 +1016,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1042,7 +1042,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1070,7 +1070,7 @@ presubmits:
       preset-digitalocean: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1101,7 +1101,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1127,7 +1127,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1155,7 +1155,7 @@ presubmits:
       preset-hetzner: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1186,7 +1186,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1214,7 +1214,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1244,7 +1244,7 @@ presubmits:
       preset-gce: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1277,7 +1277,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1303,7 +1303,7 @@ presubmits:
       preset-equinix-metal: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1331,7 +1331,7 @@ presubmits:
       preset-packet: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1362,7 +1362,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1388,7 +1388,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make
@@ -1416,7 +1416,7 @@ presubmits:
       preset-openstack: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/kubeone-e2e:v0.1.28-go-1.18
+        - image: quay.io/kubermatic/kubeone-e2e:v0.1.29-go-1.18
           imagePullPolicy: Always
           command:
             - make

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -162,7 +162,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -199,7 +199,7 @@ presubmits:
             - name: TF_VAR_bastion_user
               value: "core"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -226,7 +226,7 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -251,7 +251,7 @@ presubmits:
             - name: PROVIDER
               value: "aws"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -278,7 +278,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -305,7 +305,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -332,7 +332,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: TEST_CONFIG_API_VERSION
               value: "v1beta1"
             - name: KUBEONE_TEST_RUN
@@ -362,7 +362,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -387,7 +387,7 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -414,7 +414,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -441,7 +441,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -469,7 +469,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -494,7 +494,7 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -521,7 +521,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -548,7 +548,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -576,7 +576,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -603,7 +603,7 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -632,7 +632,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -661,7 +661,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
             - name: TF_VAR_project
@@ -691,7 +691,7 @@ presubmits:
             - name: PROVIDER
               value: "equinixmetal"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -716,7 +716,7 @@ presubmits:
             - name: PROVIDER
               value: "equinixmetal"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -743,7 +743,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -770,7 +770,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -798,7 +798,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -823,7 +823,7 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -850,7 +850,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -877,7 +877,7 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: KUBEONE_TEST_RUN
               value: "TestClusterConformance"
           resources:
@@ -911,7 +911,7 @@ presubmits:
             - name: TEST_CLUSTER_INITIAL_VERSION
               value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.9"
+              value: "1.21.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -937,9 +937,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -967,9 +967,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -997,9 +997,9 @@ presubmits:
             - name: TF_VAR_initial_machinedeployment_spotinstances
               value: "true"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1026,9 +1026,9 @@ presubmits:
             - name: PROVIDER
               value: "digitalocean"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1054,9 +1054,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1082,9 +1082,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1111,9 +1111,9 @@ presubmits:
             - name: PROVIDER
               value: "hetzner"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1139,9 +1139,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1167,9 +1167,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1196,9 +1196,9 @@ presubmits:
             - name: PROVIDER
               value: "gce"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1226,9 +1226,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1256,9 +1256,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1287,9 +1287,9 @@ presubmits:
             - name: PROVIDER
               value: "equinixmetal"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1315,9 +1315,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1343,9 +1343,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1372,9 +1372,9 @@ presubmits:
             - name: PROVIDER
               value: "openstack"
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.20.13"
+              value: "1.20.15"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1400,9 +1400,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.21.7"
+              value: "1.21.14"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN
@@ -1428,9 +1428,9 @@ presubmits:
             - name: CONTAINER_RUNTIME
               value: containerd
             - name: TEST_CLUSTER_INITIAL_VERSION
-              value: "1.22.4"
+              value: "1.22.17"
             - name: TEST_CLUSTER_TARGET_VERSION
-              value: "1.23.0"
+              value: "1.23.15"
             - name: TEST_TIMEOUT
               valut: "120m"
             - name: KUBEONE_TEST_RUN

--- a/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
+++ b/hack/images/kubeone-e2e/install-kube-tests-binaries.sh
@@ -19,8 +19,8 @@ set -euox pipefail
 declare -A full_versions
 full_versions["1.20"]="v1.20.15"
 full_versions["1.21"]="v1.21.14"
-full_versions["1.22"]="v1.22.16"
-full_versions["1.23"]="v1.23.14"
+full_versions["1.22"]="v1.22.17"
+full_versions["1.23"]="v1.23.15"
 
 root_dir=${KUBETESTS_ROOT:-"/opt/kube-test"}
 tmp_root=${TMP_ROOT:-"/tmp/get-kube"}

--- a/hack/images/kubeone-e2e/release.sh
+++ b/hack/images/kubeone-e2e/release.sh
@@ -16,7 +16,7 @@
 
 set -euox pipefail
 
-TAG=v0.1.28-go-1.18
+TAG=v0.1.29-go-1.18
 
 docker build --build-arg version=${TAG} --pull -t quay.io/kubermatic/kubeone-e2e:${TAG} .
 docker push quay.io/kubermatic/kubeone-e2e:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add tests for the December Kubernetes patch releases (1.23.15 and 1.22.17)
- Update the `kubeone-e2e` image with the latest Kubernetes binaries
  - I already manually pushed the tag because we don't have a postsubmit for that image on the release branches

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Validate support for Kubernetes patch releases 1.23.15 and 1.22.17
```

**Documentation**:
```documentation
NONE
```