### PR TITLE
Use main revision for 1.26 upgrade tests

### DIFF
--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -1420,7 +1420,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1448,7 +1448,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1476,7 +1476,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1504,7 +1504,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1532,7 +1532,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1560,7 +1560,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1588,7 +1588,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1618,7 +1618,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1648,7 +1648,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1678,7 +1678,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1709,7 +1709,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1739,7 +1739,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1767,7 +1767,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1795,7 +1795,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1823,7 +1823,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1851,7 +1851,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1879,7 +1879,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1907,7 +1907,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1935,7 +1935,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -1963,7 +1963,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9417,7 +9417,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9445,7 +9445,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9473,7 +9473,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9501,7 +9501,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9529,7 +9529,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9557,7 +9557,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9585,7 +9585,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9615,7 +9615,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9645,7 +9645,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9675,7 +9675,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9706,7 +9706,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9736,7 +9736,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9764,7 +9764,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9792,7 +9792,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9820,7 +9820,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9848,7 +9848,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9876,7 +9876,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9904,7 +9904,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9932,7 +9932,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9960,7 +9960,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -9988,7 +9988,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10016,7 +10016,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10044,7 +10044,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10072,7 +10072,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10100,7 +10100,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10128,7 +10128,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10156,7 +10156,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10184,7 +10184,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone
@@ -10212,7 +10212,7 @@ presubmits:
   clone_uri: ssh://git@github.com/kubermatic/kubeone.git
   decorate: true
   extra_refs:
-  - base_ref: release/v1.5
+  - base_ref: main
     org: kubermatic
     path_alias: k8c.io/kubeone-stable
     repo: kubeone

--- a/test/e2e/scenario_upgrade.go
+++ b/test/e2e/scenario_upgrade.go
@@ -36,7 +36,6 @@ import (
 )
 
 const (
-	kubeoneStableVersion = "1.5.1" //nolint:deadcode,varcheck
 	kubeoneStableBaseRef = "release/v1.5"
 )
 
@@ -44,8 +43,9 @@ type scenarioUpgrade struct {
 	Name                 string
 	ManifestTemplatePath string
 
-	versions []string
-	infra    Infra
+	versions           []string
+	initKubeOneVersion string
+	infra              Infra
 }
 
 func (scenario scenarioUpgrade) Title() string { return titleize(scenario.Name) }
@@ -56,6 +56,10 @@ func (scenario *scenarioUpgrade) SetInfra(infra Infra) {
 
 func (scenario *scenarioUpgrade) SetVersions(versions ...string) {
 	scenario.versions = versions
+}
+
+func (scenario *scenarioUpgrade) SetInitKubeOneVersion(version string) {
+	scenario.initKubeOneVersion = version
 }
 
 func (scenario *scenarioUpgrade) Run(ctx context.Context, t *testing.T) {
@@ -202,13 +206,18 @@ func (scenario *scenarioUpgrade) GenerateTests(wr io.Writer, generatorType Gener
 
 	cfg.Environ = scenario.infra.environ
 
+	initK1Ver := scenario.initKubeOneVersion
+	if initK1Ver == "" {
+		initK1Ver = kubeoneStableBaseRef
+	}
+
 	prowJobs = append(prowJobs,
 		newProwJob(
 			pullProwJobName(scenario.infra.name, scenario.Name, "from", up.From, "to", up.To),
 			scenario.infra.labels,
 			testTitle,
 			cfg,
-			kubeoneStableProwExtraRefs(kubeoneStableBaseRef),
+			kubeoneStableProwExtraRefs(initK1Ver),
 		),
 	)
 

--- a/test/e2e/tests_definitions.go
+++ b/test/e2e/tests_definitions.go
@@ -1244,6 +1244,10 @@ type Scenario interface {
 	Run(context.Context, *testing.T)
 }
 
+type ScenarioStable interface {
+	SetInitKubeOneVersion(version string)
+}
+
 type ProwConfig struct {
 	AlwaysRun    bool
 	RunIfChanged string

--- a/test/generator/main.go
+++ b/test/generator/main.go
@@ -40,10 +40,11 @@ type Infrastructure struct {
 }
 
 type KubeoneTest struct {
-	Scenario        string           `json:"scenario"`
-	InitVersion     string           `json:"initVersion"`
-	UpgradedVersion string           `json:"upgradedVersion"`
-	Infrastructures []Infrastructure `json:"infrastructures"`
+	Scenario           string           `json:"scenario"`
+	InitVersion        string           `json:"initVersion"`
+	UpgradedVersion    string           `json:"upgradedVersion"`
+	InitKubeOneVersion string           `json:"initKubeOneVersion"`
+	Infrastructures    []Infrastructure `json:"infrastructures"`
 }
 
 var (
@@ -142,6 +143,10 @@ func main() {
 				versions = append(versions, genTest.UpgradedVersion)
 			}
 			scenario.SetVersions(versions...)
+
+			if scn, ok := scenario.(e2e.ScenarioStable); ok {
+				scn.SetInitKubeOneVersion(genTest.InitKubeOneVersion)
+			}
 
 			cfg := e2e.ProwConfig{
 				AlwaysRun:    genInfra.AlwaysRun,

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -76,6 +76,7 @@
 - scenario: upgrade_containerd
   initVersion: v1.25.5
   upgradedVersion: v1.26.0
+  initKubeOneVersion: "main"
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -492,6 +493,7 @@
 - scenario: upgrade_containerd_external
   initVersion: v1.25.5
   upgradedVersion: v1.26.0
+  initKubeOneVersion: "main"
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for specifying what KubeOne version to use for initializing a cluster in the upgrade tests.

We use this feature for 1.26 upgrade tests because the current stable release (1.5) doesn't support 1.25, so we can't create a 1.25 cluster with KubeOne 1.5, and then upgrade it to 1.26 with KubeOne based on the latest revision.

This is supposed to be a temporary workaround, hoping that it'll not happen that we add support for two minor Kubernetes releases in a single KubeOne release.

**What type of PR is this?**
/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```