### PR TITLE
Update containerd to 1.6* on Amazon Linux 2

### DIFF
--- a/pkg/scripts/funcs.go
+++ b/pkg/scripts/funcs.go
@@ -87,5 +87,5 @@ var (
 const (
 	latestDockerVersion            = "'20.10.*'"
 	defaultContainerdVersion       = "'1.6.*'"
-	defaultAmazonContainerdVersion = "'1.4.*'"
+	defaultAmazonContainerdVersion = "'1.6.*'"
 )

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -79,7 +79,7 @@ sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-'20.10.*' \
-	containerd.io-'1.4.*'
+	containerd.io-'1.6.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -79,7 +79,7 @@ sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-'20.10.*' \
-	containerd.io-'1.4.*'
+	containerd.io-'1.6.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -79,7 +79,7 @@ sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-'20.10.*' \
-	containerd.io-'1.4.*'
+	containerd.io-'1.6.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -79,7 +79,7 @@ sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-'20.10.*' \
-	containerd.io-'1.4.*'
+	containerd.io-'1.6.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -79,7 +79,7 @@ sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-'20.10.*' \
-	containerd.io-'1.4.*'
+	containerd.io-'1.6.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.26.0.golden
@@ -79,7 +79,7 @@ sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-'20.10.*' \
-	containerd.io-'1.4.*'
+	containerd.io-'1.6.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -78,7 +78,7 @@ sudo yum install -y \
 
 
 sudo yum versionlock delete containerd || true
-sudo yum install -y containerd-'1.4.*'
+sudo yum install -y containerd-'1.6.*'
 sudo yum versionlock add containerd
 
 

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -78,7 +78,7 @@ sudo yum install -y \
 
 
 sudo yum versionlock delete containerd || true
-sudo yum install -y containerd-'1.4.*'
+sudo yum install -y containerd-'1.6.*'
 sudo yum versionlock add containerd
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -79,7 +79,7 @@ sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-'20.10.*' \
-	containerd.io-'1.4.*'
+	containerd.io-'1.6.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlAmazonLinux.golden
@@ -79,7 +79,7 @@ sudo yum versionlock delete docker containerd || true
 
 sudo yum install -y \
 	docker-'20.10.*' \
-	containerd.io-'1.4.*'
+	containerd.io-'1.6.*'
 sudo yum versionlock add docker containerd
 
 sudo mkdir -p $(dirname /etc/docker/daemon.json)

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -218,9 +218,9 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:             {"*": "quay.io/calico/node:v3.23.5"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.15"},
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
-		MachineController:      {"*": "quay.io/kubermatic/machine-controller:0eaa75744f8306bc5ae7481d73fc21a993e99f0e"},
+		MachineController:      {"*": "quay.io/kubermatic/machine-controller:48a013651278a80b22dddbad15a40bc22411c701"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.2"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:eff6d0b982b7e2bbc5adafa003f2a7f43568a28b"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:08f0a6044b0fa6f8ae40b5b08b292f795c7a2ce9"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update containerd to 1.6* on Amazon Linux 2.

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

* This should fix the failing Amazon Linux 2 periodic
* machine-controller (https://github.com/kubermatic/machine-controller/pull/1522) and OSM (https://github.com/kubermatic/operating-system-manager/pull/252) are already using containerd 1.6 on Amazon Linux 2

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update containerd to 1.6 on Amazon Linux 2
```

**Documentation**:
```documentation
NONE
```