### PR TITLE
Run E2E tests only if relevant files are changed

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -385,15 +385,16 @@ func parseContainerImageVersion(image string) (*semver.Version, error) {
 }
 
 type ProwJob struct {
-	Name      string            `json:"name"`
-	AlwaysRun bool              `json:"always_run"`
-	Optional  bool              `json:"optional"`
-	Decorate  bool              `json:"decorate"`
-	CloneURI  string            `json:"clone_uri"`
-	PathAlias string            `json:"path_alias,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
-	ExtraRefs []ProwRef         `json:"extra_refs,omitempty"`
-	Spec      *corev1.PodSpec   `json:"spec"`
+	Name         string            `json:"name"`
+	AlwaysRun    bool              `json:"always_run"`
+	RunIfChanged string            `json:"run_if_changed,omitempty"`
+	Optional     bool              `json:"optional"`
+	Decorate     bool              `json:"decorate"`
+	CloneURI     string            `json:"clone_uri"`
+	PathAlias    string            `json:"path_alias,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	ExtraRefs    []ProwRef         `json:"extra_refs,omitempty"`
+	Spec         *corev1.PodSpec   `json:"spec"`
 }
 
 type ProwRef struct {
@@ -418,14 +419,15 @@ func newProwJob(prowJobName string, labels map[string]string, testTitle string, 
 	})
 
 	return ProwJob{
-		Name:      prowJobName,
-		AlwaysRun: settings.AlwaysRun,
-		Optional:  settings.Optional,
-		Decorate:  true,
-		CloneURI:  k1CloneURI,
-		Labels:    labels,
-		ExtraRefs: extraRefs,
-		PathAlias: "k8c.io/kubeone",
+		Name:         prowJobName,
+		AlwaysRun:    settings.AlwaysRun,
+		RunIfChanged: settings.RunIfChanged,
+		Optional:     settings.Optional,
+		Decorate:     true,
+		CloneURI:     k1CloneURI,
+		Labels:       labels,
+		ExtraRefs:    extraRefs,
+		PathAlias:    "k8c.io/kubeone",
 		Spec: &corev1.PodSpec{
 			Containers: []corev1.Container{
 				{

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -46,7 +46,7 @@ presubmits:
       resources:
         requests:
           cpu: "1"
-- always_run: true
+- always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
@@ -55,6 +55,7 @@ presubmits:
   name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.15
   optional: false
   path_alias: k8c.io/kubeone
+  run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
   spec:
     containers:
     - command:
@@ -517,7 +518,7 @@ presubmits:
       resources:
         requests:
           cpu: "1"
-- always_run: true
+- always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
@@ -526,6 +527,7 @@ presubmits:
   name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.9
   optional: false
   path_alias: k8c.io/kubeone
+  run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
   spec:
     containers:
     - command:
@@ -988,7 +990,7 @@ presubmits:
       resources:
         requests:
           cpu: "1"
-- always_run: true
+- always_run: false
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   labels:
@@ -997,6 +999,7 @@ presubmits:
   name: pull-kubeone-e2e-aws-default-install-containerd-v1.25.5
   optional: false
   path_alias: k8c.io/kubeone
+  run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
   spec:
     containers:
     - command:

--- a/test/e2e/tests_definitions.go
+++ b/test/e2e/tests_definitions.go
@@ -1253,7 +1253,8 @@ type Scenario interface {
 }
 
 type ProwConfig struct {
-	AlwaysRun bool
-	Optional  bool
-	Environ   map[string]string
+	AlwaysRun    bool
+	RunIfChanged string
+	Optional     bool
+	Environ      map[string]string
 }

--- a/test/generator/main.go
+++ b/test/generator/main.go
@@ -33,9 +33,10 @@ import (
 )
 
 type Infrastructure struct {
-	Name      string `json:"name"`
-	AlwaysRun bool   `json:"alwaysRun"`
-	Optional  bool   `json:"optional"`
+	Name         string `json:"name"`
+	AlwaysRun    bool   `json:"alwaysRun"`
+	RunIfChanged string `json:"runIfChanged"`
+	Optional     bool   `json:"optional"`
 }
 
 type KubeoneTest struct {
@@ -143,8 +144,9 @@ func main() {
 			scenario.SetVersions(versions...)
 
 			cfg := e2e.ProwConfig{
-				AlwaysRun: genInfra.AlwaysRun,
-				Optional:  genInfra.Optional,
+				AlwaysRun:    genInfra.AlwaysRun,
+				RunIfChanged: genInfra.RunIfChanged,
+				Optional:     genInfra.Optional,
 			}
 
 			if err = scenario.GenerateTests(outputBuf, generatorType, cfg); err != nil {

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -4,7 +4,7 @@
     - name: aws_amzn
     - name: aws_centos
     - name: aws_default
-      alwaysRun: true
+      runIfChanged: "(.prow/|addons/|examples/|hack/|pkg/|test/)"
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
@@ -29,7 +29,7 @@
     - name: aws_amzn
     - name: aws_centos
     - name: aws_default
-      alwaysRun: true
+      runIfChanged: "(.prow/|addons/|examples/|hack/|pkg/|test/)"
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux
@@ -54,7 +54,7 @@
     - name: aws_amzn
     - name: aws_centos
     - name: aws_default
-      alwaysRun: true
+      runIfChanged: "(.prow/|addons/|examples/|hack/|pkg/|test/)"
     - name: aws_flatcar
     - name: aws_rhel
     - name: aws_rockylinux


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that we run the E2E tests only if the relevant files are changed: packages, addons, scripts, and tests themselves.

The key reason behind this change is that we don't want to run the full E2E suite when updating changelogs. That's slowing down the release process a lot, as we have to wait for all the E2E tests on both main and release branches. The same goes for updating the in-repo docs.

**What type of PR is this?**

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```