### PR TITLE
Stop applying master taint for 1.26+ clusters

### DIFF
--- a/pkg/apis/kubeone/v1beta2/defaults.go
+++ b/pkg/apis/kubeone/v1beta2/defaults.go
@@ -90,6 +90,7 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 	setDefaultLeader := true
 
 	gteKube124Condition, _ := semver.NewConstraint(">= 1.24")
+	ltKube126Condition, _ := semver.NewConstraint("< 1.26")
 	actualVer, err := semver.NewVersion(obj.Versions.Kubernetes)
 	if err != nil {
 		return
@@ -105,11 +106,13 @@ func SetDefaults_Hosts(obj *KubeOneCluster) {
 		obj.ControlPlane.Hosts[idx].ID = idx
 		defaultHostConfig(&obj.ControlPlane.Hosts[idx])
 		if obj.ControlPlane.Hosts[idx].Taints == nil {
-			obj.ControlPlane.Hosts[idx].Taints = []corev1.Taint{
-				{
-					Effect: corev1.TaintEffectNoSchedule,
-					Key:    "node-role.kubernetes.io/master",
-				},
+			if ltKube126Condition.Check(actualVer) {
+				obj.ControlPlane.Hosts[idx].Taints = []corev1.Taint{
+					{
+						Effect: corev1.TaintEffectNoSchedule,
+						Key:    "node-role.kubernetes.io/master",
+					},
+				}
 			}
 			if gteKube124Condition.Check(actualVer) {
 				obj.ControlPlane.Hosts[idx].Taints = append(obj.ControlPlane.Hosts[idx].Taints, corev1.Taint{


### PR DESCRIPTION
**What this PR does / why we need it**:

Components deployed by kubeadm v1.26 don't tolerate the master taint any longer. Therefore, this PR ensures we don't apply this taint for 1.26+ clusters.

**Which issue(s) this PR fixes**:
xref #2561 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Stop applying `node-role.kubernetes.io/master` taint for Kubernetes 1.26+ nodes
```

**Documentation**:
```documentation
NONE
```