### PR TITLE
add ca bundle to osm deployment

### DIFF
--- a/addons/operating-system-manager/deployment-controller.yaml
+++ b/addons/operating-system-manager/deployment-controller.yaml
@@ -16,6 +16,7 @@ spec:
         "prometheus.io/scrape": "true"
         "prometheus.io/port": "8080"
         "prometheus.io/path": "/metrics"
+        "kubeone.k8c.io/cabundle-hash": "{{ .Config.CABundle | sha256sum }}"
         "kubeone.k8c.io/credentials-hash": "{{ .OperatingSystemManagerCredentialsHash }}"
       labels:
         app: operating-system-manager
@@ -78,6 +79,9 @@ spec:
             - name: NO_PROXY
               value: "{{ .Config.Proxy.NoProxy }}"
 {{ .OperatingSystemManagerCredentialsEnvVars | indent 12 }}
+{{ if .Config.CABundle }}
+{{ caBundleEnvVar | indent 12 }}
+{{ end }}
           ports:
             - containerPort: 8085
           livenessProbe:
@@ -98,3 +102,9 @@ spec:
             requests:
               cpu: 50m
               memory: 128Mi
+{{ if .Config.CABundle }}
+          volumeMounts:
+{{ caBundleVolumeMount | indent 12 }}
+      volumes:
+{{ caBundleVolume | indent 8 }}
+{{ end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/kubermatic/kubeone/blob/main/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:
when `caBundle` is enabled, kubeone (cc2935dec5d34f6c1fc722d3a5983bea5a3b5e79) will deploy the `operating-system-manager` deployment with the `-ca-bundle=/etc/kubeone/certs/ca-certificates.crt` flag. 

However this fails due to the file not being present. This PR adds the corresponding volume and volumeMount to the deployment.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Propagate custom ca-bundle to operating-system-manager
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```