### PR TITLE
[release/v1.4] Updates to kubernetes-cni, cri-tools, and supported Kubernetes versions

### DIFF
--- a/pkg/apis/kubeone/validation/validation.go
+++ b/pkg/apis/kubeone/validation/validation.go
@@ -38,7 +38,7 @@ const (
 	// lowerVersionConstraint defines a semver constraint that validates Kubernetes versions against a lower bound
 	lowerVersionConstraint = ">= 1.20"
 	// upperVersionConstraint defines a semver constraint that validates Kubernetes versions against an upper bound
-	upperVersionConstraint = "<= 1.23"
+	upperVersionConstraint = "<= 1.23.15"
 )
 
 var (

--- a/pkg/apis/kubeone/validation/validation_test.go
+++ b/pkg/apis/kubeone/validation/validation_test.go
@@ -723,6 +723,13 @@ func TestValidateVersionConfig(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "invalid version config (1.23.16)",
+			versionConfig: kubeoneapi.VersionConfig{
+				Kubernetes: "1.23.16",
+			},
+			expectedError: true,
+		},
+		{
 			name: "valid version config (1.22.1)",
 			versionConfig: kubeoneapi.VersionConfig{
 				Kubernetes: "1.22.1",

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultKubernetesCNIVersion = "1.1.1"
+	defaultKubernetesCNIVersion = "1.2.0"
 	defaultCriToolsVersion      = "1.25.0"
 )
 

--- a/pkg/scripts/os.go
+++ b/pkg/scripts/os.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	defaultKubernetesCNIVersion = "1.1.1"
-	defaultCriToolsVersion      = "1.21.0"
+	defaultCriToolsVersion      = "1.25.0"
 )
 
 var migrateToContainerdScriptTemplate = heredoc.Doc(`

--- a/pkg/scripts/os_amzn.go
+++ b/pkg/scripts/os_amzn.go
@@ -155,6 +155,7 @@ sudo yum install -y \
 {{- end }}
 	kubernetes-cni-{{ .KUBERNETES_CNI_VERSION }} \
 	cri-tools-{{ .CRITOOLS_VERSION }}
+sudo yum downgrade cri-tools-{{ .CRITOOLS_VERSION }} || true
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 {{- end }}
 

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -87,7 +87,7 @@ sudo systemctl enable --now iscsid
 {{ end }}
 
 {{- if or .FORCE .UPGRADE }}
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 {{- end }}
 
 sudo yum install -y \
@@ -100,8 +100,9 @@ sudo yum install -y \
 {{- if .KUBECTL }}
 	kubectl-{{ .KUBERNETES_VERSION }} \
 {{- end }}
-	kubernetes-cni-{{ .KUBERNETES_CNI_VERSION }}
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-{{ .KUBERNETES_CNI_VERSION }} \
+	cri-tools-{{ .CRITOOLS_VERSION }}
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
@@ -110,12 +111,12 @@ sudo systemctl restart kubelet
 {{ end }}
 `
 	removeBinariesCentOSScriptTemplate = `
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 sudo yum remove -y \
 	kubelet \
 	kubeadm \
 	kubectl
-sudo yum remove -y kubernetes-cni || true
+sudo yum remove -y kubernetes-cni cri-tools || true
 `
 	disableNMCloudSetup = `
 if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active: active"; then
@@ -139,6 +140,7 @@ func KubeadmCentOS(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"FORCE":                  force,
@@ -170,6 +172,7 @@ func UpgradeKubeadmAndCNICentOS(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,
@@ -197,6 +200,7 @@ func UpgradeKubeletAndKubectlCentOS(cluster *kubeoneapi.KubeOneCluster) (string,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"PROXY":                  proxy,
 		"INSTALL_DOCKER":         cluster.ContainerRuntime.Docker,

--- a/pkg/scripts/os_centos.go
+++ b/pkg/scripts/os_centos.go
@@ -102,6 +102,7 @@ sudo yum install -y \
 {{- end }}
 	kubernetes-cni-{{ .KUBERNETES_CNI_VERSION }} \
 	cri-tools-{{ .CRITOOLS_VERSION }}
+sudo yum downgrade cri-tools-{{ .CRITOOLS_VERSION }} || true
 sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload

--- a/pkg/scripts/os_debian.go
+++ b/pkg/scripts/os_debian.go
@@ -71,9 +71,10 @@ sudo apt-get update
 
 kube_ver="{{ .KUBERNETES_VERSION }}*"
 cni_ver="{{ .KUBERNETES_CNI_VERSION }}*"
+cri_ver="{{ .CRITOOLS_VERSION }}*"
 
 {{- if or .FORCE .UPGRADE }}
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 {{- end }}
 
 {{ if .INSTALL_DOCKER }}
@@ -100,9 +101,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 {{- if .KUBECTL }}
 	kubectl=${kube_ver} \
 {{- end }}
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet
@@ -113,12 +115,12 @@ sudo systemctl restart kubelet
 `
 
 	removeBinariesDebianScriptTemplate = `
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo apt-get remove --purge -y \
 	kubeadm \
 	kubectl \
 	kubelet
-sudo apt-get remove --purge -y kubernetes-cni || true
+sudo apt-get remove --purge -y kubernetes-cni cri-tools || true
 `
 )
 
@@ -129,6 +131,7 @@ func KubeadmDebian(cluster *kubeoneapi.KubeOneCluster, force bool) (string, erro
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
@@ -156,6 +159,7 @@ func UpgradeKubeadmAndCNIDebian(cluster *kubeoneapi.KubeOneCluster) (string, err
 		"KUBEADM":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,
@@ -179,6 +183,7 @@ func UpgradeKubeletAndKubectlDebian(cluster *kubeoneapi.KubeOneCluster) (string,
 		"KUBECTL":                true,
 		"KUBERNETES_VERSION":     cluster.Versions.Kubernetes,
 		"KUBERNETES_CNI_VERSION": defaultKubernetesCNIVersion,
+		"CRITOOLS_VERSION":       defaultCriToolsVersion,
 		"CONFIGURE_REPOSITORIES": cluster.SystemPackages.ConfigureRepositories,
 		"HTTP_PROXY":             cluster.Proxy.HTTP,
 		"HTTPS_PROXY":            cluster.Proxy.HTTPS,

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-force.golden
@@ -157,7 +157,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry.golden
@@ -157,7 +157,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-overwrite_registry_insecure.golden
@@ -160,7 +160,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-proxy.golden
@@ -157,7 +157,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-simple.golden
@@ -157,7 +157,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-v1.16.1.golden
@@ -157,7 +157,6 @@ EOF
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 curl -L --output /tmp/k8s-binaries/kubectl http://127.0.0.1/kubectl.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubectl /opt/bin/kubectl
 sudo ln -sf /opt/bin/kubectl /usr/bin/

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_cilium.golden
@@ -96,8 +96,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd.golden
@@ -127,8 +127,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmAmazonLinux-with_containerd_with_insecure_registry.golden
@@ -129,8 +129,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-cilium_cluster.golden
@@ -94,8 +94,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-force.golden
@@ -122,14 +122,16 @@ sudo systemctl enable --now docker
 
 
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 
 sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-nutanix_cluster.golden
@@ -91,8 +91,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry.golden
@@ -127,8 +127,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-overwrite_registry_insecure.golden
@@ -130,8 +130,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-proxy.golden
@@ -127,8 +127,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-simple.golden
@@ -127,8 +127,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-v1.16.1.golden
@@ -127,8 +127,10 @@ sudo yum install -y \
 	kubelet-1.16.1 \
 	kubeadm-1.16.1 \
 	kubectl-1.16.1 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd.golden
@@ -131,8 +131,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmCentOS-with_containerd_with_insecure_registry.golden
@@ -133,8 +133,10 @@ sudo yum install -y \
 	kubelet-1.17.4 \
 	kubeadm-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-cilium_cluster.golden
@@ -72,7 +72,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
+cri_ver="1.25.0*"
 
 
 
@@ -85,9 +86,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-nutanix_cluster.golden
@@ -69,7 +69,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
+cri_ver="1.25.0*"
 
 
 
@@ -82,9 +83,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry.golden
@@ -66,7 +66,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
+cri_ver="1.25.0*"
 
 
 
@@ -126,9 +127,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-overwrite_registry_insecure.golden
@@ -66,7 +66,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
+cri_ver="1.25.0*"
 
 
 
@@ -129,9 +130,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-simple.golden
@@ -66,7 +66,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
+cri_ver="1.25.0*"
 
 
 
@@ -126,9 +127,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd.golden
@@ -66,7 +66,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
+cri_ver="1.25.0*"
 
 
 
@@ -128,9 +129,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmDebian-with_containerd_with_insecure_registry.golden
@@ -66,7 +66,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="1.1.1*"
+cni_ver="1.2.0*"
+cri_ver="1.25.0*"
 
 
 
@@ -130,9 +131,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	kubelet=${kube_ver} \
 	kubeadm=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-force.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.25.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.25.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-overwrite_registry_insecure.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.25.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-simple.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.25.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_cilium.golden
@@ -61,11 +61,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.25.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
+++ b/pkg/scripts/testdata/TestKubeadmFlatcar-with_containerd.golden
@@ -55,11 +55,11 @@ sudo systemctl force-reload systemd-journald
 
 
 sudo mkdir -p /opt/bin /opt/cni/bin /etc/kubernetes/pki /etc/kubernetes/manifests
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"
-CRI_TOOLS_RELEASE="v1.21.0"
+CRI_TOOLS_RELEASE="v1.25.0"
 
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}/crictl-${CRI_TOOLS_RELEASE}-linux-${HOST_ARCH}.tar.gz |
 	sudo tar -C /opt/bin -xz

--- a/pkg/scripts/testdata/TestRemoveBinariesAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesAmazonLinux.golden
@@ -3,12 +3,13 @@ export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
 sudo systemctl stop kubelet || true
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 sudo yum remove -y \
 	kubelet \
 	kubeadm \
 	kubectl \
-	kubernetes-cni
+	kubernetes-cni \
+	cri-tools
 
 # Stop kubelet
 # Remove CNI and binaries

--- a/pkg/scripts/testdata/TestRemoveBinariesCentOS.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesCentOS.golden
@@ -1,9 +1,9 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 sudo yum remove -y \
 	kubelet \
 	kubeadm \
 	kubectl
-sudo yum remove -y kubernetes-cni || true
+sudo yum remove -y kubernetes-cni cri-tools || true

--- a/pkg/scripts/testdata/TestRemoveBinariesDebian.golden
+++ b/pkg/scripts/testdata/TestRemoveBinariesDebian.golden
@@ -1,9 +1,9 @@
 set -xeuo pipefail
 export "PATH=$PATH:/sbin:/usr/local/bin:/opt/bin"
 
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 sudo apt-get remove --purge -y \
 	kubeadm \
 	kubectl \
 	kubelet
-sudo apt-get remove --purge -y kubernetes-cni || true
+sudo apt-get remove --purge -y kubernetes-cni cri-tools || true

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIAmazonLinux.golden
@@ -123,7 +123,6 @@ tar xvf node.tar.gz
 sudo install --owner=0 --group=0 --mode=0755 /tmp/k8s-binaries/kubernetes/node/bin/kubeadm /opt/bin/kubeadm
 sudo ln -sf /opt/bin/kubeadm /usr/bin/
 rm /tmp/k8s-binaries/kubernetes/node/bin/kubeadm
-sudo yum install -y cri-tools
 
 
 

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNICentOS.golden
@@ -122,12 +122,14 @@ sudo systemctl enable --now docker
 
 
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 
 sudo yum install -y \
 	kubeadm-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIDebian.golden
@@ -66,8 +66,9 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="1.1.1*"
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+cni_ver="1.2.0*"
+cri_ver="1.25.0*"
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 
 
@@ -125,9 +126,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	--no-install-recommends \
 	-y \
 	kubeadm=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeadmAndCNIFlatcar.golden
@@ -50,7 +50,7 @@ sudo systemctl restart docker
 
 
 sudo mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-${HOST_ARCH}-v1.1.1.tgz" |
+curl -L "https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-${HOST_ARCH}-v1.2.0.tgz" |
 	sudo tar -C /opt/cni/bin -xz
 
 RELEASE="v1.17.4"

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlCentOS.golden
@@ -122,13 +122,15 @@ sudo systemctl enable --now docker
 
 
 
-sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni || true
+sudo yum versionlock delete kubelet kubeadm kubectl kubernetes-cni cri-tools || true
 
 sudo yum install -y \
 	kubelet-1.17.4 \
 	kubectl-1.17.4 \
-	kubernetes-cni-1.1.1
-sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni
+	kubernetes-cni-1.2.0 \
+	cri-tools-1.25.0
+sudo yum downgrade cri-tools-1.25.0 || true
+sudo yum versionlock add kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet

--- a/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
+++ b/pkg/scripts/testdata/TestUpgradeKubeletAndKubectlDebian.golden
@@ -66,8 +66,9 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/
 sudo apt-get update
 
 kube_ver="1.17.4*"
-cni_ver="1.1.1*"
-sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni
+cni_ver="1.2.0*"
+cri_ver="1.25.0*"
+sudo apt-mark unhold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 
 
@@ -126,9 +127,10 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install \
 	-y \
 	kubelet=${kube_ver} \
 	kubectl=${kube_ver} \
-	kubernetes-cni=${cni_ver}
+	kubernetes-cni=${cni_ver} \
+	cri-tools=${cri_ver}
 
-sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+sudo apt-mark hold kubelet kubeadm kubectl kubernetes-cni cri-tools
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now kubelet


### PR DESCRIPTION
**What this PR does / why we need it**:

The latest (January 2023) Kubernetes patch releases introduced some changes to packages that are described in #2607.

We were able to easily mitigate issues on main and `release/v1.5` because those branches/versions are using containerd 1.6.

However, we cannot do that easily for `release/v1.4` because it's using containerd 1.5 and cri-tools v1.26.0 doesn't support containerd 1.5. Updating containerd to 1.6 at this point would be too complicated because we have to update it in machine-controller, OSM, and KubeOne itself.

The idea for this PR is:

* We forbid using 1.23.16 and newer with KubeOne 1.4
  * We will revisit this if the issue gets solved on the Kubernetes side
* We strongly recommend upgrading to KubeOne 1.5 as soon as possible
* We'll upgrade kubernetes-cni to v1.2.0 because it's an easy win
* We'll upgrade and enforce cri-tools to v1.25.0
  * On CentOS and Amazon Linux 2, KubeOne will automatically downgrade cri-tools to v1.25.0 if newer is present
  * On Ubuntu, downgrading is possible with the `--force` flag

**What type of PR is this?**
/kind bug
/kind api-change

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update kubernetes-cni to v1.2.0 and cri-tools to v1.25.0 to solve the issue with `crictl` not being able to interact with containerd. Set the maximum Kubernetes version to v1.23.15 because v1.23.16+ is requiring cri-tools v1.26.0 which doesn't work with containerd 1.5
```

**Documentation**:
```documentation
TBD
```