### PR TITLE
Update Azure CCM, AzureDisk CSI, and AzureFile CSI for Kubernetes 1.26

### DIFF
--- a/addons/csi-azuredisk/csi-azuredisk-controller.yaml
+++ b/addons/csi-azuredisk/csi-azuredisk-controller.yaml
@@ -41,9 +41,11 @@ spec:
             - "--timeout=15s"
             - "--leader-election"
             - "--leader-election-namespace=kube-system"
-            - "--worker-threads=50"
+            - "--worker-threads=100"
             - "--extra-create-metadata=true"
             - "--strict-topology=true"
+            - "--kube-api-qps=50"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -65,6 +67,8 @@ spec:
             - "-leader-election"
             - "--leader-election-namespace=kube-system"
             - "-worker-threads=500"
+            - "-kube-api-qps=50"
+            - "-kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/addons/csi-azurefile/csi-azurefile-controller.yaml
+++ b/addons/csi-azurefile/csi-azurefile-controller.yaml
@@ -38,6 +38,8 @@ spec:
             - "--leader-election-namespace=kube-system"
             - "--timeout=300s"
             - "--extra-create-metadata=true"
+            - "--kube-api-qps=50"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -58,6 +60,8 @@ spec:
             - "-timeout=120s"
             - "--leader-election"
             - "--leader-election-namespace=kube-system"
+            - "--kube-api-qps=50"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -243,14 +243,16 @@ func optionalResources() map[Resource]map[string]string {
 
 		// Azure CCM
 		AzureCCM: {
-			"1.23.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.23.21",
-			"1.24.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.24.8",
-			">= 1.25.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.25.3",
+			"1.23.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.23.24",
+			"1.24.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.24.11",
+			"1.25.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.25.5",
+			">= 1.26.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.26.0",
 		},
 		AzureCNM: {
-			"1.23.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.23.21",
-			"1.24.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.24.8",
-			">= 1.25.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.25.3",
+			"1.23.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.23.24",
+			"1.24.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.24.11",
+			"1.25.x":    "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.25.5",
+			">= 1.26.0": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.26.0",
 		},
 
 		// AWS EBS CSI driver

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -276,7 +276,7 @@ func optionalResources() map[Resource]map[string]string {
 		AzureFileCSISnapshotterController: {"*": "mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v5.0.1"},
 
 		// AzureDisk CSI driver
-		AzureDiskCSI:                      {"*": "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.23.0"},
+		AzureDiskCSI:                      {"*": "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.25.0"},
 		AzureDiskCSIAttacher:              {"*": "mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v3.5.0"},
 		AzureDiskCSILivenessProbe:         {"*": "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.7.0"},
 		AzureDiskCSINodeDriverRegistar:    {"*": "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.1"},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -266,7 +266,7 @@ func optionalResources() map[Resource]map[string]string {
 		AwsEbsCSISnapshotController:  {"*": "registry.k8s.io/sig-storage/snapshot-controller:v6.0.1"},
 
 		// AzureFile CSI driver
-		AzureFileCSI:                      {"*": "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.22.0"},
+		AzureFileCSI:                      {"*": "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:v1.24.0"},
 		AzureFileCSIAttacher:              {"*": "mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v3.5.0"},
 		AzureFileCSILivenessProbe:         {"*": "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.7.0"},
 		AzureFileCSINodeDriverRegistar:    {"*": "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.1"},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update Azure CCM to v1.26.0, v1.25.5, v1.24.11, v1.23.24
- Update AzureDisk CSI to v1.25.0
- Update AzureFile CSI to v1.24.0

**Which issue(s) this PR fixes**:
xref #2562 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update Azure CCM to v1.26.0, v1.25.5, v1.24.11, v1.23.24
- Update AzureDisk CSI to v1.25.0
- Update AzureFile CSI to v1.24.0
```

**Documentation**:
```documentation
NONE
```