### PR TITLE
Update metrics-server, cluster-autoscaler, and NodeLocalDNSCache (January 2023)

### DIFF
--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -397,7 +397,8 @@ func optionalResources() map[Resource]map[string]string {
 		ClusterAutoscaler: {
 			"1.23.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.1",
 			"1.24.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.0",
-			">= 1.25.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.0",
+			"1.25.x":    "registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.0",
+			">= 1.26.0": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1",
 		},
 
 		// CSI Vault Secret Provider

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -219,7 +219,7 @@ func baseResources() map[Resource]map[string]string {
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.13"},
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:0eaa75744f8306bc5ae7481d73fc21a993e99f0e"},
-		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.1"},
+		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.2"},
 		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:eff6d0b982b7e2bbc5adafa003f2a7f43568a28b"},
 	}
 }

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -216,7 +216,7 @@ func baseResources() map[Resource]map[string]string {
 		CalicoCNI:              {"*": "quay.io/calico/cni:v3.23.5"},
 		CalicoController:       {"*": "quay.io/calico/kube-controllers:v3.23.5"},
 		CalicoNode:             {"*": "quay.io/calico/node:v3.23.5"},
-		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.13"},
+		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.15"},
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
 		MachineController:      {"*": "quay.io/kubermatic/machine-controller:0eaa75744f8306bc5ae7481d73fc21a993e99f0e"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.2"},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update metrics-server from v0.6.1 to v0.6.2
- Update cluster-autoscaler to v1.26.1 for Kubernetes 1.26+ clusters
- Update NodeLocalDNSCache from v1.22.13 to v1.22.15

**Which issue(s) this PR fixes**:
xref #2562 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update metrics-server from v0.6.1 to v0.6.2
- Update cluster-autoscaler to v1.26.1 for Kubernetes 1.26+ clusters
- Update NodeLocalDNSCache from v1.22.13 to v1.22.15
```

**Documentation**:
```documentation
NONE
```