### PR TITLE
Refactor OpenStack example terraform boilerplate code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,11 @@ shfmt:
 prowfmt:
 	yq --inplace eval .prow.yaml
 
-fmt: shfmt prowfmt
+.PHONY: tffmt
+tffmt:
+	terraform fmt -write=true -recursive .
+
+fmt: shfmt prowfmt tffmt
 
 gogenerate:
 	go generate ./pkg/...

--- a/examples/terraform/azure/variables.tf
+++ b/examples/terraform/azure/variables.tf
@@ -107,7 +107,7 @@ variable "disable_kubeapi_loadbalancer" {
 # Provider specific settings
 
 variable "ip_sku" {
-  default = "Basic"
+  default     = "Basic"
   description = "SKU to use for IP addresses"
 }
 
@@ -278,6 +278,6 @@ variable "rhsm_offline_token" {
 
 variable "disable_auto_update" {
   description = "Disable automatic flatcar updates (and reboot)"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }

--- a/examples/terraform/openstack/bastion.tf
+++ b/examples/terraform/openstack/bastion.tf
@@ -14,24 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+resource "openstack_networking_port_v2" "bastion" {
+  name               = "${var.cluster_name}-bastion"
+  admin_state_up     = "true"
+  network_id         = openstack_networking_network_v2.network.id
+  security_group_ids = [openstack_networking_secgroup_v2.securitygroup.id]
+
+  fixed_ip {
+    subnet_id = openstack_networking_subnet_v2.subnet.id
+  }
+}
+
 resource "openstack_compute_instance_v2" "bastion" {
   name            = "${var.cluster_name}-bastion"
   image_name      = data.openstack_images_image_v2.image.name
   flavor_name     = var.bastion_flavor
   key_pair        = openstack_compute_keypair_v2.deployer.name
   security_groups = [openstack_networking_secgroup_v2.securitygroup.name]
+
   network {
     port = openstack_networking_port_v2.bastion.id
-  }
-}
-
-resource "openstack_networking_port_v2" "bastion" {
-  name               = "${var.cluster_name}-bastion"
-  admin_state_up     = "true"
-  network_id         = openstack_networking_network_v2.network.id
-  security_group_ids = [openstack_networking_secgroup_v2.securitygroup.id]
-  fixed_ip {
-    subnet_id = openstack_networking_subnet_v2.subnet.id
   }
 }
 

--- a/examples/terraform/openstack/control_plane.tf
+++ b/examples/terraform/openstack/control_plane.tf
@@ -14,26 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+resource "openstack_networking_port_v2" "control_plane" {
+  count = var.control_plane_vm_count
+  name  = "${var.cluster_name}-control_plane-${count.index}"
+
+  admin_state_up     = "true"
+  network_id         = openstack_networking_network_v2.network.id
+  security_group_ids = [openstack_networking_secgroup_v2.securitygroup.id]
+
+  fixed_ip {
+    subnet_id = openstack_networking_subnet_v2.subnet.id
+  }
+}
+
 resource "openstack_compute_instance_v2" "control_plane" {
-  count           = var.control_plane_vm_count
-  name            = "${var.cluster_name}-cp-${count.index}"
+  count = var.control_plane_vm_count
+  name  = "${var.cluster_name}-cp-${count.index}"
+
   image_name      = data.openstack_images_image_v2.image.name
   flavor_name     = var.control_plane_flavor
   key_pair        = openstack_compute_keypair_v2.deployer.name
   security_groups = [openstack_networking_secgroup_v2.securitygroup.name]
 
   network {
-    port = element(openstack_networking_port_v2.control_plane.*.id, count.index)
+    port = element(openstack_networking_port_v2.control_plane[*].id, count.index)
   }
 }
 
-resource "openstack_networking_port_v2" "control_plane" {
-  count              = var.control_plane_vm_count
-  name               = "${var.cluster_name}-control_plane-${count.index}"
-  admin_state_up     = "true"
-  network_id         = openstack_networking_network_v2.network.id
-  security_group_ids = [openstack_networking_secgroup_v2.securitygroup.id]
-  fixed_ip {
-    subnet_id = openstack_networking_subnet_v2.subnet.id
-  }
-}

--- a/examples/terraform/openstack/network.tf
+++ b/examples/terraform/openstack/network.tf
@@ -34,7 +34,7 @@ resource "openstack_networking_subnet_v2" "subnet" {
 
 resource "openstack_networking_router_v2" "router" {
   name                = "${var.cluster_name}-cluster"
-  admin_state_up      = "true"
+  admin_state_up      = true
   external_network_id = data.openstack_networking_network_v2.external_network.id
 }
 

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -29,7 +29,7 @@ output "kubeone_api" {
 }
 
 output "ssh_commands" {
-  value = formatlist("ssh -J ${var.bastion_user}@${openstack_networking_floatingip_v2.bastion.address} ${var.ssh_username}@%s", openstack_compute_instance_v2.control_plane.*.access_ip_v4)
+  value = formatlist("ssh -J ${var.bastion_user}@${openstack_networking_floatingip_v2.bastion.address} ${var.ssh_username}@%s", openstack_compute_instance_v2.control_plane[*].access_ip_v4)
 }
 
 output "kubeone_hosts" {
@@ -39,8 +39,8 @@ output "kubeone_hosts" {
     control_plane = {
       cluster_name         = var.cluster_name
       cloud_provider       = "openstack"
-      private_address      = openstack_compute_instance_v2.control_plane.*.access_ip_v4
-      hostnames            = openstack_compute_instance_v2.control_plane.*.name
+      private_address      = openstack_compute_instance_v2.control_plane[*].access_ip_v4
+      hostnames            = openstack_compute_instance_v2.control_plane[*].name
       ssh_agent_socket     = var.ssh_agent_socket
       ssh_port             = var.ssh_port
       ssh_private_key_file = var.ssh_private_key_file

--- a/examples/terraform/openstack/variables.tf
+++ b/examples/terraform/openstack/variables.tf
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+# Cluster Variables
 variable "cluster_name" {
   description = "Name of the cluster"
   type        = string
@@ -30,21 +31,118 @@ variable "apiserver_alternative_names" {
   type        = list(string)
 }
 
+variable "image" {
+  description = "image name to use"
+  default     = ""
+  type        = string
+}
+
+variable "image_properties_query" {
+  description = "in absence of var.image, this will be used to query API for the image"
+  default = {
+    os_distro  = "ubuntu"
+    os_version = "22.04"
+  }
+  type = map(any)
+}
+
+# Network Variables
+variable "subnet_cidr" {
+  default     = "192.168.1.0/24"
+  description = "OpenStack subnet cidr"
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.subnet_cidr, 32))
+    error_message = "Must be valid IPv4 CIDR."
+  }
+}
+
+variable "external_network_name" {
+  description = "OpenStack external network name"
+  type        = string
+}
+
+variable "subnet_dns_servers" {
+  type    = list(string)
+  default = ["8.8.8.8", "8.8.4.4"]
+
+  validation {
+    condition = alltrue([
+      for a in var.subnet_dns_servers : can(regex("^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", a))
+    ])
+    error_message = "All elements must be a valid IPv4 address."
+  }
+}
+
+# Controlplane Variables
+variable "control_plane_vm_count" {
+  description = "number of control plane instances"
+  default     = 3
+  type        = number
+}
+
+variable "control_plane_flavor" {
+  description = "OpenStack instance flavor for the control plane nodes"
+  default     = "m1.small"
+  type        = string
+}
+
+# Worker Node Variables
 variable "worker_os" {
   description = "OS to run on worker machines"
+  default     = "ubuntu"
+  type        = string
+}
 
-  # valid choices are:
-  # * ubuntu
-  # * centos
-  # * rockylinux
-  default = "ubuntu"
-  type    = string
+variable "worker_flavor" {
+  description = "OpenStack instance flavor for the worker nodes"
+  default     = "m1.small"
+  type        = string
+}
+
+# Bastion Variables
+variable "bastion_port" {
+  description = "Bastion SSH port"
+  default     = 22
+  type        = number
+}
+
+variable "bastion_user" {
+  description = "Bastion SSH username"
+  default     = "ubuntu"
+  type        = string
+}
+
+variable "bastion_host_key" {
+  description = "Bastion SSH host public key"
+  default     = null
+  type        = string
+}
+
+variable "bastion_flavor" {
+  description = "OpenStack instance flavor for the LoadBalancer node"
+  default     = "m1.tiny"
+  type        = string
+}
+
+# SSH Variables
+variable "ssh_private_key_file" {
+  description = "SSH private key file used to access instances"
+  default     = ""
+  type        = string
 }
 
 variable "ssh_public_key_file" {
   description = "SSH public key file"
   default     = "~/.ssh/id_rsa.pub"
   type        = string
+}
+
+variable "ssh_hosts_keys" {
+  description = "A list of SSH hosts public keys to verify"
+  default     = null
+  type        = list(string)
 }
 
 variable "ssh_port" {
@@ -59,99 +157,13 @@ variable "ssh_username" {
   type        = string
 }
 
-variable "ssh_private_key_file" {
-  description = "SSH private key file used to access instances"
-  default     = ""
-  type        = string
-}
-
 variable "ssh_agent_socket" {
   description = "SSH Agent socket, default to grab from $SSH_AUTH_SOCK"
   default     = "env:SSH_AUTH_SOCK"
   type        = string
 }
 
-variable "bastion_port" {
-  description = "Bastion SSH port"
-  default     = 22
-  type        = number
-}
-
-variable "bastion_user" {
-  description = "Bastion SSH username"
-  default     = "ubuntu"
-  type        = string
-}
-
-variable "ssh_hosts_keys" {
-  default     = null
-  description = "A list of SSH hosts public keys to verify"
-  type        = list(string)
-}
-
-variable "bastion_host_key" {
-  description = "Bastion SSH host public key"
-  default     = null
-  type        = string
-}
-
-variable "control_plane_vm_count" {
-  description = "number of control plane instances"
-  default     = 3
-  type        = number
-}
-
-# Provider specific settings
-
-variable "control_plane_flavor" {
-  default     = "m1.small"
-  description = "OpenStack instance flavor for the control plane nodes"
-  type        = string
-}
-
-variable "worker_flavor" {
-  default     = "m1.small"
-  description = "OpenStack instance flavor for the worker nodes"
-  type        = string
-}
-
-variable "bastion_flavor" {
-  default     = "m1.tiny"
-  description = "OpenStack instance flavor for the LoadBalancer node"
-  type        = string
-}
-
-variable "image" {
-  default     = ""
-  description = "image name to use"
-  type        = string
-}
-
-variable "image_properties_query" {
-  default = {
-    os_distro  = "ubuntu"
-    os_version = "22.04"
-  }
-  description = "in absence of var.image, this will be used to query API for the image"
-  type        = map(any)
-}
-
-variable "subnet_cidr" {
-  default     = "192.168.1.0/24"
-  description = "OpenStack subnet cidr"
-  type        = string
-}
-
-variable "external_network_name" {
-  description = "OpenStack external network name"
-  type        = string
-}
-
-variable "subnet_dns_servers" {
-  type    = list(string)
-  default = ["8.8.8.8", "8.8.4.4"]
-}
-
+# Machine Deployment Variables
 variable "initial_machinedeployment_replicas" {
   description = "Number of replicas per MachineDeployment"
   default     = 2

--- a/examples/terraform/openstack/versions.tf
+++ b/examples/terraform/openstack/versions.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = ">= 1.0.0"
+
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"

--- a/examples/terraform/vsphere/outputs.tf
+++ b/examples/terraform/vsphere/outputs.tf
@@ -28,11 +28,11 @@ output "kubeone_hosts" {
 
   value = {
     control_plane = {
-      cluster_name         = var.cluster_name
-      cloud_provider       = "vsphere"
-      private_address      = []
-      hostnames            = local.hostnames
-      public_address       = vsphere_virtual_machine.control_plane.*.guest_ip_addresses.0
+      cluster_name    = var.cluster_name
+      cloud_provider  = "vsphere"
+      private_address = []
+      hostnames       = local.hostnames
+      public_address  = vsphere_virtual_machine.control_plane.*.guest_ip_addresses.0
       # KubeOne expects an array of array for IPv6 addresses since a single host/node can have multiple IPv6 addresses.
       ipv6_addresses       = var.ip_family == "IPv4+IPv6" ? [for ip in vsphere_virtual_machine.control_plane.*.guest_ip_addresses.1 : [ip]] : null
       ssh_agent_socket     = var.ssh_agent_socket

--- a/examples/terraform/vsphere_flatcar/main.tf
+++ b/examples/terraform/vsphere_flatcar/main.tf
@@ -106,11 +106,11 @@ resource "vsphere_virtual_machine" "control_plane" {
         systemd = {
           units = [
             {
-              name = "docker.socket"
+              name    = "docker.socket"
               enabled = false
             },
             {
-              name = "docker.service"
+              name    = "docker.service"
               enabled = true
             }
           ]


### PR DESCRIPTION
**What this PR does / why we need it**:
The OpenStack terraform boilerplate code was a bit outdated, this PR refactors the codebasis and restructures the code:

- places the terraform resources in their corresponding terraform file
- Adds some useful validation checks for certain input variables. 
- bumps gobetween to its latest version.
- terraform fmt
- expand filepaths so "~./ssh" actually works

We might think about a boolean variable for disabling selinux, since the systemd script of gobetween will fail if selinux is enforcing, which is the default mode for most OS.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
<!--
/kind cleanup
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
