### PR TITLE
Forbid PodSecurityPolicy for Kubernetes 1.25+

### DIFF
--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -1568,6 +1568,30 @@ func TestValidateFeatures(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "psp enabled on 1.25",
+			features: kubeoneapi.Features{
+				PodSecurityPolicy: &kubeoneapi.PodSecurityPolicy{
+					Enable: true,
+				},
+			},
+			versions: kubeoneapi.VersionConfig{
+				Kubernetes: "1.25.5",
+			},
+			expectedError: true,
+		},
+		{
+			name: "psp enabled on 1.26",
+			features: kubeoneapi.Features{
+				PodSecurityPolicy: &kubeoneapi.PodSecurityPolicy{
+					Enable: true,
+				},
+			},
+			versions: kubeoneapi.VersionConfig{
+				Kubernetes: "1.26.0",
+			},
+			expectedError: true,
+		},
+		{
 			name: "metrics server disabled",
 			features: kubeoneapi.Features{
 				MetricsServer: &kubeoneapi.MetricsServer{


### PR DESCRIPTION
**What this PR does / why we need it**:

Forbid PodSecurityPolicy feature for Kubernetes clusters running 1.25 and newer. PodSecurityPolicies got removed from Kubernetes in 1.25. For more details, see [the official blog post](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/).

**Which issue(s) this PR fixes**:
Fixes #2454
xref #1309

**What type of PR is this?**
/kind api-change

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[ACTION REQUIRED] Forbid PodSecurityPolicy feature for Kubernetes clusters running 1.25 and newer. PodSecurityPolicies got removed from Kubernetes in 1.25. For more details, see [the official blog post](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/)
```

**Documentation**:
```documentation
NONE
```