### PR TITLE
[release/v1.5] Update kubernetes-cni to v1.2.0 and cri-tools to v1.26.0

### DIFF
--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	defaultKubernetesCNIVersion = "1.1.1"
-	defaultCriToolsVersion      = "1.21.0"
+	defaultKubernetesCNIVersion = "1.2.0"
+	defaultCriToolsVersion      = "1.26.0"
 )
 
 var migrateToContainerdScriptTemplate = heredoc.Doc(`

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -96,7 +96,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -127,7 +127,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -129,7 +129,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -94,7 +94,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -132,7 +132,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -91,7 +91,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -131,7 +131,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -134,7 +134,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -131,7 +131,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -131,7 +131,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -131,7 +131,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -133,7 +133,7 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -72,7 +72,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.23.9*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -69,7 +69,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.23.9*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.23.9*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.23.9*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.23.9*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.23.9*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.23.9*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 
 
 

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.23.9"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.23.9"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.23.9"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.23.9"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -61,11 +61,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.23.9"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.23.9"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd_with_insecure_registry.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.23.9"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.26.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -130,7 +130,7 @@ sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
 
 sudo yum install -y \
 	kubeadm-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.23.9*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -64,7 +64,7 @@ sudo systemctl restart containerd
 source /etc/kubeone/proxy-env
 
 sudo mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.23.9"

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -131,7 +131,7 @@ sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
 sudo yum install -y \
 	kubelet-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.1.1
+	kubernetes-cni-1.2.0
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -66,7 +66,7 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.23.9*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
 sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
 
 

--- a/pkg/templates/images/images.go
+++ b/pkg/templates/images/images.go
@@ -218,9 +218,9 @@ func baseResources() map[Resource]map[string]string {
 		CalicoNode:             {"*": "quay.io/calico/node:v3.23.5"},
 		DNSNodeCache:           {"*": "registry.k8s.io/dns/k8s-dns-node-cache:1.21.1"},
 		Flannel:                {"*": "quay.io/coreos/flannel:v0.15.1"},
-		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.54.2"},
+		MachineController:      {"*": "quay.io/kubermatic/machine-controller:v1.54.4"},
 		MetricsServer:          {"*": "registry.k8s.io/metrics-server/metrics-server:v0.6.1"},
-		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.1.1"},
+		OperatingSystemManager: {"*": "quay.io/kubermatic/operating-system-manager:v1.1.2"},
 	}
 }
 

--- a/test/e2e/prow.yaml
+++ b/test/e2e/prow.yaml
@@ -478,14 +478,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_23_15
+      - TestAwsAmznInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -501,14 +501,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_23_15
+      - TestAwsCentosInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -524,7 +524,7 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
@@ -532,7 +532,7 @@ presubmits:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_23_15
+      - TestAwsDefaultInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -548,14 +548,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_23_15
+      - TestAwsFlatcarInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -571,14 +571,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_23_15
+      - TestAwsRhelInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -594,14 +594,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_23_15
+      - TestAwsRockylinuxInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -617,14 +617,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_23_15
+      - TestAzureDefaultInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -642,14 +642,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_23_15
+      - TestAzureCentosInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -667,14 +667,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_23_15
+      - TestAzureFlatcarInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -693,14 +693,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_23_15
+      - TestAzureRhelInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -718,14 +718,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_23_15
+      - TestAzureRockylinuxInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -743,14 +743,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_23_15
+      - TestGceDefaultInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: gce
@@ -766,14 +766,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_23_15
+      - TestOpenstackDefaultInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -789,14 +789,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_23_15
+      - TestOpenstackCentosInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -812,14 +812,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_23_15
+      - TestOpenstackRockylinuxInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -835,14 +835,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_23_15
+      - TestOpenstackRhelInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -858,14 +858,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_23_15
+      - TestOpenstackFlatcarInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -881,14 +881,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_23_15
+      - TestVsphereDefaultInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -904,14 +904,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_23_15
+      - TestVsphereCentosInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -927,14 +927,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.15
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_23_15
+      - TestVsphereFlatcarInstallContainerdV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -950,14 +950,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdV1_24_9
+      - TestAwsAmznInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -973,14 +973,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-centos-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdV1_24_9
+      - TestAwsCentosInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -996,7 +996,7 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   run_if_changed: (.prow/|addons/|examples/|hack/|pkg/|test/)
@@ -1004,7 +1004,7 @@ presubmits:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdV1_24_9
+      - TestAwsDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -1020,14 +1020,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdV1_24_9
+      - TestAwsFlatcarInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -1043,14 +1043,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdV1_24_9
+      - TestAwsRhelInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -1066,14 +1066,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdV1_24_9
+      - TestAwsRockylinuxInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -1089,14 +1089,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdV1_24_9
+      - TestAzureDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -1114,14 +1114,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-centos-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdV1_24_9
+      - TestAzureCentosInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -1139,14 +1139,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdV1_24_9
+      - TestAzureFlatcarInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -1165,14 +1165,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdV1_24_9
+      - TestAzureRhelInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -1190,14 +1190,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdV1_24_9
+      - TestAzureRockylinuxInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -1215,14 +1215,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-gce-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallContainerdV1_24_9
+      - TestGceDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: gce
@@ -1238,14 +1238,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdV1_24_9
+      - TestOpenstackDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -1261,14 +1261,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdV1_24_9
+      - TestOpenstackCentosInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -1284,14 +1284,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdV1_24_9
+      - TestOpenstackRockylinuxInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -1307,14 +1307,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdV1_24_9
+      - TestOpenstackRhelInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -1330,14 +1330,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdV1_24_9
+      - TestOpenstackFlatcarInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -1353,14 +1353,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdV1_24_9
+      - TestVsphereDefaultInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -1376,14 +1376,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdV1_24_9
+      - TestVsphereCentosInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -1399,14 +1399,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdV1_24_9
+      - TestVsphereFlatcarInstallContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -1893,14 +1893,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerV1_23_15
+      - TestAwsAmznInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -1916,14 +1916,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerV1_23_15
+      - TestAwsCentosInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -1939,14 +1939,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-default-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerV1_23_15
+      - TestAwsDefaultInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -1962,14 +1962,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerV1_23_15
+      - TestAwsFlatcarInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -1985,14 +1985,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerV1_23_15
+      - TestAwsRhelInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -2008,14 +2008,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerV1_23_15
+      - TestAwsRockylinuxInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -2031,14 +2031,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-default-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerV1_23_15
+      - TestAzureDefaultInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -2056,14 +2056,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerV1_23_15
+      - TestAzureCentosInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -2081,14 +2081,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerV1_23_15
+      - TestAzureFlatcarInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -2107,14 +2107,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-rhel-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerV1_23_15
+      - TestAzureRhelInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -2132,14 +2132,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerV1_23_15
+      - TestAzureRockylinuxInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -2157,14 +2157,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.15
+  name: pull-kubeone-e2e-gce-default-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultInstallDockerV1_23_15
+      - TestGceDefaultInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: gce
@@ -2180,14 +2180,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-default-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerV1_23_15
+      - TestOpenstackDefaultInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2203,14 +2203,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-centos-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerV1_23_15
+      - TestOpenstackCentosInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2226,14 +2226,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerV1_23_15
+      - TestOpenstackRockylinuxInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2249,14 +2249,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerV1_23_15
+      - TestOpenstackRhelInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2272,14 +2272,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerV1_23_15
+      - TestOpenstackFlatcarInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -2295,14 +2295,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.15
+  name: pull-kubeone-e2e-vsphere-default-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerV1_23_15
+      - TestVsphereDefaultInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -2318,14 +2318,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.23.15
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerV1_23_15
+      - TestVsphereCentosInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -2341,14 +2341,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.15
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerV1_23_15
+      - TestVsphereFlatcarInstallDockerV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -2369,14 +2369,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      - TestAwsAmznStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -2397,14 +2397,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      - TestAwsCentosStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -2425,14 +2425,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      - TestAwsDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -2453,14 +2453,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -2481,14 +2481,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      - TestAwsRhelStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -2509,14 +2509,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -2537,14 +2537,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      - TestAzureDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -2567,14 +2567,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
+      - TestAzureCentosStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -2597,557 +2597,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-gce: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -3171,14 +2628,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestAzureRhelStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -3201,14 +2658,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -3231,14 +2688,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestGceDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: gce
@@ -3259,14 +2716,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -3287,14 +2744,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -3315,14 +2772,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -3343,14 +2800,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -3371,14 +2828,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -3399,14 +2856,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -3427,14 +2884,557 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.23.16-to-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: gce
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-from-v1.22.17-to-v1.23.16
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -3998,14 +3998,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAwsAmznStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -4026,14 +4026,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAwsCentosStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -4054,14 +4054,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAwsDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -4082,14 +4082,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAwsFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -4110,14 +4110,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAwsRhelStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -4138,14 +4138,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAwsRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -4166,14 +4166,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAzureDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -4196,14 +4196,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAzureCentosStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -4226,14 +4226,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAzureFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -4257,14 +4257,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAzureRhelStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -4287,14 +4287,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestAzureRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -4317,14 +4317,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-gce-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestGceDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: gce
@@ -4345,14 +4345,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestOpenstackDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -4373,14 +4373,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestOpenstackCentosStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -4401,14 +4401,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestOpenstackRockylinuxUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -4429,14 +4429,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestOpenstackRhelStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -4457,14 +4457,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestOpenstackFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -4485,14 +4485,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestVsphereDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -4513,14 +4513,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15
+      - TestVsphereFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -7930,14 +7930,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_15
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -7955,14 +7955,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.9
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_9
+      - TestAwsLongTimeoutDefaultConformanceContainerdV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -8005,14 +8005,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_15
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -8030,14 +8030,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-aws-long-timeout-default-conformance-containerd-external-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_9
+      - TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -8078,14 +8078,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.23.15
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_23_15
+      - TestAwsDefaultKubeProxyIpvsV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -8572,14 +8572,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_23_15
+      - TestAwsAmznLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -8595,14 +8595,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_23_15
+      - TestAwsCentosLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -8618,14 +8618,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_15
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -8641,14 +8641,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_15
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -8664,14 +8664,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_23_15
+      - TestAwsRhelLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -8687,14 +8687,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_15
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -8710,14 +8710,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.15
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_15
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -8735,14 +8735,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_23_15
+      - TestAzureCentosLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -8760,485 +8760,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-gce: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: gce
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_9
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -9257,14 +8786,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdV1_24_9
+      - TestAzureRhelLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -9282,14 +8811,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_9
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -9307,14 +8836,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerContainerdV1_24_9
+      - TestGceDefaultLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: gce
@@ -9330,14 +8859,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -9353,14 +8882,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -9376,14 +8905,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -9399,14 +8928,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -9422,14 +8951,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_9
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -9445,14 +8974,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_9
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -9468,14 +8997,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_9
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -9491,14 +9020,485 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_9
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_16
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-gce: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestGceDefaultLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: gce
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdV1_24_10
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -9985,14 +9985,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerDockerV1_23_15
+      - TestAwsAmznLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -10008,14 +10008,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerDockerV1_23_15
+      - TestAwsCentosLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -10031,14 +10031,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerDockerV1_23_15
+      - TestAwsDefaultLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -10054,14 +10054,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_15
+      - TestAwsFlatcarLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -10077,14 +10077,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerDockerV1_23_15
+      - TestAwsRhelLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -10100,14 +10100,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_15
+      - TestAwsRockylinuxLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -10123,14 +10123,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerDockerV1_23_15
+      - TestAzureDefaultLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -10148,14 +10148,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerDockerV1_23_15
+      - TestAzureCentosLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -10173,14 +10173,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_15
+      - TestAzureFlatcarLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -10199,14 +10199,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerDockerV1_23_15
+      - TestAzureRhelLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -10224,14 +10224,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_15
+      - TestAzureRockylinuxLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -10249,14 +10249,14 @@ presubmits:
   labels:
     preset-gce: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-gce-default-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestGceDefaultLegacyMachineControllerDockerV1_23_15
+      - TestGceDefaultLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: gce
@@ -10272,14 +10272,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_15
+      - TestOpenstackDefaultLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10295,14 +10295,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_15
+      - TestOpenstackCentosLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10318,14 +10318,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_15
+      - TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10341,14 +10341,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_15
+      - TestOpenstackRhelLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10364,14 +10364,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_15
+      - TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10387,14 +10387,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_15
+      - TestVsphereDefaultLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -10410,14 +10410,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerDockerV1_23_15
+      - TestVsphereCentosLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -10433,14 +10433,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.15
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-docker-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_15
+      - TestVsphereFlatcarLegacyMachineControllerDockerV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -10456,14 +10456,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.24.9
+  name: pull-kubeone-e2e-aws-default-kube-proxy-ipvs-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultKubeProxyIpvsV1_24_9
+      - TestAwsDefaultKubeProxyIpvsV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -10812,14 +10812,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_23_15
+      - TestAwsDefaultCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -10835,14 +10835,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_23_15
+      - TestOpenstackDefaultCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10858,14 +10858,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_23_15
+      - TestOpenstackCentosCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10881,14 +10881,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_15
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10904,14 +10904,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_23_15
+      - TestOpenstackRhelCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10927,14 +10927,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_23_15
+      - TestOpenstackFlatcarCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -10950,14 +10950,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_23_15
+      - TestAzureDefaultCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -10975,14 +10975,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_23_15
+      - TestAzureCentosCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -11000,14 +11000,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_23_15
+      - TestAzureFlatcarCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -11026,14 +11026,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_23_15
+      - TestAzureRhelCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -11051,14 +11051,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_23_15
+      - TestAzureRockylinuxCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -11076,14 +11076,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_23_15
+      - TestVsphereDefaultCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -11099,14 +11099,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_23_15
+      - TestVsphereCentosCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -11122,14 +11122,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.15
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_23_15
+      - TestVsphereFlatcarCsiCcmMigrationV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -11145,14 +11145,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-aws-default-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultCsiCcmMigrationV1_24_9
+      - TestAwsDefaultCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: aws
@@ -11168,14 +11168,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultCsiCcmMigrationV1_24_9
+      - TestOpenstackDefaultCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -11191,14 +11191,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosCsiCcmMigrationV1_24_9
+      - TestOpenstackCentosCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -11214,14 +11214,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_9
+      - TestOpenstackRockylinuxCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -11237,14 +11237,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelCsiCcmMigrationV1_24_9
+      - TestOpenstackRhelCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -11260,14 +11260,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarCsiCcmMigrationV1_24_9
+      - TestOpenstackFlatcarCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: openstack
@@ -11283,14 +11283,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-default-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultCsiCcmMigrationV1_24_9
+      - TestAzureDefaultCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -11308,14 +11308,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-centos-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosCsiCcmMigrationV1_24_9
+      - TestAzureCentosCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -11333,14 +11333,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-flatcar-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarCsiCcmMigrationV1_24_9
+      - TestAzureFlatcarCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -11359,14 +11359,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelCsiCcmMigrationV1_24_9
+      - TestAzureRhelCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -11384,14 +11384,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxCsiCcmMigrationV1_24_9
+      - TestAzureRockylinuxCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: azure
@@ -11409,14 +11409,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultCsiCcmMigrationV1_24_9
+      - TestVsphereDefaultCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -11432,14 +11432,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-vsphere-centos-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosCsiCcmMigrationV1_24_9
+      - TestVsphereCentosCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -11455,14 +11455,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-csi-ccm-migration-v1.24.10
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarCsiCcmMigrationV1_24_9
+      - TestVsphereFlatcarCsiCcmMigrationV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -12156,14 +12156,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_23_15
+      - TestAwsAmznInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -12179,14 +12179,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_23_15
+      - TestAwsCentosInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -12202,14 +12202,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_23_15
+      - TestAwsDefaultInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -12225,14 +12225,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_23_15
+      - TestAwsFlatcarInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -12248,14 +12248,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_23_15
+      - TestAwsRhelInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -12271,14 +12271,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_23_15
+      - TestAwsRockylinuxInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -12294,14 +12294,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_23_15
+      - TestAzureDefaultInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -12319,14 +12319,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_23_15
+      - TestAzureCentosInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -12344,692 +12344,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallContainerdExternalV1_24_9
+      - TestAzureFlatcarInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -13048,14 +12370,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallContainerdExternalV1_24_9
+      - TestAzureRhelInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -13073,14 +12395,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallContainerdExternalV1_24_9
+      - TestAzureRockylinuxInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -13098,14 +12420,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_9
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13121,14 +12443,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallContainerdExternalV1_24_9
+      - TestDigitaloceanCentosInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13144,14 +12466,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_9
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -13167,14 +12489,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_9
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13190,14 +12512,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallContainerdExternalV1_24_9
+      - TestEquinixmetalCentosInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13213,14 +12535,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_9
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13236,14 +12558,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_9
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -13259,14 +12581,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallContainerdExternalV1_24_9
+      - TestHetznerDefaultInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -13282,14 +12604,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallContainerdExternalV1_24_9
+      - TestHetznerCentosInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -13305,14 +12627,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallContainerdExternalV1_24_9
+      - TestHetznerRockylinuxInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -13328,14 +12650,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallContainerdExternalV1_24_9
+      - TestOpenstackDefaultInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -13351,14 +12673,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallContainerdExternalV1_24_9
+      - TestOpenstackCentosInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -13374,14 +12696,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_9
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -13397,14 +12719,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallContainerdExternalV1_24_9
+      - TestOpenstackRhelInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -13420,14 +12742,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallContainerdExternalV1_24_9
+      - TestOpenstackFlatcarInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -13443,14 +12765,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallContainerdExternalV1_24_9
+      - TestVsphereDefaultInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -13466,14 +12788,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallContainerdExternalV1_24_9
+      - TestVsphereCentosInstallContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -13489,14 +12811,692 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallContainerdExternalV1_24_9
+      - TestVsphereFlatcarInstallContainerdExternalV1_23_16
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosInstallContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-install-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarInstallContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -14190,14 +14190,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznInstallDockerExternalV1_23_15
+      - TestAwsAmznInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -14213,14 +14213,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosInstallDockerExternalV1_23_15
+      - TestAwsCentosInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -14236,14 +14236,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-aws-default-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultInstallDockerExternalV1_23_15
+      - TestAwsDefaultInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -14259,14 +14259,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarInstallDockerExternalV1_23_15
+      - TestAwsFlatcarInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -14282,14 +14282,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelInstallDockerExternalV1_23_15
+      - TestAwsRhelInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -14305,14 +14305,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxInstallDockerExternalV1_23_15
+      - TestAwsRockylinuxInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -14328,14 +14328,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-azure-default-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultInstallDockerExternalV1_23_15
+      - TestAzureDefaultInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -14353,14 +14353,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosInstallDockerExternalV1_23_15
+      - TestAzureCentosInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -14378,14 +14378,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarInstallDockerExternalV1_23_15
+      - TestAzureFlatcarInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -14404,14 +14404,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-azure-rhel-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelInstallDockerExternalV1_23_15
+      - TestAzureRhelInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -14429,14 +14429,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-azure-rockylinux-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxInstallDockerExternalV1_23_15
+      - TestAzureRockylinuxInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -14454,14 +14454,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-digitalocean-default-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultInstallDockerExternalV1_23_15
+      - TestDigitaloceanDefaultInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14477,14 +14477,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-digitalocean-centos-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosInstallDockerExternalV1_23_15
+      - TestDigitaloceanCentosInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14500,14 +14500,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-digitalocean-rockylinux-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_15
+      - TestDigitaloceanRockylinuxInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -14523,14 +14523,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-default-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultInstallDockerExternalV1_23_15
+      - TestEquinixmetalDefaultInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14546,14 +14546,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-centos-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosInstallDockerExternalV1_23_15
+      - TestEquinixmetalCentosInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14569,14 +14569,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_15
+      - TestEquinixmetalRockylinuxInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14592,14 +14592,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-flatcar-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_15
+      - TestEquinixmetalFlatcarInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -14615,14 +14615,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-hetzner-default-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultInstallDockerExternalV1_23_15
+      - TestHetznerDefaultInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -14638,14 +14638,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-hetzner-centos-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosInstallDockerExternalV1_23_15
+      - TestHetznerCentosInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -14661,14 +14661,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-hetzner-rockylinux-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxInstallDockerExternalV1_23_15
+      - TestHetznerRockylinuxInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -14684,14 +14684,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-openstack-default-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultInstallDockerExternalV1_23_15
+      - TestOpenstackDefaultInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -14707,14 +14707,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-openstack-centos-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosInstallDockerExternalV1_23_15
+      - TestOpenstackCentosInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -14730,14 +14730,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-openstack-rockylinux-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxInstallDockerExternalV1_23_15
+      - TestOpenstackRockylinuxInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -14753,14 +14753,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-openstack-rhel-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelInstallDockerExternalV1_23_15
+      - TestOpenstackRhelInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -14776,14 +14776,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-openstack-flatcar-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarInstallDockerExternalV1_23_15
+      - TestOpenstackFlatcarInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -14799,14 +14799,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-vsphere-default-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultInstallDockerExternalV1_23_15
+      - TestVsphereDefaultInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -14822,14 +14822,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-vsphere-centos-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosInstallDockerExternalV1_23_15
+      - TestVsphereCentosInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -14845,14 +14845,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.15
+  name: pull-kubeone-e2e-vsphere-flatcar-install-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarInstallDockerExternalV1_23_15
+      - TestVsphereFlatcarInstallDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -15668,14 +15668,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -15696,14 +15696,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -15724,14 +15724,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -15752,14 +15752,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -15780,14 +15780,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -15808,14 +15808,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -15836,14 +15836,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -15866,14 +15866,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -15896,809 +15896,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  extra_refs:
-  - base_ref: release/v1.4
-    org: kubermatic
-    path_alias: k8c.io/kubeone-stable
-    repo: kubeone
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -16722,14 +15927,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -16752,14 +15957,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -16782,14 +15987,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16810,14 +16015,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16838,14 +16043,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -16866,14 +16071,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16894,14 +16099,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16922,14 +16127,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16950,14 +16155,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -16978,14 +16183,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -17006,14 +16211,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -17034,14 +16239,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -17062,14 +16267,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -17090,14 +16295,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -17118,14 +16323,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -17146,14 +16351,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -17174,14 +16379,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -17202,14 +16407,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -17230,14 +16435,809 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.23.15-to-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  extra_refs:
+  - base_ref: release/v1.4
+    org: kubermatic
+    path_alias: k8c.io/kubeone-stable
+    repo: kubeone
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-containerd-external-from-v1.23.16-to-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -18053,14 +18053,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAwsAmznStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -18081,14 +18081,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAwsCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -18109,14 +18109,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAwsDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -18137,14 +18137,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -18165,14 +18165,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAwsRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -18193,14 +18193,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -18221,14 +18221,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAzureDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -18251,14 +18251,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAzureCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -18281,14 +18281,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -18312,14 +18312,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-rhel-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAzureRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -18342,14 +18342,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-azure-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -18372,14 +18372,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-digitalocean-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18400,14 +18400,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-digitalocean-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18428,14 +18428,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-digitalocean-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -18456,14 +18456,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18484,14 +18484,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18512,14 +18512,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18540,14 +18540,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -18568,14 +18568,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-hetzner-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -18596,14 +18596,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-hetzner-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestHetznerCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -18624,14 +18624,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-hetzner-rockylinux-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -18652,14 +18652,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -18680,14 +18680,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-centos-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -18708,14 +18708,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-rockylinux-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -18736,14 +18736,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-rhel-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -18764,14 +18764,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-openstack-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -18792,14 +18792,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-vsphere-default-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -18820,14 +18820,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.15
+  name: pull-kubeone-e2e-vsphere-flatcar-stable-upgrade-docker-external-from-v1.22.17-to-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15
+      - TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -19521,14 +19521,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_15
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -19544,14 +19544,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_15
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -19567,14 +19567,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_15
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -19590,14 +19590,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-flatcar-cloud-init-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_15
+      - TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -19613,14 +19613,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_15
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -19636,14 +19636,14 @@ presubmits:
   labels:
     preset-aws-e2e-kubeone: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: aws
@@ -19659,14 +19659,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_15
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -19684,14 +19684,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_15
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -19709,692 +19709,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.15
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-    preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-digitalocean: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: digitalocean
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-equinix-metal: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: equinixmetal
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: hetzner
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: openstack
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-goproxy: "true"
-    preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.15
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_15
-      env:
-      - name: PROVIDER
-        value: vsphere
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-aws-e2e-kubeone: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: aws
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_9
-      env:
-      - name: PROVIDER
-        value: azure
-      - name: TEST_TIMEOUT
-        value: 120m
-      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
-      imagePullPolicy: Always
-      name: ""
-      resources:
-        requests:
-          cpu: "1"
-- always_run: false
-  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
-  decorate: true
-  labels:
-    preset-azure: "true"
-    preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.9
-  optional: false
-  path_alias: k8c.io/kubeone
-  spec:
-    containers:
-    - command:
-      - ./test/go-test-e2e.sh
-      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -20413,14 +19735,14 @@ presubmits:
     preset-azure: "true"
     preset-goproxy: "true"
     preset-rhel: "true"
-  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -20438,14 +19760,14 @@ presubmits:
   labels:
     preset-azure: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: azure
@@ -20463,14 +19785,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20486,14 +19808,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20509,14 +19831,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -20532,14 +19854,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20555,14 +19877,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20578,14 +19900,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20601,14 +19923,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_9
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -20624,14 +19946,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -20647,14 +19969,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -20670,14 +19992,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -20693,14 +20015,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20716,14 +20038,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20739,14 +20061,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20762,14 +20084,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20785,14 +20107,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-openstack: "true"
-  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_9
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: openstack
@@ -20808,14 +20130,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_9
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -20831,14 +20153,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere: "true"
-  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_9
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_16
       env:
       - name: PROVIDER
         value: vsphere
@@ -20854,14 +20176,692 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-vsphere-legacy: "true"
-  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.9
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_9
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_16
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-amzn-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-centos-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-default-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-flatcar-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rhel-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-aws-e2e-kubeone: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-aws-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: aws
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-default-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-centos-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-flatcar-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+    preset-rhel: "true"
+  name: pull-kubeone-e2e-azure-rhel-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-azure: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-azure-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: azure
+      - name: TEST_TIMEOUT
+        value: 120m
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-digitalocean: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: digitalocean
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-equinix-metal: "true"
+    preset-goproxy: "true"
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: equinixmetal
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-hetzner: "true"
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: hetzner
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-default-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-centos-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rockylinux-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-rhel-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-openstack: "true"
+  name: pull-kubeone-e2e-openstack-flatcar-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: openstack
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-default-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere: "true"
+  name: pull-kubeone-e2e-vsphere-centos-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_10
+      env:
+      - name: PROVIDER
+        value: vsphere
+      image: quay.io/kubermatic/kubeone-e2e:v0.1.28
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: "1"
+- always_run: false
+  clone_uri: ssh://git@github.com/kubermatic/kubeone.git
+  decorate: true
+  labels:
+    preset-goproxy: "true"
+    preset-vsphere-legacy: "true"
+  name: pull-kubeone-e2e-vsphere-flatcar-legacy-machine-controller-containerd-external-v1.24.10
+  optional: false
+  path_alias: k8c.io/kubeone
+  spec:
+    containers:
+    - command:
+      - ./test/go-test-e2e.sh
+      - TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_10
       env:
       - name: PROVIDER
         value: vsphere
@@ -21107,14 +21107,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-digitalocean-default-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_15
+      - TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -21130,14 +21130,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-digitalocean-centos-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_15
+      - TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -21153,14 +21153,14 @@ presubmits:
   labels:
     preset-digitalocean: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-digitalocean-rockylinux-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_15
+      - TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: digitalocean
@@ -21176,14 +21176,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-default-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_15
+      - TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21199,14 +21199,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-centos-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_15
+      - TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21222,14 +21222,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-rockylinux-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_15
+      - TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21245,14 +21245,14 @@ presubmits:
   labels:
     preset-equinix-metal: "true"
     preset-goproxy: "true"
-  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-equinixmetal-flatcar-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_15
+      - TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: equinixmetal
@@ -21268,14 +21268,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-hetzner-default-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_15
+      - TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -21291,14 +21291,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-hetzner-centos-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_15
+      - TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner
@@ -21314,14 +21314,14 @@ presubmits:
   labels:
     preset-goproxy: "true"
     preset-hetzner: "true"
-  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.15
+  name: pull-kubeone-e2e-hetzner-rockylinux-legacy-machine-controller-docker-external-v1.23.16
   optional: false
   path_alias: k8c.io/kubeone
   spec:
     containers:
     - command:
       - ./test/go-test-e2e.sh
-      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_15
+      - TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_16
       env:
       - name: PROVIDER
         value: hetzner

--- a/test/e2e/tests_test.go
+++ b/test/e2e/tests_test.go
@@ -190,363 +190,363 @@ func TestVsphereFlatcarInstallContainerdV1_22_17(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_23_15(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_23_15(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_23_15(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_23_15(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_23_15(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_23_15(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_23_15(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_23_15(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_23_15(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_23_15(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_23_15(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_23_15(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_23_15(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_23_15(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_23_15(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_23_15(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_23_15(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_23_15(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsAmznInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsCentosInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsFlatcarInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsRhelInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdV1_24_9(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureCentosInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureFlatcarInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureRhelInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdV1_24_9(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestGceDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackCentosInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackRhelInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdV1_24_9(t *testing.T) {
+func TestVsphereDefaultInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdV1_24_9(t *testing.T) {
+func TestVsphereCentosInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdV1_24_9(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
@@ -730,525 +730,525 @@ func TestVsphereFlatcarInstallDockerV1_22_17(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerV1_23_15(t *testing.T) {
+func TestAwsAmznInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerV1_23_15(t *testing.T) {
+func TestAwsCentosInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerV1_23_15(t *testing.T) {
+func TestAwsDefaultInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerV1_23_15(t *testing.T) {
+func TestAwsFlatcarInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerV1_23_15(t *testing.T) {
+func TestAwsRhelInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerV1_23_15(t *testing.T) {
+func TestAwsRockylinuxInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerV1_23_15(t *testing.T) {
+func TestAzureDefaultInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerV1_23_15(t *testing.T) {
+func TestAzureCentosInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerV1_23_15(t *testing.T) {
+func TestAzureFlatcarInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerV1_23_15(t *testing.T) {
+func TestAzureRhelInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerV1_23_15(t *testing.T) {
+func TestAzureRockylinuxInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultInstallDockerV1_23_15(t *testing.T) {
+func TestGceDefaultInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerV1_23_15(t *testing.T) {
+func TestOpenstackDefaultInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerV1_23_15(t *testing.T) {
+func TestOpenstackCentosInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerV1_23_15(t *testing.T) {
+func TestOpenstackRhelInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerV1_23_15(t *testing.T) {
+func TestVsphereDefaultInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerV1_23_15(t *testing.T) {
+func TestVsphereCentosInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerV1_23_15(t *testing.T) {
+func TestVsphereFlatcarInstallDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestGceDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
@@ -1423,174 +1423,174 @@ func TestVsphereFlatcarStableUpgradeContainerdFromV1_21_14_ToV1_22_17(t *testing
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestGceDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
@@ -2854,21 +2854,21 @@ func TestAwsLongTimeoutDefaultConformanceContainerdV1_22_17(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_15(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_9(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
@@ -2881,21 +2881,21 @@ func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_22_17(t *testing.T
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsLongTimeoutDefaultConformanceContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_long_timeout_default"]
 	scenario := Scenarios["conformance_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
@@ -2908,12 +2908,12 @@ func TestAwsDefaultKubeProxyIpvsV1_22_17(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_23_15(t *testing.T) {
+func TestAwsDefaultKubeProxyIpvsV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
@@ -3097,363 +3097,363 @@ func TestVsphereFlatcarLegacyMachineControllerContainerdV1_22_17(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_15(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
@@ -3637,192 +3637,192 @@ func TestVsphereFlatcarLegacyMachineControllerDockerV1_22_17(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestGceDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestGceDefaultLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["gce_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_15(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerDockerV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultKubeProxyIpvsV1_24_9(t *testing.T) {
+func TestAwsDefaultKubeProxyIpvsV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["kube_proxy_ipvs"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
@@ -3952,255 +3952,255 @@ func TestVsphereFlatcarCsiCcmMigrationV1_22_17(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_23_15(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAwsDefaultCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackDefaultCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackCentosCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackRhelCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureDefaultCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureCentosCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureFlatcarCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureRhelCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestAzureRockylinuxCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestVsphereDefaultCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestVsphereCentosCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarCsiCcmMigrationV1_24_9(t *testing.T) {
+func TestVsphereFlatcarCsiCcmMigrationV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["csi_ccm_migration"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
@@ -4465,525 +4465,525 @@ func TestVsphereFlatcarInstallContainerdExternalV1_22_17(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_23_15(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsAmznInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsRhelInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureRhelInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackRhelInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereDefaultInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereCentosInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereFlatcarInstallContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
@@ -5248,264 +5248,264 @@ func TestVsphereFlatcarInstallDockerExternalV1_22_17(t *testing.T) {
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAwsAmznInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAwsCentosInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAwsDefaultInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAwsFlatcarInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAwsRhelInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAwsRockylinuxInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAzureDefaultInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAzureCentosInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAzureFlatcarInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAzureRhelInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
+func TestAzureRockylinuxInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultInstallDockerExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanDefaultInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosInstallDockerExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanCentosInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanRockylinuxInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultInstallDockerExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalDefaultInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosInstallDockerExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalCentosInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalRockylinuxInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalFlatcarInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultInstallDockerExternalV1_23_15(t *testing.T) {
+func TestHetznerDefaultInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosInstallDockerExternalV1_23_15(t *testing.T) {
+func TestHetznerCentosInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
+func TestHetznerRockylinuxInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultInstallDockerExternalV1_23_15(t *testing.T) {
+func TestOpenstackDefaultInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosInstallDockerExternalV1_23_15(t *testing.T) {
+func TestOpenstackCentosInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxInstallDockerExternalV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelInstallDockerExternalV1_23_15(t *testing.T) {
+func TestOpenstackRhelInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultInstallDockerExternalV1_23_15(t *testing.T) {
+func TestVsphereDefaultInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosInstallDockerExternalV1_23_15(t *testing.T) {
+func TestVsphereCentosInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarInstallDockerExternalV1_23_15(t *testing.T) {
+func TestVsphereFlatcarInstallDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["install_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
@@ -5761,507 +5761,507 @@ func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_21_14_ToV1_22_17(t 
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsAmznStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsRhelStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureRhelStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestHetznerDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestHetznerCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackCentosStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackRhelStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestVsphereDefaultStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_15_ToV1_24_9(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeContainerdExternalFromV1_23_16_ToV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15", "v1.24.9")
+	scenario.SetVersions("v1.23.16", "v1.24.10")
 	scenario.Run(ctx, t)
 }
 
@@ -6517,255 +6517,255 @@ func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_21_14_ToV1_22_17(t *tes
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsAmznStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAwsRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestAzureRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestDigitaloceanDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestDigitaloceanCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestDigitaloceanRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestEquinixmetalDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestEquinixmetalCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestEquinixmetalRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestEquinixmetalFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestHetznerDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestHetznerCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestHetznerRockylinuxStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackCentosStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackRhelStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestVsphereDefaultStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_15(t *testing.T) {
+func TestVsphereFlatcarStableUpgradeDockerExternalFromV1_22_17_ToV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar_stable"]
 	scenario := Scenarios["upgrade_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.22.17", "v1.23.15")
+	scenario.SetVersions("v1.22.17", "v1.23.16")
 	scenario.Run(ctx, t)
 }
 
@@ -7030,525 +7030,525 @@ func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_22_17(t *test
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsFlatcarCloudInitLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar_cloud_init"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_15(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsAmznLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_amzn"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsRhelLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAwsRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["aws_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureRhelLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestAzureRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["azure_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackRockylinuxLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackRhelLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_rhel"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestOpenstackFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["openstack_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereDefaultLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_default"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereCentosLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_centos"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
-func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_9(t *testing.T) {
+func TestVsphereFlatcarLegacyMachineControllerContainerdExternalV1_24_10(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["vsphere_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_containerd_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.24.9")
+	scenario.SetVersions("v1.24.10")
 	scenario.Run(ctx, t)
 }
 
@@ -7642,92 +7642,92 @@ func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_22_17(t *testi
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanDefaultLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanCentosLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestDigitaloceanRockylinuxLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["digitalocean_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalDefaultLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalCentosLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalRockylinuxLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestEquinixmetalFlatcarLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["equinixmetal_flatcar"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestHetznerDefaultLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_default"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestHetznerCentosLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_centos"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }
 
-func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_15(t *testing.T) {
+func TestHetznerRockylinuxLegacyMachineControllerDockerExternalV1_23_16(t *testing.T) {
 	ctx := NewSignalContext()
 	infra := Infrastructures["hetzner_rockylinux"]
 	scenario := Scenarios["legacy_machine_controller_docker_external"]
 	scenario.SetInfra(infra)
-	scenario.SetVersions("v1.23.15")
+	scenario.SetVersions("v1.23.16")
 	scenario.Run(ctx, t)
 }

--- a/test/tests.yml
+++ b/test/tests.yml
@@ -24,7 +24,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -49,7 +49,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -98,7 +98,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -122,8 +122,8 @@
     - name: vsphere_flatcar
 
 - scenario: upgrade_containerd
-  initVersion: v1.23.15
-  upgradedVersion: v1.24.9
+  initVersion: v1.23.16
+  upgradedVersion: v1.24.10
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -147,7 +147,7 @@
 
 - scenario: upgrade_containerd
   initVersion: v1.22.17
-  upgradedVersion: v1.23.15
+  upgradedVersion: v1.23.16
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -195,7 +195,7 @@
 
 - scenario: upgrade_docker
   initVersion: v1.22.17
-  upgradedVersion: v1.23.15
+  upgradedVersion: v1.23.16
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -391,12 +391,12 @@
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_long_timeout_default
 
@@ -406,12 +406,12 @@
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_long_timeout_default
 
 - scenario: conformance_containerd_external
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_long_timeout_default
 
@@ -421,7 +421,7 @@
     - name: aws_default
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_default
 
@@ -450,7 +450,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -474,7 +474,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -522,7 +522,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_docker
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -546,7 +546,7 @@
     - name: vsphere_flatcar
 
 - scenario: kube_proxy_ipvs
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_default
 
@@ -569,7 +569,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_default  
     - name: openstack_default
@@ -587,7 +587,7 @@
     - name: vsphere_flatcar
 
 - scenario: csi_ccm_migration
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_default
     - name: openstack_default
@@ -638,7 +638,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -671,7 +671,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_containerd_external
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -737,7 +737,7 @@
     - name: vsphere_flatcar
 
 - scenario: install_docker_external
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -804,7 +804,7 @@
 
 - scenario: upgrade_containerd_external
   initVersion: v1.22.17
-  upgradedVersion: v1.23.15
+  upgradedVersion: v1.23.16
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -836,8 +836,8 @@
     - name: vsphere_flatcar_stable
 
 - scenario: upgrade_containerd_external
-  initVersion: v1.23.15
-  upgradedVersion: v1.24.9
+  initVersion: v1.23.16
+  upgradedVersion: v1.24.10
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -903,7 +903,7 @@
 
 - scenario: upgrade_docker_external
   initVersion: v1.22.17
-  upgradedVersion: v1.23.15
+  upgradedVersion: v1.23.16
   infrastructures:
     - name: aws_amzn_stable
     - name: aws_centos_stable
@@ -968,7 +968,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -1001,7 +1001,7 @@
     - name: vsphere_flatcar
 
 - scenario: legacy_machine_controller_containerd_external
-  initVersion: v1.24.9
+  initVersion: v1.24.10
   infrastructures:
     - name: aws_amzn
     - name: aws_centos
@@ -1048,7 +1048,7 @@
     - name: hetzner_rockylinux
 
 - scenario: legacy_machine_controller_docker_external
-  initVersion: v1.23.15
+  initVersion: v1.23.16
   infrastructures:
     - name: digitalocean_default
     - name: digitalocean_centos


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual backport of #2606 to the `release/v1.5` branch.

**Which issue(s) this PR fixes**:
xref #2607

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update kubernetes-cni to v1.2.0 and cri-tools to v1.26.0
```

**Documentation**:
```documentation
NONE
```