### PR TITLE
Replace control_plane_replicas with control_plane_vm_count for Hetzner

### DIFF
--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -47,8 +47,9 @@ No modules.
 | <a name="input_apiserver_alternative_names"></a> [apiserver\_alternative\_names](#input\_apiserver\_alternative\_names) | subject alternative names for the API Server signing cert. | `list(string)` | `[]` | no |
 | <a name="input_bastion_host_key"></a> [bastion\_host\_key](#input\_bastion\_host\_key) | Bastion SSH host public key | `string` | `null` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | prefix for cloud resources | `string` | n/a | yes |
-| <a name="input_control_plane_replicas"></a> [control\_plane\_replicas](#input\_control\_plane\_replicas) | n/a | `number` | `3` | no |
+| <a name="input_control_plane_replicas"></a> [control\_plane\_replicas](#input\_control\_plane\_replicas) | DEPRECATED: use control\_plane\_vm\_count instead | `number` | `3` | no |
 | <a name="input_control_plane_type"></a> [control\_plane\_type](#input\_control\_plane\_type) | n/a | `string` | `"cx21"` | no |
+| <a name="input_control_plane_vm_count"></a> [control\_plane\_vm\_count](#input\_control\_plane\_vm\_count) | Number of control plane nodes in the cluster | `number` | `3` | no |
 | <a name="input_datacenter"></a> [datacenter](#input\_datacenter) | n/a | `string` | `"nbg1"` | no |
 | <a name="input_disable_kubeapi_loadbalancer"></a> [disable\_kubeapi\_loadbalancer](#input\_disable\_kubeapi\_loadbalancer) | E2E tests specific variable to disable usage of any loadbalancer in front of kubeapi-server | `bool` | `false` | no |
 | <a name="input_image"></a> [image](#input\_image) | n/a | `string` | `""` | no |

--- a/examples/terraform/hetzner/main.tf
+++ b/examples/terraform/hetzner/main.tf
@@ -103,7 +103,7 @@ resource "hcloud_network_subnet" "kubeone" {
 }
 
 resource "hcloud_server_network" "control_plane" {
-  count     = var.control_plane_replicas
+  count     = var.control_plane_vm_count
   server_id = element(hcloud_server.control_plane.*.id, count.index)
   subnet_id = hcloud_network_subnet.kubeone.id
 }
@@ -118,7 +118,7 @@ resource "hcloud_placement_group" "control_plane" {
 }
 
 resource "hcloud_server" "control_plane" {
-  count              = var.control_plane_replicas
+  count              = var.control_plane_vm_count
   name               = "${var.cluster_name}-control-plane-${count.index + 1}"
   server_type        = var.control_plane_type
   image              = local.image

--- a/examples/terraform/hetzner/variables.tf
+++ b/examples/terraform/hetzner/variables.tf
@@ -136,8 +136,20 @@ variable "control_plane_type" {
 }
 
 variable "control_plane_replicas" {
-  default = 3
-  type    = number
+  default     = 3
+  type        = number
+  description = "DEPRECATED: use control_plane_vm_count instead"
+
+  validation {
+    condition     = var.control_plane_replicas == 3
+    error_message = "control_plane_replicas is DEPRECATED, please use control_plane_vm_count instead"
+  }
+}
+
+variable "control_plane_vm_count" {
+  default     = 3
+  type        = number
+  description = "Number of control plane nodes in the cluster"
 }
 
 variable "worker_type" {


### PR DESCRIPTION
**What this PR does / why we need it**:

We use `control_plane_vm_count` for a number of control plane nodes in Terraform configs for all providers but Hetzner. This variable is called `control_plane_replicas` in Terraform configs for Hetzner. This difference makes it difficult to implement and document #2455.

Terraform doesn't provide an easy way to deprecate a variable. We considered just removing it, but if a user doesn't migrate, Terraform is going only to throw a warning. This is not ideal as it might add or remove control plane nodes which is considered too risky.

This PR uses the fact that this variable has always defaulted to 3 and that the new variable also defaults to 3. I first added a new variable and changed all references from the old to the new variable. Then, I added a validation rule for the old variable to allow setting it only to 3. This means if someone changed its value to any other value, validation is going to fail. This will also fail `terraform apply`, which is much better than just a warning.

**Which issue(s) this PR fixes**:
xref #2455 

**What type of PR is this?**
/kind deprecation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] `control_plane_replicas` variable in Terraform configs for Hetzner is renamed to `control_plane_vm_count`. If you set the old variable explicitly, make sure to migrate to the new variable before migrating to the new configs
```

**Documentation**:
```documentation
TBD
```