### PR TITLE
Update DigitalOcean CCM, GCP CSI driver, and VCD CSI driver (January 2023)

### DIFF
--- a/addons/csi-vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi-vmware-cloud-director/csi-controller.yaml
@@ -125,6 +125,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
+            - --default-fstype=ext4
             - --timeout=300s
             - --v=5
           env:
@@ -145,6 +146,7 @@ spec:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
             - --cloud-config=/etc/kubernetes/vcloud/vcloud-csi-config.yaml
             - --endpoint=$(CSI_ENDPOINT)
+            - --upgrade-rde
             - --v=5
           env:
             - name: NODE_ID

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -365,7 +365,7 @@ func optionalResources() map[Resource]map[string]string {
 		NutanixCSISnapshotValidationWebhook: {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1"},
 
 		// GCP Compute Persistent Disk CSI
-		GCPComputeCSIDriver:                    {"*": "registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.8.0"},
+		GCPComputeCSIDriver:                    {"*": "registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.8.1"},
 		GCPComputeCSIProvisioner:               {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"},
 		GCPComputeCSIAttacher:                  {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"},
 		GCPComputeCSIResizer:                   {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -337,7 +337,7 @@ func optionalResources() map[Resource]map[string]string {
 		},
 
 		// VMware Cloud Director CSI
-		VMwareCloudDirectorCSI:                    {"*": "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.2.0.latest"},
+		VMwareCloudDirectorCSI:                    {"*": "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.3.1"},
 		VMwareCloudDirectorCSIAttacher:            {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.2.1"},
 		VMwareCloudDirectorCSIProvisioner:         {"*": "registry.k8s.io/sig-storage/csi-provisioner:v2.2.2"},
 		VMwareCloudDirectorCSINodeDriverRegistrar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0"},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -286,7 +286,7 @@ func optionalResources() map[Resource]map[string]string {
 		AzureDiskCSISnapshotterController: {"*": "mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v5.0.1"},
 
 		// DigitalOcean CCM
-		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.40"},
+		DigitaloceanCCM: {"*": "docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.41"},
 
 		DigitalOceanCSI:                          {"*": "docker.io/digitalocean/do-csi-plugin:v4.4.1"},
 		DigitalOceanCSIAlpine:                    {"*": "docker.io/alpine:3"},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update DigitalOcean CCM from v0.1.40 to v0.1.41
- Update GCP CSI driver from v1.8.0 to v1.8.1
- Update VMware Cloud Director (VCD) CSI driver from v1.2.0 to v1.3.1

**Which issue(s) this PR fixes**:
xref #2562 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update DigitalOcean CCM from v0.1.40 to v0.1.41
- Update GCP CSI driver from v1.8.0 to v1.8.1
- Update VMware Cloud Director (VCD) CSI driver from v1.2.0 to v1.3.1
```

**Documentation**:
```documentation
NONE
```