### PR TITLE
Add initial support for Kubernetes 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ export GOFLAGS?=-mod=readonly -trimpath
 BUILD_DATE=$(shell if hash gdate 2>/dev/null; then gdate --rfc-3339=seconds | sed 's/ /T/'; else date --rfc-3339=seconds | sed 's/ /T/'; fi)
 GITCOMMIT=$(shell git log -1 --pretty=format:"%H")
 GITTAG=$(shell git describe --tags --always)
-DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.25.txt)
+DEFAULT_STABLE=$(shell curl -SsL https://dl.k8s.io/release/stable-1.26.txt)
 GOLDFLAGS?=-s -w -extldflags=-zrelro -extldflags=-znow \
 	-X k8c.io/kubeone/pkg/cmd.defaultKubeVersion=$(DEFAULT_STABLE) \
 	-X k8c.io/kubeone/pkg/cmd.version=$(GITTAG) \

--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -41,7 +41,7 @@ const (
 	// lowerVersionConstraint defines a semver constraint that validates Kubernetes versions against a lower bound
 	lowerVersionConstraint = ">= 1.23"
 	// upperVersionConstraint defines a semver constraint that validates Kubernetes versions against an upper bound
-	upperVersionConstraint = "<= 1.25"
+	upperVersionConstraint = "<= 1.26"
 )
 
 var (

--- a/pkg/templates/kubeadm/v1beta3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm.go
@@ -54,13 +54,13 @@ const (
 	// NB: Currently no Kubernetes version uses 3.5.6, but to avoid deleting the code
 	// we just use some super high version as a fixed version.
 	// fixedEtcd123 defines a semver constraint used to check if Kubernetes 1.23 uses fixed etcd version
-	fixedEtcd123 = ">= 1.23.99, < 1.24"
+	fixedEtcd123 = ">= 1.23.15, < 1.24"
 	// fixedEtcd124 defines a semver constraint used to check if Kubernetes 1.24 uses fixed etcd version
-	fixedEtcd124 = ">= 1.24.99, < 1.25"
-	// fixedEtcd125 defines a semver constraint used to check if Kubernetes 1.25+ uses fixed etcd version
-	fixedEtcd125 = ">= 1.25.99, < 1.26"
+	fixedEtcd124 = ">= 1.24.9, < 1.25"
+	// fixedEtcd125 defines a semver constraint used to check if Kubernetes 1.25 uses fixed etcd version
+	fixedEtcd125 = ">= 1.25.5, < 1.26"
 	// fixedEtcd126 defines a semver constraint used to check if Kubernetes 1.26+ uses fixed etcd version
-	fixedEtcd126 = ">= 1.26.99"
+	fixedEtcd126 = ">= 1.26.0"
 )
 
 const (

--- a/pkg/templates/kubeadm/v1beta3/kubeadm_test.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm_test.go
@@ -56,12 +56,6 @@ func TestEtcdVersionCorruptCheckExtraArgs(t *testing.T) {
 			expectedEtcdArgs:     etcdExtraArgs,
 		},
 		{
-			name:                 "unfixed 1.26",
-			kubeVersion:          semver.MustParse("1.26.0"),
-			expectedEtcdImageTag: fixedEtcdVersion,
-			expectedEtcdArgs:     etcdExtraArgs,
-		},
-		{
 			name:                 "fixed 1.23",
 			kubeVersion:          semver.MustParse("1.23.99"),
 			expectedEtcdImageTag: "",

--- a/pkg/templates/kubernetesconfigs/kubeproxy.go
+++ b/pkg/templates/kubernetesconfigs/kubeproxy.go
@@ -54,5 +54,5 @@ func NewKubeProxyConfiguration(cluster *kubeoneapi.KubeOneCluster) (runtime.Obje
 		}
 	}
 
-	return dropFields(kubeProxyConfig, []string{"detectLocal"}, []string{"winkernel"})
+	return dropFields(kubeProxyConfig, []string{"detectLocal"}, []string{"winkernel"}, []string{"iptables", "localhostNodePorts"})
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	labelControlPlaneNode = "node-role.kubernetes.io/control-plane"
-	prowImage             = "quay.io/kubermatic/kubeone-e2e:v0.1.28"
+	prowImage             = "quay.io/kubermatic/kubeone-e2e:v0.1.29"
 	k1CloneURI            = "ssh://git@github.com/kubermatic/kubeone.git"
 )
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -17,7 +17,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -40,7 +40,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -64,7 +64,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -87,7 +87,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -110,7 +110,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -133,7 +133,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -158,7 +158,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -183,7 +183,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -208,7 +208,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -234,7 +234,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -259,7 +259,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -282,7 +282,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -305,7 +305,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -328,7 +328,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -351,7 +351,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -374,7 +374,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -397,7 +397,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -420,7 +420,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -443,7 +443,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -466,7 +466,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -489,7 +489,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -512,7 +512,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -536,7 +536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -559,7 +559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -582,7 +582,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -605,7 +605,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -630,7 +630,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -655,7 +655,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -680,7 +680,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -706,7 +706,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -731,7 +731,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -754,7 +754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -777,7 +777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -800,7 +800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -823,7 +823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -846,7 +846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -869,7 +869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -892,7 +892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -915,7 +915,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -938,7 +938,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -961,7 +961,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -984,7 +984,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1008,7 +1008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1031,7 +1031,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1054,7 +1054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1077,7 +1077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1102,7 +1102,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1127,7 +1127,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1152,7 +1152,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1178,7 +1178,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1203,7 +1203,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1226,7 +1226,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1249,7 +1249,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1272,7 +1272,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1295,7 +1295,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1318,7 +1318,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1341,7 +1341,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1364,7 +1364,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1387,7 +1387,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1410,7 +1410,479 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: gce
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarInstallContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1433,7 +1905,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1456,7 +1928,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1479,7 +1951,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1502,7 +1974,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1525,7 +1997,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1548,7 +2020,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1573,7 +2045,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1598,7 +2070,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1623,7 +2095,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1649,7 +2121,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1674,7 +2146,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1697,7 +2169,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1720,7 +2192,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1743,7 +2215,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1766,7 +2238,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1789,7 +2261,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1812,7 +2284,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1835,7 +2307,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1858,7 +2330,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1881,7 +2353,578 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: gce
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1909,7 +2952,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1937,7 +2980,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1965,7 +3008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1993,7 +3036,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2021,7 +3064,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2049,7 +3092,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2079,7 +3122,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2109,7 +3152,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2139,7 +3182,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2170,7 +3213,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2200,7 +3243,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2228,7 +3271,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2256,7 +3299,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2284,7 +3327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2312,7 +3355,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2340,7 +3383,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2368,7 +3411,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2396,7 +3439,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2424,7 +3467,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2452,7 +3495,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2480,7 +3523,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2508,7 +3551,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2536,7 +3579,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2564,7 +3607,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2592,7 +3635,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2620,7 +3663,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2650,7 +3693,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2680,7 +3723,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2710,7 +3753,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2741,7 +3784,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2771,7 +3814,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2799,7 +3842,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2827,7 +3870,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2855,7 +3898,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2883,7 +3926,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2911,7 +3954,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2939,7 +3982,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2967,7 +4010,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -2995,7 +4038,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3023,7 +4066,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3035,18 +4078,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoContainerdV1_25_5
+      - TestAwsAmznCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3058,18 +4101,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdV1_25_5
+      - TestAwsCentosCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3081,18 +4124,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoContainerdV1_25_5
+      - TestAwsDefaultCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3104,18 +4147,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoContainerdV1_25_5
+      - TestAwsFlatcarCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3127,18 +4170,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoContainerdV1_25_5
+      - TestAwsRhelCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3150,18 +4193,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoContainerdV1_25_5
+      - TestAwsRockylinuxCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3173,20 +4216,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoContainerdV1_25_5
+      - TestAzureDefaultCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3198,20 +4241,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdV1_25_5
+      - TestAzureCentosCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3223,20 +4266,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoContainerdV1_25_5
+      - TestAzureFlatcarCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3249,20 +4292,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoContainerdV1_25_5
+      - TestAzureRhelCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3274,20 +4317,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoContainerdV1_25_5
+      - TestAzureRockylinuxCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3299,18 +4342,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoContainerdV1_25_5
+      - TestGceDefaultCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3322,18 +4365,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoContainerdV1_25_5
+      - TestOpenstackDefaultCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3345,18 +4388,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdV1_25_5
+      - TestOpenstackCentosCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3368,18 +4411,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoContainerdV1_25_5
+      - TestOpenstackRockylinuxCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3391,18 +4434,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoContainerdV1_25_5
+      - TestOpenstackRhelCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3414,18 +4457,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoContainerdV1_25_5
+      - TestOpenstackFlatcarCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3437,18 +4480,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoContainerdV1_25_5
+      - TestVsphereDefaultCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3460,18 +4503,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoContainerdV1_25_5
+      - TestVsphereCentosCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3483,18 +4526,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoContainerdV1_25_5
+      - TestVsphereFlatcarCalicoContainerdV1_26_0
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3517,7 +4560,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3540,7 +4583,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3563,7 +4606,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3586,7 +4629,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3609,7 +4652,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3632,7 +4675,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3657,7 +4700,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3682,7 +4725,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3707,7 +4750,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3733,7 +4776,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3758,7 +4801,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3781,7 +4824,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3804,7 +4847,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3827,7 +4870,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3850,7 +4893,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3873,7 +4916,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3896,7 +4939,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3919,7 +4962,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3942,7 +4985,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3965,7 +5008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -3977,18 +5020,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveContainerdV1_25_5
+      - TestAwsAmznWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4000,18 +5043,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveContainerdV1_25_5
+      - TestAwsCentosWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4023,18 +5066,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveContainerdV1_25_5
+      - TestAwsDefaultWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4046,18 +5089,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveContainerdV1_25_5
+      - TestAwsFlatcarWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4069,18 +5112,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveContainerdV1_25_5
+      - TestAwsRhelWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4092,18 +5135,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveContainerdV1_25_5
+      - TestAwsRockylinuxWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4115,20 +5158,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveContainerdV1_25_5
+      - TestAzureDefaultWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4140,20 +5183,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveContainerdV1_25_5
+      - TestAzureCentosWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4165,20 +5208,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveContainerdV1_25_5
+      - TestAzureFlatcarWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4191,20 +5234,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveContainerdV1_25_5
+      - TestAzureRhelWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4216,20 +5259,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveContainerdV1_25_5
+      - TestAzureRockylinuxWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4241,18 +5284,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveContainerdV1_25_5
+      - TestGceDefaultWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4264,18 +5307,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveContainerdV1_25_5
+      - TestOpenstackDefaultWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4287,18 +5330,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveContainerdV1_25_5
+      - TestOpenstackCentosWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4310,18 +5353,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveContainerdV1_25_5
+      - TestOpenstackRockylinuxWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4333,18 +5376,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveContainerdV1_25_5
+      - TestOpenstackRhelWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4356,18 +5399,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveContainerdV1_25_5
+      - TestOpenstackFlatcarWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4379,18 +5422,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveContainerdV1_25_5
+      - TestVsphereDefaultWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4402,18 +5445,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosWeaveContainerdV1_25_5
+      - TestVsphereCentosWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4425,18 +5468,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveContainerdV1_25_5
+      - TestVsphereFlatcarWeaveContainerdV1_26_0
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4459,7 +5502,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4482,7 +5525,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4505,7 +5548,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4528,7 +5571,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4551,7 +5594,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4574,7 +5617,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4599,7 +5642,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4624,7 +5667,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4649,7 +5692,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4675,7 +5718,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4700,7 +5743,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4723,7 +5766,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4746,7 +5789,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4769,7 +5812,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4792,7 +5835,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4815,7 +5858,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4838,7 +5881,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4861,7 +5904,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4884,7 +5927,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4907,7 +5950,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4919,18 +5962,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumContainerdV1_25_5
+      - TestAwsAmznCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4942,18 +5985,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdV1_25_5
+      - TestAwsCentosCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4965,18 +6008,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumContainerdV1_25_5
+      - TestAwsDefaultCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -4988,18 +6031,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumContainerdV1_25_5
+      - TestAwsFlatcarCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5011,18 +6054,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumContainerdV1_25_5
+      - TestAwsRhelCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5034,18 +6077,18 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumContainerdV1_25_5
+      - TestAwsRockylinuxCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5057,20 +6100,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumContainerdV1_25_5
+      - TestAzureDefaultCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5082,20 +6125,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdV1_25_5
+      - TestAzureCentosCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5107,20 +6150,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumContainerdV1_25_5
+      - TestAzureFlatcarCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5133,20 +6176,20 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumContainerdV1_25_5
+      - TestAzureRhelCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5158,20 +6201,20 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumContainerdV1_25_5
+      - TestAzureRockylinuxCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5183,18 +6226,18 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumContainerdV1_25_5
+      - TestGceDefaultCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5206,18 +6249,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumContainerdV1_25_5
+      - TestOpenstackDefaultCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5229,18 +6272,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdV1_25_5
+      - TestOpenstackCentosCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5252,18 +6295,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumContainerdV1_25_5
+      - TestOpenstackRockylinuxCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5275,18 +6318,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumContainerdV1_25_5
+      - TestOpenstackRhelCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5298,18 +6341,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumContainerdV1_25_5
+      - TestOpenstackFlatcarCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5321,18 +6364,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumContainerdV1_25_5
+      - TestVsphereDefaultCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5344,18 +6387,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumContainerdV1_25_5
+      - TestVsphereCentosCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5367,18 +6410,18 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumContainerdV1_25_5
+      - TestVsphereFlatcarCiliumContainerdV1_26_0
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5401,7 +6444,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5424,7 +6467,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5447,7 +6490,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5470,7 +6513,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5493,7 +6536,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5516,7 +6559,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5541,7 +6584,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5566,7 +6609,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5591,7 +6634,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5617,7 +6660,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5642,7 +6685,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5665,7 +6708,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5688,7 +6731,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5711,7 +6754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5734,7 +6777,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5757,7 +6800,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5780,7 +6823,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5803,7 +6846,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5826,7 +6869,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5849,7 +6892,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5874,7 +6917,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5899,7 +6942,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5924,7 +6967,32 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5949,7 +7017,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5974,7 +7042,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -5999,7 +7067,7 @@ presubmits:
         value: aws
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6011,18 +7079,43 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.25.5
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.26.0
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_25_5
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_26_0
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultKubeProxyIpvsV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6045,7 +7138,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6068,7 +7161,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6091,7 +7184,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6114,7 +7207,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6137,7 +7230,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6160,7 +7253,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6185,7 +7278,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6210,7 +7303,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6235,7 +7328,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6261,7 +7354,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6286,7 +7379,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6309,7 +7402,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6332,7 +7425,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6355,7 +7448,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6378,7 +7471,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6401,7 +7494,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6424,7 +7517,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6447,7 +7540,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6470,7 +7563,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6493,7 +7586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6516,7 +7609,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6539,7 +7632,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6562,7 +7655,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6585,7 +7678,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6608,7 +7701,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6631,7 +7724,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6656,7 +7749,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6681,7 +7774,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6706,7 +7799,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6732,7 +7825,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6757,7 +7850,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6780,7 +7873,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6803,7 +7896,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6826,7 +7919,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6849,7 +7942,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6872,7 +7965,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6895,7 +7988,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6918,7 +8011,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6941,7 +8034,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6964,7 +8057,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -6987,7 +8080,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7010,7 +8103,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7033,7 +8126,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7056,7 +8149,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7079,7 +8172,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7102,7 +8195,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7127,7 +8220,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7152,7 +8245,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7177,7 +8270,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7203,7 +8296,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7228,7 +8321,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7251,7 +8344,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7274,7 +8367,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7297,7 +8390,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7320,7 +8413,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7343,7 +8436,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7366,7 +8459,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7389,7 +8482,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7412,7 +8505,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7435,7 +8528,478 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: gce
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7458,7 +9022,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7481,7 +9045,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7504,7 +9068,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7527,7 +9091,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7550,7 +9114,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7573,7 +9137,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7598,7 +9162,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7623,7 +9187,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7648,7 +9212,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7674,7 +9238,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7699,7 +9263,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7722,7 +9286,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7745,7 +9309,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7768,7 +9332,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7791,7 +9355,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7814,7 +9378,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7837,7 +9401,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7860,7 +9424,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7883,7 +9447,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7906,7 +9470,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7929,7 +9493,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7952,7 +9516,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7975,7 +9539,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -7998,7 +9562,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8021,7 +9585,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8044,7 +9608,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8069,7 +9633,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8094,7 +9658,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8119,7 +9683,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8145,7 +9709,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8170,7 +9734,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8193,7 +9757,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8216,7 +9780,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8239,7 +9803,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8262,7 +9826,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8285,7 +9849,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8308,7 +9872,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8331,7 +9895,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8354,7 +9918,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8377,7 +9941,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8402,7 +9966,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8427,7 +9991,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8452,7 +10016,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8478,7 +10042,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8503,7 +10067,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8526,7 +10090,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8549,7 +10113,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8572,7 +10136,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8595,7 +10159,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8618,7 +10182,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8641,7 +10205,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8664,7 +10228,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8687,7 +10251,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8710,7 +10274,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8735,7 +10299,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8760,7 +10324,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8785,7 +10349,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8811,7 +10375,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8836,7 +10400,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8859,7 +10423,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8882,7 +10446,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8905,7 +10469,340 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarCsiCcmMigrationV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8928,7 +10825,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8951,7 +10848,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8974,7 +10871,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -8997,7 +10894,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9020,7 +10917,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9043,7 +10940,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9068,7 +10965,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9093,7 +10990,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9118,7 +11015,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9144,7 +11041,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9169,7 +11066,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9192,7 +11089,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9215,7 +11112,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9238,7 +11135,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9261,7 +11158,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9284,7 +11181,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9307,7 +11204,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9330,7 +11227,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9353,7 +11250,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9376,7 +11273,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9399,7 +11296,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9422,7 +11319,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9445,7 +11342,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9468,7 +11365,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9491,7 +11388,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9514,7 +11411,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9537,7 +11434,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9560,7 +11457,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9583,7 +11480,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9606,7 +11503,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9629,7 +11526,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9652,7 +11549,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9675,7 +11572,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9698,7 +11595,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9721,7 +11618,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9746,7 +11643,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9771,7 +11668,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9796,7 +11693,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9822,7 +11719,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9847,7 +11744,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9870,7 +11767,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9893,7 +11790,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9916,7 +11813,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9939,7 +11836,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9962,7 +11859,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -9985,7 +11882,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10008,7 +11905,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10031,7 +11928,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10054,7 +11951,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10077,7 +11974,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10100,7 +11997,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10123,7 +12020,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10146,7 +12043,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10169,7 +12066,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10192,7 +12089,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10215,7 +12112,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10238,7 +12135,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10261,7 +12158,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10284,7 +12181,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10307,7 +12204,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10330,7 +12227,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10353,7 +12250,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10376,7 +12273,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10399,7 +12296,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10424,7 +12321,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10449,7 +12346,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10474,7 +12371,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10500,7 +12397,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10525,7 +12422,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10548,7 +12445,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10571,7 +12468,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10594,7 +12491,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10617,7 +12514,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10640,7 +12537,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10663,7 +12560,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10686,7 +12583,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10709,7 +12606,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10732,7 +12629,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10755,7 +12652,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10778,7 +12675,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10801,7 +12698,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10824,7 +12721,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10847,7 +12744,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10870,7 +12767,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10893,7 +12790,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10916,7 +12813,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10939,7 +12836,685 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarInstallContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10962,7 +13537,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -10985,7 +13560,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11008,7 +13583,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11031,7 +13606,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11054,7 +13629,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11077,7 +13652,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11102,7 +13677,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11127,7 +13702,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11152,7 +13727,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11178,7 +13753,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11203,7 +13778,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11226,7 +13801,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11249,7 +13824,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11272,7 +13847,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11295,7 +13870,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11318,7 +13893,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11341,7 +13916,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11364,7 +13939,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11387,7 +13962,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11410,7 +13985,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11433,7 +14008,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11456,7 +14031,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11479,7 +14054,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11502,7 +14077,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11525,7 +14100,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11548,7 +14123,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11571,7 +14146,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11594,7 +14169,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11617,7 +14192,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11645,7 +14220,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11673,7 +14248,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11701,7 +14276,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11729,7 +14304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11757,7 +14332,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11785,7 +14360,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11815,7 +14390,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11845,7 +14420,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11875,7 +14450,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11906,7 +14481,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11936,7 +14511,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11964,7 +14539,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -11992,7 +14567,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12020,7 +14595,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12048,7 +14623,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12076,7 +14651,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12104,7 +14679,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12132,7 +14707,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12160,7 +14735,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12188,7 +14763,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12216,7 +14791,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12244,7 +14819,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12272,7 +14847,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12300,7 +14875,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12328,7 +14903,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12356,7 +14931,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12384,7 +14959,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12412,7 +14987,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12440,7 +15015,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12468,7 +15043,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12496,7 +15071,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12524,7 +15099,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12552,7 +15127,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12580,7 +15155,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12608,7 +15183,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12638,7 +15213,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12668,7 +15243,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12698,7 +15273,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12729,7 +15304,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12759,7 +15334,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12787,7 +15362,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12815,7 +15390,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12843,7 +15418,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12871,7 +15446,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12899,7 +15474,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12927,7 +15502,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12955,7 +15530,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -12983,7 +15558,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13011,7 +15586,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13039,7 +15614,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13067,7 +15642,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13095,7 +15670,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13123,7 +15698,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13151,7 +15726,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13179,7 +15754,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13207,7 +15782,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13235,7 +15810,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13263,7 +15838,830 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.5
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13286,7 +16684,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13309,7 +16707,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13332,7 +16730,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13355,7 +16753,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13378,7 +16776,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13401,7 +16799,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13426,7 +16824,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13451,7 +16849,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13476,7 +16874,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13502,7 +16900,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13527,7 +16925,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13550,7 +16948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13573,7 +16971,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13596,7 +16994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13619,7 +17017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13642,7 +17040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13665,7 +17063,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13688,7 +17086,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13711,7 +17109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13734,7 +17132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13757,7 +17155,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13780,7 +17178,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13803,7 +17201,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13826,7 +17224,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13849,7 +17247,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13872,7 +17270,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13895,7 +17293,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13918,7 +17316,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13941,7 +17339,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13964,7 +17362,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -13987,7 +17385,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14010,7 +17408,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14033,7 +17431,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14056,7 +17454,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14079,7 +17477,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14104,7 +17502,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14129,7 +17527,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14154,7 +17552,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14180,7 +17578,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14205,7 +17603,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14228,7 +17626,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14251,7 +17649,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14274,7 +17672,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14297,7 +17695,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14320,7 +17718,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14343,7 +17741,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14366,7 +17764,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14389,7 +17787,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14412,7 +17810,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14435,7 +17833,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14458,7 +17856,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14481,7 +17879,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14504,7 +17902,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14527,7 +17925,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14550,7 +17948,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14573,7 +17971,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14596,7 +17994,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14619,7 +18017,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14642,7 +18040,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14665,7 +18063,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14688,7 +18086,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14711,7 +18109,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14734,7 +18132,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14757,7 +18155,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14782,7 +18180,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14807,7 +18205,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14832,7 +18230,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14858,7 +18256,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14883,7 +18281,7 @@ presubmits:
         value: azure
       - name: TEST_TIMEOUT
         value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14906,7 +18304,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14929,7 +18327,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14952,7 +18350,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14975,7 +18373,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -14998,7 +18396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15021,7 +18419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15044,7 +18442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15067,7 +18465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15090,7 +18488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15113,7 +18511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15136,7 +18534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15159,7 +18557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15182,7 +18580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15205,7 +18603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15228,7 +18626,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15251,7 +18649,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15274,7 +18672,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15297,7 +18695,685 @@ presubmits:
       env:
       - name: PROVIDER
         value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15320,7 +19396,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15343,7 +19419,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15366,7 +19442,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15389,7 +19465,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15412,7 +19488,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15435,7 +19511,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15458,7 +19534,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15481,7 +19557,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15504,7 +19580,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:
@@ -15527,7 +19603,7 @@ presubmits:
       env:
       - name: PROVIDER
         value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
       imagePullPolicy: Always
       name: ""
       resources:

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -550,6 +550,186 @@ func TestVsphereFlatcarInstallContainerdV1_25_5(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestAwsAmznInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestGceDefaultInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["gce_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarInstallContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["install_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
 func TestAwsAmznInstallDockerV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
@@ -727,6 +907,186 @@ func TestVsphereFlatcarInstallDockerV1_23_15(t *testing.T) {
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.23.15")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsAmznStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestGceDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["gce_default_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar_stable"]
+	scenario := Scenarios["upgrade_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
 	scenario.Run(ctx, t)
 }
 
@@ -1090,183 +1450,183 @@ func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCalicoContainerdV1_25_5(t *testing.T) {
+func TestAwsAmznCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoContainerdV1_25_5(t *testing.T) {
+func TestAwsCentosCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoContainerdV1_25_5(t *testing.T) {
+func TestAwsDefaultCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoContainerdV1_25_5(t *testing.T) {
+func TestAwsFlatcarCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoContainerdV1_25_5(t *testing.T) {
+func TestAwsRhelCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoContainerdV1_25_5(t *testing.T) {
+func TestAwsRockylinuxCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoContainerdV1_25_5(t *testing.T) {
+func TestAzureDefaultCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdV1_25_5(t *testing.T) {
+func TestAzureCentosCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoContainerdV1_25_5(t *testing.T) {
+func TestAzureFlatcarCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoContainerdV1_25_5(t *testing.T) {
+func TestAzureRhelCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoContainerdV1_25_5(t *testing.T) {
+func TestAzureRockylinuxCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoContainerdV1_25_5(t *testing.T) {
+func TestGceDefaultCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoContainerdV1_25_5(t *testing.T) {
+func TestOpenstackDefaultCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoContainerdV1_25_5(t *testing.T) {
+func TestOpenstackCentosCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRhelCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoContainerdV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoContainerdV1_25_5(t *testing.T) {
+func TestVsphereDefaultCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoContainerdV1_25_5(t *testing.T) {
+func TestVsphereCentosCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoContainerdV1_25_5(t *testing.T) {
+func TestVsphereFlatcarCalicoContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
@@ -1450,183 +1810,183 @@ func TestVsphereFlatcarCalicoDockerV1_23_15(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveContainerdV1_25_5(t *testing.T) {
+func TestAwsAmznWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveContainerdV1_25_5(t *testing.T) {
+func TestAwsCentosWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveContainerdV1_25_5(t *testing.T) {
+func TestAwsDefaultWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveContainerdV1_25_5(t *testing.T) {
+func TestAwsFlatcarWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveContainerdV1_25_5(t *testing.T) {
+func TestAwsRhelWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveContainerdV1_25_5(t *testing.T) {
+func TestAwsRockylinuxWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveContainerdV1_25_5(t *testing.T) {
+func TestAzureDefaultWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveContainerdV1_25_5(t *testing.T) {
+func TestAzureCentosWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveContainerdV1_25_5(t *testing.T) {
+func TestAzureFlatcarWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveContainerdV1_25_5(t *testing.T) {
+func TestAzureRhelWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveContainerdV1_25_5(t *testing.T) {
+func TestAzureRockylinuxWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveContainerdV1_25_5(t *testing.T) {
+func TestGceDefaultWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveContainerdV1_25_5(t *testing.T) {
+func TestOpenstackDefaultWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveContainerdV1_25_5(t *testing.T) {
+func TestOpenstackCentosWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRhelWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveContainerdV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveContainerdV1_25_5(t *testing.T) {
+func TestVsphereDefaultWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosWeaveContainerdV1_25_5(t *testing.T) {
+func TestVsphereCentosWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveContainerdV1_25_5(t *testing.T) {
+func TestVsphereFlatcarWeaveContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
@@ -1810,183 +2170,183 @@ func TestVsphereFlatcarWeaveDockerV1_23_15(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumContainerdV1_25_5(t *testing.T) {
+func TestAwsAmznCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumContainerdV1_25_5(t *testing.T) {
+func TestAwsCentosCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumContainerdV1_25_5(t *testing.T) {
+func TestAwsDefaultCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumContainerdV1_25_5(t *testing.T) {
+func TestAwsFlatcarCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumContainerdV1_25_5(t *testing.T) {
+func TestAwsRhelCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumContainerdV1_25_5(t *testing.T) {
+func TestAwsRockylinuxCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumContainerdV1_25_5(t *testing.T) {
+func TestAzureDefaultCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdV1_25_5(t *testing.T) {
+func TestAzureCentosCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumContainerdV1_25_5(t *testing.T) {
+func TestAzureFlatcarCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumContainerdV1_25_5(t *testing.T) {
+func TestAzureRhelCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumContainerdV1_25_5(t *testing.T) {
+func TestAzureRockylinuxCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumContainerdV1_25_5(t *testing.T) {
+func TestGceDefaultCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumContainerdV1_25_5(t *testing.T) {
+func TestOpenstackDefaultCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumContainerdV1_25_5(t *testing.T) {
+func TestOpenstackCentosCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRhelCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumContainerdV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumContainerdV1_25_5(t *testing.T) {
+func TestVsphereDefaultCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumContainerdV1_25_5(t *testing.T) {
+func TestVsphereCentosCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumContainerdV1_25_5(t *testing.T) {
+func TestVsphereFlatcarCiliumContainerdV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
@@ -2197,6 +2557,15 @@ func TestAwsLongTimeoutDefaultConformanceContainerdV1_25_5(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_long_timeout_default"]
+	scenario := Scenarios["conformance_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
 func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
@@ -2224,12 +2593,21 @@ func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_5(t *testing.T)
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_25_5(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_long_timeout_default"]
+	scenario := Scenarios["conformance_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultKubeProxyIpvsV1_26_0(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
@@ -2770,6 +3148,186 @@ func TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.25.5")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsAmznLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestGceDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["gce_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
@@ -3328,6 +3886,132 @@ func TestVsphereFlatcarCsiCcmMigrationV1_25_5(t *testing.T) {
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.25.5")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarCsiCcmMigrationV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["csi_ccm_migration"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 
@@ -4114,6 +4798,267 @@ func TestVsphereFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
+func TestAwsAmznInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["install_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
 func TestAwsAmznInstallDockerExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
@@ -4897,6 +5842,267 @@ func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *t
 	scenario.Run(ctx, t)
 }
 
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_default_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_centos_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_rockylinux_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_default_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_centos_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_rockylinux_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_flatcar_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_default_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_centos_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_rockylinux_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar_stable"]
+	scenario := Scenarios["upgrade_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.Run(ctx, t)
+}
+
 func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
@@ -5677,6 +6883,267 @@ func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testi
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
 	scenario.SetVersions("v1.25.5")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_amzn"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["aws_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["azure_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["digitalocean_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["equinixmetal_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["hetzner_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rockylinux"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_rhel"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["openstack_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_default"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_centos"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
+	scenario.Run(ctx, t)
+}
+
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+	ctx := NewSignalContext()
+	infra := Infrastructures["vsphere_flatcar"]
+	scenario := Scenarios["legacy_machine_controller_containerd_external"]
+	scenario.SetInfra(infra)
+	scenario.SetVersions("v1.26.0")
 	scenario.Run(ctx, t)
 }
 

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -73,6 +73,31 @@
     - name: vsphere_centos
     - name: vsphere_flatcar
 
+- scenario: install_containerd
+  initVersion: v1.26.0
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+      runIfChanged: "(.prow/|addons/|examples/|hack/|pkg/|test/)"
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: gce_default
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_centos
+    - name: vsphere_flatcar
+
 - scenario: install_docker
   initVersion: v1.23.15
   infrastructures:
@@ -96,6 +121,31 @@
     - name: vsphere_default
     - name: vsphere_centos
     - name: vsphere_flatcar
+
+- scenario: upgrade_containerd
+  initVersion: v1.25.5
+  upgradedVersion: v1.26.0
+  infrastructures:
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: gce_default_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_centos_stable
+    - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd
   initVersion: v1.24.9
@@ -148,7 +198,7 @@
     - name: vsphere_flatcar_stable
 
 - scenario: calico_containerd
-  initVersion: v1.25.5
+  initVersion: v1.26.0
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -196,7 +246,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_containerd
-  initVersion: v1.25.5
+  initVersion: v1.26.0
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -244,7 +294,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_containerd
-  initVersion: v1.25.5
+  initVersion: v1.26.0
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -306,6 +356,11 @@
   infrastructures:
     - name: aws_long_timeout_default
 
+- scenario: conformance_containerd
+  initVersion: v1.26.0
+  infrastructures:
+    - name: aws_long_timeout_default
+
 - scenario: conformance_containerd_external
   initVersion: v1.23.15
   infrastructures:
@@ -318,11 +373,16 @@
 
 - scenario: conformance_containerd_external
   initVersion: v1.25.5
+  infrastructures:
+    - name: aws_long_timeout_default
+
+- scenario: conformance_containerd_external
+  initVersion: v1.26.0
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.25.5
+  initVersion: v1.26.0
   infrastructures:
     - name: aws_default
 
@@ -376,6 +436,30 @@
 
 - scenario: legacy_machine_controller_containerd
   initVersion: v1.25.5
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: gce_default
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_centos
+    - name: vsphere_flatcar
+
+- scenario: legacy_machine_controller_containerd
+  initVersion: v1.26.0
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -476,6 +560,24 @@
     - name: vsphere_centos
     - name: vsphere_flatcar
 
+- scenario: csi_ccm_migration
+  initVersion: v1.26.0
+  infrastructures:
+    - name: aws_default
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: vsphere_default
+    - name: vsphere_centos
+    - name: vsphere_flatcar
+
 - scenario: install_containerd_external
   initVersion: v1.23.15
   infrastructures:
@@ -544,6 +646,39 @@
 
 - scenario: install_containerd_external
   initVersion: v1.25.5
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: digitalocean_default
+    - name: digitalocean_centos
+    - name: digitalocean_rockylinux
+    - name: equinixmetal_default
+    - name: equinixmetal_centos
+    - name: equinixmetal_rockylinux
+    - name: equinixmetal_flatcar
+    - name: hetzner_default
+    - name: hetzner_centos
+    - name: hetzner_rockylinux
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_centos
+    - name: vsphere_flatcar
+
+- scenario: install_containerd_external
+  initVersion: v1.26.0
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -676,6 +811,40 @@
     - name: vsphere_centos_stable
     - name: vsphere_flatcar_stable
 
+- scenario: upgrade_containerd_external
+  initVersion: v1.25.5
+  upgradedVersion: v1.26.0
+  infrastructures:
+    - name: aws_amzn_stable
+    - name: aws_centos_stable
+    - name: aws_default_stable
+    - name: aws_flatcar_stable
+    - name: aws_rhel_stable
+    - name: aws_rockylinux_stable
+    - name: azure_default_stable
+    - name: azure_centos_stable
+    - name: azure_flatcar_stable
+    - name: azure_rhel_stable
+    - name: azure_rockylinux_stable
+    - name: digitalocean_default_stable
+    - name: digitalocean_centos_stable
+    - name: digitalocean_rockylinux_stable
+    - name: equinixmetal_default_stable
+    - name: equinixmetal_centos_stable
+    - name: equinixmetal_rockylinux_stable
+    - name: equinixmetal_flatcar_stable
+    - name: hetzner_default_stable
+    - name: hetzner_centos_stable
+    - name: hetzner_rockylinux_stable
+    - name: openstack_default_stable
+    - name: openstack_centos_stable
+    - name: openstack_rockylinux_stable
+    - name: openstack_rhel_stable
+    - name: openstack_flatcar_stable
+    - name: vsphere_default_stable
+    - name: vsphere_centos_stable
+    - name: vsphere_flatcar_stable
+
 - scenario: legacy_machine_controller_containerd_external
   initVersion: v1.23.15
   infrastructures:
@@ -744,6 +913,39 @@
 
 - scenario: legacy_machine_controller_containerd_external
   initVersion: v1.25.5
+  infrastructures:
+    - name: aws_amzn
+    - name: aws_centos
+    - name: aws_default
+    - name: aws_flatcar
+    - name: aws_rhel
+    - name: aws_rockylinux
+    - name: azure_default
+    - name: azure_centos
+    - name: azure_flatcar
+    - name: azure_rhel
+    - name: azure_rockylinux
+    - name: digitalocean_default
+    - name: digitalocean_centos
+    - name: digitalocean_rockylinux
+    - name: equinixmetal_default
+    - name: equinixmetal_centos
+    - name: equinixmetal_rockylinux
+    - name: equinixmetal_flatcar
+    - name: hetzner_default
+    - name: hetzner_centos
+    - name: hetzner_rockylinux
+    - name: openstack_default
+    - name: openstack_centos
+    - name: openstack_rockylinux
+    - name: openstack_rhel
+    - name: openstack_flatcar
+    - name: vsphere_default
+    - name: vsphere_centos
+    - name: vsphere_flatcar
+
+- scenario: legacy_machine_controller_containerd_external
+  initVersion: v1.26.0
   infrastructures:
     - name: aws_amzn
     - name: aws_centos


### PR DESCRIPTION
**What this PR does / why we need it**:

- Increase the maximum Kubernetes version to v1.26
- Use Kubernetes 1.26 as the default stable version
- Update etcd version constraints (the latest Kubernetes patch releases are using etcd 3.5.6)
- Fix an issue with parsing KubeProxyConfiguration
- Add E2E tests for Kubernetes 1.26

**Which issue(s) this PR fixes**:
xref #2561 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add initial support for Kubernetes 1.26
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/1287
```