### PR TITLE
[release/v1.5] Actually bind cri-tools version for Ubuntu, CentOS, and Amazon Linux

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -1,4 +1,4 @@
-# [v1.5.6](https://github.com/kubermatic/kubeone/releases/tag/v1.5.6) - 2023-01-26
+# [v1.5.6](https://github.com/kubermatic/kubeone/releases/tag/v1.5.6) - 2023-01-27
 
 ## Changelog since v1.5.5
 

--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -130,7 +130,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 {{- end }}
 
 {{- if and .KUBECTL .KUBECTL_URL }}
@@ -142,7 +141,7 @@ rm /tmp/k8s-binaries/kubectl
 
 {{ if .USE_KUBERNETES_REPO }}
 {{- if or .FORCE .UPGRADE }}
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 {{- end }}
 
 sudo yum install -y \
@@ -155,8 +154,9 @@ sudo yum install -y \
 {{- if .KUBECTL }}
 	kubectl-{{ .KUBERNETES_VERSION }} \
 {{- end }}
-	kubernetes-cni-{{ .KUBERNETES_CNI_VERSION }}
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-{{ .KUBERNETES_CNI_VERSION }} \
+	cri-tools-{{ .CRITOOLS_VERSION }}
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 {{- end }}
 
 sudo systemctl daemon-reload
