### PR TITLE
Update AWS images for Kubernetes 1.26

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -236,8 +236,9 @@ func optionalResources() map[Resource]map[string]string {
 
 		AwsCCM: {
 			"1.23.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.2",
-			"1.24.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.1",
-			">= 1.25.0": "registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1",
+			"1.24.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.3",
+			"1.25.x":    "registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1",
+			">= 1.26.0": "registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.0",
 		},
 
 		// Azure CCM

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -254,7 +254,7 @@ func optionalResources() map[Resource]map[string]string {
 		},
 
 		// AWS EBS CSI driver
-		AwsEbsCSI:                    {"*": "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.12.1"},
+		AwsEbsCSI:                    {"*": "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.14.0"},
 		AwsEbsCSIAttacher:            {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"},
 		AwsEbsCSILivenessProbe:       {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.6.0"},
 		AwsEbsCSINodeDriverRegistrar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update AWS CCM to v1.26.0 and v1.24.3
- Update AWS EBS CSI driver to v1.14.0

**Which issue(s) this PR fixes**:
xref #2562 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update AWS CCM to v1.26.0 and v1.24.3
- Update AWS EBS CSI driver to v1.14.0
```

**Documentation**:
```documentation
NONE
```