### PR TITLE
Update Cilium, OpenStack CCM, and Cinder CSI (January 2023)

### DIFF
--- a/addons/cni-cilium/cilium.yaml
+++ b/addons/cni-cilium/cilium.yaml
@@ -67,6 +67,7 @@ data:
   identity-allocation-mode: crd
   cilium-endpoint-gc-interval: "5m0s"
   nodes-gc-interval: "5m0s"
+  skip-cnp-status-startup-clean: "false"
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "false"
 
@@ -1352,7 +1353,7 @@ spec:
             readOnly: true
           terminationMessagePolicy: FallbackToLogsOnError
       restartPolicy: Always
-      priorityClassName:
+      priorityClassName: 
       serviceAccount: "hubble-relay"
       serviceAccountName: "hubble-relay"
       automountServiceAccountToken: false
@@ -1411,7 +1412,7 @@ spec:
         fsGroup: 1001
         runAsGroup: 1001
         runAsUser: 1001
-      priorityClassName:
+      priorityClassName: 
       serviceAccount: "hubble-ui"
       serviceAccountName: "hubble-ui"
       containers:

--- a/addons/csi-openstack-cinder/controllerplugin.yaml
+++ b/addons/csi-openstack-cinder/controllerplugin.yaml
@@ -36,6 +36,9 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--leader-election=true"
+            {{ if ge $version.Minor 26 }}
+            - "--default-fstype=ext4"
+            {{ end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/addons/csi-openstack-cinder/nodeplugin.yaml
+++ b/addons/csi-openstack-cinder/nodeplugin.yaml
@@ -1,6 +1,5 @@
 # This YAML file contains driver-registrar & csi driver nodeplugin API objects,
 # which are necessary to run csi nodeplugin for cinder.
-{{ $version := semver .Config.Versions.Kubernetes }}
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/addons/csi-openstack-cinder/snapshot-controller-rbac.yaml
+++ b/addons/csi-openstack-cinder/snapshot-controller-rbac.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v6.0.1/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v6.1.0/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
 ---
 # RBAC file for the snapshot controller.
 #

--- a/addons/csi-openstack-cinder/snapshot-controller.yaml
+++ b/addons/csi-openstack-cinder/snapshot-controller.yaml
@@ -4,7 +4,7 @@
 # It should be installed as part of the base Kubernetes distribution in an appropriate
 # namespace for components implementing base system functionality. For installing with
 # Vanilla Kubernetes, kube-system makes sense for the namespace.
-# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v5.0.1/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v6.1.0/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 ---
 kind: Deployment
 apiVersion: apps/v1

--- a/addons/csi-openstack-cinder/snapshot-webhook-rbac.yaml
+++ b/addons/csi-openstack-cinder/snapshot-webhook-rbac.yaml
@@ -4,7 +4,7 @@
 # It should be installed as part of the base Kubernetes distribution in an appropriate
 # namespace for components implementing base system functionality. For installing with
 # Vanilla Kubernetes, kube-system makes sense for the namespace.
-# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v6.0.1/deploy/kubernetes/webhook-example/rbac-snapshot-webhook.yaml
+# Source: https://github.com/kubernetes-csi/external-snapshotter/blob/v6.1.0/deploy/kubernetes/webhook-example/rbac-snapshot-webhook.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/pkg/apis/kubeone/helpers.go
+++ b/pkg/apis/kubeone/helpers.go
@@ -316,8 +316,6 @@ func (c KubeOneCluster) csiMigrationFeatureGates(complete bool) (map[string]bool
 			featureGates["InTreePluginAzureFileUnregister"] = true
 		}
 	case c.CloudProvider.Openstack != nil:
-		featureGates["CSIMigrationOpenStack"] = true
-		featureGates["ExpandCSIVolumes"] = true
 		if complete {
 			featureGates["InTreePluginOpenStackUnregister"] = true
 		}

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -305,23 +305,40 @@ func optionalResources() map[Resource]map[string]string {
 		OpenstackCCM: {
 			"1.23.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.4",
 			"1.24.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.5",
-			">= 1.25.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.25.3",
+			"1.25.x":    "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.25.3",
+			">= 1.26.0": "docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.26.0",
 		},
 
 		// OpenStack CSI
 		OpenstackCSI: {
 			"1.23.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.4",
 			"1.24.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.24.5",
-			">= 1.25.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.25.3",
+			"1.25.x":    "docker.io/k8scloudprovider/cinder-csi-plugin:v1.25.3",
+			">= 1.26.0": "docker.io/k8scloudprovider/cinder-csi-plugin:v1.26.0",
 		},
-		OpenstackCSINodeDriverRegistar: {"*": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1"},
-		OpenstackCSILivenessProbe:      {"*": "registry.k8s.io/sig-storage/livenessprobe:v2.7.0"},
-		OpenstackCSIAttacher:           {"*": "registry.k8s.io/sig-storage/csi-attacher:v3.4.0"},
-		OpenstackCSIProvisioner:        {"*": "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0"},
-		OpenstackCSIResizer:            {"*": "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"},
-		OpenstackCSISnapshotter:        {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1"},
-		OpenstackCSISnapshotController: {"*": "registry.k8s.io/sig-storage/snapshot-controller:v6.0.1"},
-		OpenstackCSISnapshotWebhook:    {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1"},
+		OpenstackCSINodeDriverRegistar: {
+			"< 1.26.0":  "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1",
+			">= 1.26.0": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2",
+		},
+		OpenstackCSILivenessProbe: {
+			"< 1.26.0":  "registry.k8s.io/sig-storage/livenessprobe:v2.7.0",
+			">= 1.26.0": "registry.k8s.io/sig-storage/livenessprobe:v2.8.0",
+		},
+		OpenstackCSIAttacher: {
+			"< 1.26.0":  "registry.k8s.io/sig-storage/csi-attacher:v3.4.0",
+			">= 1.26.0": "registry.k8s.io/sig-storage/csi-attacher:v4.0.0",
+		},
+		OpenstackCSIProvisioner: {
+			"< 1.26.0":  "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0",
+			">= 1.26.0": "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0",
+		},
+		OpenstackCSIResizer: {
+			"< 1.26.0":  "registry.k8s.io/sig-storage/csi-resizer:v1.4.0",
+			">= 1.26.0": "registry.k8s.io/sig-storage/csi-resizer:v1.6.0",
+		},
+		OpenstackCSISnapshotter:        {"*": "registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0"},
+		OpenstackCSISnapshotController: {"*": "registry.k8s.io/sig-storage/snapshot-controller:v6.1.0"},
+		OpenstackCSISnapshotWebhook:    {"*": "registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0"},
 
 		// Equinix Metal CCM
 		EquinixMetalCCM: {"*": "ghcr.io/equinix/cloud-provider-equinix-metal:v3.5.0"},

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -376,8 +376,8 @@ func optionalResources() map[Resource]map[string]string {
 		WeaveNetCNINPC:  {"*": "docker.io/weaveworks/weave-npc:2.8.1"},
 
 		// Cilium
-		Cilium:         {"*": "quay.io/cilium/cilium:v1.12.3@sha256:30de50c4dc0a1e1077e9e7917a54d5cab253058b3f779822aec00f5c817ca826"},
-		CiliumOperator: {"*": "quay.io/cilium/operator-generic:v1.12.3@sha256:816ec1da586139b595eeb31932c61a7c13b07fb4a0255341c0e0f18608e84eff"},
+		Cilium:         {"*": "quay.io/cilium/cilium:v1.12.5@sha256:06ce2b0a0a472e73334a7504ee5c5d8b2e2d7b72ef728ad94e564740dd505be5"},
+		CiliumOperator: {"*": "quay.io/cilium/operator-generic:v1.12.5@sha256:b296eb7f0f7656a5cc19724f40a8a7121b7fd725278b7d61dc91fe0b7ffd7c0e"},
 
 		// Calico VXLAN
 		CalicoVXLANCNI:        {"*": "quay.io/calico/cni:v3.23.3"},
@@ -385,7 +385,7 @@ func optionalResources() map[Resource]map[string]string {
 		CalicoVXLANNode:       {"*": "quay.io/calico/node:v3.23.3"},
 
 		// Hubble
-		HubbleRelay:     {"*": "quay.io/cilium/hubble-relay:v1.12.3@sha256:320dff9389e3fc6e2d33863510d497e8bcf245a5755236ae466a0729cc656a79"},
+		HubbleRelay:     {"*": "quay.io/cilium/hubble-relay:v1.12.5@sha256:22039a7a6cb1322badd6b0e5149ba7b11d35a54cf3ac93ce651bebe5a71ac91a"},
 		HubbleUI:        {"*": "quay.io/cilium/hubble-ui:v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e"},
 		HubbleUIBackend: {"*": "quay.io/cilium/hubble-ui-backend:v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7"},
 		CiliumCertGen:   {"*": "quay.io/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update Cilium from v1.12.3 to v1.12.5
- Update OpenStack CCM to v1.26.0 for Kubernetes 1.26+ clusters
- Update OpenStack Cinder CSI to v1.26.0 for Kubernetes 1.26+ clusters
  - This also includes its dependencies such as CSI attacher, provisioner...
- Remove enabled-by-default API server feature gates for OpenStack
  - CSIMigrationOpenStack and ExpandCSIVolumes are enabled by default at least since 1.23

**Which issue(s) this PR fixes**:
xref #2562 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update Cilium from v1.12.3 to v1.12.5
- Update OpenStack CCM to v1.26.0 for Kubernetes 1.26+ clusters
- Update OpenStack Cinder CSI to v1.26.0 for Kubernetes 1.26+ clusters
```

**Documentation**:
```documentation
NONE
```