### PR TITLE
Update kubernetes-cni to v1.2.0 and cri-tools to v1.26.0

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	defaultKubernetesCNIVersion = "1.1.1"
-	defaultCriToolsVersion      = "1.21.0"
+	defaultKubernetesCNIVersion = "1.2.0"
+	defaultCriToolsVersion      = "1.26.0"
 )
 
 var migrateToContainerdScriptTemplate = heredoc.Doc(`

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -96,7 +96,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -127,7 +127,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -129,7 +129,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -94,7 +94,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -132,7 +132,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -91,7 +91,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -131,7 +131,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -134,7 +134,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -131,7 +131,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -131,7 +131,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -131,7 +131,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -133,7 +133,7 @@ sudo yum install -y \
 	kubelet-1.26.0 \
 	kubeadm-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -72,7 +72,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.26.0*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -69,7 +69,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.26.0*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.26.0*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.26.0*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.26.0*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.26.0*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.26.0*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -61,11 +61,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.26.0"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -130,7 +130,7 @@ sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
 
 sudo yum install -y \
 	kubeadm-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.26.0*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -64,7 +64,7 @@ sudo systemctl restart containerd
 source /etc/kubeone/proxy-env
 
 sudo mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.26.0"

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -131,7 +131,7 @@ sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
 sudo yum install -y \
 	kubelet-1.26.0 \
 	kubectl-1.26.0 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.26.0*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -218,9 +218,9 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:             {"*": "quay.io/calico/node:v3.23.5"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.22.15"},
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
-		MachineController:      {"*": "quay.io/kubermatic/machine-controller:48a013651278a80b22dddbad15a40bc22411c701"},
+		MachineController:      {"*": "quay.io/kubermatic/machine-controller:50c8837f19c03d64a0cf760e25bdc0ca9e6e68c3"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.2"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:08f0a6044b0fa6f8ae40b5b08b292f795c7a2ce9"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:8688a1fde001705f4c0b394ed2f4ff4a292b20a9"},
 	}
 }
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -6,14 +6,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_24_9
+      - TestAwsAmznInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -29,14 +29,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_24_9
+      - TestAwsCentosInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -52,479 +52,7 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-gce: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.25.5
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_25_5
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.25.5
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_25_5
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
@@ -532,7 +60,7 @@ presubmits:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_25_5
+      - TestAwsDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -548,14 +76,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_25_5
+      - TestAwsFlatcarInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -571,14 +99,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_25_5
+      - TestAwsRhelInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -594,14 +122,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_25_5
+      - TestAwsRockylinuxInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -617,14 +145,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_25_5
+      - TestAzureDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -642,14 +170,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_25_5
+      - TestAzureCentosInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -667,14 +195,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_25_5
+      - TestAzureFlatcarInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -693,14 +221,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_25_5
+      - TestAzureRhelInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -718,14 +246,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_25_5
+      - TestAzureRockylinuxInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -743,14 +271,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_25_5
+      - TestGceDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: gce
@@ -766,14 +294,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_25_5
+      - TestOpenstackDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -789,14 +317,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_25_5
+      - TestOpenstackCentosInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -812,14 +340,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_25_5
+      - TestOpenstackRockylinuxInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -835,14 +363,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_25_5
+      - TestOpenstackRhelInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -858,14 +386,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_25_5
+      - TestOpenstackFlatcarInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -881,14 +409,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_25_5
+      - TestVsphereDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -904,14 +432,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_25_5
+      - TestVsphereCentosInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -927,14 +455,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_25_5
+      - TestVsphereFlatcarInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -950,14 +478,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_26_0
+      - TestAwsAmznInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -973,14 +501,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_26_0
+      - TestAwsCentosInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -996,7 +524,7 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
@@ -1004,7 +532,7 @@ presubmits:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_26_0
+      - TestAwsDefaultInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -1020,14 +548,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_26_0
+      - TestAwsFlatcarInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -1043,14 +571,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_26_0
+      - TestAwsRhelInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -1066,14 +594,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_26_0
+      - TestAwsRockylinuxInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -1089,14 +617,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_26_0
+      - TestAzureDefaultInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -1114,14 +642,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_26_0
+      - TestAzureCentosInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -1139,14 +667,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_26_0
+      - TestAzureFlatcarInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -1165,14 +693,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_26_0
+      - TestAzureRhelInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -1190,14 +718,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_26_0
+      - TestAzureRockylinuxInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -1215,14 +743,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_26_0
+      - TestGceDefaultInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: gce
@@ -1238,14 +766,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_26_0
+      - TestOpenstackDefaultInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -1261,14 +789,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_26_0
+      - TestOpenstackCentosInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -1284,14 +812,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_26_0
+      - TestOpenstackRockylinuxInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -1307,14 +835,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_26_0
+      - TestOpenstackRhelInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -1330,14 +858,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_26_0
+      - TestOpenstackFlatcarInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -1353,14 +881,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_26_0
+      - TestVsphereDefaultInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -1376,14 +904,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_26_0
+      - TestVsphereCentosInstallContainerdV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -1399,14 +927,486 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_26_0
+      - TestVsphereFlatcarInstallContainerdV1_25_6
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: gce
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdV1_26_1
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.29
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.26.1
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarInstallContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -1427,14 +1427,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAwsAmznStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -1455,14 +1455,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAwsCentosStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -1483,14 +1483,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAwsDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -1511,14 +1511,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -1539,14 +1539,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAwsRhelStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -1567,14 +1567,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -1595,14 +1595,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAzureDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -1625,14 +1625,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAzureCentosStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -1655,14 +1655,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -1686,14 +1686,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAzureRhelStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -1716,14 +1716,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -1746,14 +1746,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestGceDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: gce
@@ -1774,14 +1774,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -1802,14 +1802,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -1830,14 +1830,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -1858,14 +1858,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -1886,14 +1886,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -1914,14 +1914,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -1942,14 +1942,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestVsphereCentosStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -1970,14 +1970,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -1998,14 +1998,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAwsAmznStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -2026,14 +2026,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAwsCentosStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -2054,14 +2054,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAwsDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -2082,14 +2082,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -2110,14 +2110,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAwsRhelStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -2138,14 +2138,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -2166,14 +2166,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAzureDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -2196,14 +2196,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAzureCentosStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -2226,14 +2226,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -2257,14 +2257,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAzureRhelStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -2287,14 +2287,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -2317,14 +2317,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestGceDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: gce
@@ -2345,14 +2345,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -2373,14 +2373,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -2401,14 +2401,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -2429,14 +2429,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -2457,14 +2457,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -2485,14 +2485,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -2513,14 +2513,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestVsphereCentosStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -2541,14 +2541,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -2564,14 +2564,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-amzn-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCalicoContainerdV1_26_0
+      - TestAwsAmznCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -2587,14 +2587,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-centos-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCalicoContainerdV1_26_0
+      - TestAwsCentosCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -2610,14 +2610,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-default-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCalicoContainerdV1_26_0
+      - TestAwsDefaultCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -2633,14 +2633,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-flatcar-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCalicoContainerdV1_26_0
+      - TestAwsFlatcarCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -2656,14 +2656,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rhel-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCalicoContainerdV1_26_0
+      - TestAwsRhelCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -2679,14 +2679,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rockylinux-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCalicoContainerdV1_26_0
+      - TestAwsRockylinuxCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -2702,14 +2702,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-default-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCalicoContainerdV1_26_0
+      - TestAzureDefaultCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -2727,14 +2727,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCalicoContainerdV1_26_0
+      - TestAzureCentosCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -2752,14 +2752,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCalicoContainerdV1_26_0
+      - TestAzureFlatcarCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -2778,14 +2778,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCalicoContainerdV1_26_0
+      - TestAzureRhelCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -2803,14 +2803,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCalicoContainerdV1_26_0
+      - TestAzureRockylinuxCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -2828,14 +2828,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-gce-default-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCalicoContainerdV1_26_0
+      - TestGceDefaultCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: gce
@@ -2851,14 +2851,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCalicoContainerdV1_26_0
+      - TestOpenstackDefaultCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -2874,14 +2874,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCalicoContainerdV1_26_0
+      - TestOpenstackCentosCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -2897,14 +2897,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCalicoContainerdV1_26_0
+      - TestOpenstackRockylinuxCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -2920,14 +2920,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCalicoContainerdV1_26_0
+      - TestOpenstackRhelCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -2943,14 +2943,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCalicoContainerdV1_26_0
+      - TestOpenstackFlatcarCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -2966,14 +2966,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCalicoContainerdV1_26_0
+      - TestVsphereDefaultCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -2989,14 +2989,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCalicoContainerdV1_26_0
+      - TestVsphereCentosCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -3012,14 +3012,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-calico-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCalicoContainerdV1_26_0
+      - TestVsphereFlatcarCalicoContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -3035,14 +3035,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-amzn-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznWeaveContainerdV1_26_0
+      - TestAwsAmznWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3058,14 +3058,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-centos-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosWeaveContainerdV1_26_0
+      - TestAwsCentosWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3081,14 +3081,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-default-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultWeaveContainerdV1_26_0
+      - TestAwsDefaultWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3104,14 +3104,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-flatcar-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarWeaveContainerdV1_26_0
+      - TestAwsFlatcarWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3127,14 +3127,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rhel-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelWeaveContainerdV1_26_0
+      - TestAwsRhelWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3150,14 +3150,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rockylinux-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxWeaveContainerdV1_26_0
+      - TestAwsRockylinuxWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3173,14 +3173,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-default-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultWeaveContainerdV1_26_0
+      - TestAzureDefaultWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3198,14 +3198,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosWeaveContainerdV1_26_0
+      - TestAzureCentosWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3223,14 +3223,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarWeaveContainerdV1_26_0
+      - TestAzureFlatcarWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3249,14 +3249,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelWeaveContainerdV1_26_0
+      - TestAzureRhelWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3274,14 +3274,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxWeaveContainerdV1_26_0
+      - TestAzureRockylinuxWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3299,14 +3299,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-gce-default-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultWeaveContainerdV1_26_0
+      - TestGceDefaultWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: gce
@@ -3322,14 +3322,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultWeaveContainerdV1_26_0
+      - TestOpenstackDefaultWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3345,14 +3345,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosWeaveContainerdV1_26_0
+      - TestOpenstackCentosWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3368,14 +3368,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxWeaveContainerdV1_26_0
+      - TestOpenstackRockylinuxWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3391,14 +3391,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelWeaveContainerdV1_26_0
+      - TestOpenstackRhelWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3414,14 +3414,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarWeaveContainerdV1_26_0
+      - TestOpenstackFlatcarWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3437,14 +3437,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultWeaveContainerdV1_26_0
+      - TestVsphereDefaultWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -3460,14 +3460,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosWeaveContainerdV1_26_0
+      - TestVsphereCentosWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -3483,14 +3483,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-weave-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarWeaveContainerdV1_26_0
+      - TestVsphereFlatcarWeaveContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -3506,14 +3506,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-amzn-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznCiliumContainerdV1_26_0
+      - TestAwsAmznCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3529,14 +3529,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-centos-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosCiliumContainerdV1_26_0
+      - TestAwsCentosCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3552,14 +3552,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-default-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCiliumContainerdV1_26_0
+      - TestAwsDefaultCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3575,14 +3575,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-flatcar-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCiliumContainerdV1_26_0
+      - TestAwsFlatcarCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3598,14 +3598,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rhel-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelCiliumContainerdV1_26_0
+      - TestAwsRhelCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3621,14 +3621,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rockylinux-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxCiliumContainerdV1_26_0
+      - TestAwsRockylinuxCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -3644,14 +3644,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-default-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCiliumContainerdV1_26_0
+      - TestAzureDefaultCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3669,14 +3669,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCiliumContainerdV1_26_0
+      - TestAzureCentosCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3694,14 +3694,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCiliumContainerdV1_26_0
+      - TestAzureFlatcarCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3720,14 +3720,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCiliumContainerdV1_26_0
+      - TestAzureRhelCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3745,14 +3745,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCiliumContainerdV1_26_0
+      - TestAzureRockylinuxCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -3770,14 +3770,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-gce-default-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultCiliumContainerdV1_26_0
+      - TestGceDefaultCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: gce
@@ -3793,14 +3793,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCiliumContainerdV1_26_0
+      - TestOpenstackDefaultCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3816,14 +3816,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCiliumContainerdV1_26_0
+      - TestOpenstackCentosCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3839,14 +3839,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCiliumContainerdV1_26_0
+      - TestOpenstackRockylinuxCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3862,14 +3862,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCiliumContainerdV1_26_0
+      - TestOpenstackRhelCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3885,14 +3885,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCiliumContainerdV1_26_0
+      - TestOpenstackFlatcarCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -3908,14 +3908,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCiliumContainerdV1_26_0
+      - TestVsphereDefaultCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -3931,14 +3931,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCiliumContainerdV1_26_0
+      - TestVsphereCentosCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -3954,14 +3954,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-cilium-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCiliumContainerdV1_26_0
+      - TestVsphereFlatcarCiliumContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -3977,14 +3977,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_9
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -4002,14 +4002,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_25_5
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -4027,14 +4027,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_26_0
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -4052,14 +4052,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_9
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -4077,14 +4077,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_5
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -4102,14 +4102,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_26_0
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -4127,14 +4127,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.26.0
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_26_0
+      - TestAwsDefaultKubeProxyIpvsV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -4150,14 +4150,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_24_9
+      - TestAwsAmznLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -4173,14 +4173,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_24_9
+      - TestAwsCentosLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -4196,14 +4196,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_9
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -4219,14 +4219,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_9
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -4242,14 +4242,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_24_9
+      - TestAwsRhelLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -4265,14 +4265,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_9
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -4288,14 +4288,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_9
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -4313,14 +4313,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_24_9
+      - TestAzureCentosLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -4338,14 +4338,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_9
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -4364,14 +4364,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_24_9
+      - TestAzureRhelLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -4389,14 +4389,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_9
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -4414,14 +4414,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_24_9
+      - TestGceDefaultLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: gce
@@ -4437,14 +4437,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -4460,14 +4460,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -4483,14 +4483,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -4506,14 +4506,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -4529,14 +4529,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -4552,14 +4552,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_9
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -4575,14 +4575,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_9
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -4598,14 +4598,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_9
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -4621,14 +4621,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_25_5
+      - TestAwsAmznLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -4644,14 +4644,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_25_5
+      - TestAwsCentosLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -4667,14 +4667,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_25_5
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -4690,14 +4690,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_25_5
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -4713,14 +4713,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_25_5
+      - TestAwsRhelLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -4736,14 +4736,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_5
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -4759,14 +4759,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_25_5
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -4784,14 +4784,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_25_5
+      - TestAzureCentosLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -4809,14 +4809,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_25_5
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -4835,14 +4835,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_25_5
+      - TestAzureRhelLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -4860,14 +4860,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_5
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -4885,14 +4885,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_25_5
+      - TestGceDefaultLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: gce
@@ -4908,14 +4908,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_5
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -4931,14 +4931,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_25_5
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -4954,14 +4954,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_5
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -4977,14 +4977,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_25_5
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -5000,14 +5000,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_5
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -5023,14 +5023,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_25_5
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -5046,14 +5046,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_25_5
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -5069,14 +5069,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_5
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -5092,14 +5092,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_26_0
+      - TestAwsAmznLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -5115,14 +5115,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_26_0
+      - TestAwsCentosLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -5138,14 +5138,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_26_0
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -5161,14 +5161,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_26_0
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -5184,14 +5184,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_26_0
+      - TestAwsRhelLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -5207,14 +5207,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_26_0
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -5230,14 +5230,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_26_0
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -5255,14 +5255,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_26_0
+      - TestAzureCentosLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -5280,14 +5280,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_26_0
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -5306,14 +5306,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_26_0
+      - TestAzureRhelLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -5331,14 +5331,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_26_0
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -5356,14 +5356,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_26_0
+      - TestGceDefaultLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: gce
@@ -5379,14 +5379,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_26_0
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -5402,14 +5402,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_26_0
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -5425,14 +5425,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_26_0
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -5448,14 +5448,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_26_0
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -5471,14 +5471,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_26_0
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -5494,14 +5494,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_26_0
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -5517,14 +5517,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_26_0
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -5540,14 +5540,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_26_0
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -5563,14 +5563,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_24_9
+      - TestAwsDefaultCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -5586,14 +5586,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_24_9
+      - TestOpenstackDefaultCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -5609,14 +5609,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_24_9
+      - TestOpenstackCentosCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -5632,14 +5632,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_9
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -5655,14 +5655,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_24_9
+      - TestOpenstackRhelCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -5678,14 +5678,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_24_9
+      - TestOpenstackFlatcarCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -5701,14 +5701,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_24_9
+      - TestAzureDefaultCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -5726,14 +5726,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_24_9
+      - TestAzureCentosCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -5751,14 +5751,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_24_9
+      - TestAzureFlatcarCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -5777,14 +5777,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_24_9
+      - TestAzureRhelCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -5802,14 +5802,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_24_9
+      - TestAzureRockylinuxCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -5827,14 +5827,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_24_9
+      - TestVsphereDefaultCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -5850,14 +5850,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_24_9
+      - TestVsphereCentosCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -5873,14 +5873,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_24_9
+      - TestVsphereFlatcarCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -5896,14 +5896,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_25_5
+      - TestAwsDefaultCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -5919,14 +5919,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_25_5
+      - TestOpenstackDefaultCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -5942,14 +5942,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_25_5
+      - TestOpenstackCentosCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -5965,14 +5965,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_25_5
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -5988,14 +5988,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_25_5
+      - TestOpenstackRhelCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -6011,14 +6011,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_25_5
+      - TestOpenstackFlatcarCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -6034,14 +6034,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_25_5
+      - TestAzureDefaultCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -6059,14 +6059,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_25_5
+      - TestAzureCentosCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -6084,14 +6084,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_25_5
+      - TestAzureFlatcarCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -6110,14 +6110,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_25_5
+      - TestAzureRhelCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -6135,14 +6135,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_25_5
+      - TestAzureRockylinuxCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -6160,14 +6160,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_25_5
+      - TestVsphereDefaultCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -6183,14 +6183,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_25_5
+      - TestVsphereCentosCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -6206,14 +6206,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_25_5
+      - TestVsphereFlatcarCsiCcmMigrationV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -6229,14 +6229,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_26_0
+      - TestAwsDefaultCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -6252,14 +6252,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_26_0
+      - TestOpenstackDefaultCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -6275,14 +6275,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_26_0
+      - TestOpenstackCentosCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -6298,14 +6298,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_26_0
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -6321,14 +6321,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_26_0
+      - TestOpenstackRhelCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -6344,14 +6344,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_26_0
+      - TestOpenstackFlatcarCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -6367,14 +6367,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_26_0
+      - TestAzureDefaultCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -6392,14 +6392,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_26_0
+      - TestAzureCentosCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -6417,14 +6417,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_26_0
+      - TestAzureFlatcarCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -6443,14 +6443,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_26_0
+      - TestAzureRhelCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -6468,14 +6468,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_26_0
+      - TestAzureRockylinuxCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -6493,14 +6493,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_26_0
+      - TestVsphereDefaultCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -6516,14 +6516,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_26_0
+      - TestVsphereCentosCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -6539,14 +6539,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_26_0
+      - TestVsphereFlatcarCsiCcmMigrationV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -6562,14 +6562,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_24_9
+      - TestAwsAmznInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -6585,14 +6585,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_24_9
+      - TestAwsCentosInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -6608,14 +6608,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_24_9
+      - TestAwsDefaultInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -6631,14 +6631,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_24_9
+      - TestAwsFlatcarInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -6654,14 +6654,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_24_9
+      - TestAwsRhelInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -6677,14 +6677,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_24_9
+      - TestAwsRockylinuxInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -6700,14 +6700,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_24_9
+      - TestAzureDefaultInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -6725,14 +6725,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_24_9
+      - TestAzureCentosInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -6750,14 +6750,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_24_9
+      - TestAzureFlatcarInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -6776,14 +6776,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_24_9
+      - TestAzureRhelInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -6801,14 +6801,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_24_9
+      - TestAzureRockylinuxInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -6826,14 +6826,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_9
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: digitalocean
@@ -6849,14 +6849,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_24_9
+      - TestDigitaloceanCentosInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: digitalocean
@@ -6872,14 +6872,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_9
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: digitalocean
@@ -6895,14 +6895,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_9
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -6918,14 +6918,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_24_9
+      - TestEquinixmetalCentosInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -6941,14 +6941,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_9
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -6964,14 +6964,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_9
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -6987,14 +6987,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_24_9
+      - TestHetznerDefaultInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: hetzner
@@ -7010,14 +7010,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_24_9
+      - TestHetznerCentosInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: hetzner
@@ -7033,14 +7033,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_24_9
+      - TestHetznerRockylinuxInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: hetzner
@@ -7056,14 +7056,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_24_9
+      - TestOpenstackDefaultInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -7079,14 +7079,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_24_9
+      - TestOpenstackCentosInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -7102,14 +7102,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_9
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -7125,14 +7125,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_24_9
+      - TestOpenstackRhelInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -7148,14 +7148,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_24_9
+      - TestOpenstackFlatcarInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -7171,14 +7171,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_24_9
+      - TestVsphereDefaultInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -7194,14 +7194,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_24_9
+      - TestVsphereCentosInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -7217,14 +7217,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_24_9
+      - TestVsphereFlatcarInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -7240,14 +7240,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_25_5
+      - TestAwsAmznInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -7263,14 +7263,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_25_5
+      - TestAwsCentosInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -7286,14 +7286,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_25_5
+      - TestAwsDefaultInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -7309,14 +7309,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_25_5
+      - TestAwsFlatcarInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -7332,14 +7332,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_25_5
+      - TestAwsRhelInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -7355,14 +7355,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_25_5
+      - TestAwsRockylinuxInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -7378,14 +7378,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_25_5
+      - TestAzureDefaultInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -7403,14 +7403,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_25_5
+      - TestAzureCentosInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -7428,14 +7428,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_25_5
+      - TestAzureFlatcarInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -7454,14 +7454,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_25_5
+      - TestAzureRhelInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -7479,14 +7479,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_25_5
+      - TestAzureRockylinuxInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -7504,14 +7504,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_25_5
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: digitalocean
@@ -7527,14 +7527,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_25_5
+      - TestDigitaloceanCentosInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: digitalocean
@@ -7550,14 +7550,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_5
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: digitalocean
@@ -7573,14 +7573,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_25_5
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -7596,14 +7596,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_25_5
+      - TestEquinixmetalCentosInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -7619,14 +7619,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_5
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -7642,14 +7642,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_25_5
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -7665,14 +7665,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_25_5
+      - TestHetznerDefaultInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: hetzner
@@ -7688,14 +7688,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_25_5
+      - TestHetznerCentosInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: hetzner
@@ -7711,14 +7711,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_25_5
+      - TestHetznerRockylinuxInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: hetzner
@@ -7734,14 +7734,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_25_5
+      - TestOpenstackDefaultInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -7757,14 +7757,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_25_5
+      - TestOpenstackCentosInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -7780,14 +7780,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_25_5
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -7803,14 +7803,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_25_5
+      - TestOpenstackRhelInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -7826,14 +7826,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_25_5
+      - TestOpenstackFlatcarInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -7849,14 +7849,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_25_5
+      - TestVsphereDefaultInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -7872,14 +7872,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_25_5
+      - TestVsphereCentosInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -7895,14 +7895,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_25_5
+      - TestVsphereFlatcarInstallContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -7918,14 +7918,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_26_0
+      - TestAwsAmznInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -7941,14 +7941,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_26_0
+      - TestAwsCentosInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -7964,14 +7964,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_26_0
+      - TestAwsDefaultInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -7987,14 +7987,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_26_0
+      - TestAwsFlatcarInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -8010,14 +8010,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_26_0
+      - TestAwsRhelInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -8033,14 +8033,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_26_0
+      - TestAwsRockylinuxInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -8056,14 +8056,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_26_0
+      - TestAzureDefaultInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -8081,14 +8081,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_26_0
+      - TestAzureCentosInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -8106,14 +8106,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_26_0
+      - TestAzureFlatcarInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -8132,14 +8132,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_26_0
+      - TestAzureRhelInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -8157,14 +8157,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_26_0
+      - TestAzureRockylinuxInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -8182,14 +8182,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_26_0
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: digitalocean
@@ -8205,14 +8205,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_26_0
+      - TestDigitaloceanCentosInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: digitalocean
@@ -8228,14 +8228,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_26_0
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: digitalocean
@@ -8251,14 +8251,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_26_0
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -8274,14 +8274,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_26_0
+      - TestEquinixmetalCentosInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -8297,14 +8297,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_26_0
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -8320,14 +8320,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_26_0
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -8343,14 +8343,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_26_0
+      - TestHetznerDefaultInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: hetzner
@@ -8366,14 +8366,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_26_0
+      - TestHetznerCentosInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: hetzner
@@ -8389,14 +8389,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_26_0
+      - TestHetznerRockylinuxInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: hetzner
@@ -8412,14 +8412,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_26_0
+      - TestOpenstackDefaultInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -8435,14 +8435,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_26_0
+      - TestOpenstackCentosInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -8458,14 +8458,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_26_0
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -8481,14 +8481,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_26_0
+      - TestOpenstackRhelInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -8504,14 +8504,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_26_0
+      - TestOpenstackFlatcarInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -8527,14 +8527,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_26_0
+      - TestVsphereDefaultInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -8550,14 +8550,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_26_0
+      - TestVsphereCentosInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -8573,14 +8573,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_26_0
+      - TestVsphereFlatcarInstallContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -8601,14 +8601,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -8629,14 +8629,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -8657,14 +8657,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -8685,14 +8685,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -8713,14 +8713,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -8741,14 +8741,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -8769,14 +8769,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -8799,14 +8799,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -8829,14 +8829,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -8860,14 +8860,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -8890,14 +8890,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -8920,14 +8920,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: digitalocean
@@ -8948,14 +8948,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: digitalocean
@@ -8976,14 +8976,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9004,14 +9004,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9032,14 +9032,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9060,14 +9060,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9088,14 +9088,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9116,14 +9116,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: hetzner
@@ -9144,14 +9144,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: hetzner
@@ -9172,14 +9172,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: hetzner
@@ -9200,14 +9200,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -9228,14 +9228,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -9256,14 +9256,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -9284,14 +9284,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -9312,14 +9312,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -9340,14 +9340,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -9368,14 +9368,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -9396,14 +9396,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.24.9-to-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.24.10-to-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -9424,14 +9424,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -9452,14 +9452,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -9480,14 +9480,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -9508,14 +9508,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -9536,14 +9536,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -9564,14 +9564,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -9592,14 +9592,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -9622,14 +9622,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -9652,14 +9652,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -9683,14 +9683,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -9713,14 +9713,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -9743,14 +9743,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9771,14 +9771,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9799,14 +9799,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: digitalocean
@@ -9827,14 +9827,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9855,14 +9855,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9883,14 +9883,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9911,14 +9911,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -9939,14 +9939,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: hetzner
@@ -9967,14 +9967,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: hetzner
@@ -9995,14 +9995,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: hetzner
@@ -10023,14 +10023,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -10051,14 +10051,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -10079,14 +10079,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -10107,14 +10107,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -10135,14 +10135,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -10163,14 +10163,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -10191,14 +10191,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestVsphereCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -10219,14 +10219,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.25.5-to-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.25.6-to-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -10242,14 +10242,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -10265,14 +10265,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -10288,14 +10288,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -10311,14 +10311,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -10334,14 +10334,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -10357,14 +10357,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -10380,14 +10380,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -10405,14 +10405,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -10430,14 +10430,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -10456,14 +10456,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -10481,14 +10481,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -10506,14 +10506,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: digitalocean
@@ -10529,14 +10529,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: digitalocean
@@ -10552,14 +10552,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: digitalocean
@@ -10575,14 +10575,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -10598,14 +10598,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -10621,14 +10621,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -10644,14 +10644,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_9
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -10667,14 +10667,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: hetzner
@@ -10690,14 +10690,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: hetzner
@@ -10713,14 +10713,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: hetzner
@@ -10736,14 +10736,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -10759,14 +10759,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -10782,14 +10782,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -10805,14 +10805,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -10828,14 +10828,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -10851,14 +10851,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -10874,14 +10874,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -10897,14 +10897,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_9
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -10920,14 +10920,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -10943,14 +10943,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -10966,14 +10966,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -10989,14 +10989,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -11012,14 +11012,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -11035,14 +11035,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: aws
@@ -11058,14 +11058,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -11083,14 +11083,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -11108,14 +11108,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -11134,14 +11134,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -11159,14 +11159,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: azure
@@ -11184,14 +11184,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_5
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11207,14 +11207,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_5
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11230,14 +11230,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11253,14 +11253,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_5
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11276,14 +11276,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_5
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11299,14 +11299,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11322,14 +11322,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_5
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11345,14 +11345,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_5
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: hetzner
@@ -11368,14 +11368,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_5
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: hetzner
@@ -11391,14 +11391,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: hetzner
@@ -11414,14 +11414,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_5
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -11437,14 +11437,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_5
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -11460,14 +11460,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_5
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -11483,14 +11483,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_5
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -11506,14 +11506,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_5
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: openstack
@@ -11529,14 +11529,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_5
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -11552,14 +11552,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_5
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -11575,14 +11575,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.25.5
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.25.6
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_5
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_6
       env:
       - name: PROVIDER
         value: vsphere
@@ -11598,14 +11598,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -11621,14 +11621,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -11644,14 +11644,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -11667,14 +11667,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -11690,14 +11690,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -11713,14 +11713,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: aws
@@ -11736,14 +11736,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -11761,14 +11761,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -11786,14 +11786,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -11812,14 +11812,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -11837,14 +11837,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: azure
@@ -11862,14 +11862,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11885,14 +11885,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_26_0
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11908,14 +11908,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: digitalocean
@@ -11931,14 +11931,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11954,14 +11954,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_26_0
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -11977,14 +11977,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12000,14 +12000,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -12023,14 +12023,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: hetzner
@@ -12046,14 +12046,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_26_0
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: hetzner
@@ -12069,14 +12069,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: hetzner
@@ -12092,14 +12092,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -12115,14 +12115,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_26_0
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -12138,14 +12138,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_26_0
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -12161,14 +12161,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_26_0
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -12184,14 +12184,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: openstack
@@ -12207,14 +12207,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_26_0
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -12230,14 +12230,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_26_0
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: vsphere
@@ -12253,14 +12253,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.26.0
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.26.1
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_26_0
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_26_1
       env:
       - name: PROVIDER
         value: vsphere

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -10,4511 +10,4511 @@ import (
 func TestStub(t *testing.T) {
 	t.Skip("stub is skipped")
 }
-func TestAwsAmznInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_24_9(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_24_9(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_25_5(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_25_5(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_25_5(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_25_5(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_25_5(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_25_5(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_25_5(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_25_5(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_25_5(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_25_5(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_25_5(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_25_5(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_25_5(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_25_5(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_25_5(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_25_5(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_25_5(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_26_0(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_26_0(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_26_0(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_26_0(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_26_0(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_26_0(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_26_0(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_26_0(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_26_0(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_26_0(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_26_0(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_26_0(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_26_0(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_26_0(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_26_0(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_26_0(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_26_0(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCalicoContainerdV1_26_0(t *testing.T) {
+func TestAwsAmznCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCalicoContainerdV1_26_0(t *testing.T) {
+func TestAwsCentosCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCalicoContainerdV1_26_0(t *testing.T) {
+func TestAwsDefaultCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCalicoContainerdV1_26_0(t *testing.T) {
+func TestAwsFlatcarCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCalicoContainerdV1_26_0(t *testing.T) {
+func TestAwsRhelCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCalicoContainerdV1_26_0(t *testing.T) {
+func TestAwsRockylinuxCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCalicoContainerdV1_26_0(t *testing.T) {
+func TestAzureDefaultCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCalicoContainerdV1_26_0(t *testing.T) {
+func TestAzureCentosCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCalicoContainerdV1_26_0(t *testing.T) {
+func TestAzureFlatcarCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCalicoContainerdV1_26_0(t *testing.T) {
+func TestAzureRhelCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCalicoContainerdV1_26_0(t *testing.T) {
+func TestAzureRockylinuxCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCalicoContainerdV1_26_0(t *testing.T) {
+func TestGceDefaultCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCalicoContainerdV1_26_0(t *testing.T) {
+func TestOpenstackDefaultCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCalicoContainerdV1_26_0(t *testing.T) {
+func TestOpenstackCentosCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCalicoContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCalicoContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRhelCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCalicoContainerdV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCalicoContainerdV1_26_0(t *testing.T) {
+func TestVsphereDefaultCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCalicoContainerdV1_26_0(t *testing.T) {
+func TestVsphereCentosCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCalicoContainerdV1_26_0(t *testing.T) {
+func TestVsphereFlatcarCalicoContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["calico_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznWeaveContainerdV1_26_0(t *testing.T) {
+func TestAwsAmznWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosWeaveContainerdV1_26_0(t *testing.T) {
+func TestAwsCentosWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultWeaveContainerdV1_26_0(t *testing.T) {
+func TestAwsDefaultWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarWeaveContainerdV1_26_0(t *testing.T) {
+func TestAwsFlatcarWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelWeaveContainerdV1_26_0(t *testing.T) {
+func TestAwsRhelWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxWeaveContainerdV1_26_0(t *testing.T) {
+func TestAwsRockylinuxWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultWeaveContainerdV1_26_0(t *testing.T) {
+func TestAzureDefaultWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosWeaveContainerdV1_26_0(t *testing.T) {
+func TestAzureCentosWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarWeaveContainerdV1_26_0(t *testing.T) {
+func TestAzureFlatcarWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelWeaveContainerdV1_26_0(t *testing.T) {
+func TestAzureRhelWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxWeaveContainerdV1_26_0(t *testing.T) {
+func TestAzureRockylinuxWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultWeaveContainerdV1_26_0(t *testing.T) {
+func TestGceDefaultWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultWeaveContainerdV1_26_0(t *testing.T) {
+func TestOpenstackDefaultWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosWeaveContainerdV1_26_0(t *testing.T) {
+func TestOpenstackCentosWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxWeaveContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelWeaveContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRhelWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarWeaveContainerdV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultWeaveContainerdV1_26_0(t *testing.T) {
+func TestVsphereDefaultWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosWeaveContainerdV1_26_0(t *testing.T) {
+func TestVsphereCentosWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarWeaveContainerdV1_26_0(t *testing.T) {
+func TestVsphereFlatcarWeaveContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["weave_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznCiliumContainerdV1_26_0(t *testing.T) {
+func TestAwsAmznCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosCiliumContainerdV1_26_0(t *testing.T) {
+func TestAwsCentosCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCiliumContainerdV1_26_0(t *testing.T) {
+func TestAwsDefaultCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCiliumContainerdV1_26_0(t *testing.T) {
+func TestAwsFlatcarCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelCiliumContainerdV1_26_0(t *testing.T) {
+func TestAwsRhelCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxCiliumContainerdV1_26_0(t *testing.T) {
+func TestAwsRockylinuxCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCiliumContainerdV1_26_0(t *testing.T) {
+func TestAzureDefaultCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCiliumContainerdV1_26_0(t *testing.T) {
+func TestAzureCentosCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCiliumContainerdV1_26_0(t *testing.T) {
+func TestAzureFlatcarCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCiliumContainerdV1_26_0(t *testing.T) {
+func TestAzureRhelCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCiliumContainerdV1_26_0(t *testing.T) {
+func TestAzureRockylinuxCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultCiliumContainerdV1_26_0(t *testing.T) {
+func TestGceDefaultCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCiliumContainerdV1_26_0(t *testing.T) {
+func TestOpenstackDefaultCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCiliumContainerdV1_26_0(t *testing.T) {
+func TestOpenstackCentosCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCiliumContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCiliumContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRhelCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCiliumContainerdV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCiliumContainerdV1_26_0(t *testing.T) {
+func TestVsphereDefaultCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCiliumContainerdV1_26_0(t *testing.T) {
+func TestVsphereCentosCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCiliumContainerdV1_26_0(t *testing.T) {
+func TestVsphereFlatcarCiliumContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["cilium_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_9(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_25_5(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_26_0(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_26_0(t *testing.T) {
+func TestAwsDefaultKubeProxyIpvsV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_5(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_26_0(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_25_5(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_26_0(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_25_5(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_26_0(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_9_ToV1_25_5(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_24_10_ToV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9", "v1.25.5")
+	scenario.SetVersions("v1.24.10", "v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestVsphereCentosStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_25_5_ToV1_26_0(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_25_6_ToV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5", "v1.26.0")
+	scenario.SetVersions("v1.25.6", "v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_5(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_25_6(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.25.5")
+	scenario.SetVersions("v1.25.6")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_26_0(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_26_1(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.26.0")
+	scenario.SetVersions("v1.26.1")
 	scenario.Run(ctx, t)
 }

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -1,5 +1,5 @@
 - scenario: install_containerd
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -24,7 +24,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.25.5
+  initVersion: v1.25.6
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -49,7 +49,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -74,8 +74,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd
-  initVersion: v1.25.5
-  upgradedVersion: v1.26.0
+  initVersion: v1.25.6
+  upgradedVersion: v1.26.1
   initKubeOneVersion: "main"
   infrastructures:
     - name: aws_amzn_stable
@@ -100,8 +100,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd
-  initVersion: v1.24.9
-  upgradedVersion: v1.25.5
+  initVersion: v1.24.10
+  upgradedVersion: v1.25.6
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -125,7 +125,7 @@
     - name: vsphere_flatcar_stable
 
 - scenario: calico_containerd
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -149,7 +149,7 @@
     - name: vsphere_flatcar
 
 - scenario: weave_containerd
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -173,7 +173,7 @@
     - name: vsphere_flatcar
 
 - scenario: cilium_containerd
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -197,42 +197,42 @@
     - name: vsphere_flatcar
 
 - scenario: conformance_containerd
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.25.5
+  initVersion: v1.25.6
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.25.5
+  initVersion: v1.25.6
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_default
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -256,7 +256,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.25.5
+  initVersion: v1.25.6
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -280,7 +280,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -304,7 +304,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -322,7 +322,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.25.5
+  initVersion: v1.25.6
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -340,7 +340,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -358,7 +358,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -391,7 +391,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.25.5
+  initVersion: v1.25.6
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -424,7 +424,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -457,8 +457,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.24.9
-  upgradedVersion: v1.25.5
+  initVersion: v1.24.10
+  upgradedVersion: v1.25.6
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -491,8 +491,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.25.5
-  upgradedVersion: v1.26.0
+  initVersion: v1.25.6
+  upgradedVersion: v1.26.1
   initKubeOneVersion: "main"
   infrastructures:
     - name: aws_amzn_stable
@@ -526,7 +526,7 @@
     - name: vsphere_flatcar_stable
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -559,7 +559,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.25.5
+  initVersion: v1.25.6
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -592,7 +592,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.26.0
+  initVersion: v1.26.1
   infrastructures:
     - name: aws_amzn
     - name: aws_centos


### PR DESCRIPTION
**What this PR does / why we need it**:

Update `kubernetes-cni` to v1.2.0 and `cri-tools` to v1.26.0. This is required for the latest (January 2023) Kubernetes patch releases.

Reference: https://github.com/kubernetes/release/pull/2863 and https://github.com/kubernetes/release/pull/2821

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update kubernetes-cni to v1.2.0 and cri-tools to v1.26.0
```

**Documentation**:
```documentation
NONE
```