### PR TITLE
Remove unused code for Kubernetes 1.23

### DIFF
--- a/pkg/tasks/kubeadm_env.go
+++ b/pkg/tasks/kubeadm_env.go
@@ -20,13 +20,7 @@ import (
 	"strconv"
 
 	kubeoneapi "k8c.io/kubeone/pkg/apis/kubeone"
-	"k8c.io/kubeone/pkg/semverutil"
 	"k8c.io/kubeone/pkg/state"
-)
-
-var (
-	version124 = semverutil.MustParseConstraint("1.24.*")
-	version123 = semverutil.MustParseConstraint("1.23.*")
 )
 
 type kubeadmFlagsModifier func(flags map[string]string)
@@ -35,38 +29,8 @@ func updateKubeadmFlagsEnv(s *state.State, node *kubeoneapi.HostConfig) error {
 	modifiers := []kubeadmFlagsModifier{
 		updateKubeletNodeValues(node),
 	}
-	if m := removeNetworkPluginFlagKubelet(s, node); m != nil {
-		modifiers = append(modifiers, m)
-	}
 
 	return updateKubeadmFlagsEnvFile(s, modifiers...)
-}
-
-// removeNetworkPluginFlagKubelet removes --network-plugin flag from Kubelet
-// config because it has been removed in Kubernetes 1.24.
-// This function is executed only when upgrading cluster from 1.23 to 1.24.
-// TODO: Remove this function after dropping support for Kubernetes 1.23.
-func removeNetworkPluginFlagKubelet(s *state.State, node *kubeoneapi.HostConfig) kubeadmFlagsModifier {
-	needed := false
-	if !version124.Check(s.LiveCluster.ExpectedVersion) {
-		return nil
-	}
-	for _, cp := range s.LiveCluster.ControlPlane {
-		if cp.Config.Hostname == node.Hostname && version123.Check(cp.Kubelet.Version) {
-			needed = true
-
-			break
-		}
-	}
-	if !needed {
-		return nil
-	}
-
-	return func(flags map[string]string) {
-		// --network-plugin flag is not used with containerd and has been
-		// removed in Kubernetes 1.24
-		delete(flags, networkPluginFlag)
-	}
 }
 
 func updateKubeletNodeValues(node *kubeoneapi.HostConfig) kubeadmFlagsModifier {

--- a/pkg/templates/kubeadm/v1beta3/kubeadm.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm.go
@@ -51,10 +51,6 @@ const (
 	// (see etcdVersionCorruptCheckExtraArgs for more details)
 	fixedEtcdVersion = "3.5.6-0"
 
-	// NB: Currently no Kubernetes version uses 3.5.6, but to avoid deleting the code
-	// we just use some super high version as a fixed version.
-	// fixedEtcd123 defines a semver constraint used to check if Kubernetes 1.23 uses fixed etcd version
-	fixedEtcd123 = ">= 1.23.15, < 1.24"
 	// fixedEtcd124 defines a semver constraint used to check if Kubernetes 1.24 uses fixed etcd version
 	fixedEtcd124 = ">= 1.24.9, < 1.25"
 	// fixedEtcd125 defines a semver constraint used to check if Kubernetes 1.25 uses fixed etcd version
@@ -68,7 +64,6 @@ const (
 )
 
 var (
-	fixedEtcd123Constraint = semverutil.MustParseConstraint(fixedEtcd123)
 	fixedEtcd124Constraint = semverutil.MustParseConstraint(fixedEtcd124)
 	fixedEtcd125Constraint = semverutil.MustParseConstraint(fixedEtcd125)
 	fixedEtcd126Constraint = semverutil.MustParseConstraint(fixedEtcd126)
@@ -522,8 +517,6 @@ func etcdVersionCorruptCheckExtraArgs(kubeVersion *semver.Version, etcdImageTag 
 	switch {
 	case etcdImageTag != "":
 		return etcdImageTag, etcdExtraArgs
-	case fixedEtcd123Constraint.Check(kubeVersion):
-		fallthrough
 	case fixedEtcd124Constraint.Check(kubeVersion):
 		fallthrough
 	case fixedEtcd125Constraint.Check(kubeVersion):

--- a/pkg/templates/kubeadm/v1beta3/kubeadm_test.go
+++ b/pkg/templates/kubeadm/v1beta3/kubeadm_test.go
@@ -38,12 +38,6 @@ func TestEtcdVersionCorruptCheckExtraArgs(t *testing.T) {
 		expectedEtcdArgs     map[string]string
 	}{
 		{
-			name:                 "unfixed 1.23",
-			kubeVersion:          semver.MustParse("1.23.13"),
-			expectedEtcdImageTag: fixedEtcdVersion,
-			expectedEtcdArgs:     etcdExtraArgs,
-		},
-		{
 			name:                 "unfixed 1.24",
 			kubeVersion:          semver.MustParse("1.24.7"),
 			expectedEtcdImageTag: fixedEtcdVersion,
@@ -53,12 +47,6 @@ func TestEtcdVersionCorruptCheckExtraArgs(t *testing.T) {
 			name:                 "unfixed 1.25",
 			kubeVersion:          semver.MustParse("1.25.3"),
 			expectedEtcdImageTag: fixedEtcdVersion,
-			expectedEtcdArgs:     etcdExtraArgs,
-		},
-		{
-			name:                 "fixed 1.23",
-			kubeVersion:          semver.MustParse("1.23.99"),
-			expectedEtcdImageTag: "",
 			expectedEtcdArgs:     etcdExtraArgs,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

This cleans up some code handling special cases for Kubernetes 1.23. This PR is to be merged after cutting KubeOne 1.6.0.

**Which issue(s) this PR fixes**:
xref #2595 

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```