### PR TITLE
[release/v1.5] Update Canal/Calico to v3.23.5

### DIFF
--- a/addons/cni-canal/canal.yaml
+++ b/addons/cni-canal/canal.yaml
@@ -868,6 +868,11 @@ spec:
                   node appears to use the IP of the ingress node; this requires a
                   permissive L2 network.  [Default: Tunnel]'
                 type: string
+              bpfHostConntrackBypass:
+                description: 'BPFHostConntrackBypass Controls whether to bypass Linux
+                  conntrack in BPF mode for workloads and services. [Default: true
+                  - bypass Linux conntrack]'
+                type: boolean
               bpfKubeProxyEndpointSlicesEnabled:
                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
                   whether Felix's embedded kube-proxy accepts EndpointSlices or not.
@@ -1064,7 +1069,6 @@ spec:
                   are auto-detected.
                 type: string
               floatingIPs:
-                default: Disabled
                 description: FloatingIPs configures whether or not Felix will program
                   floating IP addresses.
                 enum:
@@ -1387,8 +1391,8 @@ spec:
                 type: boolean
               vxlanEnabled:
                 description: 'VXLANEnabled overrides whether Felix should create the
-                  VXLAN tunnel device for VXLAN networking. Optional as Felix determines
-                  this based on the existing IP pools. [Default: nil (unset)]'
+                  VXLAN tunnel device for IPv4 VXLAN networking. Optional as Felix
+                  determines this based on the existing IP pools. [Default: nil (unset)]'
                 type: boolean
               vxlanMTU:
                 description: 'VXLANMTU is the MTU to set on the IPv4 VXLAN tunnel

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -213,9 +213,9 @@ func FindResource(name string) (Resource, error) {
 
 func baseResources() map[Resource]map[string]string {
 	return map[Resource]map[string]string{
-		CalicoCNI:              {"*": "quay.io/calico/cni:v3.23.3"},
-		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.23.3"},
-		CalicoNode:             {"*": "quay.io/calico/node:v3.23.3"},
+		CalicoCNI:              {"*": "quay.io/calico/cni:v3.23.5"},
+		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.23.5"},
+		CalicoNode:             {"*": "quay.io/calico/node:v3.23.5"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.21.1"},
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.54.2"},


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual backport of #2538 to the `release/v1.5` branch.

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Canal to v3.23.5. This Canal release is supposed to fix an issue where Calico pods are crashing after upgrading from an older Calico version to a newer one (see the [Known Issues](https://docs.kubermatic.com/kubeone/v1.5/known-issues/) document for more details)
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/1281
```