@@ -170,12 +170,13 @@ sudo systemctl restart kubelet
 	removeBinariesAmazonLinuxScriptTemplate = `
 sudo systemctl stop kubelet || true
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 sudo yum remove -y \
 	kubelet \
 	kubeadm \
 	kubectl \
-	kubernetes-cni
+	kubernetes-cni \
+	cri-tools
 
 # Stop kubelet
 # Remove CNI and binaries
@@ -205,6 +206,7 @@ func KubeadmAmazonLinux(cluster *kubeoneapi.KubeOneCluster, force bool) (string,
 		"KUBECTL_URL":            cluster.AssetConfiguration.Kubectl.URL,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"FORCE":                  force,
@@ -242,6 +244,7 @@ func UpgradeKubeadmAndCNIAmazonLinux(cluster *kubeoneapi.KubeOneCluster) (string
 		"CNI_URL":                cluster.AssetConfiguration.CNI.URL,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
@@ -273,6 +276,7 @@ func UpgradeKubeletAndKubectlAmazonLinux(cluster *kubeoneapi.KubeOneCluster) (st
 		"KUBECTL_URL":            cluster.AssetConfiguration.Kubectl.URL,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -88,7 +88,7 @@ sudo systemctl enable --now iscsid
 {{ end }}
 
 {{- if or .FORCE .UPGRADE }}
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 {{- end }}
 
 sudo yum install -y \
@@ -101,8 +101,9 @@ sudo yum install -y \
 {{- if .KUBECTL }}
 	kubectl-{{ .KUBERNETES_VERSION }} \
 {{- end }}
-	kubernetes-cni-{{ .KUBERNETES_CNI_VERSION }}
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-{{ .KUBERNETES_CNI_VERSION }} \
+	cri-tools-{{ .CRITOOLS_VERSION }}
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
@@ -111,12 +112,12 @@ sudo systemctl restart kubelet
 {{ end }}
 `
 	removeBinariesCentOSScriptTemplate = `
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 sudo yum remove -y \
 	kubelet \
 	kubeadm \
 	kubectl
-sudo yum remove -y kubernetes-cni || true
+sudo yum remove -y kubernetes-cni cri-tools || true
 sudo rm -rf /opt/cni
 sudo rm -f /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 sudo systemctl daemon-reload
@@ -143,6 +144,7 @@ func KubeadmCentOS(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"FORCE":                  force,
@@ -178,6 +180,7 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
@@ -207,6 +210,7 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeoneapi.KubeOneCluster) (string,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -72,9 +72,10 @@ sudo apt-get update
 
 kube_ver="{{ .KUBERNETES_VERSION }}*"
 cni_ver="{{ .KUBERNETES_CNI_VERSION }}*"
+cri_ver="{{ .CRITOOLS_VERSION }}*"
 
 {{- if or .FORCE .UPGRADE }}
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 {{- end }}
 
 {{ if .INSTALL_DOCKER }}
@@ -101,9 +102,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 {{- if .KUBECTL }}
 	kubectl=${kube_ver} \
 {{- end }}
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
@@ -114,12 +116,12 @@ sudo systemctl restart kubelet
 `
 
 	removeBinariesDebianScriptTemplate = `
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo apt-get remove --purge -y \
 	kubeadm \
 	kubectl \
 	kubelet
-sudo apt-get remove --purge -y kubernetes-cni || true
+sudo apt-get remove --purge -y kubernetes-cni cri-tools || true
 sudo rm -rf /opt/cni
 sudo rm -f /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 sudo systemctl daemon-reload
@@ -133,6 +135,7 @@ func KubeadmDebian(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
@@ -164,6 +167,7 @@ func UpgradeKubeadmAndCNIDebian(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
@@ -189,6 +193,7 @@ func UpgradeKubeletAndKubectlDebian(cluster *kubeoneapi.KubeOneCluster) (string,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -161,7 +161,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -161,7 +161,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -164,7 +164,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -161,7 +161,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -161,7 +161,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.23.9.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.23.9.golden
@@ -161,7 +161,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -96,8 +96,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -127,8 +127,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -129,8 +129,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -94,8 +94,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -126,14 +126,15 @@ fi
 
 
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 
 sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -91,8 +91,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -131,8 +131,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -134,8 +134,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -131,8 +131,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -131,8 +131,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -131,8 +131,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -133,8 +133,9 @@ sudo yum install -y \
 	kubelet-1.23.9 \
 	kubeadm-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -73,6 +73,7 @@ sudo apt-get update
 
 kube_ver="1.23.9*"
 cni_ver="1.2.0*"
+cri_ver="1.26.0*"
 
 
 
@@ -85,9 +86,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -70,6 +70,7 @@ sudo apt-get update
 
 kube_ver="1.23.9*"
 cni_ver="1.2.0*"
+cri_ver="1.26.0*"
 
 
 
@@ -82,9 +83,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -67,6 +67,7 @@ sudo apt-get update
 
 kube_ver="1.23.9*"
 cni_ver="1.2.0*"
+cri_ver="1.26.0*"
 
 
 
@@ -130,9 +131,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -67,6 +67,7 @@ sudo apt-get update
 
 kube_ver="1.23.9*"
 cni_ver="1.2.0*"
+cri_ver="1.26.0*"
 
 
 
@@ -133,9 +134,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -67,6 +67,7 @@ sudo apt-get update
 
 kube_ver="1.23.9*"
 cni_ver="1.2.0*"
+cri_ver="1.26.0*"
 
 
 
@@ -130,9 +131,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -67,6 +67,7 @@ sudo apt-get update
 
 kube_ver="1.23.9*"
 cni_ver="1.2.0*"
+cri_ver="1.26.0*"
 
 
 
@@ -128,9 +129,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -67,6 +67,7 @@ sudo apt-get update
 
 kube_ver="1.23.9*"
 cni_ver="1.2.0*"
+cri_ver="1.26.0*"
 
 
 
@@ -130,9 +131,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestRemoveBinariesAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesAmazonLinux.golden
@@ -3,12 +3,13 @@ export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 sudo systemctl stop kubelet || true
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 sudo yum remove -y \
 	kubelet \
 	kubeadm \
 	kubectl \
-	kubernetes-cni
+	kubernetes-cni \
+	cri-tools
 
 # Stop kubelet
 # Remove CNI and binaries

--- a/pkg/scripts/testdata/TestRemoveBinariesCentOS.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesCentOS.golden
@@ -1,12 +1,12 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 sudo yum remove -y \
 	kubelet \
 	kubeadm \
 	kubectl
-sudo yum remove -y kubernetes-cni || true
+sudo yum remove -y kubernetes-cni cri-tools || true
 sudo rm -rf /opt/cni
 sudo rm -f /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestRemoveBinariesDebian.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesDebian.golden
@@ -1,12 +1,12 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo apt-get remove --purge -y \
 	kubeadm \
 	kubectl \
 	kubelet
-sudo apt-get remove --purge -y kubernetes-cni || true
+sudo apt-get remove --purge -y kubernetes-cni cri-tools || true
 sudo rm -rf /opt/cni
 sudo rm -f /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 sudo systemctl daemon-reload

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -127,7 +127,6 @@ tar xvf node.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -126,12 +126,13 @@ fi
 
 
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 
 sudo yum install -y \
 	kubeadm-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -67,7 +67,8 @@ sudo apt-get update
 
 kube_ver="1.23.9*"
 cni_ver="1.2.0*"
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+cri_ver="1.26.0*"
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 
 
@@ -129,9 +130,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--no-install-recommends \
 	-y \
 	kubeadm=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -126,13 +126,14 @@ fi
 
 
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 
 sudo yum install -y \
 	kubelet-1.23.9 \
 	kubectl-1.23.9 \
-	kubernetes-cni-1.2.0
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.26.0
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -67,7 +67,8 @@ sudo apt-get update
 
 kube_ver="1.23.9*"
 cni_ver="1.2.0*"
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+cri_ver="1.26.0*"
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 
 
@@ -130,9 +131,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	-y \
 	kubelet=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #2626 to the `release/v1.5` branch.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```