### PR TITLE
Forbid Kubernetes 1.26 for OpenStack clusters with in-tree provider

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -316,9 +316,13 @@ func ValidateKubernetesSupport(c kubeoneapi.KubeOneCluster, fldPath *field.Path)
 		return append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, ".versions.kubernetes is not a semver string"))
 	}
 
-	// vSphere CCM v1.24 supports Kubernetes 1.24 and 1.25.
-	if v.Minor() >= 26 && c.CloudProvider.Vsphere != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, "kubernetes versions 1.25.0 and newer are currently not supported for vsphere clusters"))
+	// vSphere CCM v1.25 supports Kubernetes 1.25 and 1.26.
+	if v.Minor() >= 27 && c.CloudProvider.Vsphere != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, "kubernetes versions 1.27.0 and newer are currently not supported for vsphere clusters"))
+	}
+
+	if v.Minor() >= 26 && c.CloudProvider.Openstack != nil && !c.CloudProvider.External {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions").Child("kubernetes"), c.Versions.Kubernetes, "kubernetes 1.26 and newer doesn't support in-tree cloud provider with openstack"))
 	}
 
 	return allErrs

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -922,16 +922,6 @@ func TestValidateKubernetesSupport(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "vSphere 1.25.4 cluster",
-			providerConfig: kubeoneapi.CloudProviderSpec{
-				Vsphere: &kubeoneapi.VsphereSpec{},
-			},
-			versionConfig: kubeoneapi.VersionConfig{
-				Kubernetes: "1.25.4",
-			},
-			expectedError: false,
-		},
-		{
 			name: "vSphere 1.26.0 cluster",
 			providerConfig: kubeoneapi.CloudProviderSpec{
 				Vsphere: &kubeoneapi.VsphereSpec{},
@@ -939,7 +929,83 @@ func TestValidateKubernetesSupport(t *testing.T) {
 			versionConfig: kubeoneapi.VersionConfig{
 				Kubernetes: "1.26.0",
 			},
+			expectedError: false,
+		},
+		{
+			name: "vSphere 1.27.0 cluster",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Vsphere: &kubeoneapi.VsphereSpec{},
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.27.0",
+			},
 			expectedError: true,
+		},
+		{
+			name: "OpenStack 1.25.5 cluster with in-tree cloud provider",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Openstack: &kubeoneapi.OpenstackSpec{},
+				External:  false,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.25.5",
+			},
+			expectedError: false,
+		},
+		{
+			name: "OpenStack 1.25.5 cluster with external cloud provider",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Openstack: &kubeoneapi.OpenstackSpec{},
+				External:  true,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.25.5",
+			},
+			expectedError: false,
+		},
+		{
+			name: "OpenStack 1.26.0 cluster with in-tree cloud provider",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Openstack: &kubeoneapi.OpenstackSpec{},
+				External:  false,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.26.0",
+			},
+			expectedError: true,
+		},
+		{
+			name: "OpenStack 1.26.0 cluster with external cloud provider",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Openstack: &kubeoneapi.OpenstackSpec{},
+				External:  true,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.26.0",
+			},
+			expectedError: false,
+		},
+		{
+			name: "OpenStack 1.27.0 cluster with in-tree cloud provider",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Openstack: &kubeoneapi.OpenstackSpec{},
+				External:  false,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.27.0",
+			},
+			expectedError: true,
+		},
+		{
+			name: "OpenStack 1.27.0 cluster with external cloud provider",
+			providerConfig: kubeoneapi.CloudProviderSpec{
+				Openstack: &kubeoneapi.OpenstackSpec{},
+				External:  true,
+			},
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.27.0",
+			},
+			expectedError: false,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Forbid Kubernetes 1.26 and newer for OpenStack clusters with the in-tree cloud provider
  - OpenStack in-tree cloud provider is removed starting with Kubernetes 1.26.0: https://github.com/kubernetes/kubernetes/pull/67782
  - Users are required to use the external CCM/CSI for new Kubernetes 1.26 clusters
  - Users are required to migrate to the external CCM/CSI before upgrading to Kubernetes 1.26
- Allow vSphere clusters running Kubernetes 1.26

**Which issue(s) this PR fixes**:
xref #2561 

**What type of PR is this?**
/kind api-change
/kind deprecation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Forbid Kubernetes 1.26 and newer for OpenStack clusters with the in-tree cloud provider. The in-tree cloud provider for OpenStack is removed with Kubernetes 1.26.0. Make sure to [migrate to the external CCM/CSI](https://docs.kubermatic.com/kubeone/v1.5/guides/ccm-csi-migration/) before upgrading to Kubernetes 1.26.
```

**Documentation**:
```documentation
TBD
```