### PR TITLE
Fix wrong release date for 1.4.13

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -1,4 +1,4 @@
-# [v1.4.13](https://github.com/kubermatic/kubeone/releases/tag/v1.4.13) - 2022-01-17
+# [v1.4.13](https://github.com/kubermatic/kubeone/releases/tag/v1.4.13) - 2023-01-17
 
 ## Changelog since v1.4.12
 


### PR DESCRIPTION
**What this PR does / why we need it**:

1.4.13 is supposed to be released in 2023, not 2022. :slightly_smiling_face: 

**What type of PR is this?**
/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```