### PR TITLE
Remove leftover `/tmp/k1-etc-environment` file

### DIFF
--- a/pkg/scripts/proxy.go
+++ b/pkg/scripts/proxy.go
@@ -59,6 +59,8 @@ export NO_PROXY no_proxy
 EOF
 
 envtmp=/tmp/k1-etc-environment
+# ensure we delete old file to avoid errors e.g. if username changed
+sudo rm -f /tmp/k1-etc-environment
 grep -v '#kubeone$' /etc/environment > $envtmp || true
 set +o pipefail # grep exits non-zero without match
 grep = /etc/kubeone/proxy-env | sed 's/$/#kubeone/' >> $envtmp

--- a/pkg/scripts/testdata/TestEnvironmentFile-empty-proxy.golden
+++ b/pkg/scripts/testdata/TestEnvironmentFile-empty-proxy.golden
@@ -7,6 +7,8 @@ cat <<EOF | sudo tee /etc/kubeone/proxy-env
 EOF
 
 envtmp=/tmp/k1-etc-environment
+# ensure we delete old file to avoid errors e.g. if username changed
+sudo rm -f /tmp/k1-etc-environment
 grep -v '#kubeone$' /etc/environment > $envtmp || true
 set +o pipefail # grep exits non-zero without match
 grep = /etc/kubeone/proxy-env | sed 's/$/#kubeone/' >> $envtmp

--- a/pkg/scripts/testdata/TestEnvironmentFile-http-https-no-proxy.golden
+++ b/pkg/scripts/testdata/TestEnvironmentFile-http-https-no-proxy.golden
@@ -16,6 +16,8 @@ export NO_PROXY no_proxy
 EOF
 
 envtmp=/tmp/k1-etc-environment
+# ensure we delete old file to avoid errors e.g. if username changed
+sudo rm -f /tmp/k1-etc-environment
 grep -v '#kubeone$' /etc/environment > $envtmp || true
 set +o pipefail # grep exits non-zero without match
 grep = /etc/kubeone/proxy-env | sed 's/$/#kubeone/' >> $envtmp

--- a/pkg/scripts/testdata/TestEnvironmentFile-http-https-proxy.golden
+++ b/pkg/scripts/testdata/TestEnvironmentFile-http-https-proxy.golden
@@ -13,6 +13,8 @@ export HTTPS_PROXY https_proxy
 EOF
 
 envtmp=/tmp/k1-etc-environment
+# ensure we delete old file to avoid errors e.g. if username changed
+sudo rm -f /tmp/k1-etc-environment
 grep -v '#kubeone$' /etc/environment > $envtmp || true
 set +o pipefail # grep exits non-zero without match
 grep = /etc/kubeone/proxy-env | sed 's/$/#kubeone/' >> $envtmp

--- a/pkg/scripts/testdata/TestEnvironmentFile-http-proxy.golden
+++ b/pkg/scripts/testdata/TestEnvironmentFile-http-proxy.golden
@@ -10,6 +10,8 @@ export HTTP_PROXY http_proxy
 EOF
 
 envtmp=/tmp/k1-etc-environment
+# ensure we delete old file to avoid errors e.g. if username changed
+sudo rm -f /tmp/k1-etc-environment
 grep -v '#kubeone$' /etc/environment > $envtmp || true
 set +o pipefail # grep exits non-zero without match
 grep = /etc/kubeone/proxy-env | sed 's/$/#kubeone/' >> $envtmp


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the issue reported in #2547 where we leave a file owned by potentially a non-root user.

**Which issue(s) this PR fixes**:
Fixes #2547 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Remove the leftover `/tmp/k1-etc-environment` file. This fixes an issue with `kubeone apply` failing if the username is changed
```

**Documentation**:
```documentation
NONE
```